### PR TITLE
chore(package): update @stencil/core to v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3463,12 +3463,12 @@
       }
     },
     "@stencil/core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.3.3.tgz",
-      "integrity": "sha512-/vRzeXlWvkvP9RUS11KhCa/tGYvP5DfX4O+nrEji5bp0/4+r7rJ2s7/znCaiJt98ft58bs2bMka5ALbP3xnQUg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-/iI87p7XsqE3U96ykx4SSY/btv9jZguI3JkG8RaTNlQipPUmPb0JmLei8sgijTUD/fY5TFuE3L1o8hwLI0rW3A==",
       "dev": true,
       "requires": {
-        "typescript": "3.5.3"
+        "typescript": "3.6.2"
       }
     },
     "@stencil/sass": {
@@ -21918,9 +21918,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@semantic-release/changelog": "3.0.4",
     "@semantic-release/exec": "3.3.6",
     "@semantic-release/git": "7.0.16",
-    "@stencil/core": "1.3.3",
+    "@stencil/core": "1.4.0",
     "@stencil/sass": "1.0.1",
     "@types/chart.js": "2.8.5",
     "@types/jest": "24.0.18",

--- a/src/util/dispatch-resize-event.ts
+++ b/src/util/dispatch-resize-event.ts
@@ -1,11 +1,4 @@
 export const dispatchResizeEvent = () => {
-    /*
-     * The shorthand (`window.dispatchEvent(new Event('resize'));`)
-     * causes compiler errors, so we go the long way around.
-     * See https://stackoverflow.com/a/1818513/280972
-     * /Ads
-     */
-    const resizeEvent = window.document.createEvent('UIEvents');
-    resizeEvent.initUIEvent('resize', true, false, window, 0);
+    const resizeEvent = new UIEvent('resize', { view: window, detail: 0 });
     window.dispatchEvent(resizeEvent);
 };


### PR DESCRIPTION
The `dispatch-resize-events` util has been updated to create the UIEvent in the modern way, since the way it was doing it is deprecated and started causing a compiler error with this update of Stencil. So that should be tested.

There's a slider in one of the dialog examples in the docs. If the resize-event happens as it should, that slider will work as expected. If the resize event doesn't happen, the slider should, at least intermittently, have an incorrect scaling for the thumb-placement.

### Browsers tested:

Windows:
- [x] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [x] iOS