### PR TITLE
Improve keyboard navigation for input chip-set, list, and picker

### DIFF
--- a/src/components/chip-set/chip-set.e2e.ts
+++ b/src/components/chip-set/chip-set.e2e.ts
@@ -53,72 +53,6 @@ describe('limel-chip-set', () => {
         });
     });
 
-    describe('basic chip set with removable chips', () => {
-        beforeEach(async () => {
-            page = await createPage(`<limel-chip-set></limel-chip-set>`);
-
-            const chipSet = await page.find('limel-chip-set');
-
-            const enableErrorLogger = disableErrorLogger();
-            chipSet.setProperty('value', [
-                {
-                    id: '1',
-                    text: 'Lime',
-                    removable: true,
-                },
-                {
-                    id: '2',
-                    text: 'Apple',
-                },
-            ]);
-
-            await page.waitForChanges();
-            enableErrorLogger();
-        });
-
-        it('renders the chips correctly', async () => {
-            const chips: E2EElement[] = await page.findAll(
-                'limel-chip-set >>> .mdc-chip'
-            );
-
-            expect(chips.length).toEqual(2);
-            expect(chips[0]).toEqualText('Lime');
-            expect(chips[1]).toEqualText('Apple');
-
-            let button = await chips[0].find(
-                'limel-icon[name="multiply"][role="button"]'
-            );
-            expect(button).toBeTruthy();
-
-            button = await chips[1].find(
-                'limel-icon[name="multiply"][role="button"]'
-            );
-            expect(button).toBeFalsy();
-        });
-
-        describe('when a chip delete button is clicked', () => {
-            let spy;
-
-            beforeEach(async () => {
-                const chipSet: E2EElement = await page.find('limel-chip-set');
-                spy = await chipSet.spyOnEvent('change');
-                const button: E2EElement = await page.find(
-                    'limel-chip-set >>> .mdc-chip limel-icon[role="button"]'
-                );
-                await button.click();
-            });
-
-            it('emits an change event', () => {
-                expect(spy).toHaveReceivedEventDetail([
-                    {
-                        id: '2',
-                        text: 'Apple',
-                    },
-                ]);
-            });
-        });
-    });
-
     describe('choice chip set', () => {
         beforeEach(async () => {
             page = await createPage(
@@ -356,6 +290,7 @@ describe('limel-chip-set', () => {
                 {
                     id: '1',
                     text: 'Lime',
+                    removable: true,
                 },
                 {
                     id: '2',
@@ -374,10 +309,19 @@ describe('limel-chip-set', () => {
             expect(chips.length).toEqual(2);
             expect(chips[0]).toEqualText('Lime');
             expect(chips[1]).toEqualText('Apple');
+
+            let button = await chips[0].find(
+                'limel-icon[name="multiply"][role="button"]'
+            );
+            expect(button).toBeTruthy();
+
+            button = await chips[1].find(
+                'limel-icon[name="multiply"][role="button"]'
+            );
+            expect(button).toBeFalsy();
         });
 
-        // Typing in an input field does not seem to work
-        describe.skip('when typing in the input field', () => {
+        describe('when typing in the input field', () => {
             let spy;
 
             beforeEach(async () => {
@@ -392,8 +336,30 @@ describe('limel-chip-set', () => {
                 await page.waitForChanges();
             });
 
-            it('emits an input event', async () => {
+            it('emits an input event', () => {
                 expect(spy).toHaveReceivedEventDetail('Banana');
+            });
+        });
+
+        describe('when a chip delete button is clicked', () => {
+            let spy;
+
+            beforeEach(async () => {
+                const chipSet: E2EElement = await page.find('limel-chip-set');
+                spy = await chipSet.spyOnEvent('change');
+                const button: E2EElement = await page.find(
+                    'limel-chip-set >>> .mdc-chip limel-icon[role="button"]'
+                );
+                await button.click();
+            });
+
+            it('emits a change event where the removed chip is not present', () => {
+                expect(spy).toHaveReceivedEventDetail([
+                    {
+                        id: '2',
+                        text: 'Apple',
+                    },
+                ]);
             });
         });
     });
@@ -401,19 +367,4 @@ describe('limel-chip-set', () => {
 
 async function createPage(content) {
     return newE2EPage({ html: content });
-}
-
-/**
- * Temporarily disable the error logger
- *
- * @returns {*} a function to enable it again
- */
-// tslint:disable:no-console
-function disableErrorLogger() {
-    const logger = console.error;
-    console.error = () => {}; // tslint:disable-line:no-empty
-
-    return () => {
-        console.error = logger;
-    };
 }

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -55,11 +55,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
         flex-grow: 1;
         flex-shrink: 0;
         max-height: pxToRem(35);
-
-        &.hidden {
-            max-height: 0 !important;
-            transition: max-height 250ms cubic-bezier(0.5,0,1,0);
-        }
     }
 
     .mdc-floating-label--float-above {

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -82,3 +82,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 .force-float {
     @extend .mdc-floating-label--float-above;
 }
+
+.force-invalid {
+    @extend .mdc-text-field--invalid;
+}

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -84,9 +84,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     content: "*"
 }
 
-#search-label {
-    color: rgba(0, 0, 0, 0.6);
-    bottom: pxToRem(10);
-    top: auto;
-    margin-left: 0.3rem;
+.force-float {
+    @extend .mdc-floating-label--float-above;
 }

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -66,6 +66,12 @@ export class ChipSet {
     public searchLabel: string;
 
     /**
+     * Whether the input field should be emptied when the chip-set loses focus.
+     */
+    @Prop({ reflectToAttr: true })
+    public emptyInputOnBlur: boolean = true;
+
+    /**
      * Dispatched when a chip is interacted with
      */
     @Event()
@@ -140,6 +146,17 @@ export class ChipSet {
     public async setFocus() {
         this.editMode = true;
         this.host.shadowRoot.querySelector('input').focus();
+    }
+
+    /**
+     * Used to empty the input field. Used in conjunction with `emptyInputOnBlur` to let the
+     * consumer control when the input is emptied.
+     *
+     * @returns {Promise<void>} does not return anything, but methods have to be async
+     */
+    @Method()
+    public async emptyInput() {
+        this.textValue = '';
     }
 
     public componentDidLoad() {
@@ -309,8 +326,10 @@ export class ChipSet {
      * @returns {void}
      */
     private handleInputBlur() {
+        if (this.emptyInputOnBlur) {
+            this.textValue = '';
+        }
         this.editMode = false;
-        this.textValue = '';
         this.blurred = true;
 
         // This timeout is needed in order to let a new element receive focus

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -112,6 +112,7 @@ export class ChipSet {
 
     constructor() {
         this.renderChip = this.renderChip.bind(this);
+        this.renderInputChip = this.renderInputChip.bind(this);
         this.handleInteraction = this.handleInteraction.bind(this);
         this.handleSelection = this.handleSelection.bind(this);
         this.handleRemove = this.handleRemove.bind(this);
@@ -190,7 +191,7 @@ export class ChipSet {
 
     @Watch('value')
     protected handleChangeChips() {
-        this.textValue = ' ';
+        this.textValue = '';
     }
 
     private createMDCChipSet() {
@@ -241,30 +242,16 @@ export class ChipSet {
             hiddenInput = false;
         }
 
-        // Make sure the floating label is displayed correctly by setting the value of
-        // the input to an empty/not empty value
-        let textValue = this.textValue;
-        if (!textValue && this.value.length > 0) {
-            textValue = ' ';
-        } else if (!this.value.length && !textValue.trim()) {
-            textValue = '';
-        }
-        let searchLabel = this.searchLabel;
-        if (!this.editMode || textValue.length > 0) {
-            searchLabel = '';
-        }
-
         return (
             <div
                 class={{
                     'mdc-text-field': true,
                     'mdc-text-field--invalid': this.isInvalid(),
                 }}
-                onFocus={this.handleTextFieldFocus}
-                tabindex="0"
+                onClick={this.handleTextFieldFocus}
             >
                 <div class="mdc-chip-set mdc-chip-set--input">
-                    {this.value.map(this.renderChip)}
+                    {this.value.map(this.renderInputChip)}
                     <input
                         type="text"
                         id="my-text-field"
@@ -273,34 +260,26 @@ export class ChipSet {
                         class={`mdc-text-field__input ${
                             hiddenInput ? 'hidden' : ''
                         }`}
-                        value={textValue}
+                        value={this.textValue}
                         onBlur={this.handleInputBlur}
                         onFocus={this.handleTextFieldFocus}
                         onInput={this.handleTextInput}
                         // Some browsers emit a change event on input elements, we need to stop
                         // that event from propagating since we are emitting our own change event
                         onChange={this.inputFieldOnChange}
+                        placeholder={this.searchLabel}
                     />
                 </div>
                 <label
                     class={{
                         'mdc-floating-label': true,
-                        'mdc-floating-label--float-above': !!(
-                            textValue || this.editMode
-                        ),
                         'mdc-text-field--disabled': this.disabled,
                         'mdc-text-field--required': this.required,
+                        'force-float': !!(this.value.length || this.editMode),
                     }}
                     htmlFor="my-text-field"
                 >
                     {this.label}
-                </label>
-                <label
-                    id="search-label"
-                    class="mdc-floating-label"
-                    htmlFor="my-text-field"
-                >
-                    {searchLabel}
                 </label>
                 <div class="mdc-line-ripple" />
             </div>
@@ -339,7 +318,7 @@ export class ChipSet {
      */
     private handleInputBlur() {
         this.editMode = false;
-        this.textValue = ' ';
+        this.textValue = '';
         this.blurred = true;
 
         // This timeout is needed in order to let a new element receive focus
@@ -384,7 +363,6 @@ export class ChipSet {
             case 'filter':
                 return this.renderFilterChip(chip);
 
-            case 'input':
             default:
                 return this.renderDefaultChip(chip);
         }
@@ -430,9 +408,26 @@ export class ChipSet {
             <div class="mdc-chip" tabindex="0" id={`${chip.id}`}>
                 {chip.icon ? this.renderIcon(chip) : null}
                 <div class="mdc-chip__text">{chip.text}</div>
+            </div>
+        );
+    }
+
+    private renderInputChip(chip: Chip) {
+        return (
+            <div
+                class="mdc-chip"
+                id={`${chip.id}`}
+                onClick={this.catchInputChipClicks}
+            >
+                {chip.icon ? this.renderIcon(chip) : null}
+                <div class="mdc-chip__text">{chip.text}</div>
                 {chip.removable ? this.renderTrailingIcon() : null}
             </div>
         );
+    }
+
+    private catchInputChipClicks(event) {
+        event.stopPropagation();
     }
 
     private renderIcon(chip: Chip) {
@@ -456,7 +451,6 @@ export class ChipSet {
         return (
             <limel-icon
                 class="mdc-chip__icon mdc-chip__icon--trailing"
-                tabindex="0"
                 role="button"
                 name="multiply"
             />

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -236,12 +236,6 @@ export class ChipSet {
     }
 
     private renderInputChips() {
-        // Hide the input field while we are not editing and there are chips in the set
-        let hiddenInput = true;
-        if (this.editMode || !this.value.length) {
-            hiddenInput = false;
-        }
-
         return (
             <div
                 class={{
@@ -257,9 +251,7 @@ export class ChipSet {
                         id="my-text-field"
                         required={this.required}
                         disabled={this.disabled}
-                        class={`mdc-text-field__input ${
-                            hiddenInput ? 'hidden' : ''
-                        }`}
+                        class="mdc-text-field__input"
                         value={this.textValue}
                         onBlur={this.handleInputBlur}
                         onFocus={this.handleTextFieldFocus}

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -56,13 +56,13 @@ export class ChipSet {
     /**
      * True if the control requires a value
      */
-    @Prop()
+    @Prop({ reflectToAttr: true })
     public required: boolean = false;
 
     /**
      * Search label to display when type is `input` and component is in search mode
      */
-    @Prop()
+    @Prop({ reflectToAttr: true })
     public searchLabel: string;
 
     /**

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -258,7 +258,7 @@ export class ChipSet {
             <div
                 class={{
                     'mdc-text-field': true,
-                    'mdc-text-field--invalid': this.isInvalid(),
+                    'force-invalid': this.isInvalid(),
                 }}
                 onClick={this.handleTextFieldFocus}
             >
@@ -267,7 +267,6 @@ export class ChipSet {
                     <input
                         type="text"
                         id="my-text-field"
-                        required={this.required}
                         disabled={this.disabled}
                         class="mdc-text-field__input"
                         value={this.textValue}
@@ -298,13 +297,11 @@ export class ChipSet {
 
     private isInvalid() {
         if (!this.required) {
-            return;
+            return false;
         }
-
         if (!this.blurred) {
-            return;
+            return false;
         }
-
         return !this.value || !this.value.length;
     }
 

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -138,9 +138,10 @@ export class ChipSet {
         return this.editMode;
     }
 
-    // tslint:disable-next-line:valid-jsdoc
     /**
      * Used to set focus to the chip-set input field.
+     *
+     * @returns {Promise<void>} does not return anything, but methods have to be async
      */
     @Method()
     public async setFocus() {

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -62,8 +62,8 @@ describe('limel-list', () => {
             expect(innerList.children).toHaveLength(1);
             expect(innerList.children[0]).toHaveClass('mdc-list-item');
         });
-        it('sets tabindex to -1', () => {
-            expect(innerList.children[0]).toEqualAttribute('tabindex', '-1');
+        it('does not set tabindex', () => {
+            expect(innerList.children[0]).not.toHaveAttribute('tabindex');
         });
         it('sets the aria-disabled to true', () => {
             expect(innerList.children[0]).toEqualAttribute(

--- a/src/components/picker/picker.scss
+++ b/src/components/picker/picker.scss
@@ -8,6 +8,7 @@
 }
 
 .dropdown--spinner {
+    padding-top: pxToRem(6);
     text-align: center;
 
     limel-spinner {
@@ -26,10 +27,6 @@
         max-height: pxToRem(250);
         overflow-y: auto;
     }
-}
-
-.dropdown--spinner {
-    padding-top: pxToRem(6);
 }
 
 .empty-result-message {

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -182,7 +182,6 @@ export class Picker {
         return [
             <limel-chip-set
                 style={style}
-                tabindex="0"
                 type="input"
                 label={this.label}
                 value={this.chips}
@@ -434,13 +433,17 @@ export class Picker {
      * @returns {void}
      */
     private handleKeyDown(event: KeyboardEvent) {
-        const isTab = event.key === TAB || event.keyCode === TAB_KEY_CODE;
+        const isForwardTab =
+            (event.key === TAB || event.keyCode === TAB_KEY_CODE) &&
+            !event.altKey &&
+            !event.metaKey &&
+            !event.shiftKey;
         const isUp =
             event.key === ARROW_UP || event.keyCode === ARROW_UP_KEY_CODE;
         const isDown =
             event.key === ARROW_DOWN || event.keyCode === ARROW_DOWN_KEY_CODE;
 
-        if (!isTab && !isUp && !isDown) {
+        if (!isForwardTab && !isUp && !isDown) {
             return;
         }
 
@@ -451,7 +454,7 @@ export class Picker {
 
         event.preventDefault();
 
-        if (isTab || isDown) {
+        if (isForwardTab || isDown) {
             const listElement: HTMLElement = list.shadowRoot.querySelector(
                 '.mdc-list-item:first-child'
             );

--- a/src/examples/chip-set/chip-set-input.tsx
+++ b/src/examples/chip-set/chip-set-input.tsx
@@ -40,8 +40,8 @@ export class ChipSetInputExample {
         this.onInteract = this.onInteract.bind(this);
         this.onInput = this.onInput.bind(this);
         this.onKeyUp = this.onKeyUp.bind(this);
-        this.toggleEnabled = this.toggleEnabled.bind(this);
-        this.toggleRequired = this.toggleRequired.bind(this);
+        this.setEnabled = this.setEnabled.bind(this);
+        this.setRequired = this.setRequired.bind(this);
         this.setEmptyInputOnBlur = this.setEmptyInputOnBlur.bind(this);
     }
 
@@ -69,12 +69,12 @@ export class ChipSetInputExample {
                     />
                     <limel-checkbox
                         label="Disabled"
-                        onChange={this.toggleEnabled}
+                        onChange={this.setEnabled}
                         checked={this.disabled}
                     />
                     <limel-checkbox
                         label="Required"
-                        onChange={this.toggleRequired}
+                        onChange={this.setRequired}
                         checked={this.required}
                     />
                 </limel-flex-container>
@@ -114,12 +114,12 @@ export class ChipSetInputExample {
         };
     }
 
-    private toggleEnabled() {
-        this.disabled = !this.disabled;
+    private setEnabled(event: CustomEvent<boolean>) {
+        this.disabled = event.detail;
     }
 
-    private toggleRequired() {
-        this.required = !this.required;
+    private setRequired(event: CustomEvent<boolean>) {
+        this.required = event.detail;
     }
 
     private setEmptyInputOnBlur(event: CustomEvent<boolean>) {

--- a/src/examples/chip-set/chip-set-input.tsx
+++ b/src/examples/chip-set/chip-set-input.tsx
@@ -34,6 +34,7 @@ export class ChipSetInputExample {
         this.value[3].iconColor = 'var(--lime-blue)'; // tslint:disable-line:no-magic-numbers
 
         this.chipSetOnChange = this.chipSetOnChange.bind(this);
+        this.onInteract = this.onInteract.bind(this);
         this.onInput = this.onInput.bind(this);
         this.onKeyUp = this.onKeyUp.bind(this);
         this.toggleEnabled = this.toggleEnabled.bind(this);
@@ -50,7 +51,9 @@ export class ChipSetInputExample {
                 disabled={this.disabled}
                 onChange={this.chipSetOnChange}
                 onInput={this.onInput}
+                onInteract={this.onInteract}
                 onKeyUp={this.onKeyUp}
+                searchLabel="Add an animal"
             />,
             <p>
                 <limel-flex-container justify="end">
@@ -86,6 +89,10 @@ export class ChipSetInputExample {
     private chipSetOnChange(event: CustomEvent<Chip[]>) {
         console.log(event.detail);
         this.value = event.detail;
+    }
+
+    private onInteract(event: CustomEvent<Chip>) {
+        console.log('Chip interacted with: ', event.detail);
     }
 
     private createChip(name: string): Chip {

--- a/src/examples/chip-set/chip-set-input.tsx
+++ b/src/examples/chip-set/chip-set-input.tsx
@@ -20,6 +20,9 @@ export class ChipSetInputExample {
     @State()
     private disabled: boolean = false;
 
+    @State()
+    private emptyInputOnBlur: boolean = true;
+
     constructor() {
         this.value = [
             this.createChip('Elephant'),
@@ -39,6 +42,7 @@ export class ChipSetInputExample {
         this.onKeyUp = this.onKeyUp.bind(this);
         this.toggleEnabled = this.toggleEnabled.bind(this);
         this.toggleRequired = this.toggleRequired.bind(this);
+        this.setEmptyInputOnBlur = this.setEmptyInputOnBlur.bind(this);
     }
 
     public render() {
@@ -54,9 +58,15 @@ export class ChipSetInputExample {
                 onInteract={this.onInteract}
                 onKeyUp={this.onKeyUp}
                 searchLabel="Add an animal"
+                emptyInputOnBlur={this.emptyInputOnBlur}
             />,
             <p>
                 <limel-flex-container justify="end">
+                    <limel-checkbox
+                        label="Empty input on blur"
+                        onChange={this.setEmptyInputOnBlur}
+                        checked={this.emptyInputOnBlur}
+                    />
                     <limel-checkbox
                         label="Disabled"
                         onChange={this.toggleEnabled}
@@ -110,5 +120,9 @@ export class ChipSetInputExample {
 
     private toggleRequired() {
         this.required = !this.required;
+    }
+
+    private setEmptyInputOnBlur(event: CustomEvent<boolean>) {
+        this.emptyInputOnBlur = event.detail;
     }
 }

--- a/src/examples/list/list-secondary.tsx
+++ b/src/examples/list/list-secondary.tsx
@@ -7,7 +7,12 @@ import { Component, h } from '@stencil/core';
 })
 export class SecondaryTextListExample {
     private items: Array<ListItem<number>> = [
-        { text: 'King of Tokyo', secondaryText: '2-6 players', value: 1 },
+        {
+            text: 'King of Tokyo',
+            secondaryText: '2-6 players',
+            value: 1,
+            disabled: true,
+        },
         { text: 'Smash Up!', secondaryText: '2-4 players', value: 2 },
         { text: 'Pandemic', secondaryText: '2-4 players', value: 3 },
         { text: 'Catan', secondaryText: '3-4 players', value: 4 },


### PR DESCRIPTION
Chips can't be reached by keyboard at the moment.

Fix #428 

***NB!*** We really should test this on mobile.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [x] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [x] iOS