### PR TITLE
chore(package): use GitHub Packages registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ src/components.d.ts
 src/**/readme.md
 docsDist/
 
+.npmrc
+
 *~
 *.sw[mnpcod]
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,20 @@ COPY . .
 
 RUN npm install -g npm@latest
 
+ARG GH_TOKEN
+
+RUN GH_TOKEN="${GH_TOKEN}" ./generate_npmrc.sh
+
+# RUN rm -rf node_modules
+
 # Run npm install as pptruser so we don't have to chown node_modules later
 USER pptruser
+# RUN npm cache clean --force
 RUN npm install
 
 USER root
+
+RUN rm .npmrc
 
 # chown everything to be owned by pptruser, except for the node_modules
 # folder (already done), and the .git folder (unnecessary)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,11 @@ pipeline {
     stages {
         stage('Create docker container') {
             steps {
-                sh 'make build'
+                withCredentials([
+                    string(credentialsId: 'github-access-token', variable: 'GH_TOKEN')
+                ]) {
+                    sh 'make build'
+                }
             }
         }
         stage('Lint code') {

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_DOCS_IMAGE = lime-elements-docs
 .PHONY: build
 build:
 	@# Builds the ci image lime-elements.
-	docker build --pull -t $(DOCKER_IMAGE) .
+	docker build --build-arg GH_TOKEN=${GH_TOKEN} --pull -t $(DOCKER_IMAGE) .
 
 .PHONY: lint
 lint:

--- a/generate_npmrc.sh
+++ b/generate_npmrc.sh
@@ -1,0 +1,5 @@
+cat << EOL >> ".npmrc"
+registry=https://registry.npmjs.org
+@lundalogik:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GH_TOKEN}
+EOL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1832,11 +1832,6 @@
       "resolved": "https://registry.npmjs.org/@limetech/flatpickr/-/flatpickr-4.5.5.tgz",
       "integrity": "sha512-xUpN8juzIw7bGT7D7HmoUHynOaw6fRvLvm5BUoK3vHBQqSYOSyYOI2Cdf6nfEsB/yOMANH3g1zvjCchTV3Uy+A=="
     },
-    "@limetech/lime-icons8": {
-      "version": "http://npm.lundalogik.com:4873/@limetech/lime-icons8/-/lime-icons8-2.0.0.tgz",
-      "integrity": "sha512-mc0BJttqfqMLhoV9IgsFZDQqbC2UuD7gac9K94KLUAVXkM6vijEaVs+vc4wnzdpVNCUGIxGbShdgO7jcTyCd4w==",
-      "dev": true
-    },
     "@limetech/material-components-web": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@limetech/material-components-web/-/material-components-web-1.1.1.tgz",
@@ -2422,6 +2417,11 @@
         "@babel/runtime": "^7.4.4",
         "hoist-non-react-statics": "^3.3.0"
       }
+    },
+    "@lundalogik/lime-icons8": {
+      "version": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.0.0/ce8e62da50874749bf632b53f579f5041eb515ea86bd5d9f6cc5f9ae0baabb6f",
+      "integrity": "sha512-L6ZNe1QUk1wGosCjaCGe5VC1yocgDEaqaHzYtrrNTrx7bpFk1I5lP/TEgIB3nbroTX6UPQHbsa5OTUXw9XubNg==",
+      "dev": true
     },
     "@marionebl/sander": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@commitlint/cli": "8.2.0",
     "@commitlint/config-conventional": "8.2.0",
-    "@limetech/lime-icons8": "http://npm.lundalogik.com:4873/@limetech/lime-icons8/-/lime-icons8-2.0.0.tgz",
+    "@lundalogik/lime-icons8": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.0.0/ce8e62da50874749bf632b53f579f5041eb515ea86bd5d9f6cc5f9ae0baabb6f",
     "@semantic-release/changelog": "3.0.4",
     "@semantic-release/exec": "3.3.7",
     "@semantic-release/git": "7.0.16",

--- a/stencil.config.docs.ts
+++ b/stencil.config.docs.ts
@@ -12,7 +12,7 @@ const targetWww: OutputTargetWww = {
         { src: 'examples/**/*.scss' },
         { src: 'components/**/*.md' },
         {
-            src: '../node_modules/@limetech/lime-icons8/assets/',
+            src: '../node_modules/@lundalogik/lime-icons8/assets/',
             dest: 'assets/',
         },
     ],

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -19,7 +19,7 @@ const targetWww: OutputTargetWww = {
         { src: 'examples/**/*.scss' },
         { src: 'components/**/*.md' },
         {
-            src: '../node_modules/@limetech/lime-icons8/assets/',
+            src: '../node_modules/@lundalogik/lime-icons8/assets/',
             dest: 'assets/',
         },
     ],


### PR DESCRIPTION
Developers who have access to Lime's private packages on GitHub Packages should create an `.npmrc` file containing `registry=https://npm.pkg.github.com/lundalogik` in the root of their local repo. Other developers will need to remove the dev-dependency on `@lundalogik/lime-icons8`.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS