### PR TITLE
ci(Jenkinsfile): move commitlint step after code lint and tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,16 @@ pipeline {
                 sh 'make build'
             }
         }
+        stage('Lint code') {
+            steps {
+                sh 'make lint'
+            }
+        }
+        stage('Run tests') {
+            steps {
+                sh 'make test'
+            }
+        }
         stage('Lint commits') {
             steps {
                 script {
@@ -43,16 +53,6 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage('Lint code') {
-            steps {
-                sh 'make lint'
-            }
-        }
-        stage('Run tests') {
-            steps {
-                sh 'make test'
             }
         }
 


### PR DESCRIPTION
This might seem counter-intuitive, since linting the commit-messages is fast, and it's typically
better to have fast steps run first, so as to catch errors early and make failing builds fail as
early as possible. But when addressing review feedback, it is useful to temporarily push a separate
commit of the fixes, to let the reviewer easily see the new changes. However, this commit should
generally not be merged to master as-is, but be squashed into the original commit or commits.
Therefore, it is also useful to name this temporary commit in a way that does not follow the commit
message standard, making the build fail and stopping any accidental merging. And if the build is
intentionally made to fail in this scenario, it's still useful to see if the code lint and test
steps passed before the commit lint step fails.