### PR TITLE
fix(tab-bar): hide unwanted scrollbars on Firefox

### DIFF
--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -97,6 +97,11 @@ $tab-scroller-fade-width: 65;
     }
 }
 
+.mdc-tab-scroller__scroll-area--scroll {
+    scrollbar-width: none; // This hides the scrollbars appearing under the tab bar in Firefox
+    -ms-overflow-style: none; // Same as above for IE 11
+}
+
 .mdc-tab-scroller__scroll-content {
     padding: pxToRem(8) $tab-active-outer-edge-curve-size 0
         $tab-active-outer-edge-curve-size;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1336

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
