### PR TITLE
fix(picker): ensure picker doesn't crash if its value is set to null

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -203,6 +203,8 @@ export class Picker {
     @Watch('value')
     protected onChangeValue(newValue = [], oldValue = []) {
         this.chips = this.createChips(this.value);
+        newValue = newValue || [];
+        oldValue = oldValue || [];
         if (newValue.length <= oldValue.length) {
             return;
         }

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -7,6 +7,10 @@
  * @returns {boolean} true if the element is a descendant of the parent element, false otherwise
  */
 export function isDescendant(element: Node, parent: Node) {
+    if (!parent) {
+        return false;
+    }
+
     if (parent.contains(element)) {
         return true;
     }


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
