### PR TITLE
docs: make use of docblocs for css variables

### DIFF
--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -1,3 +1,7 @@
+/**
+ * @prop --background-color: The color to use for the badge behind the icon.
+ */
+
 limel-icon {
     display: inline-block;
     color: white;

--- a/src/components/chip-set/chip-set.mdx
+++ b/src/components/chip-set/chip-set.mdx
@@ -8,14 +8,6 @@ menu: Components
 
 <limel-props name="limel-chip-set" />
 
-## CSS variables
-
-| Name                          | Description                                             |
-| ----------------------------- | ------------------------------------------------------- |
-| --icon-background-color       | Background color of the icon. Defaults to transparent   |
-| --icon-color                  | Color of the icon. Defaults to 54% black                |
-| --background-color            | Background color of the field when type is set to input |
-
 ## Example
 
 <limel-example name="limel-example-chip-set" />

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -12,6 +12,11 @@ $mdc-text-field-fullwidth-bottom-line-color: $lime-text-field-bottom-line-color;
 @import '@lime-material/textfield/mdc-text-field';
 @import '@lime-material/ripple/mdc-ripple';
 
+/**
+ * @prop --icon-background-color: Background color of the icon. Defaults to transparent.
+ * @prop --icon-color: Color of the icon. Defaults to 54% black.
+ * @prop --background-color: Background color of the field when type is set to input.
+ */
 
 :host([disabled]) {
     pointer-events: none;

--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -8,13 +8,6 @@ menu: Components
 
 <limel-props name="limel-dialog" />
 
-## CSS variables
-
-| Name                          | Description          |
-| ----------------------------- | -------------------- |
-| --dialog-width                | Width of the dialog  |
-| --dialog-height               | Height of the dialog |
-
 ## Examples
 
 ### Basic dialog

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -2,6 +2,11 @@ $mdc-dialog-max-width: false;
 $mdc-dialog-max-height: false;
 @import "@lime-material/dialog/mdc-dialog";
 
+/**
+ * @prop --dialog-width: Width of the dialog.
+ * @prop --dialog-height: Height of the dialog.
+ */
+
 slot[name="header"] {
     display: none;
 }

--- a/src/components/input-field/input-field.mdx
+++ b/src/components/input-field/input-field.mdx
@@ -8,12 +8,6 @@ menu: Components
 
 <limel-props name="limel-input-field" />
 
-## CSS variables
-
-| Name               | Description                   |
-| ------------------ | ----------------------------- |
-| --background-color | Background color of the field |
-
 ## Examples
 
 ### Input field of type text

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -14,6 +14,10 @@ $mdc-text-field-fullwidth-bottom-line-color: $lime-text-field-bottom-line-color;
 @import '@lime-material/elevation/mdc-elevation';
 @import "@lime-material/menu-surface/mdc-menu-surface";
 
+/**
+ * @prop --background-color: Background color of the field.
+ */
+
 :host {
     display: block;
 }

--- a/src/components/linear-progress/linear-progress.scss
+++ b/src/components/linear-progress/linear-progress.scss
@@ -1,5 +1,9 @@
 @import "@lime-material/linear-progress/mdc-linear-progress";
 
+/**
+ * @prop --background-color: Color to use for progress-bar track.
+ */
+
 .mdc-linear-progress {
     text-align: left;
 }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -1,5 +1,9 @@
 @import "@lime-material/list/mdc-list";
 
+/**
+ * @prop --icon-background-color: Color to use for icon background.
+ */
+
 :host {
     display: block;
 }

--- a/src/components/select/select.mdx
+++ b/src/components/select/select.mdx
@@ -8,12 +8,6 @@ menu: Components
 
 <limel-props name="limel-select" />
 
-## CSS variables
-
-| Name                          | Description                   |
-| ----------------------------- | ----------------------------- |
-| --background-color            | Background color of the field |
-
 ## Example
 
 <limel-example name="limel-example-select" />

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -5,6 +5,10 @@ $mdc-select-bottom-line-hover-color: $lime-text-field-bottom-line-color;
 @import "@lime-material/select/mdc-select";
 @import '@lime-material/ripple/mdc-ripple';
 
+/**
+ * @prop --background-color: Background color of the field.
+ */
+
 :host([hidden]) {
     display: none;
 }


### PR DESCRIPTION
Stencil can now parse docsblocs in scss-files, so we no longer
have to create tables manually in the mdx-files.