### PR TITLE
fix(table): ignore first ajax request if table is created with data

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -96,15 +96,21 @@ export class Table {
 
     private pool: ElementPool;
     private columnFactory: ColumnDefinitionFactory;
+    private firstRequest: boolean;
 
     constructor() {
         this.handleDataSorting = this.handleDataSorting.bind(this);
         this.handlePageLoaded = this.handlePageLoaded.bind(this);
+        this.handleAjaxRequesting = this.handleAjaxRequesting.bind(this);
         this.requestData = this.requestData.bind(this);
         this.onClickRow = this.onClickRow.bind(this);
         this.formatRow = this.formatRow.bind(this);
         this.pool = new ElementPool(document);
         this.columnFactory = new ColumnDefinitionFactory(this.pool);
+    }
+
+    public componentWillLoad() {
+        this.firstRequest = this.mode === 'remote';
     }
 
     public componentDidLoad() {
@@ -184,7 +190,24 @@ export class Table {
             ajaxSorting: true,
             ajaxURL: remoteUrl,
             ajaxRequestFunc: this.requestData,
+            ajaxRequesting: this.handleAjaxRequesting,
         };
+    }
+
+    private handleAjaxRequesting() {
+        const abortRequest = this.firstRequest && this.data?.length;
+        this.firstRequest = false;
+
+        if (abortRequest) {
+            setTimeout(() => {
+                this.tabulator.setMaxPage(this.calculatePageCount());
+                this.tabulator.setData(this.data);
+            });
+
+            return false;
+        }
+
+        return true;
     }
 
     private getPaginationOptions(): Tabulator.OptionsPagination {


### PR DESCRIPTION
Tabulator is requesting data with an AJAX request even though it has been given data when it was
created. It seems unnecessary for us to emit the `load` event as well when this happens, since we
can just initialize the table with the data that has been given to us.

re Lundalogik/lime-crm-components#150

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
