### PR TITLE
fix(select): only emit one change event when selecting a value

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -238,6 +238,10 @@ export class Select {
             return;
         }
 
+        if (!event.detail.selected) {
+            return;
+        }
+
         const listItem: ListItem = event.detail;
         const option: Option = listItem.value;
         this.change.emit(option);


### PR DESCRIPTION
The list component emits two `change` events when a new value is selected. One for the item that was
deselected, and one for the newly selected item. Since it is not possible to deselect a value from
the select (if it is in single select mode), only the second `change` event from the list should
generate a `change` event from the select component.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS