### PR TITLE
perf(button): hide spinners to avoid constantly running animations

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -20,6 +20,7 @@ button {
 
     limel-spinner {
         opacity: 0;
+        display: none;
         position: absolute;
     }
 
@@ -54,6 +55,7 @@ button {
         }
         limel-spinner {
             opacity: 1;
+            display: block;
         }
     }
 
@@ -64,6 +66,9 @@ button {
         }
         svg {
             opacity: 1;
+        }
+        limel-spinner {
+            display: block;
         }
     }
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/808

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
