### PR TITLE
chore(package): update package.json to match the currently used version of tabulator-tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "number-abbreviate": "^2.0.0",
     "react-jsonschema-form": "^1.8.1",
     "react-shadow-dom-retarget-events": "^1.0.11",
-    "tabulator-tables": "^4.6.3"
+    "tabulator-tables": "^4.8.2"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",


### PR DESCRIPTION
We are already using the latest version of tabulator-tables, but package.json was only
requiring an older version. This commit updates package.json to require the currently
latest version, or newer.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
