### PR TITLE
ci(github actions): remove WIP check, since github now has draft PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,11 +55,3 @@ jobs:
         uses: xt0rted/block-autosquash-commits-action@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-  wip:
-    name: "Block WIP PR:s"
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: wip/action@v1.0.0


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such