### PR TITLE
Revert "perf(limel-date-picker): on window resize, redraw picker instead of creating a new instance"

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -95,6 +95,7 @@ export class DatePicker {
 
     private picker: Picker;
 
+    private container: HTMLElement;
     private input: HTMLElement;
 
     constructor() {
@@ -169,11 +170,9 @@ export class DatePicker {
             'limel-input-field'
         );
         this.input = textfield.shadowRoot.querySelector('input');
-        const container: HTMLElement = this.host.shadowRoot.querySelector(
-            '.container'
-        );
+        this.container = this.host.shadowRoot.querySelector('.container');
 
-        this.picker.init(this.input, container, this.value);
+        this.picker.init(this.input, this.container, this.value);
         this.formattedValue = this.picker.formatDate(this.value);
     }
 
@@ -198,7 +197,7 @@ export class DatePicker {
 
     @Listen('window:resize')
     public resizeEvent() {
-        this.picker.redraw();
+        this.picker.init(this.input, this.container, this.value);
     }
 
     private handleChange(event) {

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -55,10 +55,6 @@ export abstract class Picker {
         this.flatpickr = flatpickr(element, config) as flatpickr.Instance; // tslint:disable-line:no-useless-cast
     }
 
-    public redraw() {
-        this.flatpickr.redraw();
-    }
-
     public destroy() {
         if (!this.flatpickr) {
             return;


### PR DESCRIPTION
This reverts commit 3327377b1a06d3153d6339eaa2395d1929267bba.
Date picker was not usable in dialogs with previous fix. A new instance needs to be created on redraw.

fix Lundalogik/crm-feature#838