### PR TITLE
fix(install): add postinstall.js to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "types": "dist/types/interface.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
-    "dist/"
+    "dist/",
+    "postinstall.js"
   ],
   "scripts": {
     "postinstall": "node postinstall.js",


### PR DESCRIPTION
postinstall tries to run the postinstall.js script, but the script is not included in the dist
package