### PR TITLE
fix(icon): remove unnecessary `console.error` logging

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -45,7 +45,7 @@ export class Icon {
             return;
         }
         const svgData = await this.loadSvg(name);
-        this.renderSvg(svgData, name);
+        this.renderSvg(svgData);
     }
 
     /**
@@ -65,15 +65,10 @@ export class Icon {
      * will remain the way they look in the file.
      * Therefore we inject the svg as inline markup instead.
      */
-    private renderSvg(svgData: string, name: string) {
+    private renderSvg(svgData: string) {
         const container = this.host.shadowRoot.querySelector('div.container');
         if (container) {
             container.innerHTML = svgData;
-        } else {
-            // tslint:disable-next-line:no-console
-            console.error(
-                `limel-icon: no container found when trying to render svg! icon: ${name}`
-            );
         }
     }
 }


### PR DESCRIPTION
While the `renderSvg` function is called too early, regularly if not always, it seems it always gets called again, making the icon appear correctly. Thus, the error-level logging is unnecessary.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS