### PR TITLE
fix(flatpickr): switch to @limetech/flatpickr and update to v4.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2013,6 +2013,11 @@
         "@lime-material-16px/feature-targeting": "^0.44.1"
       }
     },
+    "@limetech/flatpickr": {
+      "version": "4.5.5",
+      "resolved": "http://npm.lundalogik.com:4873/@limetech%2fflatpickr/-/flatpickr-4.5.5.tgz",
+      "integrity": "sha512-b4SP8vFC1Jxx7fvB6MY/HuStU3PfucFt8UMTtfXQ4mD++KE4mwa8oGxfy+EV/SiiKgF4h54EnSPr1zTaBCyw4g=="
+    },
     "@loadable/component": {
       "version": "5.10.1",
       "resolved": "http://npm.lundalogik.com:4873/@loadable%2fcomponent/-/component-5.10.1.tgz",
@@ -7933,11 +7938,6 @@
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
-    },
-    "flatpickr": {
-      "version": "4.5.5-lime2",
-      "resolved": "http://npm.lundalogik.com:4873/flatpickr/-/flatpickr-4.5.5-lime2.tgz",
-      "integrity": "sha512-4L/z1k4UxqWrGglp1ExFTQFdOT+eqBjnqyzhyLkQQrZee8k+nPOzG0kD+z+NRtRMyUd4V0muAwBpOAIyfWqpTg=="
     },
     "flatted": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "test:watch": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e --watch\""
   },
   "dependencies": {
+    "@limetech/flatpickr": "^4.5.5",
     "awesome-debounce-promise": "^2.1.0",
     "chart.js": "^2.8.0",
-    "flatpickr": "4.5.5-lime2",
     "jsx-dom": "^6.3.1",
     "lime-material-components-web-16px": "1.1.1-chrome.ripple.fix.2",
     "moment": "^2.24.0"

--- a/src/components/date-picker/date-picker.scss
+++ b/src/components/date-picker/date-picker.scss
@@ -1,7 +1,7 @@
 @import '../../style/variables';
 
 @import '@lime-material-16px/theme/mdc-theme';
-@import '../../../node_modules/flatpickr/dist/flatpickr.min.css';
+@import '../../../node_modules/@limetech/flatpickr/dist/flatpickr.min.css';
 
 $inactiveTextColor: var(--mdc-theme-text-disabled-on-background, #{$mdc-theme-text-disabled-on-background});
 

--- a/src/components/date-picker/pickers/DatePicker.ts
+++ b/src/components/date-picker/pickers/DatePicker.ts
@@ -1,5 +1,5 @@
+import flatpickr from '@limetech/flatpickr';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
 import { Picker } from './Picker';
 
 export class DatePicker extends Picker {

--- a/src/components/date-picker/pickers/DatetimePicker.ts
+++ b/src/components/date-picker/pickers/DatetimePicker.ts
@@ -1,5 +1,5 @@
+import flatpickr from '@limetech/flatpickr';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
 import { Picker } from './Picker';
 
 export class DatetimePicker extends Picker {

--- a/src/components/date-picker/pickers/MonthPicker.tsx
+++ b/src/components/date-picker/pickers/MonthPicker.tsx
@@ -1,5 +1,5 @@
+import flatpickr from '@limetech/flatpickr';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
 import { range } from 'lodash-es';
 import moment from 'moment/moment';
 import { Picker } from './Picker';

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -1,6 +1,6 @@
+import flatpickr from '@limetech/flatpickr';
+import FlatpickrLanguages from '@limetech/flatpickr/dist/l10n';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
-import FlatpickrLanguages from 'flatpickr/dist/l10n';
 import 'moment/locale/da';
 import 'moment/locale/fi';
 import 'moment/locale/nb';

--- a/src/components/date-picker/pickers/QuarterPicker.tsx
+++ b/src/components/date-picker/pickers/QuarterPicker.tsx
@@ -1,5 +1,5 @@
+import flatpickr from '@limetech/flatpickr';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
 import { range } from 'lodash-es';
 import moment from 'moment/moment';
 import { Picker } from './Picker';

--- a/src/components/date-picker/pickers/TimePicker.ts
+++ b/src/components/date-picker/pickers/TimePicker.ts
@@ -1,5 +1,5 @@
+import flatpickr from '@limetech/flatpickr';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
 import { Picker } from './Picker';
 
 export class TimePicker extends Picker {

--- a/src/components/date-picker/pickers/WeekPicker.ts
+++ b/src/components/date-picker/pickers/WeekPicker.ts
@@ -1,6 +1,6 @@
+import flatpickr from '@limetech/flatpickr';
+import weekSelectPlugin from '@limetech/flatpickr/dist/plugins/weekSelect/weekSelect';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
-import weekSelectPlugin from 'flatpickr/dist/plugins/weekSelect/weekSelect';
 import { Picker } from './Picker';
 
 export class WeekPicker extends Picker {

--- a/src/components/date-picker/pickers/YearPicker.tsx
+++ b/src/components/date-picker/pickers/YearPicker.tsx
@@ -1,5 +1,5 @@
+import flatpickr from '@limetech/flatpickr';
 import { EventEmitter } from '@stencil/core';
-import flatpickr from 'flatpickr';
 import { range } from 'lodash-es';
 import moment from 'moment/moment';
 import { Picker } from './Picker';


### PR DESCRIPTION
The version of flatpickr previously used was based on a fork half way between 4.5.4 and 4.5.5. This PR switches to a version that has added the same changes, but on top of v4.5.5.

The new version of flatpickr uses our own npm-namespace, so that we can publish it publicly, which will be necessary when we publish lime-elements publicly.