### PR TITLE
chore(package): update @types/prismjs to version 1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@stencil/sass": "1.3.1",
     "@types/chart.js": "2.9.20",
     "@types/jest": "24.9.1",
-    "@types/prismjs": "^1.16.0",
+    "@types/prismjs": "^1.16.1",
     "@types/puppeteer": "1.19.1",
     "@types/react": "16.9.35",
     "commitizen": "4.1.2",


### PR DESCRIPTION
PR from Greenkeeper branch. The build failed because npm was having problems, so Greenkeeper never opened a PR.