### PR TITLE
fix(chip-set): adds margin to search label

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -88,4 +88,5 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     color: rgba(0, 0, 0, 0.6);
     bottom: pxToRem(10);
     top: auto;
+    margin-left: 0.3rem;
 }


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS