### PR TITLE
Spacier tables

### DIFF
--- a/src/components/table/partial-styles/tabulator-custom-styles.scss
+++ b/src/components/table/partial-styles/tabulator-custom-styles.scss
@@ -19,11 +19,20 @@
 
     .tabulator-table {
         background-color: transparent;
-        padding: pxToRem(8);
+    }
+
+    // This provides space for box-shadow effect. Otherwise the overflow properties will cut them out
+    .tabulator-headers {
+        padding: 0 pxToRem(8);
+    }
+    // This provides space for box-shadow effect. Otherwise the overflow properties will cut them out
+    .tabulator-row {
+        width: calc(100% - #{pxToRem(16)});
+        margin-right: auto;
+        margin-left: auto;
     }
 
     .tabulator-header {
-        padding: 0 pxToRem(8);
         background-color: transparent;
 
         .tabulator-col-content {
@@ -51,7 +60,7 @@
 
     .tabulator-cell {
         height: pxToRem(44);
-        line-height: pxToRem(36);
+        line-height: pxToRem(32);
         padding-left: pxToRem(12);
         padding-right: pxToRem(8);
 

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -71,7 +71,7 @@ $tabulator-arrow-color-active: var(--lime-turquoise);
 
     .tabulator-cell {
         border-right: transparent;
-        padding-left: pxToRem(6);
+        padding: pxToRem(6) pxToRem(8);
     }
 }
 


### PR DESCRIPTION
Trying to make the new tables look more similar to the old tables, as internally people experience the old tables as less boring 🙃
This PR also removes a layout misalignment in the tables with custom styles.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
