### PR TITLE
fix(tab-bar): save tab state by making it mutable

### DIFF
--- a/src/components/tab-bar/tab-bar.e2e.ts
+++ b/src/components/tab-bar/tab-bar.e2e.ts
@@ -1,0 +1,72 @@
+import {
+    newE2EPage,
+    E2EPage,
+    E2EElement,
+    EventSpy,
+} from '@stencil/core/testing';
+import { Tab } from './tab.types';
+
+describe('limel-tab-bar', () => {
+    let page: E2EPage;
+    let component: E2EElement;
+    const tabs: Tab[] = [
+        {
+            id: 'foo',
+            active: true,
+        },
+        {
+            id: 'bar',
+        },
+        {
+            id: 'baz',
+        },
+    ];
+
+    beforeEach(async () => {
+        page = await newE2EPage();
+        await page.setContent('<limel-tab-bar></limel-tab-bar>');
+        component = await page.find('limel-tab-bar');
+        component.setProperty('tabs', tabs);
+        await page.waitForChanges();
+    });
+
+    describe('when bar tab is clicked', () => {
+        let spy: EventSpy;
+        beforeEach(async () => {
+            spy = await page.spyOnEvent('changeTab');
+            const buttons = await page.findAll('limel-tab-bar >>> button');
+            await buttons[1].click();
+        });
+
+        it('emits an event with the old inactive tab', () => {
+            expect(spy).toHaveReceivedEventTimes(2);
+            const event = spy.events.find((e) => e.detail.id === 'bar');
+            expect(event.detail).toEqual({
+                id: 'bar',
+                active: true,
+            });
+        });
+
+        it('emits an event with the active tab', () => {
+            expect(spy).toHaveReceivedEventTimes(2);
+            const event = spy.events.find((e) => e.detail.id === 'foo');
+            expect(event.detail).toEqual({
+                id: 'foo',
+                active: false,
+            });
+        });
+    });
+
+    describe('when foo tab is clicked', () => {
+        let spy: EventSpy;
+        beforeEach(async () => {
+            spy = await page.spyOnEvent('changeTab');
+            const buttons = await page.findAll('limel-tab-bar >>> button');
+            await buttons[0].click();
+        });
+
+        it('does not emit an event', () => {
+            expect(spy).toHaveReceivedEventTimes(0);
+        });
+    });
+});

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -10,7 +10,8 @@ import {
 import { MDCTabBar, MDCTabBarActivatedEvent } from '@limetech/mdc-tab-bar';
 import { strings } from '@limetech/mdc-tab-bar/constants';
 import { Tab } from './tab.types';
-import { isEqual } from 'lodash-es';
+import { isEqual, difference } from 'lodash-es';
+import { setActiveTab } from './tabs';
 
 const { TAB_ACTIVATED_EVENT } = strings;
 const SCROLL_DISTANCE_ON_CLICK_PX = 150;
@@ -25,7 +26,7 @@ export class TabBar {
     /**
      * List of tabs to display
      */
-    @Prop()
+    @Prop({ mutable: true })
     public tabs: Tab[] = [];
 
     /**
@@ -172,13 +173,13 @@ export class TabBar {
 
     private handleTabActivated(event: MDCTabBarActivatedEvent) {
         const index = event.detail.index;
-        const oldSelectedTab = this.tabs.find((tab) => tab.active === true);
+        const newTabs = setActiveTab(this.tabs, index);
 
-        if (oldSelectedTab) {
-            this.changeTab.emit({ ...oldSelectedTab, active: false });
-        }
+        difference(newTabs, this.tabs).forEach((tab: Tab) => {
+            this.changeTab.emit(tab);
+        });
 
-        this.changeTab.emit({ ...this.tabs[index], active: true });
+        this.tabs = newTabs;
     }
 
     private handleScroll() {

--- a/src/components/tab-bar/tabs.spec.ts
+++ b/src/components/tab-bar/tabs.spec.ts
@@ -1,0 +1,48 @@
+import { Tab } from './tab.types';
+import { setActiveTab } from './tabs';
+
+describe('setActiveTab', () => {
+    const tabs: Tab[] = [
+        {
+            id: 'foo',
+            active: true,
+        },
+        {
+            id: 'bar',
+        },
+        {
+            id: 'baz',
+        },
+    ];
+
+    describe('when bar is activated', () => {
+        it('returns a list of the same size', () => {
+            const newTabs = setActiveTab(tabs, 1);
+            expect(newTabs.length).toEqual(3);
+        });
+
+        it('sets bar to active', () => {
+            const newTabs = setActiveTab(tabs, 1);
+            expect(newTabs[1].active).toBeTruthy();
+        });
+
+        it('sets foo to inactive', () => {
+            const newTabs = setActiveTab(tabs, 1);
+            expect(newTabs[0].active).toBeFalsy();
+        });
+
+        it('does not change baz', () => {
+            const newTabs = setActiveTab(tabs, 1);
+            expect(newTabs[2]).toBe(tabs[2]);
+        });
+    });
+
+    describe('when foo is activated', () => {
+        it('only changes foo', () => {
+            const newTabs = setActiveTab(tabs, 0);
+            expect(newTabs[0]).not.toBe(tabs[0]);
+            expect(newTabs[1]).toBe(tabs[1]);
+            expect(newTabs[2]).toBe(tabs[2]);
+        });
+    });
+});

--- a/src/components/tab-bar/tabs.ts
+++ b/src/components/tab-bar/tabs.ts
@@ -1,0 +1,26 @@
+import { Tab } from './tab.types';
+
+/**
+ * Set a tabs `active` state to true in a list of tabs. The previous tab with
+ * `active` set to true will have it set to `false` instead.
+ *
+ * @param {Tab[]} tabs list of tabs
+ * @param {number} index the index of the tab to set to active
+ *
+ * @returns {Tab[]} a copy of the list of tabs with the changed tabs replaced
+ */
+export function setActiveTab(tabs: Tab[], index: number): Tab[] {
+    const oldSelectedTabIndex = tabs.findIndex((t) => t.active === true);
+    const result = [...tabs];
+
+    if (oldSelectedTabIndex !== -1) {
+        result[oldSelectedTabIndex] = {
+            ...tabs[oldSelectedTabIndex],
+            active: false,
+        };
+    }
+
+    result[index] = { ...tabs[index], active: true };
+
+    return result;
+}


### PR DESCRIPTION
If tabs are changed rapidly, Stencil will schedule the update of the tabs prop. This will leave us
in a state were the tabs prop still have the old value of the tabs when a new tab is selected, and
thus we will not find the old active tab and cannot deactivate it. To fix this, the tabs prop is
made mutable and we store any changes made to the tabs before we emit the changed tabs in the
`changeTab` event.

fix Lundalogik/crm-feature#1327

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
