### PR TITLE
feat(button): add `has-reduced-presence` helper class

### DIFF
--- a/guides.ts
+++ b/guides.ts
@@ -7,6 +7,10 @@ export default [
     },
     {
         name: 'DesignGuidelines',
-        children: ['src/color-system.md', 'src/size-rhythms.md'],
+        children: [
+            'src/color-system.md',
+            'src/decluttering.md',
+            'src/size-rhythms.md',
+        ],
     },
 ] as Guide[];

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -84,3 +84,20 @@ button {
         }
     }
 }
+
+:host(.has-reduced-presence) {
+    button {
+        transition: opacity 300ms ease-in-out;
+
+        &[disabled]:not(.loading):not(.just-loaded) {
+            opacity: 0;
+
+            limel-icon,
+            .label {
+                // Avoid fading in the label while
+                // simultaneously fading out the button.
+                opacity: 0;
+            }
+        }
+    }
+}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -3,6 +3,7 @@ import { Component, Element, h, Prop, Watch } from '@stencil/core';
 /**
  * @exampleComponent limel-example-button
  * @exampleComponent limel-example-button-click
+ * @exampleComponent limel-example-button-reduce-presence
  */
 @Component({
     tag: 'limel-button',

--- a/src/components/button/examples/button-click.tsx
+++ b/src/components/button/examples/button-click.tsx
@@ -5,7 +5,7 @@ import { Component, h, State } from '@stencil/core';
  *
  * The click handler in this example sets the attributes `loading` and
  * `disabled` to `true`. After 1 second, the `loading` attribute is set to
- * `false` again. After another 4 seconds, the button is once again enabled.
+ * `false` again. After another 5 seconds, the button is once again enabled.
  *
  * When the `loading` attribute changes from `true` to `false`, the button
  * automatically displays a checkmark icon for 2 seconds. Note that our click
@@ -39,7 +39,7 @@ export class ButtonClickExample {
         this.loading = true;
 
         const TIME_LOADING = 1000;
-        const TIME_DISABLED = 4000;
+        const TIME_DISABLED = 5000;
         setTimeout(() => {
             this.loading = false;
             setTimeout(() => {

--- a/src/components/button/examples/button-reduce-presence.tsx
+++ b/src/components/button/examples/button-reduce-presence.tsx
@@ -1,0 +1,51 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Reduce Presence
+ *
+ * This example is identical to the one above, except that here, the
+ * `has-reduced-presence` class has been set to `true`. This will hide the
+ * button when it is disabled. However, it will also make sure that the button
+ * remains visible while the loading animation is ongoing. When the animation is
+ * done and the checkmark has been shown, the button will hide.
+ *
+ * Read more in the [Design Guidelines](/#/DesignGuidelines/decluttering.md)
+ */
+@Component({
+    tag: 'limel-example-button-reduce-presence',
+    shadow: true,
+})
+export class ButtonReducePresenceExample {
+    @State()
+    private loading = false;
+
+    @State()
+    private disabled = false;
+
+    public render() {
+        return (
+            <limel-button
+                class="has-reduced-presence"
+                label="Click me!"
+                primary={true}
+                loading={this.loading}
+                disabled={this.disabled}
+                onClick={this.onClick}
+            />
+        );
+    }
+
+    private onClick() {
+        this.disabled = true;
+        this.loading = true;
+
+        const TIME_LOADING = 1000;
+        const TIME_DISABLED = 5000;
+        setTimeout(() => {
+            this.loading = false;
+            setTimeout(() => {
+                this.disabled = false;
+            }, TIME_DISABLED);
+        }, TIME_LOADING);
+    }
+}

--- a/src/decluttering.md
+++ b/src/decluttering.md
@@ -1,0 +1,24 @@
+# Reducing UI clutter and cognitive load
+
+A user interface with too many elements requires more processing from users' brains. When fewer things on the screen try to attract the user's attention, it becomes easier for the user to "consume" the UI. This is what we mean when we talk about "reducing cognitive load". In the end, our goal is for the user to spend their mental energy on the problem at hand, not at the tool they are using to solve it (our UI).
+
+## Buttons
+
+Buttons are particularly strong elements in the UI, since they are meant to perform important actions. Thus, an effective way of reducing clutter is to hide buttons that aren't useful at the moment. This most commonly applies to disabled buttons.
+
+Disabled buttons can convey important information, but when they don't, they should be hidden. Here are some examples:
+
+1. **When there are invalid fields, or empty required fields**
+   We can anticipate that the user might try to save their changes, and showing a disabled Save button is part of telling the user that there is something they need to do before saving is possible. This should be combined with other clear visual hints on what to do, like highlighting the invalid field and displaying a validation error message.
+2. **When the user has made no changes**
+   This example can be divided into two groups:
+   - *The user is in a distinct "flow" with discrete steps, and is prevented from continuing to the next step.* Common examples are so called "wizards". In this case, a disabled Save or Continue button should be kept visible, for the same reason as in example 1.
+   - *Making and saving changes is just one of the possible "things to do" on the current page.* Examples include forms that are used both for displaying and changing information (common for configuration or settings pages), or a feed, with an input for adding new posts. In this case, a disabled Save button isn't useful. We don't even know that the user has any intention of using it. Once the user updates the information, or starts writing in the input field, it's time to display the Save button, along with any other controls that might have also been hidden.
+
+:::note
+Keep in mind that a SAVE button can be disabled but visible, to tell the
+users that requirements are not met, or there are errors.
+
+Such cases should be accompanied with other clear visual hints where the
+errors or progress-blockers are located in the UI.
+:::


### PR DESCRIPTION
Adding `has-reduced-presence` to limel-button hides the button when it is disabled and not either loading or showing the checkmark after loading.

fix: Lundalogik/crm-feature#1581

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
