### PR TITLE
fix(limel-dialog): make it possible to open the dialog again after clicking the scrim

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -47,7 +47,7 @@ export class Dialog {
             this.mdcDialog.open();
         }
 
-        this.mdcDialog.listen('MDCDialog:cancel', () => {
+        this.mdcDialog.listen('MDCDialog:closed', () => {
             this.close.emit();
             this.open = false;
         });


### PR DESCRIPTION
fix #150