### PR TITLE
fix(input-field): ensure that the label floats if value of the native input field changes

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -231,7 +231,9 @@ export class InputField {
                     class={`
                         mdc-floating-label
                         ${
-                            this.value || this.isFocused
+                            this.value ||
+                            this.isFocused ||
+                            this.mdcTextField?.value
                                 ? 'mdc-floating-label--float-above'
                                 : ''
                         }


### PR DESCRIPTION
# How to repro issue

1. Open the docz application and route to the docs for `limel-input`
2. Open dev-tools and inspect the native input field of an empty `limel-input`-field
3. Open the console and type `$0.value = 'whatever you want'`
4. Click outside the input field. The label will now appear over the text value and not above it as expected.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
