### PR TITLE
docs(input-field): remove documentation for `--background-color` which is no longer supported

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -8,7 +8,6 @@
 @import '@limetech/mdc-menu-surface/mdc-menu-surface';
 
 /**
- * @prop --background-color: Background color of the field.
  * @prop --textarea-height: Height of the field when type is set to `textarea`
  */
 


### PR DESCRIPTION
I'm not sure exactly when support for this was removed, but it doesn't work now, and we've changed the styles of limel-input so that it's using semitransparent backgrounds, gently tinting whatever background the component is used on, so there's no real need for setting the background colour anyway.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
