### PR TITLE
fix(chip-set): only emit one startEdit event when focusing on it

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -390,6 +390,10 @@ export class ChipSet {
      * @returns {void}
      */
     private handleTextFieldFocus() {
+        if (this.editMode) {
+            return;
+        }
+
         this.editMode = true;
         this.startEdit.emit();
     }


### PR DESCRIPTION
fix Lundalogik/crm-feature#1474

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
