### PR TITLE
fix(select): render select menu in document.body

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -68,20 +68,16 @@ export class List {
         this.handleAction = this.handleAction.bind(this);
     }
 
-    public componentDidLoad() {
-        this.mdcList = new MDCList(
-            this.element.shadowRoot.querySelector('.mdc-list')
-        );
-
-        this.handleType();
+    public connectedCallback() {
+        this.setup();
     }
 
-    public componentDidUnload() {
-        if (this.selectable) {
-            this.mdcList.unlisten(ACTION_EVENT, this.handleAction);
-        }
+    public disconnectedCallback() {
+        this.teardown();
+    }
 
-        this.mdcList.destroy();
+    public componentDidLoad() {
+        this.setup();
     }
 
     public render() {
@@ -95,6 +91,21 @@ export class List {
 
     @Watch('type')
     protected handleType() {
+        this.setupListeners();
+    }
+
+    private setup() {
+        const element = this.element.shadowRoot.querySelector('.mdc-list');
+        if (!element) {
+            return;
+        }
+
+        this.mdcList = new MDCList(element);
+
+        this.setupListeners();
+    }
+
+    private setupListeners() {
         this.mdcList.unlisten(ACTION_EVENT, this.handleAction);
 
         this.selectable = ['selectable', 'radio', 'checkbox'].includes(
@@ -108,6 +119,14 @@ export class List {
 
         this.mdcList.listen(ACTION_EVENT, this.handleAction);
         this.mdcList.singleSelection = !this.multiple;
+    }
+
+    private teardown() {
+        if (this.selectable) {
+            this.mdcList.unlisten(ACTION_EVENT, this.handleAction);
+        }
+
+        this.mdcList.destroy();
     }
 
     private handleAction(event: MDCListActionEvent) {

--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -1,0 +1,7 @@
+@import '../../style/variables';
+@import "@limetech/mdc-menu-surface/mdc-menu-surface";
+
+.mdc-menu-surface {
+    width: 100%;
+    max-height: 100%;
+}

--- a/src/components/menu-surface/menu-surface.tsx
+++ b/src/components/menu-surface/menu-surface.tsx
@@ -1,0 +1,172 @@
+import { Corner, MDCMenuSurface } from '@limetech/mdc-menu-surface';
+import {
+    Component,
+    Element,
+    Event,
+    EventEmitter,
+    h,
+    Prop,
+} from '@stencil/core';
+import { isDescendant } from '../../util/dom';
+import {
+    ESCAPE,
+    ESCAPE_KEY_CODE,
+    TAB,
+    TAB_KEY_CODE,
+} from '../../util/keycodes';
+
+@Component({
+    tag: 'limel-menu-surface',
+    shadow: true,
+    styleUrl: 'menu-surface.scss',
+})
+export class MenuSurface {
+    /**
+     * True if the menu surface is open, false otherwise
+     */
+    @Prop()
+    public open = false;
+
+    /**
+     * Emitted when the menu surface is dismissed and should be closed
+     */
+    @Event()
+    public dismiss: EventEmitter<void>;
+
+    @Element()
+    private host: HTMLElement;
+
+    private menuSurface: MDCMenuSurface;
+
+    constructor() {
+        this.handleDocumentClick = this.handleDocumentClick.bind(this);
+        this.handleDocumentScroll = this.handleDocumentScroll.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleResize = this.handleResize.bind(this);
+    }
+
+    public connectedCallback() {
+        this.setup();
+    }
+
+    public disconnectedCallback() {
+        this.teardown();
+    }
+
+    public componentDidLoad() {
+        this.setup();
+    }
+
+    public render() {
+        return (
+            <div
+                class={{
+                    'mdc-menu-surface': true,
+                    'mdc-menu-surface--open': this.open,
+                }}
+                tabindex="-1"
+            >
+                <slot />
+            </div>
+        );
+    }
+
+    private setup() {
+        const menuElement = this.host.shadowRoot.querySelector(
+            '.mdc-menu-surface'
+        );
+        if (!menuElement) {
+            return;
+        }
+
+        this.menuSurface = new MDCMenuSurface(menuElement);
+        this.menuSurface.setAnchorCorner(Corner.TOP_START);
+
+        document.addEventListener('mousedown', this.handleDocumentClick, {
+            capture: true,
+        });
+        document.addEventListener('wheel', this.handleDocumentScroll, {
+            passive: true,
+        });
+        this.host.addEventListener('keydown', this.handleKeyDown);
+        window.addEventListener('resize', this.handleResize, {
+            passive: true,
+        });
+    }
+
+    private teardown() {
+        this.menuSurface.destroy();
+        document.removeEventListener('mousedown', this.handleDocumentClick, {
+            capture: true,
+        });
+        document.removeEventListener('wheel', this.handleDocumentScroll);
+        this.host.removeEventListener('keydown', this.handleKeyDown);
+        window.removeEventListener('resize', this.handleResize);
+    }
+
+    private handleDocumentClick(event) {
+        if (this.open && !isDescendant(event.target, this.host)) {
+            this.dismiss.emit();
+            this.preventClickEventPropagation();
+        }
+    }
+
+    private handleDocumentScroll(event) {
+        if (this.open && !isDescendant(event.target, this.host)) {
+            this.dismiss.emit();
+        }
+    }
+
+    private handleResize() {
+        if (this.open) {
+            this.dismiss.emit();
+        }
+    }
+
+    private preventClickEventPropagation() {
+        // When the menu surface is open, we want to stop the `click` event from propagating
+        // when clicking outside the surface itself. This is to prevent any dialog that might
+        // be open from closing, etc. However, when dragging a scrollbar no `click` event is emitted,
+        // only mousedown and mouseup. So we listen for `mousedown` and attach a one-time listener
+        // for `click`, so we can capture and "kill" it.
+        document.addEventListener('click', this.stopEvent, {
+            capture: true,
+            once: true,
+        });
+        // We also capture and "kill" the next `mouseup` event.
+        document.addEventListener('mouseup', this.stopEvent, {
+            capture: true,
+            once: true,
+        });
+        // If the user dragged the scrollbar, no `click` event happens. So when we get the
+        // `mouseup` event, remove the handler for `click` if it's still there.
+        // Otherwise, we would catch the next click even though the menu is no longer open.
+        document.addEventListener(
+            'mouseup',
+            () => {
+                document.removeEventListener('click', this.stopEvent, {
+                    capture: true,
+                });
+            },
+            {
+                once: true,
+            }
+        );
+    }
+
+    private stopEvent(event) {
+        event.stopPropagation();
+        event.preventDefault();
+    }
+
+    private handleKeyDown(event: KeyboardEvent) {
+        const isEscape =
+            event.key === ESCAPE || event.keyCode === ESCAPE_KEY_CODE;
+        const isTab = event.key === TAB || event.keyCode === TAB_KEY_CODE;
+
+        if (this.open && (isEscape || isTab)) {
+            event.stopPropagation();
+            this.dismiss.emit();
+        }
+    }
+}

--- a/src/components/portal/portal.scss
+++ b/src/components/portal/portal.scss
@@ -1,0 +1,3 @@
+:host(limel-portal) {
+    display: block;
+}

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -1,0 +1,146 @@
+import { Component, Element, h, Prop } from '@stencil/core';
+
+/**
+ * The portal component provides a way to render children into a DOM node that exist outside
+ * the DOM hierarchy of the parent component.
+ *
+ * There are some caveats when using this component
+ *
+ * * Events might not bubble up as expected since the content is moved out to another DOM node
+ * * Any styling that is applied to content from the parent will be lost, if the content is
+ *   just another web compoent it will work without any issues
+ * * When the node is moved in the DOM, `componentDidUnload`, `disconnectedCallback` and `connectedCallback`
+ *   will be invoked, so `componentDidUnload` can not be used as a destructor (which is the wrong behavior anyway)
+ */
+@Component({
+    tag: 'limel-portal',
+    shadow: true,
+    styleUrl: 'portal.scss',
+})
+export class Portal {
+    /**
+     * True if the content within the portal should be visible
+     *
+     * If the content is from within a dialog for instance, this can be set to
+     * true from false when the dialog opens to position the content properly
+     */
+    @Prop()
+    public visible = false;
+
+    /**
+     * A unique ID
+     */
+    @Prop()
+    public containerId: string;
+
+    /**
+     * Dynamic styling that can be applied to the container holding the content
+     */
+    @Prop()
+    public containerStyle: object = {};
+
+    /**
+     * Parent element to move the content to
+     */
+    @Prop()
+    public parent: HTMLElement = document.body;
+
+    @Element()
+    private host: HTMLElement;
+
+    private container: HTMLElement;
+
+    public connectedCallback() {
+        this.attachContainer();
+        this.styleContainer();
+    }
+
+    public disconnectedCallback() {
+        this.removeContainer();
+    }
+
+    public componentDidLoad() {
+        this.createContainer();
+        this.attachContainer();
+        this.styleContainer();
+    }
+
+    public componentDidUpdate() {
+        this.styleContainer();
+    }
+
+    public render() {
+        return <slot />;
+    }
+
+    private createContainer() {
+        const slot: HTMLSlotElement = this.host.shadowRoot.querySelector(
+            'slot'
+        );
+        const content = slot.assignedElements();
+
+        this.container = document.createElement('div');
+        this.container.setAttribute('id', this.containerId);
+        content.forEach(element => {
+            this.container.appendChild(element);
+        });
+    }
+
+    private attachContainer() {
+        if (!this.container) {
+            return;
+        }
+
+        this.parent.appendChild(this.container);
+    }
+
+    private removeContainer() {
+        this.container.parentElement.removeChild(this.container);
+    }
+
+    private styleContainer() {
+        if (!this.container) {
+            return;
+        }
+
+        const rect: any = this.host.getBoundingClientRect();
+        const [x, y] = this.getPosition(rect);
+        const viewportHeight = this.getViewportHeight();
+        const containerHeight = viewportHeight - rect.y;
+
+        this.container.style.position = 'absolute';
+        this.container.style.left = `${x}px`;
+        this.container.style.top = `${y}px`;
+        this.container.style.width = `${rect.width}px`;
+        this.container.style.height = `${containerHeight}px`;
+        this.container.style.display = 'block';
+        if (!this.visible) {
+            this.container.style.display = 'none';
+        }
+
+        Object.keys(this.containerStyle).forEach(property => {
+            this.container.style[property] = this.containerStyle[property];
+        });
+    }
+
+    private getPosition(rect: DOMRect) {
+        let x = rect.x;
+        let y = rect.y;
+
+        let element: HTMLElement = this.container.parentElement;
+        while (element) {
+            x += element.scrollLeft;
+            y += element.scrollTop;
+            element = element.parentElement;
+        }
+
+        return [x, y];
+    }
+
+    private getViewportHeight() {
+        return Math.max(
+            document.documentElement.clientHeight,
+            window.innerHeight || 0
+        );
+    }
+}

--- a/src/components/select/select.mdx
+++ b/src/components/select/select.mdx
@@ -33,3 +33,7 @@ When importing Option, see [Import Statements](/#import-statements).
 ### Changing Available Options
 
 <limel-example name="limel-example-select-change-options" path="select" />
+
+### Select field inside a dialog
+
+<limel-example name="limel-example-select-dialog" path="select" />

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -126,18 +126,9 @@ $mdc-select-bottom-line-hover-color: $lime-text-field-bottom-line-color;
         }
     }
 
-    .mdc-menu-surface {
-        left: 0;
-        top: pxToRem(56);
-        width: 100%;
-    }
-
-    .mdc-menu-surface--scrim {
-        position: fixed;
-        width: 100%;
-        height: 100%;
-        top: 0;
-        left: 0;
-        z-index: 5;
+    &.limel-select--empty {
+        limel-portal {
+            margin-top: pxToRem(-8);
+        }
     }
 }

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -1,10 +1,4 @@
 import { FunctionalComponent, h } from '@stencil/core';
-import {
-    ENTER,
-    ENTER_KEY_CODE,
-    SPACE,
-    SPACE_KEY_CODE,
-} from '../../util/keycodes';
 import { isMultiple } from '../../util/multiple';
 import { ListItem } from '../list/list-item.types';
 import { Option } from './option.types';
@@ -78,7 +72,9 @@ export const NativeSelectTemplate: FunctionalComponent<
 };
 
 interface MenuSelectTemplateProps extends SelectTemplateProps {
+    id: string;
     onChange?: (event: CustomEvent<ListItem | ListItem[]>) => void;
+    onTriggerPress: (event: KeyboardEvent) => void;
     isOpen: boolean;
     open: () => void;
     close: () => void;
@@ -109,6 +105,7 @@ export const MenuSelectTemplate: FunctionalComponent<
             ${props.disabled ? 'mdc-select--disabled' : ''}
             ${props.required ? 'limel-select--required' : ''}
             ${!isValid ? 'limel-select--invalid' : ''}
+            ${!hasValue ? 'limel-select--empty' : ''}
         `}
         >
             <div
@@ -118,7 +115,7 @@ export const MenuSelectTemplate: FunctionalComponent<
                     limel-select-trigger
                     ${props.isOpen ? 'mdc-select--focused' : ''}
                 `}
-                slot="trigger"
+                onKeyPress={props.onTriggerPress}
             >
                 <i class="mdc-select__dropdown-icon" />
                 <div class="limel-select__selected-text">
@@ -144,37 +141,18 @@ export const MenuSelectTemplate: FunctionalComponent<
                 `}
                 />
             </div>
-            {props.isOpen ? (
-                <div class="mdc-menu-surface--scrim" onClick={props.close} />
-            ) : null}
-            <div
-                class={`
-                mdc-menu-surface
-                ${props.isOpen ? 'mdc-menu-surface--open' : ''}
-            `}
-                tabindex="-1"
-            >
-                <limel-list
-                    items={items}
-                    type={props.multiple ? 'checkbox' : 'selectable'}
-                    onKeyDown={handleListKeys}
-                    onKeyUp={handleListKeys}
-                    onChange={props.onChange}
-                />
-            </div>
+            <limel-portal containerId={props.id} visible={props.isOpen}>
+                <limel-menu-surface open={props.isOpen} onDismiss={props.close}>
+                    <limel-list
+                        items={items}
+                        type={props.multiple ? 'checkbox' : 'selectable'}
+                        onChange={props.onChange}
+                    />
+                </limel-menu-surface>
+            </limel-portal>
         </div>
     );
 };
-
-function handleListKeys(event: KeyboardEvent) {
-    const isEnter = event.key === ENTER || event.keyCode === ENTER_KEY_CODE;
-    const isSpace = event.key === SPACE || event.keyCode === SPACE_KEY_CODE;
-
-    if (isSpace || isEnter) {
-        event.stopPropagation();
-        event.preventDefault();
-    }
-}
 
 function isSelected(option: Option, value: Option | Option[]): boolean {
     if (!value) {

--- a/src/examples/select/select-dialog.scss
+++ b/src/examples/select/select-dialog.scss
@@ -1,0 +1,9 @@
+limel-dialog {
+    --dialog-height: 200px;
+}
+
+limel-icon {
+    height: 300px;
+    width: 300px;
+    color: var(--lime-dark-grey);
+}

--- a/src/examples/select/select-dialog.tsx
+++ b/src/examples/select/select-dialog.tsx
@@ -1,0 +1,114 @@
+import { Component, h, State } from '@stencil/core';
+import { Option } from '../../interface';
+
+@Component({
+    shadow: true,
+    tag: 'limel-example-select-dialog',
+    styleUrl: 'select-dialog.scss',
+})
+export class SelectDialogExample {
+    @State()
+    public heroValue: Option;
+
+    @State()
+    public villainValue: Option;
+
+    @State()
+    public open = false;
+
+    private heroOptions: Option[] = [
+        { text: 'Luke Skywalker', value: 'luke' },
+        { text: 'Han Solo', value: 'han' },
+        { text: 'Leia Organa', value: 'leia' },
+    ];
+
+    private villainOptions: Option[] = [
+        { text: 'BB-9E', value: 'bb-9e' },
+        { text: 'Unkar Plutt', value: 'unkar' },
+        { text: 'Zam Wessell', value: 'zam' },
+        { text: 'Greedo', value: 'greedo' },
+        { text: 'Evazan and Baba', value: 'evazan_baba' },
+        { text: 'Bossk', value: 'bossk' },
+        { text: 'Count Dooku', value: 'dooku' },
+        { text: 'Captain Phasma', value: 'phasma' },
+        { text: 'Commander Cody', value: 'cody' },
+        { text: 'DJ', value: 'dj' },
+        { text: 'Supreme Leader Snoke', value: 'snoke' },
+        { text: 'Jango Fett', value: 'jango' },
+        { text: 'General Grievous', value: 'grievous' },
+        { text: 'General Hux', value: 'hux' },
+        { text: 'Orson Krennic', value: 'orson' },
+        { text: 'Sebulba', value: 'sebulba' },
+        { text: 'Boba Fett', value: 'boba' },
+        { text: 'Watto', value: 'watto' },
+        { text: 'Jar Jar Binks', value: 'jarjar' },
+        { text: 'The Sarlacc', value: 'sarlacc' },
+        { text: 'Darth Maul', value: 'maul' },
+        { text: 'Jabba the Hutt', value: 'jabba' },
+        { text: 'Anakin Skywalker', value: 'anakin' },
+        { text: 'Grand Moff Tarkin', value: 'tarkin' },
+        { text: 'Kylo Ren', value: 'ren' },
+        { text: 'Emperor Palpatine', value: 'palpatine' },
+        { text: 'Darth Vader', value: 'vader' },
+    ];
+
+    constructor() {
+        this.handleHeroChange = this.handleHeroChange.bind(this);
+        this.handleButtonClick = this.handleButtonClick.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.handleVillainChange = this.handleVillainChange.bind(this);
+    }
+
+    public render() {
+        return [
+            <limel-button
+                label="Select characters"
+                primary={true}
+                onClick={this.handleButtonClick}
+            />,
+            <limel-dialog onClose={this.handleClose} open={this.open}>
+                <limel-select
+                    label="Favorite hero"
+                    value={this.heroValue}
+                    options={this.heroOptions}
+                    onChange={this.handleHeroChange}
+                />
+                <limel-select
+                    label="Loathed villain"
+                    value={this.villainValue}
+                    options={this.villainOptions}
+                    onChange={this.handleVillainChange}
+                />
+                <limel-icon name="star_wars" />
+
+                <limel-flex-container justify="end" slot="button">
+                    <limel-button
+                        primary={true}
+                        label="Close"
+                        onClick={this.handleClose}
+                    />
+                </limel-flex-container>
+            </limel-dialog>,
+            <p>Favorite hero: {this.heroValue && this.heroValue.text}</p>,
+            <p>
+                Loathed villain: {this.villainValue && this.villainValue.text}
+            </p>,
+        ];
+    }
+
+    private handleHeroChange(event: CustomEvent<Option>) {
+        this.heroValue = event.detail;
+    }
+
+    private handleVillainChange(event: CustomEvent<Option>) {
+        this.villainValue = event.detail;
+    }
+
+    private handleButtonClick() {
+        this.open = true;
+    }
+
+    private handleClose() {
+        this.open = false;
+    }
+}

--- a/src/util/random-string.ts
+++ b/src/util/random-string.ts
@@ -1,7 +1,13 @@
 export const createRandomString = () => {
     const USE_HEX = 36;
     const SKIP_LEADING_ZERODOT = 2;
+    const ASCII_A = 97;
+    const NUMBER_OF_LETTERS = 26;
+
     return (
+        String.fromCharCode(
+            ASCII_A + Math.floor(Math.random() * NUMBER_OF_LETTERS)
+        ) +
         Math.random()
             .toString(USE_HEX)
             .substring(SKIP_LEADING_ZERODOT) +


### PR DESCRIPTION
This PR introduces a new component called `limel-portal` which takes the portal concept from React (https://reactjs.org/docs/portals.html) and puts it into a component. This allows us to display dropdowns, tooltips and other popovers which are placed inside dialogs in a nicer way without hiding the content inside the dialog itself. There might be a few caveats, but it seems to work quite good.

* Events might not bubble up as expected since the content is moved out to another DOM node
* Any styling that is applied to content from the parent will be lost, if the content is just another web compoent it will work without any issues
* When the node is moved in the DOM, Stencil will invoke the `componentDidUnload`, `disconnectedCallback` and `connectedCallback`, so `componentDidUnload` can not be used as a destructor (which is not the correct way to use it anyway, but we seem to have misinterpreted it in a few places)

This PR only fixes the `limel-select` component, if we find this to be a good solution we should fix the `limel-picker` and autocomplete in `limel-input-field` as well. They should be able to make use of the new `limel-menu-surface` without any issues

fix Lundalogik/crm-feature#839

### Browsers tested:

Windows:
- [x] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [x] iOS