### PR TITLE
fix(input-field): correct placement of label for input-field type of …

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -26,7 +26,10 @@
     @include mdc-states-focus-opacity(0, true);
 
     .mdc-floating-label {
-        top: $floating-label-top-value;
+        &:not(.textarea-label) {
+            top: $floating-label-top-value;
+        }
+
         right: pxToRem(
             8
         ); //This is a hack to force the label truncate when container is too little. Otherwise due to position: absolute it won't. Kia

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -260,6 +260,12 @@ export class InputField {
             'mdc-text-field--required': this.required,
         };
 
+        const labelClassList = {
+            'mdc-floating-label': true,
+            'textarea-label': true,
+            'mdc-floating-label--float-above': !!this.value || this.isFocused,
+        };
+
         return [
             <div class={classList}>
                 {this.renderCharacterCounter()}
@@ -278,7 +284,7 @@ export class InputField {
                 <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading" />
                     <div class="mdc-notched-outline__notch">
-                        <label htmlFor="textarea" class="mdc-floating-label">
+                        <label htmlFor="textarea" class={labelClassList}>
                             {this.label}
                         </label>
                     </div>


### PR DESCRIPTION
…textarea  when the value is prefilled

fix #722

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
