### PR TITLE
Fix picker icons in edge

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -55,8 +55,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 
 .mdc-chip__icon--trailing svg {
     display: block;
-    height: 100%;
-    width: 100%;
 }
 
 .mdc-text-field {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -532,7 +532,7 @@ export class ChipSet {
     }
 
     private renderTrailingIcon() {
-        const svgData = `<svg width="32" height="32" x="0px" y="0px" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+        const svgData = `<svg style="height:100%;width:100%;" width="32" height="32" x="0px" y="0px" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
     <line fill="none" id="svg_1" stroke="currentColor" stroke-width="2" x1="8" x2="24" y1="8" y2="24"/>
     <line fill="none" id="svg_2" stroke="currentColor" stroke-width="2" x1="24" x2="8" y1="8" y2="24"/>
 </svg>`;

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -77,6 +77,11 @@
             }
         }
     }
+
+    // Tweaks to display the icon correctly in Edge
+    limel-icon.mdc-list-item__graphic {
+        display: block;
+    }
 }
 
 .mdc-list:not(.mdc-list--avatar-list) {


### PR DESCRIPTION
How to test in Edge:
- run `npm run docz:build`
- `cd .docz/dist`
- run `serve` 

--> docz site available in windows VM

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox
- [x] Edge

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS