### PR TITLE
feat(tabs): new tab-bar and tab-panel components

### DIFF
--- a/src/components/tab-bar/tab-bar.mdx
+++ b/src/components/tab-bar/tab-bar.mdx
@@ -6,8 +6,6 @@ menu: Components
 
 # Tab bar 
 
-### 🚧 This feature is work in progress. It can be tested out by setting the feature switch `enableTabs` 🚧
-
 <limel-props name="limel-tab-bar" />
 
 ## Example

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -3,10 +3,11 @@
 @import '@limetech/mdc-tab-scroller/mdc-tab-scroller';
 @import '@limetech/mdc-tab-indicator/mdc-tab-indicator';
 @import '@limetech/mdc-tab/mdc-tab';
+
 :host {
-  display: block;
+    display: block;
 }
 
 .mdc-tab-bar__icon {
-  margin-right: .5rem;
+    margin-right: .5rem;
 }

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -10,7 +10,6 @@ import {
 import { MDCTabBar, MDCTabBarActivatedEvent } from '@limetech/mdc-tab-bar';
 import { strings } from '@limetech/mdc-tab-bar/constants';
 import { Tab } from './tab.types';
-import config from '../../global/config';
 import { isEqual } from 'lodash-es';
 
 const { TAB_ACTIVATED_EVENT } = strings;
@@ -22,7 +21,7 @@ const { TAB_ACTIVATED_EVENT } = strings;
 })
 export class TabBar {
     @Element()
-    private element: HTMLElement;
+    private host: HTMLElement;
 
     /**
      * List of tabs to display
@@ -72,7 +71,7 @@ export class TabBar {
     }
 
     private setup() {
-        const element = this.element.shadowRoot.querySelector('.mdc-tab-bar');
+        const element = this.host.shadowRoot.querySelector('.mdc-tab-bar');
         if (!element) {
             return;
         }
@@ -83,7 +82,7 @@ export class TabBar {
         (this
             .mdcTabBar as any).foundation_.adapter_.getFocusedTabIndex = () => {
             const tabElements = this.getTabElements();
-            const activeElement = this.element.shadowRoot.activeElement;
+            const activeElement = this.host.shadowRoot.activeElement;
             return tabElements.indexOf(activeElement);
         };
 
@@ -96,9 +95,7 @@ export class TabBar {
     }
 
     private getTabElements() {
-        return [].slice.call(
-            this.element.shadowRoot.querySelectorAll('.mdc-tab')
-        );
+        return [].slice.call(this.host.shadowRoot.querySelectorAll('.mdc-tab'));
     }
 
     private setupListeners() {
@@ -117,11 +114,6 @@ export class TabBar {
     }
 
     public render() {
-        const featFlag = config.featureSwitches.enableTabs;
-        if (!featFlag) {
-            return;
-        }
-
         return (
             <div class="mdc-tab-bar" role="tablist">
                 <div class="mdc-tab-scroller">

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -20,20 +20,20 @@ const { TAB_ACTIVATED_EVENT } = strings;
     shadow: true,
 })
 export class TabBar {
-    @Element()
-    private host: HTMLElement;
-
     /**
      * List of tabs to display
      */
     @Prop()
     public tabs: Tab[];
 
-    private mdcTabBar: MDCTabBar;
-    private setupMdc = false;
-
     @Event()
     private changeTab: EventEmitter<Tab>;
+
+    @Element()
+    private host: HTMLElement;
+
+    private mdcTabBar: MDCTabBar;
+    private setupMdc = false;
 
     constructor() {
         this.handleTabActivated = this.handleTabActivated.bind(this);

--- a/src/components/tab-panel/tab-panel.mdx
+++ b/src/components/tab-panel/tab-panel.mdx
@@ -6,24 +6,17 @@ menu: Components
 
 # Tab panel 
 
-The `tab-panel` component uses the `tab-bar` component together with custom slotted components and will display the 
-content for the currently active tab. Each slotted component must have an id equal to the id of the tab
-it belongs to.
+The `tab-panel` component uses the `tab-bar` component together with custom slotted components and will display the content for the currently active tab. Each slotted component must have an id equal to the id of the corresponding tab it belongs to.
 
-The `tab-panel` component will automatically set each tab configuration on the corresponding slotted component as a
-property named `tab` so that the component can take action upon that. Sometimes it might be desirable to not load data
-or render anything until the tab is active. 
+The `tab-panel` component will automatically set each tab configuration on the corresponding slotted component as a property named `tab` so that the component can take action upon that. Sometimes it might be desirable to not load data or render anything until the tab is active. 
 
-The slotted components can also emit the `changeTab` event to update anything inside the actual tab, e.g. to change
-the icon, color or badge.
+The slotted components can also emit the `changeTab` event to update anything inside the actual tab, e.g. to change the icon, color or badge.
 
 <limel-props name="limel-tab-panel" />
 
 ## Example
 
-This example illustrates how to add custom components inside the `tab-panel`. Each component will simulate loading the
-data it needs once the tab has been activated and then display the actual content. If the button is pressed, the 
-component will emit the `changeTab` event to change the badge inside the corresponding tab.
+This example illustrates how to add custom components inside the `tab-panel`. Each component will simulate loading the data it needs once the tab has been activated and then display the actual content. If the button is pressed, the component will emit the `changeTab` event to change the badge inside the corresponding tab.
 
 <limel-example name="limel-example-tab-panel" />
 

--- a/src/components/tab-panel/tab-panel.mdx
+++ b/src/components/tab-panel/tab-panel.mdx
@@ -6,10 +6,8 @@ menu: Components
 
 # Tab panel 
 
-### 🚧 This feature is work in progress. It can be tested out by setting the feature switch `enableTabs` 🚧
-
 The `tab-panel` component uses the `tab-bar` component together with custom slotted components and will display the 
-content for the currently active tab. Each slotted component must have an id equal to the id of the corresponding tab
+content for the currently active tab. Each slotted component must have an id equal to the id of the tab
 it belongs to.
 
 The `tab-panel` component will automatically set each tab configuration on the corresponding slotted component as a
@@ -31,6 +29,6 @@ component will emit the `changeTab` event to change the badge inside the corresp
 
 ### Custom component
 
-This is the component that is used for each tab in the example above.
+This is the component that is used in the panel for each tab in the example above.
 
 <limel-example name="limel-example-tab-panel-content" path="tab-panel" code-only={true} />

--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -20,11 +20,11 @@ export class TabPanel {
     @Prop({ mutable: true })
     public tabs: Tab[] = [];
 
-    @Element()
-    private host: HTMLElement;
-
     @Event()
     protected changeTab: EventEmitter<Tab>;
+
+    @Element()
+    private host: HTMLElement;
 
     private slotElements: HTMLElement[];
 

--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -10,7 +10,8 @@ import {
 import { Tab } from '../tab-bar/tab.types';
 
 /**
- * @slot - Content to put inside the `tab-panel`. Each slotted element must have the `id` attribute equal to the id of the tab it belongs to.
+ * @slot - Content to put inside the `tab-panel`. Each slotted element must
+ *         have the `id` attribute equal to the id of the tab it belongs to.
  */
 @Component({
     tag: 'limel-tab-panel',


### PR DESCRIPTION
There are no more tasks right now for the tab-bar and tab-panel and the interfaces are probably how we want them, so we can probably remove the feature switches now :slightly_smiling_face: 

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS