### PR TITLE
Prettier default arrow parens

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "arrowParens": "avoid",
   "singleQuote": true,
   "tabWidth": 4,
   "overrides": [

--- a/publish-docs.js
+++ b/publish-docs.js
@@ -225,7 +225,9 @@ function remove(pattern) {
 function updateVersionList() {
     shell.cd('docsDist');
 
-    const files = fs.readdirSync('versions').filter(file => file !== 'latest');
+    const files = fs
+        .readdirSync('versions')
+        .filter((file) => file !== 'latest');
     fs.writeFileSync(
         'versions.js',
         `window.versions = ${JSON.stringify(files)};`

--- a/rollup-plugin-docz-starter.ts
+++ b/rollup-plugin-docz-starter.ts
@@ -20,7 +20,7 @@ function doczStarter() {
             const docz = spawn('npx', ['docz', 'dev']);
             started = true;
 
-            docz.on('close', code => {
+            docz.on('close', (code) => {
                 console.log('📔 - Closing Docz...', code);
             });
         },

--- a/src/components/button/examples/button.tsx
+++ b/src/components/button/examples/button.tsx
@@ -54,7 +54,7 @@ export class ButtonExample {
             },
         ];
 
-        return controls.map(control => {
+        return controls.map((control) => {
             return (
                 <limel-switch
                     label={control.label}

--- a/src/components/checkbox/checkbox.template.tsx
+++ b/src/components/checkbox/checkbox.template.tsx
@@ -10,7 +10,9 @@ interface CheckboxTemplateProps {
     label?: string;
 }
 
-export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = props => {
+export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = (
+    props
+) => {
     return (
         <div class="mdc-form-field ">
             <div

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -248,7 +248,7 @@ export class ChipSet {
         this.mdcChipSet = new MDCChipSet(
             this.host.shadowRoot.querySelector('.mdc-chip-set')
         );
-        this.mdcChipSet.chips.forEach(chip => {
+        this.mdcChipSet.chips.forEach((chip) => {
             chip.shouldRemoveOnTrailingIconClick = false;
         });
 
@@ -403,7 +403,7 @@ export class ChipSet {
     }
 
     private handleInteractionEvent(event: MDCChipInteractionEvent) {
-        const chip = this.value.find(item => {
+        const chip = this.value.find((item) => {
             return `${item.id}` === event.detail.chipId;
         });
         this.emitInteraction(chip);
@@ -414,7 +414,7 @@ export class ChipSet {
     }
 
     private handleSelection(event: MDCChipSelectionEvent) {
-        let chip = this.value.find(item => {
+        let chip = this.value.find((item) => {
             return `${item.id}` === event.detail.chipId;
         });
         chip = { ...chip, selected: event.detail.selected };
@@ -426,7 +426,7 @@ export class ChipSet {
     }
 
     private removeChip(id: string | number) {
-        const newValue = this.value.filter(chip => {
+        const newValue = this.value.filter((chip) => {
             return `${chip.id}` !== `${id}`;
         });
         this.change.emit(newValue);

--- a/src/components/config/config.tsx
+++ b/src/components/config/config.tsx
@@ -21,7 +21,7 @@ export class Config {
      * Copy any config settings to the global config object
      */
     private setGlobalConfig() {
-        Object.keys(this.config).forEach(key => {
+        Object.keys(this.config).forEach((key) => {
             globalConfig[key] = this.config[key];
         });
     }

--- a/src/components/date-picker/pickers/MonthPicker.tsx
+++ b/src/components/date-picker/pickers/MonthPicker.tsx
@@ -110,7 +110,7 @@ export class MonthPicker extends Picker {
     private renderMonthsPicker(fp): any {
         return (
             <div className="datepicker-months-container">
-                {range(NBROFMONTHS).map(index => {
+                {range(NBROFMONTHS).map((index) => {
                     const renderedMonth = this.renderMonth(index, fp);
                     this.months.push(renderedMonth);
                     return renderedMonth;
@@ -139,7 +139,7 @@ export class MonthPicker extends Picker {
 
     private selectMonth(selectedDates, dateString, fp) {
         if (!this.nativePicker) {
-            this.months.forEach(month => {
+            this.months.forEach((month) => {
                 month.classList.remove('selected');
             });
 

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -92,7 +92,7 @@ export abstract class Picker {
     }
 
     private handleCloseForNativePicker(selectedDates) {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             setTimeout(() => {
                 const pickerDate = this.getPickerDate(selectedDates);
                 this.change.emit(pickerDate);
@@ -102,7 +102,7 @@ export abstract class Picker {
     }
 
     private handleCloseForFlatpickr(selectedDates) {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             // Since we allow manual editing of the input value, and
             // flatpickr only picks up these changes when the user presses
             // enter in the input, we need to check if the input string

--- a/src/components/date-picker/pickers/QuarterPicker.tsx
+++ b/src/components/date-picker/pickers/QuarterPicker.tsx
@@ -117,7 +117,7 @@ export class QuarterPicker extends Picker {
         const endQuarter = 5;
         return (
             <div className="datepicker-quarters-container">
-                {range(startQuarter, endQuarter).map(quarter => {
+                {range(startQuarter, endQuarter).map((quarter) => {
                     const renderedQuarter = this.renderQuarter(quarter, fp);
                     this.quarters.push(renderedQuarter);
                     return renderedQuarter;
@@ -152,14 +152,14 @@ export class QuarterPicker extends Picker {
                 .locale(this.getMomentLang())
                 .format('MMM');
         });
-        return months.map(month => {
+        return months.map((month) => {
             return <span className="datepicker-month-in-quarter">{month}</span>;
         });
     }
 
     private selectQuarter(selectedDates, dateString, fp) {
         if (!this.nativePicker) {
-            this.quarters.forEach(quarter => {
+            this.quarters.forEach((quarter) => {
                 quarter.classList.remove('selected');
             });
 

--- a/src/components/date-picker/pickers/YearPicker.tsx
+++ b/src/components/date-picker/pickers/YearPicker.tsx
@@ -80,7 +80,7 @@ export class YearPicker extends Picker {
         const yearsInterval = 5;
         return (
             <div className="datepicker-years-container">
-                {range(-yearsInterval, yearsInterval).map(index => {
+                {range(-yearsInterval, yearsInterval).map((index) => {
                     const year = moment().add(index, 'years');
                     const renderedYear = this.renderYear(year, fp);
                     this.years.push(renderedYear);
@@ -107,7 +107,7 @@ export class YearPicker extends Picker {
 
     private selectYear(selectedDates, dateString) {
         if (!this.nativePicker) {
-            this.years.forEach(year => {
+            this.years.forEach((year) => {
                 if (
                     dateString !== '' &&
                     selectedDates[0] &&

--- a/src/components/form/templates/common.ts
+++ b/src/components/form/templates/common.ts
@@ -71,7 +71,7 @@ function sortDataByProperties(data: any, properties: object) {
     }
 
     const newData = {};
-    Object.keys(properties).forEach(key => (newData[key] = data[key]));
+    Object.keys(properties).forEach((key) => (newData[key] = data[key]));
     return newData;
 }
 
@@ -90,7 +90,7 @@ function getRequiredEntry(data: any, subSchema: any) {
     if (!('required' in subSchema)) {
         return [null, null];
     }
-    const firstNonEmptyRequiredKey = Object.keys(data).find(key =>
+    const firstNonEmptyRequiredKey = Object.keys(data).find((key) =>
         subSchema.required.includes(key)
     );
     if (!firstNonEmptyRequiredKey) {
@@ -116,13 +116,13 @@ function findSubSchema(schema: any, formSchema: any) {
 function findSchemaTitle(value: any, schema: any) {
     if (isArrayType(schema) && schema.items.anyOf) {
         const titles = schema.items.anyOf
-            .filter(item => value.includes(item.const))
-            .map(item => item.title);
+            .filter((item) => value.includes(item.const))
+            .map((item) => item.title);
         return titles.join(', ');
     }
 
     if (schema.oneOf) {
-        return schema.oneOf.find(item => value === item.const).title;
+        return schema.oneOf.find((item) => value === item.const).title;
     }
 
     return value;

--- a/src/components/form/templates/field.ts
+++ b/src/components/form/templates/field.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const FieldTemplate = props => {
+export const FieldTemplate = (props) => {
     const { classNames, children } = props;
     return React.createElement(
         'div',

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -37,7 +37,7 @@ function renderCollapsibleField(props: ObjectFieldTemplateProps) {
 }
 
 function renderProperties(properties: ObjectFieldProperty[]) {
-    return properties.map(element => element.content);
+    return properties.map((element) => element.content);
 }
 
 function isCollapsible(schema: any) {

--- a/src/components/form/widgets/select.ts
+++ b/src/components/form/widgets/select.ts
@@ -46,7 +46,7 @@ export class Select extends React.Component {
         }
 
         if (isMultiple(event.detail)) {
-            const value = event.detail.map(option => option.value);
+            const value = event.detail.map((option) => option.value);
             props.onChange(value);
 
             return;

--- a/src/components/icon/examples/icon-finder.tsx
+++ b/src/components/icon/examples/icon-finder.tsx
@@ -86,9 +86,11 @@ export class IconFinder {
 
     private searchIcons() {
         this.icons = [];
-        this.indexedIcons.forEach(icon => {
-            this.value.forEach(search => {
-                const hits = icon.tags.filter(tag => tag.includes(search.text));
+        this.indexedIcons.forEach((icon) => {
+            this.value.forEach((search) => {
+                const hits = icon.tags.filter((tag) =>
+                    tag.includes(search.text)
+                );
                 if (hits.length || icon.id.includes(search.text)) {
                     this.icons.push(icon);
                 }

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -418,7 +418,7 @@ export class InputField {
             this.isFocused && (
                 <div class="autocomplete-list mdc-elevation-transition mdc-elevation--z4 mdc-menu-surface mdc-menu-surface--open">
                     <ul class="mdc-list">
-                        {filteredCompletions.map(completion => {
+                        {filteredCompletions.map((completion) => {
                             return (
                                 <li
                                     class="mdc-list-item"
@@ -446,7 +446,7 @@ export class InputField {
             return this.completions;
         }
         return this.completions.filter(
-            completion =>
+            (completion) =>
                 completion.toLowerCase().indexOf(filter.toLowerCase()) > -1
         );
     };

--- a/src/components/list/examples/list-checkbox-icons.tsx
+++ b/src/components/list/examples/list-checkbox-icons.tsx
@@ -59,7 +59,7 @@ export class ListCheckboxIconsExample {
     private selectedItems: ListItem[] = [];
 
     constructor() {
-        this.selectedItems = this.items.filter(item => {
+        this.selectedItems = this.items.filter((item) => {
             return !!item.selected;
         });
         this.handleChange = this.handleChange.bind(this);

--- a/src/components/list/examples/list-radio-button-icons.tsx
+++ b/src/components/list/examples/list-radio-button-icons.tsx
@@ -59,7 +59,7 @@ export class ListRadioButtonIconsExample {
     private selectedItem: ListItem;
 
     constructor() {
-        this.selectedItem = this.items.filter(item => {
+        this.selectedItem = this.items.filter((item) => {
             return !!item.selected;
         })[0];
         this.handleChange = this.handleChange.bind(this);

--- a/src/components/list/list-renderer.tsx
+++ b/src/components/list/list-renderer.tsx
@@ -31,11 +31,11 @@ export class ListRenderer {
         items = items || [];
         this.config = { ...this.defaultConfig, ...config };
 
-        this.twoLines = items.some(item => {
+        this.twoLines = items.some((item) => {
             return 'secondaryText' in item && !!item.secondaryText;
         });
 
-        this.hasIcons = items.some(item => {
+        this.hasIcons = items.some((item) => {
             return 'icon' in item && !!item.icon;
         });
 

--- a/src/components/list/radio-button/radio-button.template.tsx
+++ b/src/components/list/radio-button/radio-button.template.tsx
@@ -8,7 +8,9 @@ interface RadioButtonTemplateProps {
     label?: string;
 }
 
-export const RadioButtonTemplate: FunctionalComponent<RadioButtonTemplateProps> = props => {
+export const RadioButtonTemplate: FunctionalComponent<RadioButtonTemplateProps> = (
+    props
+) => {
     return (
         <div class="mdc-form-field">
             <div

--- a/src/components/menu/examples/menu.tsx
+++ b/src/components/menu/examples/menu.tsx
@@ -110,9 +110,9 @@ export class MenuExample {
         this.menuOpen = !this.menuOpen;
     };
 
-    private onSelect = event => {
+    private onSelect = (event) => {
         console.log('item selected', event.detail);
-        this.items = this.items.map(item => {
+        this.items = this.items.map((item) => {
             if (!('separator' in item)) {
                 item.disabled = item.text === event.detail.text;
             }

--- a/src/components/picker/examples/picker-empty-suggestions.tsx
+++ b/src/components/picker/examples/picker-empty-suggestions.tsx
@@ -84,7 +84,7 @@ export class PickerExample {
     }
 
     private search(query: string): Promise<ListItem[]> {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             if (query === '') {
                 // Simulate some network delay
                 setTimeout(() => {
@@ -93,7 +93,7 @@ export class PickerExample {
             }
             // Simulate some network delay
             setTimeout(() => {
-                const filteredItems = this.allItems.filter(item => {
+                const filteredItems = this.allItems.filter((item) => {
                     return item.text
                         .toLowerCase()
                         .includes(query.toLowerCase());

--- a/src/components/picker/examples/picker-icons.tsx
+++ b/src/components/picker/examples/picker-icons.tsx
@@ -169,13 +169,13 @@ export class PickerIconsExample {
     }
 
     private search(query: string): Promise<ListItem[]> {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             if (query === '') {
                 resolve([]);
             }
             // Simulate some network delay
             setTimeout(() => {
-                const filteredItems = this.allItems.filter(item => {
+                const filteredItems = this.allItems.filter((item) => {
                     const searchText =
                         item.text.toLowerCase() +
                         ' ' +

--- a/src/components/picker/examples/picker-multiple.tsx
+++ b/src/components/picker/examples/picker-multiple.tsx
@@ -82,7 +82,7 @@ export class PickerMultipleExample {
     }
 
     private search(query: string): Promise<ListItem[]> {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             // Simulate some network delay
             const NETWORK_DELAY = 500;
             setTimeout(() => {
@@ -92,7 +92,7 @@ export class PickerMultipleExample {
                     return;
                 }
 
-                const filteredItems = this.allItems.filter(item => {
+                const filteredItems = this.allItems.filter((item) => {
                     return item.text
                         .toLowerCase()
                         .includes(query.toLowerCase());

--- a/src/components/picker/examples/picker.tsx
+++ b/src/components/picker/examples/picker.tsx
@@ -83,13 +83,13 @@ export class PickerExample {
     }
 
     private search(query: string): Promise<ListItem[]> {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             if (query === '') {
                 resolve(this.allItems);
             }
             // Simulate some network delay
             setTimeout(() => {
-                const filteredItems = this.allItems.filter(item => {
+                const filteredItems = this.allItems.filter((item) => {
                     return item.text
                         .toLowerCase()
                         .includes(query.toLowerCase());

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -309,7 +309,7 @@ export class Picker {
     }
 
     private renderListResult() {
-        const hasIcons = this.items.some(item => {
+        const hasIcons = this.items.some((item) => {
             return 'icon' in item && !!item.icon;
         });
 
@@ -445,8 +445,8 @@ export class Picker {
         let newValue = null;
         if (this.multiple) {
             const chips = event.detail as Chip[];
-            newValue = chips.map(chip => {
-                return (this.value as ListItem[]).find(item => {
+            newValue = chips.map((chip) => {
+                return (this.value as ListItem[]).find((item) => {
                     return `${item.value}` === chip.id;
                 });
             });
@@ -529,7 +529,7 @@ export class Picker {
             this.items = result;
             if (this.multiple) {
                 const values = this.value as ListItem[];
-                this.items = result.filter(item => {
+                this.items = result.filter((item) => {
                     return !values.includes(item);
                 });
             }

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -83,7 +83,7 @@ export class Portal {
 
         this.container = document.createElement('div');
         this.container.setAttribute('id', this.containerId);
-        content.forEach(element => {
+        content.forEach((element) => {
             this.container.appendChild(element);
         });
     }
@@ -120,7 +120,7 @@ export class Portal {
             this.container.style.display = 'none';
         }
 
-        Object.keys(this.containerStyle).forEach(property => {
+        Object.keys(this.containerStyle).forEach((property) => {
             this.container.style[property] = this.containerStyle[property];
         });
     }

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -24,7 +24,9 @@ interface SelectTemplateProps {
     checkValid: boolean;
 }
 
-export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = props => {
+export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = (
+    props
+) => {
     let hasValue = !!props.value;
     if (isMultiple(props.value)) {
         hasValue = props.value.length > 0;
@@ -61,7 +63,7 @@ const SelectValue: FunctionalComponent<
     SelectTemplateProps & {
         hasValue: boolean;
     }
-> = props => {
+> = (props) => {
     const containerClassList = {
         'limel-select-trigger': true,
         'limel-select--focused': props.isOpen,
@@ -93,7 +95,7 @@ const SelectValue: FunctionalComponent<
     );
 };
 
-const HelperText: FunctionalComponent<{ text: string }> = props => {
+const HelperText: FunctionalComponent<{ text: string }> = (props) => {
     if (typeof props.text !== 'string') {
         return;
     }
@@ -108,7 +110,7 @@ const HelperText: FunctionalComponent<{ text: string }> = props => {
     );
 };
 
-const SelectDropdown: FunctionalComponent<SelectTemplateProps> = props => {
+const SelectDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
     if (props.native) {
         return <NativeDropdown {...props} />;
     }
@@ -116,7 +118,7 @@ const SelectDropdown: FunctionalComponent<SelectTemplateProps> = props => {
     return <MenuDropdown {...props} />;
 };
 
-const MenuDropdown: FunctionalComponent<SelectTemplateProps> = props => {
+const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
     const items = createMenuItems(props.options, props.value);
 
     return (
@@ -132,7 +134,7 @@ const MenuDropdown: FunctionalComponent<SelectTemplateProps> = props => {
     );
 };
 
-const NativeDropdown: FunctionalComponent<SelectTemplateProps> = props => {
+const NativeDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
     return (
         <select
             required={props.required}
@@ -144,7 +146,7 @@ const NativeDropdown: FunctionalComponent<SelectTemplateProps> = props => {
             disabled={props.disabled}
             multiple={props.multiple}
         >
-            {props.options.map(option => {
+            {props.options.map((option) => {
                 return (
                     <option
                         key={option.value}
@@ -166,7 +168,7 @@ function isSelected(option: Option, value: Option | Option[]): boolean {
     }
 
     if (isMultiple(value)) {
-        return value.some(o => option.value === o.value);
+        return value.some((o) => option.value === o.value);
     }
 
     return option.value === value.value;
@@ -176,7 +178,7 @@ function createMenuItems(
     options: Option[],
     value: Option | Option[]
 ): Array<ListItem<Option>> {
-    return options.map(option => {
+    return options.map((option) => {
         const selected = isSelected(option, value);
         const { text, disabled } = option;
 
@@ -195,7 +197,7 @@ function getSelectedText(value: Option | Option[]): string {
     }
 
     if (isMultiple(value)) {
-        return value.map(option => option.text).join(', ');
+        return value.map((option) => option.text).join(', ');
     }
 
     return value.text;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -228,7 +228,7 @@ export class Select {
 
         if (isMultiple(event.detail)) {
             const listItems: ListItem[] = event.detail;
-            const options: Option[] = listItems.map(item => item.value);
+            const options: Option[] = listItems.map((item) => item.value);
             this.change.emit(options);
 
             return;
@@ -287,7 +287,9 @@ export class Select {
                 return !!optionElement.selected;
             })
             .map((optionElement: HTMLOptionElement) => {
-                return this.options.find(o => o.value === optionElement.value);
+                return this.options.find(
+                    (o) => o.value === optionElement.value
+                );
             });
 
         if (this.multiple) {

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -114,7 +114,7 @@ export class Slider {
         this.mdcSlider.value = this.multiplyByFactor(this.value);
     }
 
-    private changeHandler = event => {
+    private changeHandler = (event) => {
         this.change.emit(event.detail.value / this.factor);
     };
 

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -91,7 +91,7 @@ export class Switch {
         }
     }
 
-    private onChange = event => {
+    private onChange = (event) => {
         event.stopPropagation();
         this.change.emit(event.target.checked);
     };

--- a/src/components/tab-bar/examples/tab-bar.tsx
+++ b/src/components/tab-bar/examples/tab-bar.tsx
@@ -75,7 +75,7 @@ export class TabBarExample {
 
     private onChange(event: CustomEvent<Tab>) {
         this.text = event.detail.text;
-        this.tabs = this.tabs.map(tab => {
+        this.tabs = this.tabs.map((tab) => {
             if (tab.id === event.detail.id) {
                 return event.detail;
             }

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -60,8 +60,8 @@ export class TabBar {
 
     @Watch('tabs')
     protected tabsChanged(newTabs: Tab[], oldTabs: Tab[]) {
-        const newIds = newTabs.map(tab => tab.id);
-        const oldIds = oldTabs.map(tab => tab.id);
+        const newIds = newTabs.map((tab) => tab.id);
+        const oldIds = oldTabs.map((tab) => tab.id);
 
         if (isEqual(newIds, oldIds)) {
             return;
@@ -107,7 +107,7 @@ export class TabBar {
 
     private handleTabActivated(event: MDCTabBarActivatedEvent) {
         const index = event.detail.index;
-        const oldSelectedTab = this.tabs.find(tab => tab.active === true);
+        const oldSelectedTab = this.tabs.find((tab) => tab.active === true);
 
         if (oldSelectedTab) {
             this.changeTab.emit({ ...oldSelectedTab, active: false });

--- a/src/components/tab-panel/examples/tab-panel.tsx
+++ b/src/components/tab-panel/examples/tab-panel.tsx
@@ -48,7 +48,7 @@ export class TabPanelExample {
     }
 
     private handleChangeTab(event: CustomEvent<Tab>) {
-        this.tabs = this.tabs.map(tab => {
+        this.tabs = this.tabs.map((tab) => {
             if (tab.id === event.detail.id) {
                 return event.detail;
             }

--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -65,7 +65,7 @@ export class TabPanel {
     }
 
     private setTabStatus(tab: Tab) {
-        const element = this.slotElements.find(e => e.id === tab.id);
+        const element = this.slotElements.find((e) => e.id === tab.id);
         if (!element) {
             return;
         }
@@ -80,7 +80,7 @@ export class TabPanel {
     }
 
     private handleChangeTabs(event: CustomEvent<Tab>) {
-        this.tabs = this.tabs.map(tab => {
+        this.tabs = this.tabs.map((tab) => {
             if (tab.id === event.detail.id) {
                 return event.detail;
             }

--- a/src/examples/example.tsx
+++ b/src/examples/example.tsx
@@ -36,13 +36,13 @@ export class Example {
         const path = this.path || type;
         const tsxUrl = `${BASE_URL}public/stencil/components/${path}/examples/${type}.tsx`;
 
-        this.fetchData(tsxUrl).then(tsxData => {
+        this.fetchData(tsxUrl).then((tsxData) => {
             this.tsxCode = prism.highlight(tsxData, prism.languages.tsx, 'tsx');
 
             const styleUrlMatch = tsxData.match(/styleUrl: '(.*)'/);
             if (styleUrlMatch) {
                 const scssUrl = `${BASE_URL}public/stencil/components/${path}/examples/${styleUrlMatch[1]}`;
-                this.fetchData(scssUrl).then(scssData => {
+                this.fetchData(scssUrl).then((scssData) => {
                     this.scssCode = prism.highlight(
                         scssData,
                         prism.languages.scss,
@@ -94,7 +94,7 @@ export class Example {
     }
 
     private fetchData(url) {
-        return fetch(url).then(data => {
+        return fetch(url).then((data) => {
             if (data.status === 404) { // tslint:disable-line:no-magic-numbers prettier
                 throw new Error('404');
             }

--- a/src/examples/props.tsx
+++ b/src/examples/props.tsx
@@ -23,7 +23,7 @@ export class Props {
     public componentWillLoad() {
         const type = this.name.replace('limel-', '');
         const url = `${BASE_URL}public/stencil/components/${type}/readme.md`;
-        this.fetchData(url).then(data => {
+        this.fetchData(url).then((data) => {
             this.propsTableHtml = this.converter.makeHtml(data);
         });
     }
@@ -33,7 +33,7 @@ export class Props {
     }
 
     private fetchData(url) {
-        return fetch(url).then(data => {
+        return fetch(url).then((data) => {
             return data.body
                 .getReader()
                 .read()

--- a/src/global/icon-cache.ts
+++ b/src/global/icon-cache.ts
@@ -29,7 +29,7 @@ export class IconCache {
      * Creates and returns a promise that will be resolved when SVG data is available
      */
     private getIcon(name, path) {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             if (!this.resolveFunctions[name]) {
                 this.resolveFunctions[name] = [];
                 this.fetchData(name, path);
@@ -78,7 +78,7 @@ export class IconCache {
      */
     private resolvePromises(name, svgData) {
         const resolves = this.resolveFunctions[name];
-        resolves.forEach(resolve => {
+        resolves.forEach((resolve) => {
             resolve(svgData);
         });
         this.resolveFunctions[name] = null;


### PR DESCRIPTION
Since version 1.9, Prettier has had an option to always wrap arrow function arguments with parentheses. In version 2.0, this behavior has become the default.

```js
// Input
const fn = (x) => y => x + y;

// Prettier 1.19
const fn = x => y => x + y;

// Prettier 2.0
const fn = (x) => (y) => x + y;
```

At first glance, avoiding parentheses in the isolated example above may look like a better choice because it results in less visual noise. However, when Prettier removes parentheses, it becomes harder to add type annotations, extra arguments, default values, or a variety of other things. Consistent use of parentheses provides a better developer experience when editing real codebases, which justifies the change.

You are encouraged to use the new default value, but if the old behavior is still preferred, please configure Prettier with { "arrowParens": "avoid" }.