### PR TITLE
fix: correct scss imports so we do not break consumer builds

### DIFF
--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 /**
  * @prop --background-color: The color to use for the badge behind the icon.
  */

--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 limel-button-group {
     align-items: center;
     display: flex;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,3 +1,4 @@
+@import '../../style/variables';
 @import "@lime-material/button/mdc-button";
 
 :host {

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 $mdc-textarea-background: $mdc-theme-background;
 // $mdc-textarea-disabled-background: $mdc-theme-background;
 

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 :host {
     display: block;
 }

--- a/src/components/date-picker/date-picker.scss
+++ b/src/components/date-picker/date-picker.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import '@lime-material/theme/mdc-theme';
 @import '../../../node_modules/flatpickr/dist/flatpickr.min.css';
 

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 $mdc-dialog-max-width: false;
 $mdc-dialog-max-height: false;
 @import "@lime-material/dialog/mdc-dialog";

--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 /**
  * @prop --lime-grid-area: Grid layout
  * @prop --lime-grid-columns: Number of columns in the grid, defaults to 8

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/icon-button/mdc-icon-button";
 
 :host {

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 :host {
     background-color: rgba(0, 0, 0, 0);
     display: inline-block;

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 $mdc-textarea-background: $mdc-theme-background;
 // $mdc-textarea-disabled-background: $mdc-theme-background;
 

--- a/src/components/linear-progress/linear-progress.scss
+++ b/src/components/linear-progress/linear-progress.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/linear-progress/mdc-linear-progress";
 
 /**

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/list/mdc-list";
 
 /**

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/list/mdc-list";
 @import "@lime-material/menu/mdc-menu";
 @import "@lime-material/menu-surface/mdc-menu-surface";

--- a/src/components/multi-select/multi-select.scss
+++ b/src/components/multi-select/multi-select.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import '@lime-material/form-field/mdc-form-field';
 @import '@lime-material/checkbox/mdc-checkbox';
 @import "@lime-material/floating-label/mdc-floating-label";

--- a/src/components/picker/picker.scss
+++ b/src/components/picker/picker.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/elevation/mdc-elevation";
 @import "@lime-material/menu-surface/mdc-menu-surface";
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 $mdc-select-fill-color: $mdc-theme-background;
 $mdc-select-bottom-line-idle-color: $lime-text-field-bottom-line-color;
 $mdc-select-bottom-line-hover-color: $lime-text-field-bottom-line-color;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import '@lime-material/slider/mdc-slider';
 @import "@lime-material/floating-label/mdc-floating-label";
 

--- a/src/components/snackbar/snackbar.scss
+++ b/src/components/snackbar/snackbar.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/button/mdc-button";
 @import "@lime-material/snackbar/mdc-snackbar";
 

--- a/src/components/spinner/spinner.scss
+++ b/src/components/spinner/spinner.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 :host {
     animation-duration: 1s;
     animation-iteration-count: infinite;

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -1,3 +1,5 @@
+@import '../../style/variables';
+
 @import "@lime-material/switch/mdc-switch";
 
 .mdc-switch {

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -7,13 +7,10 @@ const targetDist: OutputTargetDist = {
 };
 
 export const config: Config = {
+    copy: [{ src: 'style/' }],
     namespace: 'lime-elements',
     outputTargets: [targetDist],
-    plugins: [
-        sass({
-            injectGlobalPaths: ['src/style/variables.scss'],
-        }),
-    ],
+    plugins: [sass()],
     excludeSrc: [
         '**/test/**',
         '**/examples/**',

--- a/stencil.config.docs.ts
+++ b/stencil.config.docs.ts
@@ -19,11 +19,7 @@ export const config: Config = {
     hashFileNames: false,
     namespace: 'lime-elements',
     outputTargets: [targetWww],
-    plugins: [
-        sass({
-            injectGlobalPaths: ['src/style/variables.scss'],
-        }),
-    ],
+    plugins: [sass()],
     globalScript: 'src/global/index.ts',
     globalStyle: 'src/global/colors.scss',
 };

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -17,11 +17,7 @@ export const config: Config = {
     ],
     namespace: 'lime-elements',
     outputTargets: [targetWww],
-    plugins: [
-        sass({
-            injectGlobalPaths: ['src/style/variables.scss'],
-        }),
-    ],
+    plugins: [sass()],
     tsconfig: './tsconfig.dev.json',
     globalScript: 'src/global/index.ts',
     globalStyle: 'src/global/colors.scss',


### PR DESCRIPTION
We need to explicitly import `src/style/variables.scss` in each component's scss-file instead of using the `injectGlobalPaths` config for the scss-compiler.

fix #329