### PR TITLE
fix(tab-bar): remove limel-icons when no icon name provided  in limel-tab-bar

### DIFF
--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -209,7 +209,12 @@ export class TabBar {
     }
 
     private renderIcon(tab: Tab) {
+        if (!tab.icon) {
+            return;
+        }
+
         const style = { color: '' };
+
         if (tab.iconColor) {
             style.color = tab.iconColor;
         }


### PR DESCRIPTION

fix: Lundalogik/lime-elements#847
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
