### PR TITLE
fix(menu): when dropdown is rendered upwards from trigger, do not cover the trigger

### DIFF
--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -35,12 +35,12 @@ $menu-item-background-color: #ebebeb;
         }
 
         &:not(.limel-portal--fixed) {
+            z-index: -999999;
             position: absolute;
-
-            :host(*[open-direction='left']) & {
-                right: 0;
-                bottom: 0;
-            }
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
         }
     }
 }


### PR DESCRIPTION
Instead of the dropdown extending upwards from the bottom of the trigger, covering the trigger
element, make it extend upwards from the top of the trigger.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
