### PR TITLE
perf(linear-progress): remove continuous buffering animation

### DIFF
--- a/src/components/linear-progress/linear-progress.tsx
+++ b/src/components/linear-progress/linear-progress.tsx
@@ -48,7 +48,6 @@ export class LinearProgress {
                         : ''
                 }`}
             >
-                <div class="mdc-linear-progress__buffering-dots" />
                 <div class="mdc-linear-progress__buffer" />
                 <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
                     <span class="mdc-linear-progress__bar-inner" />


### PR DESCRIPTION
the `<div class="mdc-linear-progress__buffering-dots" />` is not used/offered by lime elements, but the div was rendered, causing a continuously running animation, creating visual disturbance on iPads, and lowering the performance on all platforms.
fix: https://github.com/Lundalogik/crm-feature/issues/1319

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
