### PR TITLE
feat(form): add template for object fields

### DIFF
--- a/src/components/form/form.mdx
+++ b/src/components/form/form.mdx
@@ -14,6 +14,10 @@ menu: Components
 
 <limel-example name="limel-example-form" />
 
+### Nested data
+
+<limel-example name="limel-example-nested-form" path="form"/>
+
 ### Dynamic schema
 
 <limel-example name="limel-example-dynamic-form" path="form"/>

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -1,0 +1,1 @@
+@import '../../style/variables';

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -1,1 +1,68 @@
-export const ObjectFieldTemplate = undefined; // TODO implement object field template
+import React from 'react';
+import { ObjectFieldProperty, ObjectFieldTemplateProps } from './types';
+
+export const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
+    const id = props.idSchema.$id;
+    if (id === 'root' || !isCollapsible(props.schema)) {
+        return renderFieldWithTitle(props);
+    }
+
+    if (isCollapsible(props.schema)) {
+        return renderCollapsibleField(props);
+    }
+
+    return renderProperties(props.properties);
+};
+
+function renderFieldWithTitle(props: ObjectFieldTemplateProps) {
+    return React.createElement(
+        'div',
+        {},
+        renderTitle(props.title),
+        renderDescription(props.description),
+        renderProperties(props.properties)
+    );
+}
+
+function renderCollapsibleField(props: ObjectFieldTemplateProps) {
+    return React.createElement(
+        'limel-collapsible-section',
+        {
+            header: props.title,
+        },
+        renderDescription(props.description),
+        renderProperties(props.properties)
+    );
+}
+
+function renderProperties(properties: ObjectFieldProperty[]) {
+    return properties.map(element => element.content);
+}
+
+function renderTitle(title: string) {
+    if (!title) {
+        return;
+    }
+
+    return React.createElement(
+        'h1',
+        { className: 'mdc-typography mdc-typography--headline1' },
+        title
+    );
+}
+
+function renderDescription(description: string) {
+    if (!description) {
+        return;
+    }
+
+    return React.createElement(
+        'p',
+        { className: 'mdc-typography mdc-typography--body1' },
+        description
+    );
+}
+
+function isCollapsible(schema: any) {
+    return !!schema.lime?.collapsible;
+}

--- a/src/components/form/templates/types.ts
+++ b/src/components/form/templates/types.ts
@@ -1,0 +1,68 @@
+// These are defined by react-jsonschema-form and added
+// here as interfaces for type hinting
+
+export interface TemplateProps {
+    disabled: boolean;
+    readonly: boolean;
+    required: boolean;
+    schema: any;
+    uiSchema: any;
+    formContext: any;
+}
+
+export interface FieldTemplateProps extends TemplateProps {
+    id: string;
+    classNames: string;
+    label: string;
+    description: any;
+    rawDescription: string;
+    children: any;
+    errors: any;
+    rawErrors: string[];
+    help: any;
+    rawHelp: string;
+    hidden: boolean;
+    displayLabel: boolean;
+    fields: any[];
+}
+
+export interface ObjectFieldTemplateProps extends TemplateProps {
+    title: string;
+    description: string;
+    properties: ObjectFieldProperty[];
+    idSchema: any;
+    formData: object;
+}
+
+export interface ObjectFieldProperty {
+    content: any;
+    name: string;
+    disabled: boolean;
+    readonly: boolean;
+}
+
+export interface ArrayFieldTemplateProps extends TemplateProps {
+    canAdd: boolean;
+    className: string;
+    idSchema: any;
+    items: ArrayFieldItem[];
+    onAddClick: (event: any) => void;
+    title: string;
+    formData: object;
+}
+
+export interface ArrayFieldItem {
+    children: any;
+    className: string;
+    disabled: boolean;
+    hasMoveDown: boolean;
+    hasMoveUp: boolean;
+    hasRemove: boolean;
+    hasToolbar: boolean;
+    index: number;
+    key: string;
+    onAddIndexClick: (index: number) => (event: any) => void;
+    onDropIndexClick: (index: number) => (event: any) => void;
+    onReorderClick: (index: number, newIndex: number) => (event: any) => void;
+    readonly: boolean;
+}

--- a/src/examples/form/nested-form.tsx
+++ b/src/examples/form/nested-form.tsx
@@ -1,0 +1,80 @@
+import { Component, h, State } from '@stencil/core';
+
+const schema = {
+    type: 'object',
+    properties: {
+        name: {
+            type: 'string',
+            title: 'Name',
+        },
+        age: {
+            type: 'integer',
+            title: 'Age',
+        },
+        address: {
+            type: 'object',
+            title: 'Location',
+            description: 'Please enter your location',
+            properties: {
+                city: {
+                    type: 'string',
+                    title: 'City',
+                },
+                country: {
+                    type: 'string',
+                    title: 'Country',
+                    description: 'It might also be a planet',
+                },
+            },
+        },
+        data: {
+            type: 'object',
+            title: 'Data',
+            description: 'Some additional data we would like you to submit',
+            properties: {
+                eyeColor: {
+                    type: 'string',
+                    title: 'Eye color',
+                },
+                shoeSize: {
+                    type: 'integer',
+                    title: 'Shoe size',
+                },
+            },
+            lime: {
+                collapsible: true,
+            },
+        },
+    },
+};
+
+@Component({
+    tag: 'limel-example-nested-form',
+    shadow: true,
+})
+export class NestedFormExample {
+    @State()
+    private formData: object = {};
+
+    constructor() {
+        this.handleFormChange = this.handleFormChange.bind(this);
+    }
+
+    public render() {
+        return [
+            <limel-form
+                onChange={this.handleFormChange}
+                value={this.formData}
+                schema={schema}
+            />,
+            <br />,
+            <br />,
+            'Value: ',
+            <pre>{JSON.stringify(this.formData, null, '    ')}</pre>,
+        ];
+    }
+
+    private handleFormChange(event) {
+        this.formData = event.detail;
+    }
+}


### PR DESCRIPTION
### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS