### PR TITLE
fix(list): center-align contents of lists with or without secondary text

### DIFF
--- a/src/components/list/examples/list-secondary.tsx
+++ b/src/components/list/examples/list-secondary.tsx
@@ -15,6 +15,7 @@ export class SecondaryTextListExample {
         },
         { text: 'Smash Up!', secondaryText: '2-4 players', value: 2 },
         { text: 'Pandemic', secondaryText: '2-4 players', value: 3 },
+        { text: 'Memory', value: 3 },
         { text: 'Catan', secondaryText: '3-4 players', value: 4 },
         { text: 'Ticket to Ride', secondaryText: '2-5 players', value: 5 },
     ];

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -129,12 +129,20 @@
         }
     }
 
-    &.mdc-list--two-line.list--compact {
-        .mdc-list-item {
-            height: 4rem;
+    &.mdc-list--two-line {
+        .mdc-list-item__primary-text {
+            margin-top: pxToRem(-12);
+        }
+        .mdc-list-item__text {
+            align-self: center;
+        }
+        &.list--compact {
+            .mdc-list-item {
+                height: 4rem;
 
-            .mdc-list-item__text {
-                margin-top: pxToRem(-4);
+                .mdc-list-item__text {
+                    margin-top: pxToRem(-4);
+                }
             }
         }
     }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/740
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
