### PR TITLE
feat(input-field): add support for regex pattern

### DIFF
--- a/src/components/input-field/examples/input-field-pattern.tsx
+++ b/src/components/input-field/examples/input-field-pattern.tsx
@@ -1,0 +1,32 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Input Field with pattern
+ */
+@Component({
+    tag: 'limel-example-input-field-pattern',
+    shadow: true,
+})
+export class InputFieldPatternExample {
+    @State()
+    private value;
+
+    constructor() {
+        this.changeHandler = this.changeHandler.bind(this);
+    }
+
+    public render() {
+        return (
+            <limel-input-field
+                label="Personal identity number (YYYYMMDD-XXXX)"
+                value={this.value}
+                pattern={'[0-9]{8}[-][0-9]{4}'}
+                onChange={this.changeHandler}
+            />
+        );
+    }
+
+    private changeHandler(event) {
+        this.value = event.detail;
+    }
+}

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -33,6 +33,7 @@ import { ListItem } from '@limetech/lime-elements';
  * @exampleComponent limel-example-input-field-error-icon
  * @exampleComponent limel-example-input-field-textarea
  * @exampleComponent limel-example-input-field-search
+ * @exampleComponent limel-example-input-field-pattern
  */
 @Component({
     tag: 'limel-input-field',
@@ -91,6 +92,15 @@ export class InputField {
      */
     @Prop({ reflect: true })
     public leadingIcon: string;
+
+    /**
+     * Regular expression that the current value of the input field must match.
+     * No forward slashes should be specified around the pattern.
+     * Only used if type is `text`, `tel`, `email`, `url`, `password`
+     * or `search`.
+     */
+    @Prop({ reflect: true })
+    public pattern: string;
 
     /**
      * Type of textfield
@@ -245,6 +255,7 @@ export class InputField {
                     required={this.required}
                     disabled={this.disabled}
                     type={this.type}
+                    pattern={this.pattern}
                     onWheel={this.handleWheel}
                     onKeyDown={this.onKeyDown}
                     {...additionalProps}

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -285,8 +285,8 @@ export class InputField {
 
     @Watch('value')
     protected valueWatcher(newValue: string) {
-        if (this.type === 'textarea' && newValue !== this.mdcTextField.value) {
-            this.mdcTextField.value = newValue;
+        if (newValue !== this.mdcTextField.value) {
+            this.mdcTextField.value = newValue || '';
         }
     }
 


### PR DESCRIPTION
Required by https://github.com/Lundalogik/limepkg-esign/pull/530

Commit one:
* We want to use the pattern attribute provided on the input tag.
Pattern is not supported for all available input types, for example not for number. How should we handle this? Seems like pattern is not applied when I'm using it with `number` type, so it don't break at least. Is that enough?

Commit two:
* Discover some weirdness. 
I was trying to change `this.value` programmatically from our add-on without keystrokes so it matched the pattern. However, it turned out that `mdcTextValue` was out of sync with `this.value`, so the UI displayed that the value did not match the pattern even though it was a match!

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
