### PR TITLE
fix(menu): force tall bottom menus to render inside the viewport

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -53,6 +53,10 @@
     }
 }
 
+.mdc-menu {
+    max-height: 80vh; // force tall menus render inside the viewport when menu is at the bottom of the screen
+}
+
 .mdc-list {
     --mdc-theme-text-icon-on-background: var(--icon-color, rgb(157, 157, 157));
     padding: 0;

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -12,7 +12,7 @@ $menu-item-background-color: #ebebeb;
 
 .menu__trigger {
     border-color: transparent;
-    border-width: pxToRem(1);
+    border-width: 1px;
     border-style: solid;
     background: none;
     color: #afafaf;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1225

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
