### PR TITLE
fix(chip-set): render input really "hidden", when it's hidden.

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -121,7 +121,9 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
             // This class is added, as soon as there is a chip selected and displayed
             // This input field should not be visually visible as it breaks the UI in some cases
             // But it should be rendered to be able to tab between fields and do other keyboard commands /Kia
-            padding: 0;
+            opacity: 0;
+            position: absolute;
+            z-index: -100;
         }
     }
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/789

Use `position: absolut;`, `opacity: 0; `and `z-index: -100;`to really hide the input field and render it below all other chips which are visible.

Note
User doesn't have to click on the `<input>` itself to activate it. They click on the container of it -the picker- to activate the input field and make it `focused`.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
