### PR TITLE
build(dev-env): add dev-config for dev-build

### DIFF
--- a/stencil.config.dev.ts
+++ b/stencil.config.dev.ts
@@ -19,4 +19,5 @@ export const config: Config = {
     plugins: [
         sass(),
     ],
+    tsconfig: './tsconfig.dev.json'
 };

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "allowUnreachableCode": true,
+        "declaration": false,
+        "experimentalDecorators": true,
+        "lib": ["dom", "es2015"],
+        "moduleResolution": "node",
+        "module": "es2015",
+        "target": "es2015",
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "jsx": "react",
+        "jsxFactory": "h"
+    },
+    "include": ["src", "types/jsx.d.ts"],
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Make the dev-build more forgiving by easing the restrictive compiler options.