### PR TITLE
fix(limel-select): ensure select element don't crash when it's list element doesn't exist

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -204,7 +204,7 @@ export class Select {
             const list: HTMLElement = document.querySelector(
                 `#${this.portalId} limel-menu-surface limel-list`
             );
-            const firstItem: HTMLElement = list.shadowRoot.querySelector(
+            const firstItem: HTMLElement = list?.shadowRoot?.querySelector(
                 '[tabindex]'
             );
 


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
