### PR TITLE
New props for lists that need striped styles

### DIFF
--- a/src/components/list/examples/list-striped.tsx
+++ b/src/components/list/examples/list-striped.tsx
@@ -1,0 +1,30 @@
+import { ListItem } from '@limetech/lime-elements';
+import { Component, h } from '@stencil/core';
+
+@Component({
+    tag: 'limel-example-list-striped',
+    shadow: true,
+})
+export class StripedListExample {
+    private items: Array<ListItem<number>> = [
+        {
+            text: 'King of Tokyo',
+            secondaryText: '2-6 players',
+            value: 1,
+            disabled: true,
+        },
+        { text: 'Smash Up!', secondaryText: '2-4 players', value: 2 },
+        { text: 'Pandemic', secondaryText: '2-4 players', value: 3 },
+        { text: 'Catan', secondaryText: '3-4 players', value: 4 },
+        { text: 'Ticket to Ride', secondaryText: '2-5 players', value: 5 },
+    ];
+
+    public render() {
+        return (
+            <limel-list
+                items={this.items}
+                class="has-striped-rows has-interactive-items"
+            />
+        );
+    }
+}

--- a/src/components/list/list.mdx
+++ b/src/components/list/list.mdx
@@ -8,23 +8,32 @@ menu: Components
 
 <limel-props name="limel-list" />
 
+## Custom styles
+
+| Class name              | Description                                                                                     |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| `has-striped-rows`      | Adds distinct styling by which every other row (list item) gets a darker background.            |
+| `has-interactive-items` | Adds more affordance by applying an elevated visual effect on list item, when they are hovered. |
+
+
+
 ## Examples
 
 ### Basic list with separator
 
-<limel-example name="limel-example-list" /> 
+<limel-example name="limel-example-list" />
 
 ### List with secondary text
 
-<limel-example name="limel-example-list-secondary" path="list" /> 
+<limel-example name="limel-example-list-secondary" path="list" />
 
 ### List with selectable items
 
-<limel-example name="limel-example-list-selectable" path="list" /> 
+<limel-example name="limel-example-list-selectable" path="list" />
 
 ### List with icons
 
-<limel-example name="limel-example-list-icons" path="list" /> 
+<limel-example name="limel-example-list-icons" path="list" />
 
 ### List with badge icons
 
@@ -49,3 +58,12 @@ menu: Components
 ### List with action menu
 
 <limel-example name="limel-example-list-action" path="list" />
+
+### List with custom styles
+Adding the `has-striped-rows` class to the list will make the items more distinct by adding different background colors to even and odd rows.
+
+Also, by taking advantage of the `has-interactive-items`, hovering on a list item which is not `disabled` will display an elevated visual effect, giving it more affordance and a solid feeling of interactivity.
+
+**Note:** to get both effects, you need to apply both of these classes.
+
+<limel-example name="limel-example-list-striped" path="list" />

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -22,11 +22,10 @@
     display: none;
 }
 
-.mdc-list {
-    --mdc-theme-text-icon-on-background: var(--icon-color, rgb(157, 157, 157));
-    padding: 0;
-    border: 1px solid #f6f6f7;
-    border-radius: pxToRem(6);
+:host(.has-striped-rows) {
+    .mdc-list {
+        border: 1px solid #f6f6f7;
+    }
 
     .mdc-list-item {
         &:nth-child(even) {
@@ -35,13 +34,11 @@
         &:nth-child(odd) {
             background-color: rgba(#fafafb, 0.5);
         }
-        &:first-child {
-            border-radius: pxToRem(6) pxToRem(6) pxToRem(0) pxToRem(0);
-        }
-        &:last-child {
-            border-radius: pxToRem(0) pxToRem(0) pxToRem(6) pxToRem(6);
-        }
+    }
+}
 
+:host(.has-interactive-items) {
+    .mdc-list-item {
         &:not(.mdc-list-item--disabled) {
             @include is-flat-clickable();
             &:hover {
@@ -52,6 +49,21 @@
                     background-color: #fff;
                 }
             }
+        }
+    }
+}
+
+.mdc-list {
+    --mdc-theme-text-icon-on-background: var(--icon-color, rgb(157, 157, 157));
+    padding: 0;
+    border-radius: pxToRem(6);
+
+    .mdc-list-item {
+        &:first-child {
+            border-radius: pxToRem(6) pxToRem(6) pxToRem(0) pxToRem(0);
+        }
+        &:last-child {
+            border-radius: pxToRem(0) pxToRem(0) pxToRem(6) pxToRem(6);
         }
     }
 


### PR DESCRIPTION
Fix: Lundalogik/lime-elements#725

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
