### PR TITLE
ci(jenkins): change which GitHub-credentials are used by Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,14 +46,15 @@ pipeline {
 
         stage('Publish package') {
             environment {
-                GH_TOKEN = credentials('github-access-token')
                 NPM_TOKEN = credentials('devnpm-access-token')
                 CI = true
             }
             steps {
-                script {
-                    if (env.BRANCH_NAME == 'master') {
-                        sh 'make release'
+                sshagent(['663e4b49-30f6-4c46-a018-a37ba604d7c8']) {
+                    script {
+                        if (env.BRANCH_NAME == 'master') {
+                            sh 'make release'
+                        }
                     }
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ test:
 .PHONY: release
 release:
 	@# Bumps and publishes.
-	docker run --rm -e CI -e GH_TOKEN -e NPM_TOKEN -w /lime $(DOCKER_IMAGE) npm run publish
+	docker run --rm -e CI -e NPM_TOKEN -w /lime $(DOCKER_IMAGE) npm run publish


### PR DESCRIPTION
`semantic-release` needs push-access to master in order to commit
and push the updated CHANGELOG.md