### PR TITLE
Fix dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cm": "git-cz",
     "dev": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --docs\"",
     "watch": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --watch --docs\"",
+    "watch:prod": "cross-env-shell SASS_PATH=node_modules \"stencil build --watch --docs\"",
     "docz:build": "npm run dev && docz build && cross-env-shell NODE_ENV=prod SASS_PATH=node_modules \"stencil build --docs --config stencil.config.docs.ts\"",
     "docz:publish": "node publish-docs.js",
     "lint": "npm run lint:src && npm run lint:specs && npm run lint:examples && npm run lint:config",

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -1,15 +1,14 @@
 import { Config } from '@stencil/core';
-import { OutputTargetDist } from '@stencil/core/dist/declarations/output-targets';
 import { sass } from '@stencil/sass';
-
-const targetDist: OutputTargetDist = {
-    type: 'dist',
-    copy: [{ src: 'style/' }],
-};
 
 export const config: Config = {
     namespace: 'lime-elements',
-    outputTargets: [targetDist],
+    outputTargets: [
+        {
+            type: 'dist',
+            copy: [{ src: 'style/' }],
+        },
+    ],
     commonjs: {
         namedExports: {
             'node_modules/react-dom/index.js': [

--- a/stencil.config.docs.ts
+++ b/stencil.config.docs.ts
@@ -1,27 +1,26 @@
 import { Config } from '@stencil/core';
-import { OutputTargetWww } from '@stencil/core/dist/declarations/output-targets';
 import { sass } from '@stencil/sass';
-
-const targetWww: OutputTargetWww = {
-    type: 'www',
-    serviceWorker: null,
-    dir: '.docz/dist/stencil',
-    baseUrl: '/',
-    copy: [
-        { src: 'components/**/examples/**/*.tsx' },
-        { src: 'components/**/examples/**/*.scss' },
-        { src: 'components/**/*.md' },
-        {
-            src: '../node_modules/@lundalogik/lime-icons8/assets/',
-            dest: 'assets/',
-        },
-    ],
-};
 
 export const config: Config = {
     hashFileNames: false,
     namespace: 'lime-elements',
-    outputTargets: [targetWww],
+    outputTargets: [
+        {
+            type: 'www',
+            serviceWorker: null,
+            dir: '.docz/dist/stencil',
+            baseUrl: '/',
+            copy: [
+                { src: 'components/**/examples/**/*.tsx' },
+                { src: 'components/**/examples/**/*.scss' },
+                { src: 'components/**/*.md' },
+                {
+                    src: '../node_modules/@lundalogik/lime-icons8/assets/',
+                    dest: 'assets/',
+                },
+            ],
+        },
+    ],
     commonjs: {
         namedExports: {
             'node_modules/react-dom/index.js': [

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,35 +1,30 @@
 import { Config } from '@stencil/core';
-import {
-    OutputTargetDist,
-    OutputTargetWww,
-} from '@stencil/core/dist/declarations/output-targets';
 import { sass } from '@stencil/sass';
 import doczStarter from './rollup-plugin-docz-starter';
-
-const targetDist: OutputTargetDist = {
-    type: 'dist',
-    copy: [{ src: 'style/' }],
-};
-
-const targetWww: OutputTargetWww = {
-    type: 'www',
-    serviceWorker: null,
-    dir: '.docz/public/stencil',
-    copy: [
-        { src: 'components/**/examples/**/*.tsx' },
-        { src: 'components/**/examples/**/*.scss' },
-        { src: 'components/**/*.md' },
-        {
-            src: '../node_modules/@lundalogik/lime-icons8/assets/',
-            dest: 'assets/',
-        },
-    ],
-};
 
 export const config: Config = {
     hashFileNames: false,
     namespace: 'lime-elements',
-    outputTargets: [targetDist, targetWww],
+    outputTargets: [
+        {
+            type: 'dist',
+            copy: [{ src: 'style/' }],
+        },
+        {
+            type: 'www',
+            serviceWorker: null,
+            dir: '.docz/public/stencil',
+            copy: [
+                { src: 'components/**/examples/**/*.tsx' },
+                { src: 'components/**/examples/**/*.scss' },
+                { src: 'components/**/*.md' },
+                {
+                    src: '../node_modules/@lundalogik/lime-icons8/assets/',
+                    dest: 'assets/',
+                },
+            ],
+        },
+    ],
     commonjs: {
         namedExports: {
             'node_modules/react-dom/index.js': [


### PR DESCRIPTION
When running `npm run watch` (or `npm start`), lime-elements is built in dev-mode. However, StencilJS does not output the loader files necessary to load lime-elements in Angular when built in this mode. So we add `npm run watch:prod` for building the prod-build with a running watcher, thus gaining the benefits of auto-build while also being able to load the result in lime-webclient.