### PR TITLE
feat(table): add support for local and remote sorting

### DIFF
--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -1,4 +1,4 @@
-import { Column } from './table.types';
+import { Column, ColumnSorter } from './table.types';
 
 /**
  * Create Tabulator column definitions from a limel-table column configuration
@@ -79,3 +79,28 @@ export function createCustomComponent(
 
     return element;
 }
+
+// Tabulator seems to also have this `field` property, that does not appear on
+// the interface for some reason
+interface TabulatorSorter extends Tabulator.Sorter {
+    field: string;
+}
+
+/**
+ * Create a column sorter from a tabulator sorter
+ *
+ * @param {Column[]} columns all available columns in the table
+ *
+ * @return {Function} function that creates a sorter from a tabulator sorter
+ */
+export const createColumnSorter = (columns: Column[]) => (
+    sorter: TabulatorSorter
+): ColumnSorter => {
+    const column = columns.find((col) => col.field === sorter.field);
+    const direction = sorter.dir.toUpperCase() as 'ASC' | 'DESC';
+
+    return {
+        column: column,
+        direction: direction,
+    };
+};

--- a/src/components/table/examples/table-local.tsx
+++ b/src/components/table/examples/table-local.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column, ColumnSorter } from '../table.types';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 
@@ -14,10 +14,14 @@ export class TableExampleLocal {
     @State()
     private currentPage: number = 1;
 
+    @State()
+    private currentSorting: string = 'None';
+
     private pageSize = 10;
 
     constructor() {
         this.handleChangePage = this.handleChangePage.bind(this);
+        this.handleSort = this.handleSort.bind(this);
     }
 
     public componentWillLoad() {
@@ -43,6 +47,10 @@ export class TableExampleLocal {
         this.currentPage = event.detail;
     }
 
+    private handleSort(event: CustomEvent<ColumnSorter[]>) {
+        this.currentSorting = event.detail[0].column.title;
+    }
+
     public render() {
         return [
             <limel-table
@@ -50,8 +58,10 @@ export class TableExampleLocal {
                 columns={this.columns}
                 pageSize={this.pageSize}
                 onChangePage={this.handleChangePage}
+                onSort={this.handleSort}
             />,
             <p>Current page is: {this.currentPage}</p>,
+            <p>Currently sorting on: {this.currentSorting}</p>,
         ];
     }
 }

--- a/src/components/table/examples/table-remote.tsx
+++ b/src/components/table/examples/table-remote.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column, TableParams } from '../table.types';
+import { Column, TableParams, ColumnSorter } from '../table.types';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 
@@ -46,11 +46,31 @@ export class TableExampleRemote {
 
     private handleLoad(event: CustomEvent<TableParams>) {
         console.log('Loading new data', event.detail);
+        const sorter = event.detail.sorters[0];
 
         this.currentPage = event.detail.page;
+        if (sorter) {
+            this.allData = [...data].sort(this.compareBy(sorter));
+        }
 
         this.loadData();
     }
+
+    /**
+     * This will only handle how to compare strings. This means the two number
+     * columns in the example will not be sorted in the correct way
+     */
+    private compareBy = (sorter: ColumnSorter) => (a: Bird, b: Bird) => {
+        const column = sorter.column;
+        const fieldA = a[column.field];
+        const fieldB = b[column.field];
+
+        if (sorter.direction === 'ASC') {
+            return String(fieldA).localeCompare(String(fieldB));
+        }
+
+        return String(fieldB).localeCompare(String(fieldA));
+    };
 
     /**
      * Simulate some network delay, like loading data from a server

--- a/src/components/table/table.mdx
+++ b/src/components/table/table.mdx
@@ -26,10 +26,10 @@ menu: Components
 
 <limel-example name="limel-example-table-food" path="table" code-only={true}/>
 
-## Local pagination
+## Local sorting and pagination
 
 <limel-example name="limel-example-table-local" path="table"/>
 
-## Remote pagination
+## Remote sorting and pagination
 
 <limel-example name="limel-example-table-remote" path="table"/>

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -51,9 +51,26 @@ export interface TableComponent<T extends object = any> {
     data?: T;
 }
 
+export interface ColumnSorter {
+    /**
+     * The column being sorted
+     */
+    column: Column;
+
+    /**
+     * The direction to sort on
+     */
+    direction: 'ASC' | 'DESC';
+}
+
 export interface TableParams {
     /**
      * The current page being set
      */
     page: number;
+
+    /**
+     * Sorters applied to the current page
+     */
+    sorters?: ColumnSorter[];
 }


### PR DESCRIPTION
requires #829

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
