### PR TITLE
fix(types): publish auto generated types for the source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "es2017": "dist/esm/index.js",
   "jsnext:main": "dist/esm/index.js",
   "main": "dist/index.cjs.js",
-  "types": "dist/types/interface.d.ts",
+  "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/"


### PR DESCRIPTION
fix: Lundalogik/crm-feature#1467

This is something you should do according to this:
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

This is also a requirement in the latest version of lime-crm-components.
The compiler cannot find the Element interfaces anymore without this
fix (HTMLLimelBadgeElement etc). This caused a lot of tests to fail and
without this fix we would have to use the more generic HTMLElement
interface instead.

The types that we previously had here are already exposed in `index.ts`

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
