### PR TITLE
feat(input-field): add support for a helper text next to the input field

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -43,6 +43,12 @@ export class InputField {
     public label: string;
 
     /**
+     * Optional helper text to display below the input field when it has focus
+     */
+    @Prop({ reflectToAttr: true })
+    public helperText: string;
+
+    /**
      * Set to `true` to indicate that the field is required.
      * Defaults to `false`.
      */
@@ -167,6 +173,7 @@ export class InputField {
                 {this.renderTrailingIcon()}
                 <div class="mdc-line-ripple" />
             </label>,
+            this.renderHelperText(),
             <div class="autocomplete-list-container">
                 {this.renderDropdown()}
             </div>,
@@ -179,6 +186,18 @@ export class InputField {
 
     private onBlur() {
         this.isFocused = false;
+    }
+
+    private renderHelperText() {
+        if (this.helperText === null || this.helperText === undefined) {
+            return;
+        }
+
+        return (
+            <div class="mdc-text-field-helper-line">
+                <div class="mdc-text-field-helper-text">{this.helperText}</div>
+            </div>
+        );
     }
 
     private renderTrailingIcon() {

--- a/src/examples/input-field/input-field-text-inline.tsx
+++ b/src/examples/input-field/input-field-text-inline.tsx
@@ -22,11 +22,13 @@ export class InputFieldTextExample {
             <section>
                 <limel-input-field
                     label="First Field"
+                    helperText="This is a helper text"
                     value={this.firstValue}
                     onChange={this.firstOnChange}
                 />
                 <limel-input-field
                     label="Second Field"
+                    helperText=""
                     value={this.secondValue}
                     onChange={this.secondOnChange}
                 />

--- a/src/examples/input-field/input-field-text.tsx
+++ b/src/examples/input-field/input-field-text.tsx
@@ -29,6 +29,7 @@ export class InputFieldTextExample {
         return [
             <limel-input-field
                 label="Text Field"
+                helperText="Please enter a useful message!"
                 value={this.value}
                 required={this.required}
                 invalid={this.invalid}


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS