### PR TITLE
test(tslint): disable rule `no-implicit-dependencies`

### DIFF
--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -1,4 +1,4 @@
-import { Component } from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+import { Component } from '@stencil/core';
 
 @Component({
     styleUrl: 'button-group.scss',

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, Watch } from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+import { Component, Element, Prop, Watch } from '@stencil/core';
 
 @Component({
     shadow: true,

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -1,4 +1,4 @@
-import { MDCDialog } from '@material/dialog'; // tslint:disable-line:no-implicit-dependencies
+import { MDCDialog } from '@material/dialog';
 import {
     Component,
     Element,
@@ -7,7 +7,7 @@ import {
     Prop,
     State,
     Watch,
-} from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+} from '@stencil/core';
 
 @Component({
     shadow: true,

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1,4 +1,4 @@
-import { MDCSelect } from '@material/select'; // tslint:disable-line:no-implicit-dependencies
+import { MDCSelect } from '@material/select';
 import {
     Component,
     Element,
@@ -6,7 +6,7 @@ import {
     EventEmitter,
     Prop,
     State,
-} from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+} from '@stencil/core';
 import { IOption } from './option';
 
 @Component({

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,4 +1,4 @@
-import { Component } from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+import { Component } from '@stencil/core';
 
 @Component({
     shadow: true,

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, Prop } from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+import { Component, Event, EventEmitter, Prop } from '@stencil/core';
 
 @Component({
     shadow: true,

--- a/src/components/text-field/text-field.tsx
+++ b/src/components/text-field/text-field.tsx
@@ -1,4 +1,4 @@
-import { MDCTextField } from '@material/textfield'; // tslint:disable-line:no-implicit-dependencies
+import { MDCTextField } from '@material/textfield';
 import {
     Component,
     Element,
@@ -6,7 +6,7 @@ import {
     EventEmitter,
     Prop,
     State,
-} from '@stencil/core'; // tslint:disable-line:no-implicit-dependencies
+} from '@stencil/core';
 
 @Component({
     shadow: true,

--- a/tslint.js
+++ b/tslint.js
@@ -34,7 +34,13 @@ module.exports = {
         'no-ex-assign': true,
         'no-extra-boolean-cast': true,
         'no-extra-semi': true,
-        'no-implicit-dependencies': [true],
+
+        // It would be nice to have this enabled, but as long as tslint
+        // doesn't support whitelisting imports, enabling it will mean
+        // a minimum of one `tslint:disable-line:no-implicit-dependencies`
+        // comment in each file.
+        'no-implicit-dependencies': false,
+
         'no-inner-declarations': true,
         'no-invalid-regexp': true,
         'no-regex-spaces': true,


### PR DESCRIPTION
While this is a good rule to have to avoid accidentally adding a production dependency as a
devDependenvy and have the released product fail when a user compiles their code (or worse, at
runtime), the amount of false positives due to imports from Stencil makes it too much of a hassle.