### PR TITLE
fix(table): render sorting arrow correctly

### DIFF
--- a/src/components/table/partial-styles/tabulator-arrow.scss
+++ b/src/components/table/partial-styles/tabulator-arrow.scss
@@ -1,6 +1,10 @@
+.tabulator-col-sorter {
+    right: pxToRem(16) !important;
+}
 .tabulator-arrow {
+    position: absolute;
     transition: border 0.2s ease;
-    top: pxToRem(12) !important;
+    top: pxToRem(4);
 
     [aria-sort='none'] & {
         border-bottom-color: $tabulator-arrow-color !important;
@@ -39,7 +43,7 @@
     }
 
     [aria-sort='desc'] & {
-        top: pxToRem(20) !important;
+        top: pxToRem(10);
 
         &:before {
             top: pxToRem(-12);


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/974
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
