### PR TITLE
fix(select): correct default selection, which was broken in v26.1.1

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -113,6 +113,10 @@ export class Select {
         if (this.host.hasAttribute('data-native')) {
             this.isMobileDevice = true;
         }
+
+        if (!this.value) {
+            this.change.emit(this.options[0]);
+        }
     }
 
     public componentDidLoad() {


### PR DESCRIPTION
fix #573

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS