### PR TITLE
fix(table): make Tabulator look more like old tables in web client

### DIFF
--- a/src/components/table/partial-styles/tabulator-arrow.scss
+++ b/src/components/table/partial-styles/tabulator-arrow.scss
@@ -1,6 +1,6 @@
 .tabulator-arrow {
     transition: border 0.2s ease;
-    top: pxToRem(8) !important;
+    top: pxToRem(12) !important;
 
     [aria-sort='none'] & {
         border-bottom-color: $tabulator-arrow-color !important;
@@ -39,7 +39,7 @@
     }
 
     [aria-sort='desc'] & {
-        top: pxToRem(16) !important;
+        top: pxToRem(20) !important;
 
         &:before {
             top: pxToRem(-12);

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -32,6 +32,11 @@ $tabulator-arrow-color-active: var(--lime-turquoise);
             background-color: $table-header-background-color;
             border-right-color: #fafafb;
 
+            .tabulator-col-content {
+                padding-top: pxToRem(8);
+                padding-bottom: pxToRem(8);
+            }
+
             &.tabulator-sortable {
                 &:hover {
                     background-color: $table-header-background-color-hover;
@@ -40,6 +45,7 @@ $tabulator-arrow-color-active: var(--lime-turquoise);
         }
 
         .tabulator-col-title {
+            font-weight: 500;
             padding-left: pxToRem(2);
         }
     }
@@ -78,11 +84,12 @@ $tabulator-arrow-color-active: var(--lime-turquoise);
 
     .tabulator-cell {
         border-right: transparent;
-        padding: pxToRem(6) pxToRem(8);
+        padding: pxToRem(8);
     }
 }
 
 .tabulator-col,
 .tabulator-cell {
     max-width: pxToRem(600);
+    font-size: pxToRem(13);
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1354
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
