### PR TITLE
fix(date-picker): Remove animation when rendering picker

### DIFF
--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -35,6 +35,7 @@ export abstract class Picker {
             parseDate: this.nativePicker ? undefined : this.parseDate,
             appendTo: container,
             defaultDate: value,
+            animate: false,
         };
 
         config = { ...config, ...this.getConfig(this.nativePicker) };


### PR DESCRIPTION
Without this fix, our custom pickers (Quarter picker for instance) gets cropped when it's in the
bottom of a dialog or in the bottom of the screen.