### PR TITLE
fix(badge): make badges with one digit appear like a full circle

### DIFF
--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -5,9 +5,8 @@
  * @prop --badge-text-color: badge text color
  */
 
-
 :host {
-  display: block;
+    display: block;
 }
 
 * {

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -10,6 +10,10 @@
   display: block;
 }
 
+* {
+    box-sizing: border-box;
+}
+
 .badge-container {
     display: inline-block;
     font-size: pxToRem(11);

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -12,14 +12,14 @@
 
 .badge-container {
     display: inline-block;
-    font-size: 0.7rem;
-    min-width: 1.2rem;
-    height: 1.2rem;
-    border-radius: 1.2rem;
-    line-height: 1.2rem;
+    font-size: pxToRem(11);
+    min-width: pxToRem(20);
+    height: pxToRem(20);
+    border-radius: pxToRem(20);
+    line-height: pxToRem(20);
     text-align: center;
     background-color:  var(--badge-background-color, #EEF1F5);
     color:  var(--badge-text-color, #7D899C);
-    padding: 0 0.3rem;
-    margin-left: 0.25rem;
+    padding: 0 pxToRem(5);
+    margin-left: pxToRem(4);
 }

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -9,6 +9,10 @@
     display: block;
 }
 
+:host([hidden]) {
+    display: none;
+}
+
 * {
     box-sizing: border-box;
 }


### PR DESCRIPTION
Badges that have only 1 digit had a stretched shape. This both looks unusual and wastes a bit of space.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS