### PR TITLE
feat(icon-button): show label for icon button on hover

### DIFF
--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -81,6 +81,7 @@ export class IconButton {
                 class={`mdc-icon-button`}
                 disabled={this.disabled}
                 aria-label={this.label}
+                title={this.label}
                 {...buttonAttributes}
             >
                 <limel-icon name={this.icon} {...iconAttributes} />


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/768

Use what's written in `area-label` as `title` to improve usability and make it easier to perceive buttons with unclear icons.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
