### PR TITLE
fix(input-field): fix alignment input field with error icon

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -200,8 +200,7 @@ export class InputField {
             'mdc-text-field--invalid': this.isInvalid(),
             'mdc-text-field--disabled': this.disabled,
             'mdc-text-field--required': this.required,
-            'mdc-text-field--with-trailing-icon':
-                !!this.getIcon() && !!this.trailingIcon,
+            'mdc-text-field--with-trailing-icon': !!this.getIcon(),
             'mdc-text-field--with-leading-icon':
                 !!this.getIcon() && !!this.leadingIcon,
         };


### PR DESCRIPTION
fix: Lundalogik/lime-elements#783

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
