### PR TITLE
fix(table): calculate column width for custom components

### DIFF
--- a/src/components/table/columns.spec.ts
+++ b/src/components/table/columns.spec.ts
@@ -17,6 +17,7 @@ describe('createCustomComponent', () => {
             getField: () => field,
             getData: () => data,
             getValue: () => value,
+            getColumn: () => null,
         };
 
         column = {

--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -1,4 +1,5 @@
 import { Column, ColumnSorter, ColumnAggregatorFunction } from './table.types';
+import Tabulator from 'tabulator-tables';
 
 /**
  * Create Tabulator column definitions from a limel-table column configuration
@@ -86,9 +87,41 @@ export function createCustomComponent(
         data: data,
     };
 
+    element.style.display = 'inline-block';
     Object.assign(element, props);
 
+    createResizeObserver(element, cell.getColumn());
+
     return element;
+}
+
+function createResizeObserver(
+    element: HTMLElement,
+    column: Tabulator.ColumnComponent
+) {
+    if (!('ResizeObserver' in window)) {
+        return;
+    }
+
+    const RESIZE_TIMEOUT = 1000;
+    const COLUMN_PADDING = 16;
+
+    const observer = new ResizeObserver(() => {
+        const width = element.getBoundingClientRect().width;
+
+        if (width < column.getWidth()) {
+            return;
+        }
+
+        column.setWidth(width + COLUMN_PADDING);
+    });
+    observer.observe(element);
+
+    // We give the component some time to resize itself before we
+    // stop listening for resize events
+    setTimeout(() => {
+        observer.unobserve(element);
+    }, RESIZE_TIMEOUT);
 }
 
 // Tabulator seems to also have this `field` property, that does not appear on

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -27,6 +27,20 @@ export interface Column<T extends object = any> {
 
 export type TableFormatter = (value: any, data?: object) => string;
 
+/**
+ * Definition for a component to be displayed in a cell in the table
+ *
+ * @note The table will display the component as `inline-block` in order
+ * to give the column the correct size. If the component should have the
+ * full width of the column, this might have to be overridden by setting
+ * the display mode to `block`, e.g.
+ *
+ * ```css
+ * :host(*) {
+ *     display: block !important;
+ * }
+ * ```
+ */
 export interface TableComponentDefinition {
     /**
      * Name of the component

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,22 @@
+// The ResizeObserver API is available in all major browsers. However,
+// TypeScript has yet to implement any type declarations for it. A basic
+// incomplete version of the API is declared here just to get the compiler
+// not to throw errors.
+//
+// https://github.com/microsoft/TypeScript/issues/37861
+
+interface IResizeObserver {
+    new (callback: ResizeObserverCallback): IResizeObserver;
+    disconnect: () => void;
+    observe: (element: Element, options?: object) => void;
+    unobserve: (element: Element) => void;
+}
+
+type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
+
+interface ResizeObserverEntry {
+    target: Element;
+    contentRect: DOMRectReadOnly;
+}
+
+declare const ResizeObserver: IResizeObserver;


### PR DESCRIPTION
fix Lundalogik/crm-feature#1237

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
