### PR TITLE
perf(table): improve tables' loading speed in chrome

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -55,6 +55,8 @@ $tabulator-arrow-color-active: var(--lime-turquoise);
 }
 
 .tabulator-row {
+    content-visibility: auto; //Currently (2020-Sep-04), this works only in Chrome 85+ https://web.dev/content-visibility/
+
     &.tabulator-selectable {
         transition: background-color 0.2s ease;
         &:not(.active) {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1361

## Affects Chrome 85+
At this time, `content-visibility: auto;` works in Chrome 85 and above. (as far as I know [Kia]). More here: https://web.dev/content-visibility/

## performance test
Tested with an object with 60 deals. I think in an object with a lot of table rows (`.tabulator-row`), this will have an even more notable impact. Performance analysis shows from the second the page is refreshed > until the user clicks on the *deals* tab and its content is loaded. 

### Reload page > Go to deals tab (With this change)
![Screen Shot 2020-09-04 at 16 25 22](https://user-images.githubusercontent.com/35954987/92250976-714f8f80-eecc-11ea-8bb3-343cfb3c1997.png)


### Reload page > Go to deals tab  (Without this)
 change
![Screen Shot 2020-09-04 at 16 26 24](https://user-images.githubusercontent.com/35954987/92250991-757bad00-eecc-11ea-9901-a1cf6a0c5eb6.png)



______________

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
