### PR TITLE
fix: reduce margin-top in mdc-chip-set-input

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -55,7 +55,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     }
 
     &.mdc-chip-set--input {
-        margin-top: pxToRem(20);
+        margin-top: pxToRem(12);
         width: 100%;
 
         .mdc-chip--selected {


### PR DESCRIPTION
to make this element work fine with other elements on the screen.

Before
![Screen Shot 2020-04-14 at 15 24 39](https://user-images.githubusercontent.com/35954987/79232203-7e110f80-7e67-11ea-8ea2-4ead8459952b.png)

After:
![Screen Shot 2020-04-14 at 15 49 30](https://user-images.githubusercontent.com/35954987/79232361-b6185280-7e67-11ea-8ad1-5c2c7dd2e701.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
