### PR TITLE
ci(semantic-release): disable publishing of docs to aws, because it doesn't work anyway

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ module.exports = {
             '@semantic-release/exec',
             {
                 publishCmd:
-                    'npm run docz:publish -- --v=${nextRelease.version} --dryRun=${options.dryRun}',
+                    'npm run docz:publish -- --v=${nextRelease.version} --noPublish --dryRun=${options.dryRun}',
             },
         ],
     ],


### PR DESCRIPTION
This is a temporary fix. Everything should work just as it has so far, but with release-builds
passing instead of failing at the very last command in the last step. Docs still need to be
published to aws manually, but they should be built and pushed to github by the release-build.

re #571