### PR TITLE
docs(pxtorem): remove pxToRem function from examples

### DIFF
--- a/src/examples/banner/banner.scss
+++ b/src/examples/banner/banner.scss
@@ -1,5 +1,3 @@
-@import '../../style/functions.scss';
-
 limel-banner {
     --icon-background-color: var(--lime-deep-red);
     position: fixed;
@@ -12,6 +10,6 @@ limel-banner {
     }
 
     limel-button:not(last-child) {
-        margin-right: pxToRem(10);
+        margin-right: 10/1.6rem;
     }
 }

--- a/src/examples/button/button.scss
+++ b/src/examples/button/button.scss
@@ -1,10 +1,8 @@
-@import '../../style/functions';
-
 limel-switch {
-    margin-right: pxToRem(15);
+    margin-right: 15/1.6rem;
 }
 
 limel-button {
     display: block;
-    margin-bottom: pxToRem(20);
+    margin-bottom: 20/1.6rem;
 }

--- a/src/examples/color/color-table.scss
+++ b/src/examples/color/color-table.scss
@@ -1,17 +1,15 @@
-@import '../../style/functions';
-
 .grid {
     display: grid;
-    grid-template-columns: pxToRem(250) pxToRem(250) pxToRem(250);
-    grid-template-rows: pxToRem(150) pxToRem(150) pxToRem(150) pxToRem(150);
-    grid-gap: pxToRem(10);
+    grid-template-columns: 250/1.6rem 250/1.6rem 250/1.6rem;
+    grid-template-rows: 150/1.6rem 150/1.6rem 150/1.6rem 150/1.6rem;
+    grid-gap: 10/1.6rem;
 }
 
 .tile {
     color: white;
     text-align: center;
-    line-height: pxToRem(150);
-    border-radius: pxToRem(3);
+    line-height: 150/1.6rem;
+    border-radius: 3/1.6rem;
 
     pre {
         margin: 0;

--- a/src/examples/color/color.scss
+++ b/src/examples/color/color.scss
@@ -1,11 +1,9 @@
-@import '../../style/functions';
-
 limel-button {
     --lime-primary-color: var(--lime-blue);
 }
 
 .box {
     background-color: var(--lime-green);
-    width: pxToRem(50);
-    height: pxToRem(50);
+    width: 50/1.6rem;
+    height: 50/1.6rem;
 }

--- a/src/examples/dialog/dialog-form.scss
+++ b/src/examples/dialog/dialog-form.scss
@@ -1,7 +1,5 @@
-@import '../../style/functions';
-
 limel-flex-container {
     limel-button:not(:first-child) {
-        margin-right: pxToRem(10);
+        margin-right: 10/1.6rem;
     }
 }

--- a/src/examples/dialog/dialog-size.scss
+++ b/src/examples/dialog/dialog-size.scss
@@ -1,6 +1,4 @@
-@import '../../style/functions';
-
 limel-dialog {
-    --dialog-width: pxToRem(400);
+    --dialog-width: 400/1.6rem;
     --dialog-height: 50%;
 }

--- a/src/examples/dialog/dialog-size.tsx
+++ b/src/examples/dialog/dialog-size.tsx
@@ -24,7 +24,7 @@ export class DialogSizeExample {
             <limel-dialog open={this.isOpen} onClose={this.closeDialog}>
                 <p>This dialog has a custom size set through CSS variables:</p>
                 <p>
-                    <code>--dialog-width: pxToRem(400)</code>
+                    <code>--dialog-width: 400/1.6rem</code>
                 </p>
                 <p>
                     <code>--dialog-height: 50%</code>

--- a/src/examples/flex-container/flex-container.scss
+++ b/src/examples/flex-container/flex-container.scss
@@ -1,41 +1,39 @@
-@import '../../style/functions';
-
 limel-flex-container {
-    margin-bottom: pxToRem(20);
+    margin-bottom: 20/1.6rem;
 
     &.container {
-        height: pxToRem(600);
-        border: pxToRem(1) solid var(--lime-dark-grey);
-        border-radius: pxToRem(3);
+        height: 600/1.6rem;
+        border: 1/1.6rem solid var(--lime-dark-grey);
+        border-radius: 3/1.6rem;
     }
 
     div {
         display: block;
-        padding: pxToRem(25) pxToRem(50);
+        padding: 25/1.6rem 50/1.6rem;
 
         text-align: center;
         color: white;
-        font-size: pxToRem(20);
+        font-size: 20/1.6rem;
         line-height: 0;
 
         &:nth-child(1) {
             background-color: var(--lime-red);
-            padding: pxToRem(12.5) pxToRem(50);
+            padding: 12.5/1.6rem 50/1.6rem;
         }
         &:nth-child(2) {
             background-color: var(--lime-orange);
-            padding: pxToRem(50);
+            padding: 50/1.6rem;
         }
         &:nth-child(3) {
             background-color: var(--lime-green);
         }
         &:nth-child(4) {
             background-color: var(--lime-blue);
-            padding: pxToRem(25) pxToRem(100);
+            padding: 25/1.6rem 100/1.6rem;
         }
         &:nth-child(5) {
             background-color: var(--lime-magenta);
-            padding: pxToRem(25);
+            padding: 25/1.6rem;
         }
     }
 }

--- a/src/examples/icon/icon-background.scss
+++ b/src/examples/icon/icon-background.scss
@@ -1,12 +1,10 @@
-@import '../../style/functions';
-
 :host(limel-example-icon-background) {
     display: flex;
     flex-direction: column;
 
     limel-icon {
         color: white;
-        margin-bottom: pxToRem(10);
+        margin-bottom: 10/1.6rem;
 
         &.company {
             background-color: var(--lime-blue)

--- a/src/examples/icon/icon.scss
+++ b/src/examples/icon/icon.scss
@@ -1,5 +1,3 @@
-@import '../../style/functions';
-
 .lime-green {
     limel-icon {
         color: var(--lime-green);
@@ -26,7 +24,7 @@
 
 .custom-size {
     limel-icon {
-        height: pxToRem(100);
-        width: pxToRem(100);
+        height: 100/1.6rem;
+        width: 100/1.6rem;
     }
 }

--- a/src/examples/input-field/input-field-text-inline.scss
+++ b/src/examples/input-field/input-field-text-inline.scss
@@ -1,5 +1,3 @@
-@import '../../style/functions';
-
 p {
     font-size: small;
 }
@@ -9,10 +7,10 @@ section {
 
     limel-input-field {
         display: inline-block;
-        width: calc(50% - pxToRem(10));
+        width: calc(50% - 10/1.6rem);
 
         &:first-of-type {
-            margin-right: pxToRem(20);
+            margin-right: 20/1.6rem;
         }
     }
 }

--- a/src/examples/switch/switch.scss
+++ b/src/examples/switch/switch.scss
@@ -1,6 +1,4 @@
-@import '../../style/functions';
-
 limel-switch {
-    margin: pxToRem(20) 0;
+    margin: 20/1.6rem 0;
     display: block;
 }


### PR DESCRIPTION
The pxToRem() function isn't exported, so we shouldn't use it in examples.