### PR TITLE
fix(list): tall menus render outside screen on Safari iOS+address bar

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -54,7 +54,7 @@
 }
 
 .mdc-menu {
-    max-height: 80vh; // force tall menus render inside the viewport when menu is at the bottom of the screen
+    max-height: 70vh; // force tall menus render inside the viewport when menu is at the bottom of the screen
 }
 
 .mdc-list {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1233


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
