### PR TITLE
fix(tab-panel): use a max height to prevent layout shifts caused by loading of tabs.

### DIFF
--- a/src/components/tab-panel/tab-panel.scss
+++ b/src/components/tab-panel/tab-panel.scss
@@ -3,6 +3,7 @@
 :host(limel-tab-panel) {
     display: block;
     height: 100%;
+    max-height: 3.5rem;
 }
 
 .tab-panel {


### PR DESCRIPTION
Since `tab-panel` seems to be loaded before the `tab-bar`'s content and its respective CSS is loaded, the UI will shift during loading. The `max-height` value will limit this layout shift. So the shift will happen from 0 (before `tab-panel` itself is loaded) to `3.5rem` which is the accumulated height of the tab-bar. This improves the experience, but doesn't solve the problem fully. We need a loading for tabs.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
