### PR TITLE
fix(table): use default formatter for column if invalid component config is provided

### DIFF
--- a/src/components/table/columns.spec.ts
+++ b/src/components/table/columns.spec.ts
@@ -214,5 +214,23 @@ describe('createCustomComponent', () => {
             expect(params.component).toEqual(column.component);
             expect(params.formatter).toBe(column.formatter);
         });
+
+        it('uses the default formatter if the element set in the custom component config does not exist', () => {
+            column.formatter = () => '';
+            column.component = {
+                name: 'not-existing-component',
+            };
+
+            const definition = factory.create(column);
+            expect(definition.formatter).toBe(undefined);
+        });
+
+        it('uses the default formatter if the custom component misses a name prop', () => {
+            column.formatter = () => '';
+            column.component = {} as any;
+
+            const definition = factory.create(column);
+            expect(definition.formatter).toBe(undefined);
+        });
     });
 });

--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -21,7 +21,7 @@ export class ColumnDefinitionFactory {
             field: column.field,
         };
 
-        if (column.component || column.formatter) {
+        if (column.component?.name || column.formatter) {
             definition.formatter = createFormatter(column, this.pool);
             definition.formatterParams = column as object;
         }
@@ -50,11 +50,34 @@ export function createFormatter(
         return formatCell;
     }
 
+    if (!columnElementExists(column)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Failed to render custom component for column "${column.field.toString()}". Custom element <${
+                column.component.name
+            }/> does not exist. Using the default formatter.`
+        );
+
+        return;
+    }
+
     return (cell: Tabulator.CellComponent) => {
         const value = formatCell(cell, column);
 
         return createCustomComponent(cell, column, value, pool);
     };
+}
+
+function columnElementExists(column: Column<any>) {
+    const name = column.component.name;
+    if (typeof name === 'string') {
+        const isNativeElement = !name.includes('-');
+        const customElementExists = customElements.get(column.component.name);
+
+        return isNativeElement || customElementExists;
+    } else {
+        return false;
+    }
 }
 
 /**


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1507

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
