### PR TITLE
Transparent input field background

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -1,5 +1,6 @@
 @import '../../style/mixins';
 @import '../../style/internal/mdc-variables';
+@import '../input-field/input-field';
 
 $mdc-textarea-background: $mdc-theme-background;
 // $mdc-textarea-disabled-background: $mdc-theme-background;
@@ -13,8 +14,6 @@ $mdc-text-field-fullwidth-bottom-line-color: $lime-text-field-bottom-line-color;
 $mdc-chip-background-color: #fff;
 
 @import '@limetech/mdc-chips/mdc-chips';
-@import '@limetech/mdc-textfield/mdc-text-field';
-@import '@limetech/mdc-ripple/mdc-ripple';
 
 /**
  * @prop --icon-background-color: Background color of the icon. Defaults to transparent.
@@ -138,14 +137,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
             border-bottom-width: pxToRem(1);
         }
     }
-}
-
-.mdc-text-field:not(.mdc-text-field--disabled) {
-    background-color: var(--background-color, #ffffff);
-}
-
-.mdc-text-field--disabled:not(.mdc-text-field--textarea) {
-    background-color: var(--background-color-disabled, #fafafa);
 }
 
 .mdc-text-field--disabled .mdc-chip {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -287,7 +287,7 @@ export class ChipSet {
 
     private renderInputChips() {
         return (
-            <div
+            <label
                 class={{
                     'mdc-text-field': true,
                     'mdc-text-field--disabled': this.readonly || this.disabled,
@@ -330,7 +330,7 @@ export class ChipSet {
                     {this.label}
                 </label>
                 <div class="mdc-line-ripple" />
-            </div>
+            </label>
         );
     }
 

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -287,7 +287,7 @@ export class ChipSet {
 
     private renderInputChips() {
         return (
-            <label
+            <div
                 class={{
                     'mdc-text-field': true,
                     'mdc-text-field--disabled': this.readonly || this.disabled,
@@ -330,7 +330,7 @@ export class ChipSet {
                     {this.label}
                 </label>
                 <div class="mdc-line-ripple" />
-            </label>
+            </div>
         );
     }
 

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -35,7 +35,8 @@ $mdc-text-field-fullwidth-bottom-line-color: $lime-text-field-bottom-line-color;
     @include mdc-states-focus-opacity(0, true);
 }
 
-label {
+label,
+div {
     &.mdc-text-field {
         transition: background-color 0.2s ease;
 

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -35,6 +35,29 @@ $mdc-text-field-fullwidth-bottom-line-color: $lime-text-field-bottom-line-color;
     @include mdc-states-focus-opacity(0, true);
 }
 
+label {
+    &.mdc-text-field {
+        transition: background-color 0.2s ease;
+
+        &:not(.mdc-text-field--disabled) {
+            // this has to be written this way to be able to override MD styles
+            background-color: transparent;
+
+            &:hover {
+                background-color: #f1f1f3;
+            }
+        }
+
+        &.mdc-text-field--focused {
+            background-color: #f6f6f7;
+        }
+
+        &.mdc-text-field--disabled {
+            background-color: transparent;
+        }
+    }
+}
+
 .mdc-text-field__formatted_input {
     display: None;
 }

--- a/src/examples/example.scss
+++ b/src/examples/example.scss
@@ -5,6 +5,7 @@
     border-bottom-width: 0;
     border-radius: 5px 5px 0 0;
     padding: 1.5em;
+    background-color: #fafafb;
 }
 
 @media (min-width: 420px) {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/747

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
