### PR TITLE
fix(limel-select): ellipsis when text overflow

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -58,6 +58,9 @@ $mdc-select-bottom-line-hover-color: $lime-text-field-bottom-line-color;
 
     .limel-select__selected-text {
         line-height: pxToRem(28);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     .limel-select-trigger {


### PR DESCRIPTION
fix #426 
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS