### PR TITLE
chore(package): add `@types/puppeteer` to greenkeeper.ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   "greenkeeper": {
     "ignore": [
       "@types/jest",
+      "@types/puppeteer",
       "jest",
       "jest-cli",
       "puppeteer"


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS