### PR TITLE
fix(picker): handle updates to the `searcher` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cm": "git-cz",
     "dev": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --docs\"",
     "watch": "shx rm -rf .docz/ && cross-env-shell SASS_PATH=node_modules \"stencil build --dev --watch --docs\"",
+    "watch:prod": "shx rm -rf .docz/ && cross-env-shell SASS_PATH=node_modules \"stencil build --watch --docs\"",
     "docz:build": "npm run dev && docz build && cross-env-shell NODE_ENV=prod SASS_PATH=node_modules \"stencil build --docs --config stencil.config.docs.ts\"",
     "docz:publish": "node publish-docs.js",
     "lint": "npm run lint:src && npm run lint:specs && npm run lint:examples && npm run lint:config",

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -147,16 +147,6 @@ export class Picker {
         this.portalId = createRandomString();
     }
 
-    @Watch('value')
-    public onChangeValue(newValue = [], oldValue = []) {
-        this.chips = this.createChips(this.value);
-        if (newValue.length <= oldValue.length) {
-            return;
-        }
-
-        this.chipSet?.setFocus(true);
-    }
-
     public componentDidLoad() {
         this.debouncedSearch = AwesomeDebouncePromise(
             this.searcher,
@@ -211,6 +201,16 @@ export class Picker {
             />,
             <div class="mdc-menu-surface--anchor">{this.renderDropdown()}</div>,
         ];
+    }
+
+    @Watch('value')
+    protected onChangeValue(newValue = [], oldValue = []) {
+        this.chips = this.createChips(this.value);
+        if (newValue.length <= oldValue.length) {
+            return;
+        }
+
+        this.chipSet?.setFocus(true);
     }
 
     private createChips(value: ListItem | ListItem[]): Chip[] {

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -129,7 +129,7 @@ export class Picker {
     // should not trigger a re-render by itself.
     private chipSetEditMode = false;
 
-    private debouncedSearch;
+    private debouncedSearch: Searcher;
     private chipSet: HTMLLimelChipSetElement;
     private portalId: string;
 
@@ -143,15 +143,13 @@ export class Picker {
         this.handleListChange = this.handleListChange.bind(this);
         this.handleStopEditAndBlur = this.handleStopEditAndBlur.bind(this);
         this.handleSurfaceDismissed = this.handleSurfaceDismissed.bind(this);
+        this.createDebouncedSearcher = this.createDebouncedSearcher.bind(this);
 
         this.portalId = createRandomString();
     }
 
     public componentDidLoad() {
-        this.debouncedSearch = AwesomeDebouncePromise(
-            this.searcher,
-            SEARCH_DEBOUNCE
-        );
+        this.createDebouncedSearcher(this.searcher);
         this.chipSet = this.element.shadowRoot.querySelector(CHIP_SET_TAG_NAME);
         this.chips = this.createChips(this.value);
     }
@@ -211,6 +209,17 @@ export class Picker {
         }
 
         this.chipSet?.setFocus(true);
+    }
+
+    @Watch('searcher')
+    protected createDebouncedSearcher(newValue: Searcher) {
+        if (typeof newValue !== 'function') {
+            return;
+        }
+        this.debouncedSearch = AwesomeDebouncePromise(
+            newValue,
+            SEARCH_DEBOUNCE
+        );
     }
 
     private createChips(value: ListItem | ListItem[]): Chip[] {


### PR DESCRIPTION
A debounced version of the searcher function was created and stored when the component was created, but there was no handling of updates, and no handling for missing values. The debounced version will now only be created if the value of the `searcher` property is a function, and if the value is updated, a new debounced version will be created, replacing the old one.

re Lundalogik/crm-feature#1017

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Firefox

Linux:
- [x] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
