### PR TITLE
feat(limel-icon-button): add component

### DIFF
--- a/src/assets/icons/Lime/heart_filled.svg
+++ b/src/assets/icons/Lime/heart_filled.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<path d="m16,8.25c0,0 2.91,-3.25 6.5,-3.25s6.5,2.95 6.5,6.5c0,2.201 -2.167,4.333 -2.167,4.333l-10.833,10.834l-10.833,-10.834c0,0 -2.167,-2.133 -2.167,-4.333c0,-3.55 2.91,-6.5 6.5,-6.5s6.5,3.25 6.5,3.25z" fill="#000000" id="svg_1" stroke="#000000" stroke-miterlimit="10" stroke-width="2"/>
+</svg>

--- a/src/assets/icons/Lime/heart_outlined.svg
+++ b/src/assets/icons/Lime/heart_outlined.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<path d="m16,8.25c0,0 2.91,-3.25 6.5,-3.25s6.5,2.95 6.5,6.5c0,2.201 -2.167,4.333 -2.167,4.333l-10.833,10.834l-10.833,-10.834c0,0 -2.167,-2.133 -2.167,-4.333c0,-3.55 2.91,-6.5 6.5,-6.5s6.5,3.25 6.5,3.25z" fill="none" id="svg_1" stroke="#000000" stroke-miterlimit="10" stroke-width="2"/>
+</svg>

--- a/src/components/icon-button/icon-button.e2e.ts
+++ b/src/components/icon-button/icon-button.e2e.ts
@@ -1,0 +1,26 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('limel-icon-button', async () => {
+    let page;
+    describe('smoke test', () => {
+        let mdcIconButton;
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-icon-button icon="Lime/heart_outlined" label="Add favorite"></limel-switch>
+            `);
+            mdcIconButton = await page.find(
+                'limel-icon-button >>> .mdc-icon-button'
+            );
+        });
+        it('displays the correct label', () => {
+            expect(mdcIconButton).toEqualAttribute(
+                'aria-label',
+                'Add favorite'
+            );
+        });
+    });
+});
+
+async function createPage(content) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/icon-button/icon-button.mdx
+++ b/src/components/icon-button/icon-button.mdx
@@ -1,0 +1,13 @@
+---
+name: Icon Button
+route: /icon-button
+menu: Components
+---
+
+# Icon Button
+
+<limel-props name="limel-icon-button" />
+
+## Example
+
+<limel-example name="limel-example-icon-button" />

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -1,0 +1,14 @@
+@import "@lime-material/theme/mdc-theme";
+@import "@lime-material/icon-button/mdc-icon-button";
+
+:host {
+    display: inline-block;
+}
+
+:host([hidden]) {
+    display: none;
+}
+
+:host([disabled]) {
+    pointer-events: none;
+}

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -1,0 +1,56 @@
+import { MDCRipple } from '@lime-material/ripple';
+import { Component, Element, Prop } from '@stencil/core';
+
+@Component({
+    tag: 'limel-icon-button',
+    shadow: true,
+    styleUrl: 'icon-button.scss',
+})
+export class IconButton {
+    /**
+     * The icon to display.
+     */
+    @Prop({ reflectToAttr: true })
+    public icon: string;
+
+    /**
+     * The text to show to screenreaders and other assistive tech.
+     */
+    @Prop({ reflectToAttr: true })
+    public label: string;
+
+    /**
+     * Set to `true` to disable the button.
+     * Defaults to `false`.
+     */
+    @Prop({ reflectToAttr: true })
+    public disabled = false;
+
+    @Element()
+    private host: HTMLElement;
+
+    private mdcIconButtonRipple;
+
+    public componentDidLoad() {
+        this.mdcIconButtonRipple = new MDCRipple(
+            this.host.shadowRoot.querySelector('.mdc-icon-button')
+        );
+        this.mdcIconButtonRipple.unbounded = true;
+    }
+
+    public componentDidUnload() {
+        this.mdcIconButtonRipple.destroy();
+    }
+
+    public render() {
+        return (
+            <button
+                class={`mdc-icon-button`}
+                disabled={this.disabled}
+                aria-label={this.label}
+            >
+                <limel-icon name={this.icon} />
+            </button>
+        );
+    }
+}

--- a/src/examples/icon-button/icon-button.tsx
+++ b/src/examples/icon-button/icon-button.tsx
@@ -1,0 +1,52 @@
+import { Component, State } from '@stencil/core';
+
+@Component({
+    tag: 'limel-example-icon-button',
+    shadow: true,
+})
+export class IconButtonExample {
+    @State()
+    private isFavorite = false;
+
+    public render() {
+        return [
+            <section>
+                <h3>Basic Usage</h3>
+                <p>
+                    <limel-icon-button
+                        label="Add favourite"
+                        icon="Lime/heart_outlined"
+                    />
+                </p>
+            </section>,
+            <section>
+                <h3>Toggle State</h3>
+                <p>
+                    <limel-icon-button
+                        label={
+                            this.isFavorite ? 'Remove favorite' : 'Add favorite'
+                        }
+                        icon={
+                            this.isFavorite
+                                ? 'Lime/heart_filled'
+                                : 'Lime/heart_outlined'
+                        }
+                        onClick={() => {
+                            this.isFavorite = !this.isFavorite;
+                        }}
+                    />
+                </p>
+            </section>,
+            <section>
+                <h3>Disabled</h3>
+                <p>
+                    <limel-icon-button
+                        label="Add favourite"
+                        icon="Lime/heart_outlined"
+                        disabled={true}
+                    />
+                </p>
+            </section>,
+        ];
+    }
+}


### PR DESCRIPTION
The limel-icon-button can be used for simple actions where an icon conveys the meaning of the button
sufficiently. Common examples are adding a favourite or bookmark, or marking something with a
thumbsup or thumbsdown.

fix #186