### PR TITLE
build(flatpickr): switch to version published on npmjs.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2015,7 +2015,7 @@
     "@limetech/flatpickr": {
       "version": "4.5.5",
       "resolved": "http://npm.lundalogik.com:4873/@limetech%2fflatpickr/-/flatpickr-4.5.5.tgz",
-      "integrity": "sha512-b4SP8vFC1Jxx7fvB6MY/HuStU3PfucFt8UMTtfXQ4mD++KE4mwa8oGxfy+EV/SiiKgF4h54EnSPr1zTaBCyw4g=="
+      "integrity": "sha512-xUpN8juzIw7bGT7D7HmoUHynOaw6fRvLvm5BUoK3vHBQqSYOSyYOI2Cdf6nfEsB/yOMANH3g1zvjCchTV3Uy+A=="
     },
     "@loadable/component": {
       "version": "5.10.1",


### PR DESCRIPTION
Switch from the package published on our internal Verdaccio to the package published on npmjs.com. The hash is different because a new option had to be set in flatpickr's package.json, but no source code has been changed.