### PR TITLE
fix(chip-set): make chips truncate when their content is too long

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -27,6 +27,12 @@ $mdc-chip-background-color: #fff;
 .mdc-chip {
     background-color: $mdc-chip-background-color;
     @include is-elevated-clickable;
+    max-width: 100%;
+
+    span[role='gridcell'] {
+        // This is needed to force mdc-chip__text (which is inside this span) to truncate
+        min-width: 0;
+    }
 
     &:hover {
         background-color: $mdc-chip-background-color;
@@ -40,6 +46,7 @@ $mdc-chip-background-color: #fff;
 .mdc-chip__text {
     overflow: hidden;
     text-overflow: ellipsis;
+    display: block;
 }
 
 limel-icon.mdc-chip__icon.mdc-chip__icon--leading {


### PR DESCRIPTION
fix: Lundalogik/lime-elements#711

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
