### PR TITLE
fix(form): remove double titles and descriptions from form fields

### DIFF
--- a/src/components/form/templates/field.ts
+++ b/src/components/form/templates/field.ts
@@ -1,1 +1,12 @@
-export const FieldTemplate = undefined; // TODO implement field template
+import React from 'react';
+
+export const FieldTemplate = props => {
+    const { classNames, children } = props;
+    return React.createElement(
+        'div',
+        {
+            className: classNames,
+        },
+        children
+    );
+};

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -34,10 +34,11 @@ $mdc-select-bottom-line-hover-color: $lime-text-field-bottom-line-color;
         width: 100%;
         height: pxToRem(56);
         position: relative;
+        margin-bottom: pxToRem(19);
     }
 
     &.limel-select--with-helper-text {
-        margin-bottom: pxToRem(19);
+        height: pxToRem(75);
     }
 
     .limel-select__selected-text {
@@ -114,31 +115,13 @@ $mdc-select-bottom-line-hover-color: $lime-text-field-bottom-line-color;
     }
 
     limel-portal {
-        margin-top: pxToRem(-6);
-    }
-
-    &.limel-select--with-helper-text {
-        limel-portal {
-            margin-top: pxToRem(-19);
-        }
-    }
-
-    &.limel-select--empty {
-        limel-portal {
-            margin-top: pxToRem(-7);
-        }
-
-        &.limel-select--with-helper-text {
-            limel-portal {
-                margin-top: pxToRem(-19);
-            }
-        }
+        margin-top: pxToRem(-19);
     }
 
     .mdc-select-helper-text {
         margin-left: 1rem;
         margin-right: 1rem;
-        margin-top: pxToRem(-7);
+        margin-top: pxToRem(-19);
     }
 }
 


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS