### PR TITLE
fix(limel-dialog): open dialog on Microsoft Edge several times

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -82,7 +82,7 @@ export class Dialog {
         const { activate, deactivate } = util.createFocusTrapInstance(
             this.host.shadowRoot.querySelector('.mdc-dialog__surface'),
             focusTrap.default,
-            this.host.shadowRoot.getElementById('initialFocusEl')
+            this.host.shadowRoot.querySelector('#initialFocusEl')
         );
 
         this.mdcDialog.foundation_.adapter_.trapFocus = () => {


### PR DESCRIPTION
fix #314 

to test it open https://lundalogik.github.io/lime-elements/versions/0.0.0-devKatja/#/dialog in Edge (or simulate it browserstack) and see whether you can open a dialog without getting a exception