### PR TITLE
Add `'nb'` for Norsk Bokmål as permitted language option for date-picker

### DIFF
--- a/src/components/date-picker/date.types.ts
+++ b/src/components/date-picker/date.types.ts
@@ -7,4 +7,4 @@ export type DateType =
     | 'quarter'
     | 'year';
 
-export type Languages = 'en' | 'sv' | 'no' | 'fi' | 'da';
+export type Languages = 'da' | 'en' | 'fi' | 'no' | 'sv';

--- a/src/components/date-picker/date.types.ts
+++ b/src/components/date-picker/date.types.ts
@@ -7,4 +7,4 @@ export type DateType =
     | 'quarter'
     | 'year';
 
-export type Languages = 'da' | 'en' | 'fi' | 'no' | 'sv';
+export type Languages = 'da' | 'en' | 'fi' | 'nb' | 'no' | 'sv';

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -31,6 +31,7 @@ export abstract class Picker {
         this.handleClose = this.handleClose.bind(this);
         this.parseDate = this.parseDate.bind(this);
         this.formatDate = this.formatDate.bind(this);
+        this.getFlatpickrLang = this.getFlatpickrLang.bind(this);
     }
 
     public init(element: HTMLElement, container: HTMLElement, value?: Date) {
@@ -42,7 +43,9 @@ export abstract class Picker {
             parseDate: this.nativePicker ? undefined : this.parseDate,
             appendTo: container,
             defaultDate: value,
-            locale: FlatpickrLanguages[this.language] || FlatpickrLanguages.en,
+            locale:
+                FlatpickrLanguages[this.getFlatpickrLang()] ||
+                FlatpickrLanguages.en,
             getWeek: this.getWeek,
         };
         config = { ...config, ...this.getConfig(this.nativePicker) };
@@ -85,6 +88,10 @@ export abstract class Picker {
         } else {
             return this.handleCloseForFlatpickr(selectedDates);
         }
+    }
+
+    protected getFlatpickrLang() {
+        return this.language === 'nb' ? 'no' : this.language;
     }
 
     protected getMomentLang() {


### PR DESCRIPTION
`no` is a non-standard option used in a lot of Lime CRM databases. We convert `no` to `nb` already,
but we should of course also support using the standard language code for Norsk Bokmål.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [x] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
