### PR TITLE
fix(dialog): fix broken max-height, so that dialog is never taller than viewport

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -1,7 +1,6 @@
 @import '../../style/internal/mdc-variables';
 
-$mdc-dialog-max-width: false;
-$mdc-dialog-max-height: false;
+$mdc-dialog-max-width: null;
 @import '@limetech/mdc-dialog/mdc-dialog';
 
 /**
@@ -19,30 +18,27 @@ slot[name='header'] {
 }
 
 .mdc-dialog {
-    .mdc-dialog__container {
-        width: var(--dialog-width, auto);
-        height: var(--dialog-height, auto);
-        max-height: 100%;
+    @include mdc-dialog-max-width(1000rem, $mdc-dialog-margin);
 
-        &.full-screen {
-            width: 100%;
+    &.full-screen {
+        @include mdc-dialog-max-height(1000rem, $mdc-dialog-margin);
+        .mdc-dialog__container {
             height: 100%;
+            width: 100%;
 
             .mdc-dialog__surface {
                 height: 100%;
+                width: 100%;
             }
         }
     }
+    .mdc-dialog__container {
+        height: 100%;
+    }
 
     .mdc-dialog__surface {
-        width: 100%;
-        height: 100%;
-
-        .mdc-dialog__body--scrollable {
-            max-height: inherit;
-            border: 0;
-            overflow: auto;
-        }
+        width: var(--dialog-width, auto);
+        height: var(--dialog-height, auto);
     }
 
     .mdc-dialog__title {

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -124,18 +124,17 @@ export class Dialog {
     public render() {
         return (
             <div
-                class="mdc-dialog"
+                class={{
+                    'mdc-dialog': true,
+                    'full-screen': !!this.fullscreen,
+                }}
                 role="alertdialog"
                 aria-modal="true"
                 aria-labelledby={'limel-dialog-title-' + this.id}
                 aria-describedby={'limel-dialog-content-' + this.id}
             >
                 <input hidden={true} id="initialFocusEl" />
-                <div
-                    class={`mdc-dialog__container ${
-                        this.fullscreen ? 'full-screen' : ''
-                    }`}
-                >
+                <div class="mdc-dialog__container">
                     <div class="mdc-dialog__surface">
                         {this.renderHeading()}
                         <div


### PR DESCRIPTION
This modifies how we set `height`, `max-height`, `width`, and `max-width`, so that we better conform to how MDC is setting those values.

fix #786

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
