### PR TITLE
Make input labels truncate

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -27,6 +27,7 @@
 
     .mdc-floating-label {
         top: $floating-label-top-value;
+        right: pxToRem(8); //This is a hack to force the label truncate when container is too little. Otherwise due to position: absolute it won't. Kia
     }
 }
 

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -27,7 +27,9 @@
 
     .mdc-floating-label {
         top: $floating-label-top-value;
-        right: pxToRem(8); //This is a hack to force the label truncate when container is too little. Otherwise due to position: absolute it won't. Kia
+        right: pxToRem(
+            8
+        ); //This is a hack to force the label truncate when container is too little. Otherwise due to position: absolute it won't. Kia
     }
 }
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -42,6 +42,9 @@
 
         .mdc-floating-label {
             top: $floating-label-top-value;
+            right: pxToRem(
+                16
+            ); //This is a hack to force the label truncate when container is too little. Otherwise due to position: absolute it won't. Kia
             transform: translateY(-50%);
 
             &.mdc-floating-label--float-above {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/780

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
