### PR TITLE
fix(chip-set): styles when chip is selected

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -55,7 +55,12 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
         width: 100%;
 
         .mdc-chip--selected {
-            box-shadow: var(--button-shadow-pressed);
+            // When chip is selected with keyboard (backspace / arrow-keys) to be deleted
+            box-shadow: 0 0 0 pxToRem(3) var(--lime-deep-red);
+
+            .mdc-chip__icon--trailing {
+                color: var(--lime-deep-red);
+            }
         }
     }
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/782

Chips can be selected using keyboard (backspace / arrow-keys) to be deleted. No other action is possible, so the styles are focused on "Delete".

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
