### PR TITLE
fix(button-group): remove visual defects on iOS

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -46,6 +46,7 @@
     input[type='radio'] {
         width: 0;
         position: absolute;
+        border: none; // This removes some visual defects on iOS, created by "user agent styles"
     }
 
     span[role='gridcell'] {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1320
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
