### PR TITLE
Improve chip styles

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -33,7 +33,7 @@ $mdc-text-field-fullwidth-bottom-line-color: $lime-text-field-bottom-line-color;
 
 limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     background-color: var(--icon-background-color, transparent);
-    margin-left: pxToRem(-12) !important;
+    margin-left: pxToRem(-11) !important;
     color: var(--icon-color, rgba(0,0,0,.54));
 }
 

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -53,8 +53,29 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     }
 }
 
-.mdc-chip__icon--trailing svg {
-    display: block;
+.mdc-chip__icon {
+    &.mdc-chip__icon--trailing {
+        margin-left: pxToRem(8);
+        margin-right: pxToRem(-8);
+        transition: background-color .2s ease;
+
+        width: pxToRem(22);
+        height: pxToRem(22);
+
+        &:hover {
+            background-color: rgba($lime-deep-red, .2);
+
+            svg {
+                transform: scale(.7);
+            }
+        }
+
+        svg {
+            transition: transform .2s ease;
+            display: block;
+            transform: scale(.9);
+        }
+    }
 }
 
 .mdc-text-field {


### PR DESCRIPTION
These changes align leading icons more correctly within the chips, since they are slightly smaller than the chip itself, then there should be equal margin around the chip:
old: <img width="303" alt="Screen Shot 2020-04-02 at 13 42 50" src="https://user-images.githubusercontent.com/35954987/78245523-e535d800-74e7-11ea-9764-8291a30dcc66.png">
 new:<img width="214" alt="Screen Shot 2020-04-02 at 13 35 59" src="https://user-images.githubusercontent.com/35954987/78245136-37c2c480-74e7-11ea-9c10-82a8b2f8ef7d.png">

... and also makes the remove (x) buttons on chips better:
<img width="222" alt="Screen Shot 2020-04-02 at 13 40 16" src="https://user-images.githubusercontent.com/35954987/78245280-82444100-74e7-11ea-9aa0-9f0d7e4c5b12.png">


It's hard to know whether the cursor is hovering the (x) buttons that remove chips, or whether it's hovering the chip itself. These two of course result in totally different consequences. Therefore it's important to give proper feedback to users, when they hover on the (x) buttons. Also, since their previous size was too small, it was really hard to target them on touch screen devices. Now increased size makes it slightly easier.



### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS