### PR TITLE
fix(input-field): sync invalid state to underlying mdctextfield

### DIFF
--- a/src/components/input-field/examples/input-field-error-icon.tsx
+++ b/src/components/input-field/examples/input-field-error-icon.tsx
@@ -7,25 +7,50 @@ const MIN_LENGTH = 6;
 })
 export class InputFieldErrorIconExample {
     @State()
-    private value;
+    private valueNative: string;
+
+    @State()
+    private valueConsumer: string;
 
     constructor() {
-        this.onChange = this.onChange.bind(this);
+        this.onChangeNative = this.onChangeNative.bind(this);
+        this.onChangeConsumer = this.onChangeConsumer.bind(this);
+        this.isInvalid = this.isInvalid.bind(this);
     }
 
     public render() {
-        return (
+        return [
             <limel-input-field
-                label="Text Field"
+                label="Text Field with native validation"
                 minlength={MIN_LENGTH}
                 helperText="Please enter at least 6 characters!"
-                value={this.value}
-                onChange={this.onChange}
-            />
-        );
+                value={this.valueNative}
+                onChange={this.onChangeNative}
+            />,
+            <limel-input-field
+                label="Text Field with consumer validation"
+                type={'email'}
+                invalid={this.isInvalid()}
+                helperText="Please enter an email with the domain 'test.com'"
+                value={this.valueConsumer}
+                onChange={this.onChangeConsumer}
+            />,
+        ];
     }
 
-    private onChange(event) {
-        this.value = event.detail;
+    private onChangeNative(event: CustomEvent<string>) {
+        this.valueNative = event.detail;
+    }
+    private onChangeConsumer(event: CustomEvent<string>) {
+        this.valueConsumer = event.detail;
+    }
+
+    private isInvalid() {
+        const substringLength = 9;
+        return !!(
+            this.valueConsumer &&
+            this.valueConsumer.substr(-substringLength, substringLength) !==
+                '@test.com'
+        );
     }
 }

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -188,6 +188,12 @@ export class InputField {
         }
     }
 
+    public componentDidUpdate() {
+        if (this.invalid) {
+            this.mdcTextField.valid = false;
+        }
+    }
+
     public render() {
         if (this.type === 'textarea') {
             return this.renderTextArea();


### PR DESCRIPTION
The mdcTextField will not respect the invalid class put onto the containing label component
and will instead reset the classes based on its own calculation of whether or not the component
is valid, likely based on native input attributes such as required and the type. This sync update
forces the mdcTextField into an invalid state if the invalid prop is set, otherwise it
lets mdcTextField determine if the component is valid or not.

## Steps to reproduce
* Pull master
* Get lime-elements into the browser somehow
* Insert `<limel-text-field invalid help-text="help text" value=""></limel-input-field>` into the dom
* The text field should be red signifying that it is invalid (since the invalid prop is set). 
* Click to focus the input field
* Click away to blur the input field
* Note that the red styling due to the invalid state is missing due to loss of focus. This is incorrect the red styling should remain since the invalid prop is set

fix #791

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
