### PR TITLE
revert(core-styles): revert "let color palette be exported & accessible in webclient"

### DIFF
--- a/src/global/core-styles.scss
+++ b/src/global/core-styles.scss
@@ -1,5 +1,4 @@
 // These are exported for external use.
 
 @import '../style/colors.scss';
-@import '../style/color-palette-extended-light-mode-only.css';
 @import '../style/shadows.scss';


### PR DESCRIPTION
This reverts commit 5b27cb650e816d69594e72068cf897fb3d039b61.

BREAKING CHANGE: The color palettes should be imported by the consumer, as described in the
documentation and the release notes for v27.0.0. The reverted change was a mistake due to
miscommunication. Our apologies.

Re #924

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
