### PR TITLE
feat(chip-set): add optional delimiters between chips

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -242,3 +242,8 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
         background-color: transparent;
     }
 }
+
+.delimiter {
+    opacity: 0.5;
+    padding: 0 pxToRem(2);
+}

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -96,6 +96,12 @@ export class ChipSet {
     public leadingIcon: string = null;
 
     /**
+     * For chip-set of type `input`. Sets delimiters between chips.
+     */
+    @Prop({ reflectToAttr: true })
+    public delimiter: string = null;
+
+    /**
      * Dispatched when a chip is interacted with
      */
     @Event()
@@ -160,6 +166,7 @@ export class ChipSet {
         this.handleDeleteAllIconClick = this.handleDeleteAllIconClick.bind(
             this
         );
+        this.renderDelimiter = this.renderDelimiter.bind(this);
     }
 
     /**
@@ -521,7 +528,8 @@ export class ChipSet {
             attributes.tabindex = 0;
         }
 
-        return (
+        return [
+            this.renderDelimiter(index),
             <div
                 class={{
                     'mdc-chip': true,
@@ -538,8 +546,8 @@ export class ChipSet {
                 {chip.removable && !this.readonly && !this.disabled
                     ? this.renderChipRemoveButton()
                     : null}
-            </div>
-        );
+            </div>,
+        ];
     }
 
     private catchInputChipClicks(event) {
@@ -601,5 +609,13 @@ export class ChipSet {
     }
     private handleDeleteAllIconClick() {
         this.change.emit([]);
+    }
+
+    private renderDelimiter(index: Number) {
+        if (index === 0 || !this.delimiter) {
+            return;
+        }
+
+        return <div class="delimiter">{this.delimiter}</div>;
     }
 }

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -32,6 +32,9 @@ export class ChipSetInputExample {
     @State()
     private hasLeadingIcon: boolean = true;
 
+    @State()
+    private delimiter: string = '&';
+
     constructor() {
         this.value = [
             this.createChip('Elephant'),
@@ -55,6 +58,7 @@ export class ChipSetInputExample {
         this.setEmptyInputOnBlur = this.setEmptyInputOnBlur.bind(this);
         this.setMaxItems = this.setMaxItems.bind(this);
         this.setLeadingIcon = this.setLeadingIcon.bind(this);
+        this.useDelimiters = this.useDelimiters.bind(this);
     }
 
     public render() {
@@ -75,6 +79,7 @@ export class ChipSetInputExample {
                     onKeyUp={this.onKeyUp}
                     searchLabel="Add an animal"
                     emptyInputOnBlur={this.emptyInputOnBlur}
+                    delimiter={this.delimiter}
                 />
                 <limel-input-field
                     label="Max items"
@@ -109,6 +114,11 @@ export class ChipSetInputExample {
                         label={'Leading icon'}
                         onChange={this.setLeadingIcon}
                         checked={this.hasLeadingIcon}
+                    />
+                    <limel-checkbox
+                        label="Use delimiters"
+                        onChange={this.useDelimiters}
+                        checked={this.delimiter !== null}
                     />
                 </limel-flex-container>
             </p>,
@@ -175,5 +185,9 @@ export class ChipSetInputExample {
 
     private setMaxItems(event: CustomEvent<string>) {
         this.maxItems = +event.detail;
+    }
+
+    private useDelimiters(event: CustomEvent<boolean>) {
+        this.delimiter = event.detail ? '&' : null;
     }
 }


### PR DESCRIPTION
fix Lundalogik/crm-feature#1351

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
