### PR TITLE
ci(jenkinsfile): remove commitlint step from Jenkins build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,36 +29,6 @@ pipeline {
                 sh 'make test'
             }
         }
-        stage('Lint commits') {
-            steps {
-                script {
-                    if (env.BRANCH_NAME.substring(0,3) == 'PR-') {
-                        commitHashes = sh (
-                            // Get all commits on the current branch,
-                            // that does not appear on master
-                            script: 'git cherry origin/master',
-                            // Return the response, instead of printing
-                            // it to the log.
-                            returnStdout: true
-                        // Split on whitespace.
-                        ).trim().split();
-
-                        // Commits are listed on the format `+ <hash>`,
-                        // so even indexes are '+',
-                        // and odd indexes are the hashes.
-                        for (i = 0; i < commitHashes.size(); i += 2) {
-
-                            // A '+' means this is a commit that will be
-                            // added to master. Those are the ones we
-                            // want to lint.
-                            if (commitHashes[i] == '+') {
-                                sh "make commitlint HASH=${commitHashes[i+1]}"
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
         stage('Build and release') {
             environment {


### PR DESCRIPTION
We are now running commitlint as a GitHub Action instead.