### PR TITLE
Don't render empty footer for limel-dialog

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -76,6 +76,8 @@ export class Dialog {
 
     private id: string;
 
+    private showFooter: boolean;
+
     constructor() {
         this.handleMdcOpened = this.handleMdcOpened.bind(this);
         this.handleMdcClosed = this.handleMdcClosed.bind(this);
@@ -99,6 +101,8 @@ export class Dialog {
         if (!element) {
             return;
         }
+
+        this.showFooter = !!this.host.querySelector('[slot="button"]');
 
         this.mdcDialog = new MDCDialog(element);
         if (this.open) {
@@ -162,9 +166,7 @@ export class Dialog {
                         >
                             <slot />
                         </div>
-                        <footer class="mdc-dialog__actions">
-                            <slot name="button" />
-                        </footer>
+                        {this.renderFooter()}
                     </div>
                 </div>
                 <div class="mdc-dialog__scrim" />
@@ -257,5 +259,15 @@ export class Dialog {
         }
 
         return null;
+    }
+
+    private renderFooter() {
+        if (this.showFooter) {
+            return (
+                <footer class="mdc-dialog__actions">
+                    <slot name="button" />
+                </footer>
+            );
+        }
     }
 }


### PR DESCRIPTION
fix: #1009

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
