### PR TITLE
perf(portal): create popper instance when portal is displayed

### DIFF
--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -73,16 +73,16 @@ export class Portal {
     @Watch('visible')
     protected onVisible() {
         if (!this.visible) {
+            this.hideContainer();
+            this.styleContainer();
+            this.destroyPopper();
+
             return;
         }
 
-        if (!this.popperInstance) {
-            return;
-        }
-
-        setTimeout(() => {
-            const popperConfig = this.createPopperConfig();
-            this.popperInstance.setOptions(popperConfig);
+        this.createPopper();
+        this.styleContainer();
+        requestAnimationFrame(() => {
             this.showContainer();
         });
     }
@@ -98,8 +98,7 @@ export class Portal {
 
     public disconnectedCallback() {
         this.removeContainer();
-        this.popperInstance?.destroy();
-        this.popperInstance = null;
+        this.destroyPopper();
     }
 
     public connectedCallback() {
@@ -112,21 +111,14 @@ export class Portal {
         this.attachContainer();
         this.styleContainer();
 
-        const popperConfig = this.createPopperConfig();
-        this.popperInstance = createPopper(
-            this.host,
-            this.container,
-            popperConfig
-        );
+        if (this.visible) {
+            this.createPopper();
+        }
     }
 
     public componentDidLoad() {
         this.loaded = true;
         this.connectedCallback();
-    }
-
-    public componentDidUpdate() {
-        this.styleContainer();
     }
 
     public render() {
@@ -174,10 +166,8 @@ export class Portal {
 
         if (this.visible) {
             this.container.style.display = 'block';
-            this.container.style.opacity = '1';
         } else {
             this.container.style.display = 'none';
-            this.container.style.opacity = '0';
         }
 
         if (this.inheritParentWidth) {
@@ -205,6 +195,17 @@ export class Portal {
         const elementContent = element.querySelector('*');
 
         return this.getContentWidth(elementContent);
+    }
+
+    private createPopper() {
+        const config = this.createPopperConfig();
+
+        this.popperInstance = createPopper(this.host, this.container, config);
+    }
+
+    private destroyPopper() {
+        this.popperInstance?.destroy();
+        this.popperInstance = null;
     }
 
     private createPopperConfig(): Partial<


### PR DESCRIPTION
The popper instance has an event listener on scroll, which causes severe performance issues when
there are a lot of portals on a page e.g. menues in list items etc. The popper instance does not
have to be created until something is actually displayed and needs to be positioned.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [x] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
