### PR TITLE
fix(chip-set): make search bar more distinct when it has-chips

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -156,6 +156,14 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
             z-index: -100;
         }
     }
+    &:not(.mdc-text-field--disabled).has-chips {
+        background-color: rgba(
+            241,
+            241,
+            243,
+            0.5
+        ); // Same color as when focused or hovered
+    }
 }
 
 .mdc-text-field--disabled .mdc-chip {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1436

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
