### PR TITLE
fix(switch): ensure no exception is thrown in the console

### DIFF
--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -107,6 +107,10 @@ export class Switch {
 
     @Watch('value')
     protected valueWatcher(newValue, oldValue) {
+        if (!this.mdcSwitch) {
+            return;
+        }
+
         if (newValue !== oldValue) {
             this.mdcSwitch.checked = newValue;
         }


### PR DESCRIPTION
fix: Lundalogik/crm-feature#1514

This fix ensures that the switch value is not updated if the
component has not loaded.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
