### PR TITLE
fix: fix dependency on lime-material-components-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:specs:watch": "stencil test --spec --watch"
   },
   "dependencies": {
-    "lime-material-components-web": "^0.38.0"
+    "lime-material-components-web": "http://npm.lundalogik.com:4873/lime-material-components-web/-/lime-material-components-web-0.38.0.tgz"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.1.2",


### PR DESCRIPTION
The dependency didn't work when installing lime-elements in lime-webclient because lime-webclient
doesn't use the same default registry.