### PR TITLE
fix(tab-panel): set correct display on panels when new tabs are given

### DIFF
--- a/src/components/tab-panel/tab-panel.e2e.ts
+++ b/src/components/tab-panel/tab-panel.e2e.ts
@@ -1,0 +1,97 @@
+import { newE2EPage, E2EPage, E2EElement } from '@stencil/core/testing';
+import { Tab } from '../tab-bar/tab.types';
+
+describe('tab-panel', () => {
+    let page: E2EPage;
+    let tabPanel: E2EElement;
+    let tabs: Tab[] = [];
+
+    beforeEach(async () => {
+        page = await newE2EPage();
+        await page.setContent(`
+            <limel-tab-panel>
+                <div id="foo">Foo</div>
+                <div id="bar">Bar</div>
+            </limel-tab-panel>
+        `);
+        tabs = [
+            {
+                id: 'foo',
+                active: true,
+                text: 'Foo',
+            },
+            {
+                id: 'bar',
+                text: 'Bar',
+            },
+        ];
+        tabPanel = await page.find('limel-tab-panel');
+        tabPanel.setProperty('tabs', tabs);
+
+        await page.waitForChanges();
+    });
+
+    it('renders the component', () => {
+        expect(tabPanel).toEqualHtml(`
+            <limel-tab-panel class="hydrated">
+                <mock:shadow-root>
+                    <div class="tab-panel">
+                        <limel-tab-bar class="hydrated"></limel-tab-bar>
+                        <div class="tab-content">
+                            <slot></slot>
+                        </div>
+                    </div>
+                </mock:shadow-root>
+                <div id="foo">Foo</div>
+                <div id="bar" style="display: none;">Bar</div>
+            </limel-tab-panel>
+        `);
+    });
+
+    describe('when new tabs are given', () => {
+        beforeEach(async () => {
+            tabs = [
+                {
+                    id: 'cat',
+                    text: 'Cat',
+                },
+                {
+                    id: 'dog',
+                    text: 'Dog',
+                    active: true,
+                },
+            ];
+
+            await page.$eval('body', (body) => {
+                let element = body.querySelector('#foo');
+                element.id = 'cat';
+                element.textContent = 'Cat';
+
+                element = body.querySelector('#bar');
+                element.id = 'dog';
+                element.textContent = 'Dog';
+            });
+            await page.waitForChanges();
+
+            tabPanel.setProperty('tabs', tabs);
+            await page.waitForChanges();
+        });
+
+        it('sets the correct display on the panels', () => {
+            expect(tabPanel).toEqualHtml(`
+                <limel-tab-panel class="hydrated">
+                    <mock:shadow-root>
+                        <div class="tab-panel">
+                            <limel-tab-bar class="hydrated"></limel-tab-bar>
+                            <div class="tab-content">
+                                <slot></slot>
+                            </div>
+                        </div>
+                    </mock:shadow-root>
+                    <div id="cat" style="display: none;">Cat</div>
+                    <div id="dog">Dog</div>
+                </limel-tab-panel>
+            `);
+        });
+    });
+});

--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -6,6 +6,7 @@ import {
     EventEmitter,
     Event,
     Host,
+    Watch,
 } from '@stencil/core';
 import { Tab } from '../tab-bar/tab.types';
 
@@ -81,6 +82,12 @@ export class TabPanel {
         slot.removeEventListener('slotchange', this.setSlotElements);
     }
 
+    @Watch('tabs')
+    public tabsChanged() {
+        this.hidePanels();
+        this.tabs.forEach(this.setTabStatus);
+    }
+
     public render() {
         return (
             <Host onChangeTab={this.handleChangeTabs}>
@@ -96,7 +103,9 @@ export class TabPanel {
 
     private setSlotElements() {
         const slot = this.getSlot();
+        this.hidePanels();
         this.slotElements = [].slice.call(slot.assignedElements());
+        this.tabs.forEach(this.setTabStatus);
     }
 
     private setTabStatus(tab: Tab) {
@@ -128,5 +137,11 @@ export class TabPanel {
 
     private getSlot(): HTMLSlotElement {
         return this.host.shadowRoot.querySelector('slot');
+    }
+
+    private hidePanels() {
+        this.slotElements.forEach((element) => {
+            element.style.display = 'none';
+        });
     }
 }


### PR DESCRIPTION
If the tab panel is given a new set of tabs with new IDs, we need to hide all the old panels since
we do not know if one of the old panels should be visible or not. Otherwise content from two tabs
might be visible at the same time.

fix Lundalogik/crm-feature#1494

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
