### PR TITLE
Docs bring back guidelines for tabs

### DIFF
--- a/src/components/tab-bar/examples/tab-bar-with-dynamic-tab-width.tsx
+++ b/src/components/tab-bar/examples/tab-bar-with-dynamic-tab-width.tsx
@@ -2,7 +2,7 @@ import { Component, h, State } from '@stencil/core';
 import { Tab } from '@limetech/lime-elements';
 
 /**
- * Tab bars with custom styles
+ * Default UI of Tab bars
  * By default, tabs dynamically adjust their width to their own content, which
  * means a tab with a larger label will be bigger than one with a shorter one.
  * This is the preferred layout for tabs.

--- a/src/components/tab-bar/examples/tab-bar-with-equal-tab-width.tsx
+++ b/src/components/tab-bar/examples/tab-bar-with-equal-tab-width.tsx
@@ -2,6 +2,7 @@ import { Component, h, State } from '@stencil/core';
 import { Tab } from '@limetech/lime-elements';
 
 /**
+ * Tab bars with custom styles
  * In some situations and for the sake of UI design, you may want to have tabs
  * that equally share the available screen width and stretch. To get such a
  * result, you can add the `has-tabs-with-equal-width` class to the tab bar.

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -18,6 +18,21 @@ const SCROLL_DISTANCE_ON_CLICK_PX = 150;
 const HIDE_SCROLL_BUTTONS_WHEN_SCROLLED_LESS_THAN_PX = 40;
 
 /**
+ * Tabs are great to organize information hierarchically in the interface and divide it into distinct categories. Using tabs, you can create groups of content that are related and at the same level in the hierarchy.
+ * :::warning
+ * Tab bars should be strictly used for navigation at the top levels.
+ * They should never be used to perform actions, or navigate away from the view which contains them.
+ * :::
+ * An exception for using tab bars in a high level of hierarchy is their usage in modals. This is because modals are perceived as a separate place and not a part of the current context. Therefore you can use tab bars in a modal to group and organize its content.
+ * A tab bar can contain an unlimited number of tabs. However, depending on the device width and width of the tabs, the number of tabs that are visible at the same time will vary. When there is limited horizontal space, the component shows a left-arrow and/or right-arrow button, which scrolls and reveals the additional tabs. The tab bar can also be swiped left and right on a touch-device.
+ *:::tip Other things to consider
+ * * Never divide the content of a tab using a nested tab bar.
+ * * Never place two tab bars within the same screen.
+ * * Never use background color for icons in tabs.
+ * * Avoid having long labels for tabs.
+ * * A tab will never be removed or get disabled, even if there is no content under it.
+ * :::
+ *
  * @exampleComponent limel-example-tab-bar
  * @exampleComponent limel-example-tab-bar-with-dynamic-tab-width
  * @exampleComponent limel-example-tab-bar-with-equal-tab-width


### PR DESCRIPTION
## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
