### PR TITLE
[WIP] refactor: add path for `@limetech/lime-elements` and clean up imports in examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
     "test": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e\"",
     "test:watch": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e --watch\""
   },
+  "paths": {
+    "@limetech/lime-elements": [
+      "src/interface"
+    ]
+  },
   "dependencies": {
     "@limetech/flatpickr": "^4.5.5",
     "@limetech/material-components-web": "^1.1.1",

--- a/src/components/list/list.mdx
+++ b/src/components/list/list.mdx
@@ -12,54 +12,36 @@ menu: Components
 
 ### Basic list with separator
 
-When importing ListItem and ListSeparator, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-list" /> 
 
 ### List with secondary text
-
-When importing ListItem, see [Import Statements](/#import-statements).
 
 <limel-example name="limel-example-list-secondary" path="list" /> 
 
 ### List with selectable items
 
-When importing ListItem, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-list-selectable" path="list" /> 
 
 ### List with icons
-
-When importing ListItem, see [Import Statements](/#import-statements).
 
 <limel-example name="limel-example-list-icons" path="list" /> 
 
 ### List with badge icons
 
-When importing ListItem, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-list-badge-icons" path="list" />
 
 ### List with checkboxes
-
-When importing ListItem, see [Import Statements](/#import-statements).
 
 <limel-example name="limel-example-list-checkbox" path="list" />
 
 ### List with checkboxes and icons
 
-When importing ListItem, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-list-checkbox-icons" path="list" />
 
 ### List with radio buttons
 
-When importing ListItem, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-list-radio-button" path="list" />
 
 ### List with radio buttons and icons
-
-When importing ListItem, see [Import Statements](/#import-statements).
 
 <limel-example name="limel-example-list-radio-button-icons" path="list" />

--- a/src/components/menu/menu.mdx
+++ b/src/components/menu/menu.mdx
@@ -9,5 +9,5 @@ menu: Components
 <limel-props name="limel-menu" />
 
 ## Example
-When importing ListItem and ListSeparator, see [Import Statements](/#import-statements).
+
 <limel-example name="limel-example-menu" /> 

--- a/src/components/picker/picker.mdx
+++ b/src/components/picker/picker.mdx
@@ -10,24 +10,16 @@ menu: Components
 
 ## Example
 
-When importing ListItem, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-picker" />
 
 ### Multiple values
-
-When importing ListItem, see [Import Statements](/#import-statements).
 
 <limel-example name="limel-example-picker-multiple" path="picker" />
 
 ### With icons and displaying full list without cutting content
 
-When importing ListItem, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-picker-icons" path="picker" />
 
 ### With no suggestions and a message for empty search results
-
-When importing ListItem, see [Import Statements](/#import-statements).
 
 <limel-example name="limel-example-picker-empty-suggestions" path="picker" />

--- a/src/components/select/select.mdx
+++ b/src/components/select/select.mdx
@@ -10,8 +10,6 @@ menu: Components
 
 ## Example
 
-When importing Option, see [Import Statements](/#import-statements).
-
 <limel-example name="limel-example-select" />
 
 ### Select multiple values

--- a/src/examples/chip-set/chip-set-choice.tsx
+++ b/src/examples/chip-set/chip-set-choice.tsx
@@ -1,5 +1,5 @@
+import { Chip } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Chip } from '../../components/chip-set/chip.types';
 
 @Component({
     tag: 'limel-example-chip-set-choice',

--- a/src/examples/chip-set/chip-set-filter.tsx
+++ b/src/examples/chip-set/chip-set-filter.tsx
@@ -1,5 +1,5 @@
+import { Chip } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Chip } from '../../components/chip-set/chip.types';
 
 @Component({
     tag: 'limel-example-chip-set-filter',

--- a/src/examples/chip-set/chip-set-input.tsx
+++ b/src/examples/chip-set/chip-set-input.tsx
@@ -1,5 +1,5 @@
+import { Chip } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Chip } from '../../components/chip-set/chip.types';
 import { ENTER, ENTER_KEY_CODE } from '../../util/keycodes';
 
 @Component({

--- a/src/examples/dialog/dialog-heading.tsx
+++ b/src/examples/dialog/dialog-heading.tsx
@@ -1,6 +1,5 @@
+import { DialogHeading, Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { DialogHeading } from '../../components/dialog/dialog.types';
-import { Option } from '../../components/select/option.types';
 
 @Component({
     tag: 'limel-example-dialog-heading',

--- a/src/examples/file/file.tsx
+++ b/src/examples/file/file.tsx
@@ -1,5 +1,5 @@
+import { FileInfo } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { FileInfo } from '../../components/file/file.types';
 
 @Component({
     tag: 'limel-example-file',

--- a/src/examples/flex-container/flex-container.tsx
+++ b/src/examples/flex-container/flex-container.tsx
@@ -1,10 +1,10 @@
-import { Component, h, State } from '@stencil/core';
 import {
     FlexContainerAlign,
     FlexContainerDirection,
     FlexContainerJustify,
-} from '../../components/flex-container/flex-container.types';
-import { Option } from '../../components/select/option.types';
+    Option,
+} from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
 
 @Component({
     tag: 'limel-example-flex-container',

--- a/src/examples/list/list-badge-icons.tsx
+++ b/src/examples/list/list-badge-icons.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-badge-icons',

--- a/src/examples/list/list-checkbox-icons.tsx
+++ b/src/examples/list/list-checkbox-icons.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-checkbox-icons',

--- a/src/examples/list/list-checkbox.tsx
+++ b/src/examples/list/list-checkbox.tsx
@@ -1,5 +1,5 @@
+import { ListItem, ListSeparator } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem, ListSeparator } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-checkbox',

--- a/src/examples/list/list-icons.tsx
+++ b/src/examples/list/list-icons.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-icons',

--- a/src/examples/list/list-radio-button-icons.tsx
+++ b/src/examples/list/list-radio-button-icons.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-radio-button-icons',

--- a/src/examples/list/list-radio-button.tsx
+++ b/src/examples/list/list-radio-button.tsx
@@ -1,5 +1,5 @@
+import { ListItem, ListSeparator } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem, ListSeparator } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-radio-button',

--- a/src/examples/list/list-secondary.tsx
+++ b/src/examples/list/list-secondary.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-secondary',

--- a/src/examples/list/list-selectable.tsx
+++ b/src/examples/list/list-selectable.tsx
@@ -1,5 +1,5 @@
+import { ListItem, ListSeparator } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem, ListSeparator } from '../../interface';
 
 @Component({
     tag: 'limel-example-list-selectable',

--- a/src/examples/list/list.tsx
+++ b/src/examples/list/list.tsx
@@ -1,5 +1,5 @@
+import { ListItem, ListSeparator } from '@limetech/lime-elements';
 import { Component, h } from '@stencil/core';
-import { ListItem, ListSeparator } from '../../interface';
 
 @Component({
     tag: 'limel-example-list',

--- a/src/examples/menu/menu.tsx
+++ b/src/examples/menu/menu.tsx
@@ -1,5 +1,5 @@
+import { ListItem, ListSeparator } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem, ListSeparator } from '../../interface';
 
 const icons = ['copy', 'cut', 'paste', '', 'add', 'delete'];
 const iconColors = [

--- a/src/examples/picker/picker-empty-suggestions.tsx
+++ b/src/examples/picker/picker-empty-suggestions.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 const NETWORK_DELAY = 500;
 

--- a/src/examples/picker/picker-icons.tsx
+++ b/src/examples/picker/picker-icons.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 const NETWORK_DELAY = 500;
 

--- a/src/examples/picker/picker-multiple.tsx
+++ b/src/examples/picker/picker-multiple.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 @Component({
     tag: 'limel-example-picker-multiple',

--- a/src/examples/picker/picker.tsx
+++ b/src/examples/picker/picker.tsx
@@ -1,5 +1,5 @@
+import { ListItem } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ListItem } from '../../interface';
 
 const NETWORK_DELAY = 500;
 

--- a/src/examples/select/select-change-options.tsx
+++ b/src/examples/select/select-change-options.tsx
@@ -1,5 +1,5 @@
+import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Option } from '../../interface';
 
 @Component({
     shadow: true,

--- a/src/examples/select/select-initially-empty-required.tsx
+++ b/src/examples/select/select-initially-empty-required.tsx
@@ -1,5 +1,5 @@
+import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Option } from '../../interface';
 
 @Component({
     shadow: true,

--- a/src/examples/select/select-initially-empty.tsx
+++ b/src/examples/select/select-initially-empty.tsx
@@ -1,5 +1,5 @@
+import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Option } from '../../interface';
 
 @Component({
     shadow: true,

--- a/src/examples/select/select-multiple.tsx
+++ b/src/examples/select/select-multiple.tsx
@@ -1,5 +1,5 @@
+import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Option } from '../../interface';
 
 @Component({
     shadow: true,

--- a/src/examples/select/select-preselected.tsx
+++ b/src/examples/select/select-preselected.tsx
@@ -1,5 +1,5 @@
+import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Option } from '../../interface';
 
 @Component({
     shadow: true,

--- a/src/examples/select/select.tsx
+++ b/src/examples/select/select.tsx
@@ -1,5 +1,5 @@
+import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Option } from '../../interface';
 
 @Component({
     shadow: true,

--- a/src/index.mdx
+++ b/src/index.mdx
@@ -8,20 +8,6 @@ menu: Home
 
 This is the documentation for Lime Elements. Under *Components*, you will find documentation for each available component, along with examples of use.
 
-## Import Statements
-
-Some components use interfaces which, in the examples, are referred to with a relative path, like this:
-
-```ts
-import { Option } from '../../interface';
-```
-
-When using these interfaces in your own project, the import path changes to `'lime-elements'`, as follows:
-
-```ts
-import { Option } from 'lime-elements';
-```
-
 ## Colors
 
 It's possible to change the color of many components by setting custom CSS properties. They can be defined on any element, and will affect all descendants of that element.


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS