### PR TITLE
fix(chip-set): reflect properties `type` and `label` to attribute

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -38,13 +38,13 @@ export class ChipSet {
      *
      * If no type is set, a basic set of chips without additional functionality will be rendered
      */
-    @Prop()
+    @Prop({ reflectToAttr: true })
     public type?: 'choice' | 'filter' | 'input';
 
     /**
      * Label to display for the input field when type is `input`
      */
-    @Prop()
+    @Prop({ reflectToAttr: true })
     public label: string;
 
     /**


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS