### PR TITLE
Better tabs, inspired by Chrome

### DIFF
--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -4,10 +4,102 @@
 @import '@limetech/mdc-tab-indicator/mdc-tab-indicator';
 @import '@limetech/mdc-tab/mdc-tab';
 
+$tab-content-background-color: #fff;
+$tab-background-color: #f6f6f7;
+$tab-border-radius: .65rem;
+$tab-active-outer-edge-curve-size: .75rem;
+$tab-separator-width: .125rem;
+$tab-separator-background-color: #e8e8ea;
+
 :host {
     display: block;
 }
 
 .mdc-tab-bar__icon {
     margin-right: .5rem;
+}
+
+.mdc-tab-indicator {
+    .mdc-tab-indicator__content  {
+        border: none;
+    }
+}
+
+.mdc-tab-scroller__scroll-content {
+    padding: .5rem $tab-active-outer-edge-curve-size 0 $tab-active-outer-edge-curve-size;
+    background-color: $tab-background-color;
+}
+
+.mdc-tab__ripple {
+    box-sizing: border-box;
+    border-radius: $tab-border-radius;
+    border: {
+        style: solid;
+        color: transparent;
+        width: .25rem;
+    };
+    opacity: .7;
+
+    &:before,
+    &:after {
+        transition: background-color .2s ease;
+    }
+}
+
+.mdc-tab {
+    border-radius:0;
+}
+
+.mdc-tab {
+    background-color: transparent;
+
+    &:not(.mdc-tab--active) {
+        &:after {
+            content: '';
+            display: block;
+            background-color: $tab-separator-background-color;
+            width: $tab-separator-width;
+            height: 1rem;
+            margin: auto;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            border-radius: 1rem;
+            right: -$tab-separator-width;
+        }
+
+        &:last-of-type {
+            &:after {
+                display: none;
+            }
+        }
+    }
+}
+
+.mdc-tab--active {
+    border-radius: $tab-border-radius $tab-border-radius 0 0;
+    background-color: $tab-content-background-color;
+    z-index: 2;
+
+    &:before,
+    &:after {
+        content: '';
+        display: block;
+        width: $tab-active-outer-edge-curve-size;
+        height: $tab-active-outer-edge-curve-size;
+        position: absolute;
+        bottom: 0;
+        background-color: $tab-content-background-color;
+
+        -webkit-mask-image: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2' clip-rule='evenodd' viewBox='0 0 50 50'><defs/><path d='M0 0c0 27.594 22.406 50 50 50H0V0z'/></svg>"); //For chrome and Safari the browser prefix is needed. (last checked Apr 2020)
+        mask-image: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2' clip-rule='evenodd' viewBox='0 0 50 50'><defs/><path d='M0 0c0 27.594 22.406 50 50 50H0V0z'/></svg>");
+    }
+
+    &:before {
+        left: -$tab-active-outer-edge-curve-size;
+        transform: rotateY(180deg);
+    }
+    &:after {
+        right: -$tab-active-outer-edge-curve-size;
+    }
 }

--- a/src/components/tab-panel/examples/tab-panel.scss
+++ b/src/components/tab-panel/examples/tab-panel.scss
@@ -1,7 +1,9 @@
+$tab-content-background-color: #fff;
+
 limel-example-tab-panel-content {
     display: flex;
     height: 10rem;
-    background-color: #eee;
+    background-color: $tab-content-background-color;
     justify-content: center;
     align-items: center;
 }


### PR DESCRIPTION
fix Lundalogik/lime-elements#690

Vanilla tabs from Material Design have two major problems. Firstly, they are ugly and lifeless, too flat and rigid. Secondly, the active tab indicator (the accented bottom border) is not a decent visual sign to indicate which tab is active. It looks like a divider, but what you want to do is actually connecting the active tab to its contents, not separating it from its contents, using a divider. A better UI design for tabs is actually something similar to what Google Chrome has. In Chrome, the active tab is visually distinct due to its background color, therefore users notice it directly. It also looks connected to what is rendered below it, with a minimalist design.
**GIF Example: Tab Bar**
![tab-bar](https://user-images.githubusercontent.com/35954987/78374963-6cf51280-75cc-11ea-87b7-953ad5e1dbac.gif)

**GIF Example: Tab Panel**
![tab-panel](https://user-images.githubusercontent.com/35954987/78374975-70889980-75cc-11ea-99b6-22ee51c26f3a.gif)

Here I tried to do the same thing inspired by Google Chrome, also taking into account the upcoming dark-mode. 

Dark mode will require proper usage of css variables on visual elements that can dynamically switch colors. This is specially important for outer curved edges on the active tab; which were pretty tricky to make with pure css. 

**Note** that in this PR, I'm not using css variables, and rather use colors as sass variables, copied as HEX directly from our paletts. The reason is that we still haven't started the dark-mode project, and need to do some finalization / optimization in our palettes.


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
