### PR TITLE
Address potential source of bugs in limel-chip-set

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -94,8 +94,13 @@ export class ChipSet {
         this.handleTextInput = this.handleTextInput.bind(this);
     }
 
+    /**
+     * Used to set focus to the chip-set input field.
+     *
+     * @returns {void}
+     */
     @Method()
-    public focus() {
+    public setFocus() {
         this.editMode = true;
         this.host.shadowRoot.querySelector('input').focus();
     }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -109,7 +109,7 @@ export class Picker {
         }
 
         const chipSet = this.element.shadowRoot.querySelector('limel-chip-set');
-        chipSet.focus();
+        chipSet.setFocus();
     }
 
     public componentDidLoad() {


### PR DESCRIPTION
The build produces the following warning, and this change fixes this potential cause of bugs:

> [ WARN  ]  build warn
> The @Method() name "focus" used within the "ChipSet" class is a rename the "focus" method so it does not conflict with an existing standardized prototype member. Reusing method names that are already defined on the element's prototype may cause unexpected runtime errors or user-interface issues on various browsers, so it's best to avoid them entirely.

The PR includes two commits, the first moves stuff around a little, the other contains the actual code change. It might be easier to review them one at a time.