### PR TITLE
fix(tab-bar): fix tab-bar crashes when previous tabs are undefined

### DIFF
--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -26,7 +26,7 @@ export class TabBar {
      * List of tabs to display
      */
     @Prop()
-    public tabs: Tab[];
+    public tabs: Tab[] = [];
 
     /**
      * Emitted when a tab has been changed
@@ -104,7 +104,7 @@ export class TabBar {
     }
 
     @Watch('tabs')
-    protected tabsChanged(newTabs: Tab[], oldTabs: Tab[]) {
+    protected tabsChanged(newTabs: Tab[] = [], oldTabs: Tab[] = []) {
         const newIds = newTabs.map((tab) => tab.id);
         const oldIds = oldTabs.map((tab) => tab.id);
 


### PR DESCRIPTION
fix: Lundalogik/lime-elements#852

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
