### PR TITLE
fix(dialog): set dialog surface to 100% height

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -23,6 +23,7 @@ slot[name="header"] {
     .mdc-dialog__container {
         width: var(--dialog-width, auto);
         height: var(--dialog-height, auto);
+        max-height: 100%;
 
         &.full-screen {
             width: 100%;
@@ -36,6 +37,7 @@ slot[name="header"] {
 
     .mdc-dialog__surface {
         width: 100%;
+        height: 100%;
 
         .mdc-dialog__body--scrollable  {
             max-height: inherit;


### PR DESCRIPTION
`--dialog-height` was not working correctly since the surface of the dialog did not expand to the
actual height of the dialog

fix #590

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS