### PR TITLE
fix(date-picker): support native picker for mobile devices again

### DIFF
--- a/src/components/date-picker/dateFormatter.ts
+++ b/src/components/date-picker/dateFormatter.ts
@@ -3,26 +3,27 @@ import 'moment/locale/fi';
 import 'moment/locale/nb';
 import 'moment/locale/sv';
 import moment from 'moment/moment';
-import { isAndroidDevice, isIOSDevice } from '../../util/device';
 import { DateType } from './date.types';
 
 export class DateFormatter {
-    private isMobile: boolean;
     private language: string;
 
     public constructor(language: string = 'en') {
         this.language = language;
-        this.isMobile = isIOSDevice() || isAndroidDevice();
     }
 
-    public formatDate(date: Date, dateFormat) {
-        if (this.isMobile) {
-            return date ? JSON.stringify(date) : '';
-        }
+    public formatDate(date: Date, dateFormat: string) {
         if (date) {
             return moment(date).locale(this.getLanguage()).format(dateFormat);
         }
         return '';
+    }
+
+    public parseDate(date: string, dateFormat: string) {
+        if (date) {
+            return moment(date, dateFormat).toDate();
+        }
+        return null;
     }
 
     public getLanguage() {


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
