### PR TITLE
fix(input-field): do not prevent scrolling while hovering numeric input fields

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -256,7 +256,6 @@ export class InputField {
                     disabled={this.disabled}
                     type={this.type}
                     pattern={this.pattern}
-                    onWheel={this.handleWheel}
                     onKeyDown={this.onKeyDown}
                     {...additionalProps}
                     value={this.value}
@@ -623,11 +622,6 @@ export class InputField {
 
         if (isSpace || isEnter) {
             this.action.emit();
-        }
-    }
-    private handleWheel(event: MouseEvent) {
-        if (this.type === 'number') {
-            event.preventDefault();
         }
     }
 }


### PR DESCRIPTION
In Firefox on Windows, scrolling changes the value of the input, but only if the input is focused. When that happens, the page will not scroll, which should indicate to the user that something else happened instead.

Scroll behaviour when initiating scroll while hovering the input element in different browsers on BrowserStack:
 - Windows:
   - Firefox updates the value and prevents scrolling of page when input is focused, does not update value and allows scrolling of page when input is not focused
   - Chrome and Edge scroll the page, not the value, regardless of focus state
 - macOS:
   - Chrome, Safari, Firefox, Edge (yes, Edge on macOS 🙄), and Opera all scroll the page, not the value, regardless of focus state

fix Lundalogik/crm-feature#1538

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
