### PR TITLE
fix(table): set max page of tabulator when totalRows is updated

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -164,12 +164,19 @@ export class Table {
         }
 
         this.pool.releaseAll();
-        this.tabulator.setData(this.data);
+        setTimeout(() => {
+            this.tabulator.setData(this.data);
+        });
     }
 
     @Watch('columns')
     public updateColumns() {
         this.tabulator.setColumns(this.getColumnDefinitions());
+    }
+
+    @Watch('totalRows')
+    public updateMaxPage() {
+        this.tabulator.setMaxPage(this.calculatePageCount());
     }
 
     private getOptions(): Tabulator.Options {


### PR DESCRIPTION
fix Lundalogik/crm-feature#1509

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
