### PR TITLE
feat(stencil): update to StencilJS v2

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,6 @@
     <link href="/style/color-palette-extended.css" rel="stylesheet" />
     <link href="/build/lime-elements.css" rel="stylesheet" />
     <script type="module" src="/build/lime-elements.esm.js"></script>
-    <script nomodule src="/build/lime-elements.js"></script>
 
     <link href="/assets/kompendium/kompendium/kompendium.css" rel="stylesheet" />
     <script type="module" src="/assets/kompendium/kompendium/kompendium.esm.js"></script>


### PR DESCRIPTION
And trigger release.

BREAKING CHANGE: Lime Elements no longer supplies ES5-builds. Browser support for ES Modules (esm)
is now required. If you are loading `lime-elements` with one `<script type="module" src="…">` tag
and one `<script nomodule src="…">` tag, you should remove the latter.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
