### PR TITLE
fix(form): use Ajv to validate instead of rjsf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4436,14 +4436,21 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        }
       }
     },
     "ajv-errors": {
@@ -9605,7 +9612,8 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@limetech/material-components-web": "^4.0.1-p4.0.0.1",
     "@popperjs/core": "^2.4.2",
     "@types/tabulator-tables": "^4.6.7",
+    "ajv": "^6.12.2",
     "awesome-debounce-promise": "^2.1.0",
     "chart.js": "^2.9.3",
     "flatpickr": "^4.6.3",

--- a/src/components/form/validators/format.ts
+++ b/src/components/form/validators/format.ts
@@ -1,0 +1,3 @@
+export function isInteger(data: string): boolean {
+    return Number.isInteger(Number(data));
+}

--- a/src/components/form/validators/index.ts
+++ b/src/components/form/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './format';


### PR DESCRIPTION
Sometimes, the validator in rjsf incorectly reports validation errors when dependencies are used
within the schema. The reported error did not make any sense since it complained about properties
that did not exist, neither in the schema or the data that was validated. Using Ajv to validate the
form data does not report any errors, even though rjsf also uses Ajv under the hood.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
