### PR TITLE
fix(table): loader appears smoothly, instead of blinking into the screen

### DIFF
--- a/src/components/table/partial-styles/tabulator-loader.scss
+++ b/src/components/table/partial-styles/tabulator-loader.scss
@@ -1,0 +1,40 @@
+@keyframes fade-in-tabulator-loader {
+    0% {
+        background: transparent;
+    }
+    100% {
+        background: rgba(var(--contrast-1400), 0.4);
+    }
+}
+
+@keyframes spin-tabulator-loader {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.tabulator {
+    .tabulator-loader {
+        animation: fade-in-tabulator-loader 0.5s ease 0.5s forwards;
+        animation-iteration-count: 1;
+        cursor: progress;
+        background: transparent;
+
+        .tabulator-loader-msg {
+            animation: spin-tabulator-loader 0.4s linear infinite;
+
+            color: transparent; // gets rid of default "loading" label
+            font-size: 0; // gets rid of default "loading" label
+            border-radius: 50%;
+            border: pxToRem(3) solid
+                rgb(var(--lime-brand-color-flexible-turquoise)) !important;
+            border-top-color: transparent !important;
+
+            width: pxToRem(20);
+            height: pxToRem(20);
+
+            background-color: transparent !important;
+            padding: 0;
+        }
+    }
+}

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -9,6 +9,7 @@ $tabulator-arrow-color-active: var(--lime-turquoise);
 
 @import './partial-styles/tabulator-arrow';
 @import './partial-styles/tabulator-paginator';
+@import './partial-styles/tabulator-loader';
 @import './partial-styles/tabulator-custom-styles';
 
 :host {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1452

Now, normally loading only shows a spinner. If loading takes more time, user will see a backdrop that dimmes out the content until everything is loaded.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
