### PR TITLE
fix(button-groups): make entire chip look clickable

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -33,6 +33,10 @@
         }
     }
 
+    label {
+        cursor: pointer;
+    }
+
     span[role='gridcell'] {
         &:focus-within {
             outline: none;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1293
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
