### PR TITLE
test(form): add e2e-tests for limel-form

### DIFF
--- a/src/components/form/widgets/input-field.e2e.ts
+++ b/src/components/form/widgets/input-field.e2e.ts
@@ -1,0 +1,78 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('form input-field', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    const schema = {
+        title: 'Registration form',
+        type: 'object',
+        properties: {
+            name: {
+                type: 'string',
+                title: 'Name',
+                default: '',
+                description: 'Enter your heroic name',
+            },
+        },
+    };
+    const props = { schema };
+
+    await page.setContent('<div></div>');
+    await page.$eval('div', (elm: any, { schema }) => {
+        const form = document.createElement('limel-form');
+        form.schema = schema;
+        elm.appendChild(form);
+    }, props);
+
+    await page.waitForChanges();
+    const form = await page.find('limel-form');
+    expect(form).toHaveClass('hydrated');
+
+    const limelInput = await page.find('limel-form >>> limel-input-field');
+    expect(limelInput).toHaveClass('hydrated');
+
+    await page.waitForChanges();
+    await page.waitForChanges();
+    await page.waitForChanges();
+    const inp = await form.find('limel-input-field >>> .mdc-text-field__input');
+    console.log('input', inp, '\n\n-----\n\n-----\n\n-----\n\n');
+    console.log('\n\n-----\n\n-----\n\n-----\n\n');
+
+    // expect(form).toEqualHtml('<limel-input-field></limel-input-field>');
+    // expect(limelInput).toEqualHtml('<limel-input-field></limel-input-field>');
+    expect(inp).toEqualHtml('<limel-input-field></limel-input-field>');
+
+    // console.log('limel-form', form.nodeName);
+    // console.log('div', form.shadowRoot.childNodes[0].nodeName);
+    // console.log('form', form.shadowRoot.childNodes[0].childNodes[0].nodeName);
+    // console.log('div', form.shadowRoot.childNodes[0].childNodes[0].childNodes[0].nodeName);
+    // console.log('div', form.shadowRoot.childNodes[0].childNodes[0].childNodes[0].childNodes[0].nodeName);
+    // console.log('h1', form.shadowRoot.childNodes[0].childNodes[0].childNodes[0].childNodes[0].childNodes[0].nodeName);
+    // console.log('div', form.shadowRoot.childNodes[0].childNodes[0].childNodes[0].childNodes[0].childNodes[1].nodeName);
+    // console.log('limel-input-field', form.shadowRoot.childNodes[0].childNodes[0].childNodes[0].childNodes[0].childNodes[1].childNodes[0].nodeName);
+    // // console.log('limel-input-field', limelInput.nodeName);
+    // console.log('label', limelInput.shadowRoot.childNodes[0].nodeName);
+    // console.log('input', limelInput.shadowRoot.childNodes[0].childNodes[0], '----\n\n');
+    //
+    // const input = limelInput.shadowRoot.childNodes[0].childNodes[0];
+    //
+    // console.log('input', input);
+
+    // let value = await input.getProperty('value');
+    // expect(value).toBe('');
+    //
+    // await input.press('8');
+    // await input.press('8');
+    // await input.press(' ');
+    //
+    // await page.keyboard.down('Shift');
+    // await input.press('KeyM');
+    // await input.press('KeyP');
+    // await input.press('KeyH');
+    // await page.keyboard.up('Shift');
+
+    await page.waitForChanges();
+    let value2 = await limelInput.getProperty('value');
+    expect(value2).toBe('88 MPH');
+  });
+});

--- a/src/components/form/widgets/input-field.e2e.ts
+++ b/src/components/form/widgets/input-field.e2e.ts
@@ -38,9 +38,20 @@ describe('form input-field', () => {
     console.log('input', inp, '\n\n-----\n\n-----\n\n-----\n\n');
     console.log('\n\n-----\n\n-----\n\n-----\n\n');
 
-    // expect(form).toEqualHtml('<limel-input-field></limel-input-field>');
-    // expect(limelInput).toEqualHtml('<limel-input-field></limel-input-field>');
-    expect(inp).toEqualHtml('<limel-input-field></limel-input-field>');
+    // await page.debugger();
+
+    await page.$eval('div', () => {
+        const input = document.querySelector('limel-form').shadowRoot.querySelector('limel-input-field').shadowRoot.querySelector('input');
+        input.focus();
+        const eventA = new KeyboardEvent('keypress', {
+            bubbles: true,
+            cancelable: true,
+            code: 'KeyA',
+            composed: true,
+            key: 'a',
+        });
+        input.dispatchEvent(eventA);
+    });
 
     // console.log('limel-form', form.nodeName);
     // console.log('div', form.shadowRoot.childNodes[0].nodeName);
@@ -73,6 +84,6 @@ describe('form input-field', () => {
 
     await page.waitForChanges();
     let value2 = await limelInput.getProperty('value');
-    expect(value2).toBe('88 MPH');
+    expect(value2).toBe('a');
   });
 });

--- a/src/components/input-field/examples/input-field-text.tsx
+++ b/src/components/input-field/examples/input-field-text.tsx
@@ -38,6 +38,7 @@ export class InputFieldTextExample {
                 invalid={this.invalid}
                 disabled={this.disabled}
                 onChange={this.changeHandler}
+                onKeyPress={(event) => console.log(event)}
             />,
             <p>
                 <limel-flex-container justify="end">


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
