### PR TITLE
fix(dialog): make headers & headings look nicer

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -51,16 +51,24 @@ slot[name='header'] {
             --dialog-heading-title-color,
             #{$mdc-theme-text-primary-on-background}
         );
+        &:before {
+            height: 1rem; // Kia: Not sure what `:before` is used for, but it's default MD height is 2.5rem, which makes the header very tall.
+        }
+    }
+
+    .mdc-dialog__title,
+    .dialog__heading {
+        padding: pxToRem(12);
+        background-color: rgb(var(--contrast-300));
     }
 
     .dialog__heading {
         display: flex;
         align-items: center;
-        margin: pxToRem(30) pxToRem(24) pxToRem(5);
         flex-shrink: 0;
 
         limel-icon {
-            margin-right: pxToRem(15);
+            margin-right: pxToRem(12);
             color: var(--dialog-heading-icon-color, #{$mdc-theme-secondary});
 
             &[badge] {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1529
## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
