### PR TITLE
fix(table): always update table pages after data has been updated or loaded

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -230,7 +230,7 @@ export class Table {
     }
 
     private handleAjaxRequesting() {
-        const abortRequest = this.firstRequest && this.data?.length;
+        const abortRequest = this.firstRequest && !!this.data?.length;
         this.firstRequest = false;
 
         if (abortRequest) {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -121,6 +121,7 @@ export class Table {
         this.requestData = this.requestData.bind(this);
         this.onClickRow = this.onClickRow.bind(this);
         this.formatRow = this.formatRow.bind(this);
+        this.updateMaxPage = this.updateMaxPage.bind(this);
         this.pool = new ElementPool(document);
         this.columnFactory = new ColumnDefinitionFactory(this.pool);
     }
@@ -174,9 +175,8 @@ export class Table {
         this.tabulator.setColumns(this.getColumnDefinitions());
     }
 
-    @Watch('totalRows')
-    public updateMaxPage() {
-        this.tabulator.setMaxPage(this.calculatePageCount());
+    private updateMaxPage() {
+        this.tabulator?.setMaxPage(this.calculatePageCount());
     }
 
     private getOptions(): Tabulator.Options {
@@ -194,6 +194,8 @@ export class Table {
             rowClick: this.onClickRow,
             rowFormatter: this.formatRow,
             initialSort: this.getColumnSorter(),
+            dataLoaded: this.updateMaxPage,
+            dataFiltered: this.updateMaxPage,
         };
     }
 
@@ -233,7 +235,7 @@ export class Table {
 
         if (abortRequest) {
             setTimeout(() => {
-                this.tabulator.setMaxPage(this.calculatePageCount());
+                this.updateMaxPage();
                 this.tabulator.setData(this.data);
             });
 


### PR DESCRIPTION
fix Lundalogik/crm-feature#1509

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
