### PR TITLE
fix: correct scss-imports to remove build-error in consuming plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,7 @@
   "types": "dist/types/interface.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
-    "dist/",
-    "/dist/**/*.js",
-    "/dist/**/*.json",
-    "/dist/**/*.css",
-    "/dist/**/*.ts"
+    "dist/"
   ],
   "scripts": {
     "build": "cross-env-shell NODE_ENV=prod SASS_PATH=node_modules \"stencil build --config stencil.config.dist.ts && node copy-icons.js\"",

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/list/mdc-list";
 @import "@lime-material/elevation/mdc-elevation";
 

--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -1,5 +1,3 @@
-@import "../../style/variables";
-
 limel-button-group {
     align-items: center;
     display: flex;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/theme/mdc-theme";
 @import "@lime-material/typography/mdc-typography";
 @import "@lime-material/button/mdc-button";

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -1,5 +1,3 @@
-@import "../../style/variables";
-
 :host {
     display: block;
 }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/theme/mdc-theme";
 @import "@lime-material/typography/mdc-typography";
 @import "@lime-material/dialog/mdc-dialog";

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/list/mdc-list";
 
 :host {

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/list/mdc-list";
 @import "@lime-material/menu/mdc-menu";
 @import "@lime-material/menu-surface/mdc-menu-surface";

--- a/src/components/picker/picker.scss
+++ b/src/components/picker/picker.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/elevation/mdc-elevation";
 
 :host {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/theme/mdc-theme";
 @import "@lime-material/select/mdc-select";
 

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import '@lime-material/theme/mdc-theme';
 @import '@lime-material/slider/mdc-slider';
 

--- a/src/components/spinner/spinner.scss
+++ b/src/components/spinner/spinner.scss
@@ -1,5 +1,3 @@
-@import "../../style/variables";
-
 :host {
     animation-duration: 1s;
     animation-iteration-count: infinite;

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import "@lime-material/typography/mdc-typography";
 @import "@lime-material/switch/mdc-switch";
 

--- a/src/components/text-field/text-field.scss
+++ b/src/components/text-field/text-field.scss
@@ -1,4 +1,3 @@
-@import "../../style/variables";
 @import '@lime-material/theme/mdc-theme';
 @import '@lime-material/textfield/mdc-text-field';
 

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -9,7 +9,11 @@ const targetDist: OutputTargetDist = {
 export const config: Config = {
     namespace: 'lime-elements',
     outputTargets: [targetDist],
-    plugins: [sass()],
+    plugins: [
+        sass({
+            injectGlobalPaths: ['src/style/variables.scss'],
+        }),
+    ],
     excludeSrc: [
         '**/test/**',
         '**/examples/**',


### PR DESCRIPTION
When using lime-elements in plugins built with Stencil, building the plugin would generate errors
caused by imports in our scss-files. This has been fixed.