### PR TITLE
feat(table): add default sorting

### DIFF
--- a/src/components/table/examples/table-default-sorted.tsx
+++ b/src/components/table/examples/table-default-sorted.tsx
@@ -1,0 +1,54 @@
+import { Component, h, State } from '@stencil/core';
+import { Column, ColumnSorter } from '../table.types';
+import { data, Bird } from './birds';
+import { capitalize } from 'lodash-es';
+
+@Component({
+    tag: 'limel-example-table-default-sorted',
+    styleUrl: 'table.scss',
+    shadow: true,
+})
+export class TableExampleDefaultSorted {
+    @State()
+    private columns: Array<Column<Bird>> = [];
+
+    private tableData: Bird[] = data;
+    private sortedColumns: ColumnSorter[] = [];
+
+    public componentWillLoad() {
+        this.columns = [
+            { title: 'Name', field: 'name' },
+            { title: 'Binominal name', field: 'binominalName' },
+            {
+                title: 'Wingspan',
+                field: 'wingspan',
+                formatter: this.addUnit('cm'),
+            },
+            { title: 'Nest type', field: 'nest', formatter: capitalize },
+            {
+                title: 'Eggs per clutch',
+                field: 'eggs',
+            },
+            { title: 'Origin', field: 'origin' },
+        ];
+
+        this.sortedColumns = [
+            { column: this.columns[0], direction: 'ASC' },
+            { column: this.columns[4], direction: 'ASC' },
+        ];
+    }
+
+    render() {
+        return (
+            <limel-table
+                data={this.tableData}
+                columns={this.columns}
+                sorting={this.sortedColumns}
+            />
+        );
+    }
+
+    private addUnit = (unit: string) => (value: any) => {
+        return `${value} ${unit}`;
+    };
+}

--- a/src/components/table/table.mdx
+++ b/src/components/table/table.mdx
@@ -36,6 +36,10 @@ menu: Components
 
 <limel-example name="limel-example-table-activate-row" path="table"/>
 
+## Default Sorted columns
+
+<limel-example name="limel-example-table-default-sorted" path="table"/>
+
 # Custom styles
 <limel-example name="limel-example-table-low-density" path="table"/>
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -55,6 +55,13 @@ export class Table {
     public totalRows: number;
 
     /**
+     * The initial sorted columns
+     */
+
+    @Prop()
+    public sorting: ColumnSorter[] = [];
+
+    /**
      * Active row in the table
      */
     @Prop({ mutable: true })
@@ -170,7 +177,17 @@ export class Table {
             ...paginationOptions,
             rowClick: this.onClickRow,
             rowFormatter: this.formatRow,
+            initialSort: this.getColumnSorter(),
         };
+    }
+
+    private getColumnSorter(): Tabulator.Sorter[] {
+        return this.sorting.map((sorter: ColumnSorter) => {
+            return {
+                column: String(sorter.column.field),
+                dir: sorter.direction.toLocaleLowerCase() as Tabulator.SortDirection,
+            };
+        });
     }
 
     private getColumnDefinitions(): Tabulator.ColumnDefinition[] {


### PR DESCRIPTION
fix #961

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
