### PR TITLE
fix(limel-form): no error is thrown when parsing keys from schema w/o…

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -14,7 +14,7 @@ import { retrieveSchema } from 'react-jsonschema-form/lib/utils';
  *
  * @returns {any[]} the array of keys
  */
-const getDifferentKeys = (a: object, b: object): any[] => {
+const getDifferentKeys = (a: object = {}, b: object = {}): any[] => {
     const keys = union(Object.keys(a), Object.keys(b));
 
     return keys.filter((key) => {


### PR DESCRIPTION
… properties key

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
