### PR TITLE
refactor: make watchers `protected` instead of `public`

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -33,19 +33,6 @@ export class Dialog {
 
     private mdcDialog: MDCDialog;
 
-    @Watch('open')
-    public watchHandler(newValue: boolean, oldValue: boolean) {
-        if (oldValue === newValue) {
-            return;
-        }
-
-        if (newValue) {
-            this.mdcDialog.show();
-        } else {
-            this.mdcDialog.close();
-        }
-    }
-
     public componentDidLoad() {
         this.mdcDialog = new MDCDialog(
             this.host.shadowRoot.querySelector('.mdc-dialog')
@@ -90,5 +77,18 @@ export class Dialog {
                 <div class="mdc-dialog__backdrop" />
             </aside>
         );
+    }
+
+    @Watch('open')
+    protected watchHandler(newValue: boolean, oldValue: boolean) {
+        if (oldValue === newValue) {
+            return;
+        }
+
+        if (newValue) {
+            this.mdcDialog.show();
+        } else {
+            this.mdcDialog.close();
+        }
     }
 }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -58,13 +58,6 @@ export class Menu {
     private menu: MDCMenu;
     private listRenderer = new ListRenderer();
 
-    @Watch('open')
-    public openWatcher(newValue: boolean) {
-        if (newValue !== this.menu.open) {
-            this.menu.open = newValue;
-        }
-    }
-
     public componentDidLoad() {
         const menuElement = this.element.shadowRoot.querySelector('.mdc-menu');
         this.menu = new MDCMenu(menuElement);
@@ -100,6 +93,13 @@ export class Menu {
                 {this.disabled ? <div class="menu-disabled" /> : null}
             </div>
         );
+    }
+
+    @Watch('open')
+    protected openWatcher(newValue: boolean) {
+        if (newValue !== this.menu.open) {
+            this.menu.open = newValue;
+        }
     }
 
     private renderTrigger() {

--- a/src/examples/text-field/text-field.tsx
+++ b/src/examples/text-field/text-field.tsx
@@ -22,12 +22,6 @@ export class TextFieldExample {
         this.invalid = this.required && !this.value;
     }
 
-    @Watch('required')
-    public watchRequired() {
-        console.log('watch required');
-        this.invalid = this.required && !this.value;
-    }
-
     public render() {
         return [
             <limel-button-group>
@@ -53,5 +47,23 @@ export class TextFieldExample {
             />,
             <span>Value: {this.value}</span>,
         ];
+    }
+
+    /*
+     * `public`, `protected`, and `private` are just compiler hints
+     * in TypeScript, and doesn't actually affect the compiled code
+     * in any way. We can take advantage of this, because while
+     * watchers are being called from outside the component by the
+     * "framework" code, they should never be called by any outside
+     * code we write ourselves. The `protected`-label ensures we
+     * would get a compiler-error if we tried to call the function
+     * from outside the component, while also *not* giving a compiler
+     * error because the function isn't used internally (like `private`
+     * would have done).
+     */
+    @Watch('required')
+    protected watchRequired() {
+        console.log('watch required');
+        this.invalid = this.required && !this.value;
     }
 }


### PR DESCRIPTION
`public`, `protected`, and `private` are just compiler hints in TypeScript, and doesn't actually
affect the compiled code in any way. We can take advantage of this, because while watchers are being
called from outside the component by the "framework" code, they should never be called by any
outside code we write ourselves. The `protected`-label ensures we would get a compiler-error if we
tried to call the function from outside the component, while also *not* giving a compiler error
because the function isn't used internally (like `private` would have done).