### PR TITLE
fix(schema-form): emit undefined instead of null for empty value

### DIFF
--- a/src/components/form/widgets/input-field.ts
+++ b/src/components/form/widgets/input-field.ts
@@ -38,7 +38,7 @@ export class InputField extends React.Component {
             return;
         }
 
-        let value = null;
+        let value;
         if (event.detail !== '') {
             value = event.detail;
         }


### PR DESCRIPTION
fix #859 

Should widget support undefined values?
- [x] Input field 
  - Should support emitting undefined instead of null if the input field is empty to support non required input field values
- [x] Select field
  - Can have a value of undefined initially, but can never be set back to undefined because to clear a select you would have to select the empty/null option, and since the options of the schema form selects are generated via the schema, and since a jsonschema cannot contain undefined since it is not a valid jsonschema value, select elements do not need to support being set back to undefined
- [x] Checkbox
  - Can have an initial value of undefined, but once it is selected does not need to ever emit undefined since it doesn't make sense for the component. Checkbox components should only ever emit true/false
- [ ] Date picker
  - Will need to be verified and updated once https://github.com/Lundalogik/lime-elements/pull/823 is merged.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
