### PR TITLE
style: improve order of props in Component decorator

### DIFF
--- a/src/components/autocomplete/autocomplete.tsx
+++ b/src/components/autocomplete/autocomplete.tsx
@@ -9,9 +9,9 @@ import {
 } from '@stencil/core';
 
 @Component({
+    tag: 'limel-autocomplete',
     shadow: true,
     styleUrl: 'autocomplete.scss',
-    tag: 'limel-autocomplete',
 })
 export class Autocomplete {
     @Prop()

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -10,8 +10,8 @@ import {
 
 @Component({
     tag: 'limel-dialog',
-    styleUrl: 'dialog.scss',
     shadow: true,
+    styleUrl: 'dialog.scss',
 })
 export class Dialog {
     /**

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -12,8 +12,8 @@ import { ListRenderer } from '../list/list-renderer';
 
 @Component({
     tag: 'limel-menu',
-    styleUrl: 'menu.scss',
     shadow: true,
+    styleUrl: 'menu.scss',
 })
 export class Menu {
     @Prop({ reflectToAttr: true })

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -12,8 +12,8 @@ import { ListItem } from '../list/list-item';
 
 @Component({
     tag: 'limel-picker',
-    styleUrl: 'picker.scss',
     shadow: true,
+    styleUrl: 'picker.scss',
 })
 export class Picker {
     /**

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -11,8 +11,8 @@ import { IOption } from './option';
 
 @Component({
     tag: 'limel-select',
-    styleUrl: 'select.scss',
     shadow: true,
+    styleUrl: 'select.scss',
 })
 export class Select {
     @Prop({ reflectToAttr: true })

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -2,8 +2,8 @@ import { Component, Prop } from '@stencil/core';
 
 @Component({
     tag: 'limel-spinner',
-    styleUrl: 'spinner.scss',
     shadow: true,
+    styleUrl: 'spinner.scss',
 })
 export class Spinner {
     /**

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -10,8 +10,8 @@ import {
 
 @Component({
     tag: 'limel-switch',
-    styleUrl: 'switch.scss',
     shadow: true,
+    styleUrl: 'switch.scss',
 })
 export class Switch {
     @Prop({ reflectToAttr: true })


### PR DESCRIPTION
`tag` most important, `shadow` second most. `styleUrl` is the least important, thus placed last.