### PR TITLE
fix(select): don't set focus on first item if null

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -214,7 +214,9 @@ export class Select {
                 '[tabindex]'
             );
 
-            firstItem.focus();
+            if (firstItem) {
+                firstItem.focus();
+            }
         });
     }
 


### PR DESCRIPTION
Currently we are setting focus on the first item in the list. If the list is empty, this will result in a `cannot read property focus of null` error.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS