### PR TITLE
fix(dialog): prevent header from shrinking due to large body

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -52,6 +52,7 @@ slot[name="header"] {
         display: flex;
         align-items: center;
         margin: pxToRem(30) pxToRem(24) pxToRem(5);
+        flex-shrink: 0;
 
         limel-icon {
             margin-right: pxToRem(15);


### PR DESCRIPTION
prevent content to hide the header on scroll bounce

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS