### PR TITLE
build(postinstall): fix postinstall to check if files exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "dist/"
   ],
   "scripts": {
-    "postinstall": "npm run install-flatpickr && npm run rm-jsx-dom-types",
-    "install-flatpickr": "cp ./src/dev-assets/hack/flatpickr.js ./node_modules/flatpickr/dist/flatpickr.js",
-    "rm-jsx-dom-types": "node remove-jsx-dom-types.js",
+    "postinstall": "node postinstall.js",
     "build": "cross-env-shell NODE_ENV=prod SASS_PATH=node_modules \"stencil build --config stencil.config.dist.ts\"",
     "cm": "git-cz",
     "dev": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --docs\"",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+// Copy pre-built version of flatpickr
+// TODO: remove this when a new version of flatpickr has been released
+fs.exists('src/dev-assets/hack/flatpickr.js', () => {
+    fs.copyFile(
+        'src/dev-assets/hack/flatpickr.js',
+        'node_modules/flatpickr/dist/flatpickr.js',
+        () => {
+            console.log(
+                'copied src/dev-assets/hack/flatpickr.js to node_modules'
+            );
+        }
+    );
+});
+
+// Remove type definitions for jsx-dom
+fs.exists('node_modules/jsx-dom/jsx-dom.d.ts', () => {
+    fs.unlink('node_modules/jsx-dom/jsx-dom.d.ts', () => {
+        console.log('jsx-dom.d.ts removed!');
+    });
+});

--- a/remove-jsx-dom-types.js
+++ b/remove-jsx-dom-types.js
@@ -1,4 +1,0 @@
-const fs = require('fs');
-fs.unlink('node_modules/jsx-dom/jsx-dom.d.ts', () => {
-    console.log('jsx-dom.d.ts removed!');
-});


### PR DESCRIPTION
The postinstall hook runs when this package is installed by other packages as well, causing npm
install to fail since the postinstall hook where dependent on local files in this package