### PR TITLE
ci(greenkeeper): add GitHub Actions workflow for Greenkeeper-branches

### DIFF
--- a/.github/workflows/greenkeeper.yml
+++ b/.github/workflows/greenkeeper.yml
@@ -1,0 +1,23 @@
+name: Greenkeeper
+on:
+  push:
+    branches:
+      - greenkeeper**
+jobs:
+  ci:
+    name: Greenkeeper CI
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: npm install
+      run: |
+        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
+        npm ci
+        rm .npmrc
+    - run: npm run build
+    - run: npm test --if-present


### PR DESCRIPTION
Greenkeeper will only open a PR if there's a successful CI-build on the branch Greenkeeper creates for an update.