### PR TITLE
Scrolling pickers and correct handling of label

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -323,7 +323,9 @@ export class ChipSet {
                         'mdc-text-field--disabled':
                             this.readonly || this.disabled,
                         'mdc-text-field--required': this.required,
-                        'force-float': !!(this.value.length || this.editMode),
+                        'mdc-floating-label--float-above': !!(
+                            this.value.length || this.editMode
+                        ),
                     }}
                     htmlFor="my-text-field"
                 >

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -142,7 +142,6 @@ export class Picker {
         this.handleInteract = this.handleInteract.bind(this);
         this.handleListChange = this.handleListChange.bind(this);
         this.handleStopEditAndBlur = this.handleStopEditAndBlur.bind(this);
-        this.handleSurfaceDismissed = this.handleSurfaceDismissed.bind(this);
         this.createDebouncedSearcher = this.createDebouncedSearcher.bind(this);
 
         this.portalId = createRandomString();
@@ -353,7 +352,6 @@ export class Picker {
             >
                 <limel-menu-surface
                     open={!!content}
-                    onDismiss={this.handleSurfaceDismissed}
                     style={{ '--menu-surface-width': '100%' }}
                 >
                     {content}
@@ -382,17 +380,6 @@ export class Picker {
 
         this.chipSet.emptyInput();
         this.textValue = '';
-        this.handleSearchResult('', []);
-    }
-
-    /**
-     * Reset text value and search result, when list got closed.
-     *
-     * @returns {void}
-     */
-    private handleSurfaceDismissed() {
-        this.textValue = '';
-        this.chipSet.setFocus(true);
         this.handleSearchResult('', []);
     }
 


### PR DESCRIPTION
fix #705 

This PR fixes:
- Keep the picker dropdown when scrolling
- Make the label "not floating" when first adding input text and then closing pickers/input chip sets

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
