### PR TITLE
fix(date-picker): improve handling of focus on the input field

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -284,7 +284,6 @@ export class DatePicker {
         );
         event.stopPropagation();
         if (this.type !== 'datetime' && this.type !== 'time') {
-            this.textField.blur();
             this.hideCalendar();
         }
         this.change.emit(date);

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -33,6 +33,7 @@ export abstract class Picker {
 
         this.getWeek = this.getWeek.bind(this);
         this.handleClose = this.handleClose.bind(this);
+        this.handleOnClose = this.handleOnClose.bind(this);
         this.parseDate = this.parseDate.bind(this);
         this.formatDate = this.formatDate.bind(this);
         this.getFlatpickrLang = this.getFlatpickrLang.bind(this);
@@ -45,6 +46,7 @@ export abstract class Picker {
             formatDate: this.nativePicker ? undefined : this.formatDate,
             parseDate: this.nativePicker ? undefined : this.parseDate,
             appendTo: container,
+            onClose: this.handleOnClose,
             defaultDate: value,
             onValueUpdate: this.handleClose,
             inline: !this.nativePicker,
@@ -111,5 +113,9 @@ export abstract class Picker {
 
     private parseDate(date: string) {
         return moment(date, this.dateFormat, this.getMomentLang()).toDate();
+    }
+
+    private handleOnClose() {
+        this.flatpickr.element.focus();
     }
 }


### PR DESCRIPTION
This commit ensures that the input element has focus when the datepicker closes. It also fixes a bug
where it could look like several input fields had focus at the same time.

fix #764


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
