### PR TITLE
Fix table flickering

### DIFF
--- a/src/components/table/columns.spec.ts
+++ b/src/components/table/columns.spec.ts
@@ -3,6 +3,7 @@ import {
     createCustomComponent,
     createFormatter,
 } from './columns';
+import { ElementPool } from './element-pool';
 import { Column } from './table.types';
 
 describe('createCustomComponent', () => {
@@ -12,6 +13,7 @@ describe('createCustomComponent', () => {
     let data: Record<string, any>;
     let column: Column;
     let factory: ColumnDefinitionFactory;
+    let pool: ElementPool;
 
     beforeEach(() => {
         cell = {
@@ -33,7 +35,8 @@ describe('createCustomComponent', () => {
 
         field = 'foo';
         value = 'FOO';
-        factory = new ColumnDefinitionFactory();
+        pool = new ElementPool(document);
+        factory = new ColumnDefinitionFactory(pool);
     });
 
     describe('createCustomComponent', () => {
@@ -48,7 +51,7 @@ describe('createCustomComponent', () => {
                 },
             };
 
-            const component = createCustomComponent(cell, column, value);
+            const component = createCustomComponent(cell, column, value, pool);
             expect(component.tagName.toLowerCase()).toEqual('h1');
             expect(component).toHaveProperty('field', 'foo');
             expect(component).toHaveProperty('limetype', 'bar');
@@ -66,7 +69,7 @@ describe('createCustomComponent', () => {
         describe('when formatter is given', () => {
             beforeEach(() => {
                 column.formatter = (v) => `formatted: ${v}`;
-                formatCell = createFormatter(column);
+                formatCell = createFormatter(column, pool);
             });
 
             it('returns the formatted value', () => {
@@ -79,7 +82,7 @@ describe('createCustomComponent', () => {
                 column.component = {
                     name: 'h1',
                 };
-                formatCell = createFormatter(column);
+                formatCell = createFormatter(column, pool);
             });
 
             it('returns the formatted value', () => {
@@ -95,7 +98,7 @@ describe('createCustomComponent', () => {
                 column.component = {
                     name: 'h1',
                 };
-                formatCell = createFormatter(column);
+                formatCell = createFormatter(column, pool);
             });
 
             it('returns the formatted value', () => {

--- a/src/components/table/columns.spec.ts
+++ b/src/components/table/columns.spec.ts
@@ -1,7 +1,7 @@
 import {
-    createColumnDefinition,
+    ColumnDefinitionFactory,
     createCustomComponent,
-    formatCell,
+    createFormatter,
 } from './columns';
 import { Column } from './table.types';
 
@@ -11,6 +11,7 @@ describe('createCustomComponent', () => {
     let field: string;
     let data: Record<string, any>;
     let column: Column;
+    let factory: ColumnDefinitionFactory;
 
     beforeEach(() => {
         cell = {
@@ -32,6 +33,7 @@ describe('createCustomComponent', () => {
 
         field = 'foo';
         value = 'FOO';
+        factory = new ColumnDefinitionFactory();
     });
 
     describe('createCustomComponent', () => {
@@ -58,19 +60,29 @@ describe('createCustomComponent', () => {
         });
     });
 
-    describe('formatCell', () => {
+    describe('createFormatter', () => {
+        let formatCell: Function;
+
         describe('when formatter is given', () => {
-            it('returns the formatted value', () => {
+            beforeEach(() => {
                 column.formatter = (v) => `formatted: ${v}`;
+                formatCell = createFormatter(column);
+            });
+
+            it('returns the formatted value', () => {
                 expect(formatCell(cell, column)).toEqual('formatted: FOO');
             });
         });
 
         describe('when component is given', () => {
-            it('returns the formatted value', () => {
+            beforeEach(() => {
                 column.component = {
                     name: 'h1',
                 };
+                formatCell = createFormatter(column);
+            });
+
+            it('returns the formatted value', () => {
                 const component = formatCell(cell, column) as HTMLElement;
                 expect(component.tagName.toLowerCase()).toEqual('h1');
                 expect(component).toHaveProperty('value', 'FOO');
@@ -78,11 +90,15 @@ describe('createCustomComponent', () => {
         });
 
         describe('when both formatter and component is given', () => {
-            it('returns the formatted value', () => {
+            beforeEach(() => {
                 column.formatter = (v) => `formatted: ${v}`;
                 column.component = {
                     name: 'h1',
                 };
+                formatCell = createFormatter(column);
+            });
+
+            it('returns the formatted value', () => {
                 const component = formatCell(cell, column) as HTMLElement;
                 expect(component.tagName.toLowerCase()).toEqual('h1');
                 expect(component).toHaveProperty('value', 'formatted: FOO');
@@ -90,7 +106,7 @@ describe('createCustomComponent', () => {
         });
     });
 
-    describe('createColumnDefinition', () => {
+    describe('ColumnDefinitionFactory.create', () => {
         it('converts a limel-table column config to a Tabulator column definition', () => {
             column.formatter = () => '';
             column.component = {
@@ -100,7 +116,7 @@ describe('createCustomComponent', () => {
                 },
             };
 
-            const definition = createColumnDefinition(column);
+            const definition = factory.create(column);
             expect(definition).toHaveProperty('field', 'foo');
             expect(definition).toHaveProperty('title', 'Foo');
 

--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -134,12 +134,13 @@ function createResizeObserver(
 
     const observer = new ResizeObserver(() => {
         const width = element.getBoundingClientRect().width;
+        const newWidth = width + COLUMN_PADDING;
 
-        if (width < column.getWidth()) {
+        if (newWidth < column.getWidth()) {
             return;
         }
 
-        column.setWidth(width + COLUMN_PADDING);
+        column.setWidth(newWidth);
     });
     observer.observe(element);
 

--- a/src/components/table/element-pool.spec.ts
+++ b/src/components/table/element-pool.spec.ts
@@ -1,0 +1,78 @@
+import { ElementPool } from './element-pool';
+
+describe('ElementPool', () => {
+    let pool: ElementPool;
+
+    beforeEach(() => {
+        pool = new ElementPool(document);
+    });
+
+    describe('get', () => {
+        it('returns an element', () => {
+            const foo = pool.get('foo');
+            expect(foo).toBeTruthy();
+        });
+
+        describe('when called multiple times', () => {
+            it('returns different elements', () => {
+                const foo1 = pool.get('foo');
+                expect(foo1).toBeTruthy();
+
+                const foo2 = pool.get('foo');
+                expect(foo2).toBeTruthy();
+
+                expect(foo1).not.toBe(foo2);
+            });
+        });
+    });
+
+    describe('release', () => {
+        it('makes `get` return the released element again', () => {
+            const foo1 = pool.get('foo');
+            pool.release(foo1);
+
+            const foo2 = pool.get('foo');
+
+            expect(foo1).toBe(foo2);
+        });
+
+        describe('when getting an element with different name', () => {
+            it('still creates a new element', () => {
+                const foo = pool.get('foo');
+                pool.release(foo);
+
+                const bar = pool.get('bar');
+
+                expect(foo).not.toBe(bar);
+            });
+        });
+    });
+
+    describe('releaseAll', () => {
+        it('releases all elements in the pool', () => {
+            const foo1 = pool.get('foo');
+            const foo2 = pool.get('foo');
+            const bar = pool.get('bar');
+
+            pool.releaseAll();
+
+            expect(pool.get('foo')).toBe(foo1);
+            expect(pool.get('foo')).toBe(foo2);
+            expect(pool.get('bar')).toBe(bar);
+        });
+    });
+
+    describe('clear', () => {
+        it('removes all elements in the pool', () => {
+            const foo1 = pool.get('foo');
+            const foo2 = pool.get('foo');
+            const bar = pool.get('bar');
+
+            pool.clear();
+
+            expect(pool.get('foo')).not.toBe(foo1);
+            expect(pool.get('foo')).not.toBe(foo2);
+            expect(pool.get('bar')).not.toBe(bar);
+        });
+    });
+});

--- a/src/components/table/element-pool.ts
+++ b/src/components/table/element-pool.ts
@@ -1,0 +1,68 @@
+export class ElementPool {
+    private pool: Record<string, HTMLElement[]>;
+    private usedElements: WeakMap<Element, boolean>;
+    private document: Document;
+
+    constructor(document: Document) {
+        this.document = document;
+        this.releaseAll();
+        this.clear();
+    }
+
+    /**
+     * Get an element from the pool
+     *
+     * @param {string} name tag name of the element
+     *
+     * @returns {HTMLElement} the element
+     */
+    public get(name: string): HTMLElement {
+        let element = this.pool[name]?.find(this.isFree);
+        if (!element) {
+            element = this.createElement(name);
+        }
+
+        this.usedElements.set(element, true);
+
+        return element;
+    }
+
+    private isFree = (element: HTMLElement) => {
+        return !this.usedElements.has(element);
+    };
+
+    /**
+     * Release an element from the pool so that it can be reused
+     *
+     * @param {HTMLElement} element the element to release from the pool
+     */
+    public release(element: HTMLElement): void {
+        this.usedElements.delete(element);
+    }
+
+    /**
+     * Release all elements from the pool so that they can be reused
+     */
+    public releaseAll() {
+        this.usedElements = new WeakMap();
+    }
+
+    /**
+     * Remove all elements from the pool and makes them available for garbage
+     * collection
+     */
+    public clear() {
+        this.pool = {};
+    }
+
+    private createElement(name: string) {
+        const element = this.document.createElement(name);
+        if (!(name in this.pool)) {
+            this.pool[name] = [];
+        }
+
+        this.pool[name].push(element);
+
+        return element;
+    }
+}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -9,7 +9,7 @@ import {
 } from '@stencil/core';
 import TabulatorTable from 'tabulator-tables';
 import { Column, TableParams, ColumnSorter } from './table.types';
-import { createColumnDefinition, createColumnSorter } from './columns';
+import { ColumnDefinitionFactory, createColumnSorter } from './columns';
 import { isEqual } from 'lodash-es';
 
 const FIRST_PAGE = 1;
@@ -93,12 +93,15 @@ export class Table {
 
     private resolver: (data: any) => void;
 
+    private columnFactory: ColumnDefinitionFactory;
+
     constructor() {
         this.handleDataSorting = this.handleDataSorting.bind(this);
         this.handlePageLoaded = this.handlePageLoaded.bind(this);
         this.requestData = this.requestData.bind(this);
         this.onClickRow = this.onClickRow.bind(this);
         this.formatRow = this.formatRow.bind(this);
+        this.columnFactory = new ColumnDefinitionFactory();
     }
 
     public componentDidLoad() {
@@ -157,7 +160,7 @@ export class Table {
     }
 
     private getColumnDefinitions(): Tabulator.ColumnDefinition[] {
-        return this.columns.map(createColumnDefinition);
+        return this.columns.map(this.columnFactory.create);
     }
 
     private getAjaxOptions(): Tabulator.OptionsData {


### PR DESCRIPTION
When sorting in the table, new elements were created all the time for the custom components. This is
a waste of resources and also made the table flicker due to elements being expensive to create and
boot up. This PR introduces an object pool for all custom components in a table. As soon as the
table is given new data, all old components will be released from the pool so that they can be
reused.

fix Lundalogik/crm-feature#1384

The last commit of this PR should probably be it's own PR, but it was such a small fix so I included it here anyway!

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
