### PR TITLE
fix(picker): remove leaking of internal implementation details through the `interact` event

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -97,7 +97,7 @@ export class Picker {
      * Fired when clicking on a selected value
      */
     @Event()
-    private interact: EventEmitter<Chip>;
+    private interact: EventEmitter<ListItem>;
 
     @State()
     private items: Array<ListItem<number | string>>;
@@ -224,6 +224,7 @@ export class Picker {
             removable: true,
             icon: listItem.icon,
             iconColor: listItem.iconColor,
+            value: listItem,
         };
     }
 
@@ -421,7 +422,7 @@ export class Picker {
 
     private handleInteract(event: CustomEvent<Chip>) {
         event.stopPropagation();
-        this.interact.emit(event.detail);
+        this.interact.emit(event.detail ? event.detail.value : event.detail);
     }
 
     /**


### PR DESCRIPTION
BREAKING CHANGE: The `interact` event used to supply a `Chip` used internally by limel-picker, instead of the `ListItem` supplied to limel-picker by the consumer. This has now been fixed. Implementations relying on the incorrect behavior will need to be updated.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS