### PR TITLE
docs: small style fix for multiline values - use full width

### DIFF
--- a/src/examples/example-value.scss
+++ b/src/examples/example-value.scss
@@ -22,6 +22,7 @@ code {
 }
 
 pre > code {
+    display: block;
     border-radius: pxToRem(8);
     margin: pxToRem(8) 0;
     padding: pxToRem(16);


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
