### PR TITLE
Improve collapsible section

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -148,7 +148,7 @@ export class Form {
         // Due to a bug in react-jsonschema-form, validation will stop working if the schema is updated.
         // A workaround at the moment is to always give it a unique ID
         // https://github.com/rjsf-team/react-jsonschema-form/issues/1563
-        const id = `${this.schema.id}-${createRandomString()}`;
+        const id = `${this.schema.$id}-${createRandomString()}`;
         this.modifiedSchema = {
             ...this.schema,
             id: id,

--- a/src/components/form/templates/array-field-collapsible-item.ts
+++ b/src/components/form/templates/array-field-collapsible-item.ts
@@ -2,6 +2,7 @@ import { Action } from '@limetech/lime-elements';
 import React from 'react';
 import { findTitle } from './common';
 import { ArrayFieldItem, Runnable } from './types';
+import { isEmpty } from 'lodash-es';
 
 interface CollapsibleItemProps {
     /**
@@ -32,10 +33,12 @@ interface CollapsibleItemProps {
 
 export class CollapsibleItemTemplate extends React.Component {
     public refs: { section: any };
+    private isOpen: boolean;
 
     constructor(public props: CollapsibleItemProps) {
         super(props);
         this.handleAction = this.handleAction.bind(this);
+        this.isOpen = isEmpty(props.data);
     }
 
     public componentDidMount() {
@@ -56,13 +59,15 @@ export class CollapsibleItemTemplate extends React.Component {
     }
 
     public render() {
-        const { data, schema, index, formSchema } = this.props;
+        const { data, schema, formSchema } = this.props;
+
         return React.createElement(
             'limel-collapsible-section',
             {
-                header: findTitle(data, schema, formSchema) || index,
+                header: findTitle(data, schema, formSchema) || 'New item',
                 className: 'limel-form-array-item--object',
                 ref: 'section',
+                'is-open': this.isOpen,
             },
             this.props.item.children
         );

--- a/src/components/form/templates/common.spec.ts
+++ b/src/components/form/templates/common.spec.ts
@@ -31,6 +31,9 @@ const schema = {
         title: {
             type: 'string',
         },
+        koko: {
+            type: 'string',
+        },
         name: {
             type: 'string',
             oneOf: [
@@ -46,37 +49,69 @@ const schema = {
                 },
             ],
         },
-        nested: {
-            type: 'object',
-            $ref: '#/definitions/nested',
-        },
-        list1: {
-            type: 'array',
-            items: {
-                type: 'string',
-                anyOf: [
-                    {
-                        type: 'string',
-                        const: 'item1',
-                        title: 'Item1',
-                    },
-                    {
-                        type: 'string',
-                        const: 'item2',
-                        title: 'Item2',
-                    },
-                ],
-            },
-        },
-        list2: {
-            type: 'array',
-            items: {
-                type: 'object',
-                $ref: '#/definitions/nested',
-            },
+    },
+};
+
+const nestedFirstSchema: any = { ...schema };
+nestedFirstSchema['properties'] = {
+    nested: {
+        type: 'object',
+        $ref: '#/definitions/nested',
+    },
+    data: {
+        type: 'string',
+    },
+};
+
+const nestedFirstWithTitleSchema: any = { ...schema };
+nestedFirstWithTitleSchema['properties'] = {
+    nested: {
+        type: 'object',
+        $ref: '#/definitions/nested',
+    },
+    data: {
+        type: 'string',
+    },
+    title: {
+        type: 'string',
+    },
+};
+
+const list1FirstSchema: any = { ...schema };
+list1FirstSchema['properties'] = {
+    list1: {
+        type: 'array',
+        items: {
+            type: 'string',
+            anyOf: [
+                {
+                    type: 'string',
+                    const: 'item1',
+                    title: 'Item1',
+                },
+                {
+                    type: 'string',
+                    const: 'item2',
+                    title: 'Item2',
+                },
+            ],
         },
     },
 };
+
+const list2FirstSchema: any = { ...schema };
+list2FirstSchema['properties'] = {
+    list2: {
+        type: 'array',
+        items: {
+            type: 'object',
+            $ref: '#/definitions/nested',
+        },
+    },
+};
+
+const schemaRequiredProperty: any = { ...schema };
+schemaRequiredProperty['required'] = ['data'];
 
 describe('findTitle()', () => {
     [
@@ -109,16 +144,40 @@ describe('findTitle()', () => {
             output: 'title',
         },
         {
-            input: [{ nested: { data: 'nestedName' } }, schema, schema],
+            input: [
+                { nested: { data: 'nestedName' } },
+                nestedFirstSchema,
+                schema,
+            ],
             output: 'Nested name',
         },
         {
-            input: [{ list1: ['item1'] }, schema, schema],
+            input: [
+                { nested: { data: 'nestedName' }, title: 'My title' },
+                nestedFirstWithTitleSchema,
+                schema,
+            ],
+            output: 'My title',
+        },
+        {
+            input: [{ list1: ['item1'] }, list1FirstSchema, schema],
             output: 'Item1',
         },
         {
-            input: [{ list2: [{ data: 'itemData' }] }, schema, schema],
+            input: [
+                { list2: [{ data: 'itemData' }] },
+                list2FirstSchema,
+                schema,
+            ],
             output: 'Item data',
+        },
+        {
+            input: [
+                { koko: 'loko', data: 'test' },
+                schemaRequiredProperty,
+                schema,
+            ],
+            output: 'test',
         },
     ].forEach(({ input, output }) => {
         const inputJson = JSON.stringify(input[1]);


### PR DESCRIPTION
fix Lundalogik/lime-admin#84

This PR includes fixes for:
- Expand collapsible section when adding a new collapsible field to reveal its content (also updated default title to _New item_ instead of the array index)
- How to choose a section title:
    1. Take field with title or name key
    2. Take required field
    3. Take first occurrence of string field with value

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS