### PR TITLE
fix(select): do not emit change event when component is mounted

### DIFF
--- a/src/components/select/select.e2e.ts
+++ b/src/components/select/select.e2e.ts
@@ -327,8 +327,8 @@ describe('limel-select (native)', () => {
                 await appleOption.click();
             });
 
-            it('emits one change event', () => {
-                expect(spy).toHaveReceivedEventTimes(1);
+            it('emits change event', () => {
+                expect(spy).toHaveReceivedEvent();
             });
 
             it('passes the selected option as the event details', () => {

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -74,6 +74,7 @@ export class Select {
     @State()
     private menuOpen: boolean = false;
 
+    private hasChanged: boolean = false;
     private checkValid: boolean = false;
 
     /**
@@ -112,10 +113,6 @@ export class Select {
         // We can set this attribute in tests to force rendering of the native select
         if (this.host.hasAttribute('data-native')) {
             this.isMobileDevice = true;
-        }
-
-        if (!this.value) {
-            this.change.emit(this.options[0]);
         }
     }
 
@@ -244,7 +241,16 @@ export class Select {
     }
 
     private openMenu() {
+        if (this.emitFirstChangeEvent()) {
+            this.hasChanged = true;
+            this.change.emit(this.options[0]);
+        }
+
         this.menuOpen = true;
+    }
+
+    private emitFirstChangeEvent() {
+        return !this.hasChanged && this.isMobileDevice && !this.value;
     }
 
     private closeMenu() {


### PR DESCRIPTION
The change event should not be emitted when component is mounted since it will set focus and scroll
to the component when the page is loaded. The event is only needed on mobile devices that has not a value preselected, and it is enough to send it the first time the menu is opened.

related to #574 #573

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS