### PR TITLE
fix(picker): the `interact` event supplies a `ListItem<number | string>` instead of `ListItem<any>`

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -97,7 +97,7 @@ export class Picker {
      * Fired when clicking on a selected value
      */
     @Event()
-    private interact: EventEmitter<ListItem>;
+    private interact: EventEmitter<ListItem<number | string>>;
 
     @State()
     private items: Array<ListItem<number | string>>;


### PR DESCRIPTION


### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS