### PR TITLE
feat(grid): set default row height to 2.5rem (40px)

### DIFF
--- a/src/components/grid/grid.scss
+++ b/src/components/grid/grid.scss
@@ -3,7 +3,7 @@
 /**
  * @prop --lime-grid-area: Grid layout
  * @prop --lime-grid-columns: Number of columns in the grid, defaults to 4
- * @prop --lime-grid-cell-height: Height of grid cells, defaults to `4rem` (64px)
+ * @prop --lime-grid-cell-height: Height of grid cells, defaults to `2.5rem` (40px)
  * @prop --lime-grid-gutter: width of the gutter between columns and rows, defaults to `1rem` (16px) - see https://material.io/design/layout/responsive-layout-grid.html#breakpoints for guidelines
  */
 
@@ -25,7 +25,7 @@ slot {
     );
     grid-gap: var(--lime-grid-gutter, pxToRem(16));
     grid-auto-flow: row dense;
-    grid-auto-rows: var(--lime-grid-cell-height, pxToRem(64));
+    grid-auto-rows: var(--lime-grid-cell-height, pxToRem(40));
     margin: 0;
     height: 100%;
     width: 100%;

--- a/src/examples/grid/grid.scss
+++ b/src/examples/grid/grid.scss
@@ -15,10 +15,19 @@ limel-grid {
 
     --lime-grid-area:
         "drd drd blu dbl"
+        "drd drd blu dbl"
+        "trq trq blu dbl"
         "trq trq blu dbl"
         "red red red red"
+        "red red red red"
+        "red red red red"
         "dgr mag mag lgr"
-        "ora ora yel yel"
+        "dgr mag mag lgr"
+        "dgr mag mag lgr"
+        "ora mag mag yel"
+        "ora mag mag yel"
+        "grn grn .   .  "
+        "grn grn .   .  "
         "grn grn .   .  "
         "grn grn .   .  ";
 }


### PR DESCRIPTION
BREAKING CHANGE: The default row height of the limel-grid component has been set to 2.5rem (40px). The row height of any given instance of limel-grid can be set using the `--lime-grid-cell-height` CSS variable.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS