### PR TITLE
perf(dev-server): create link to node_modules instead of copying 5000+ files

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-sonarjs": "^0.5.0",
     "jest": "^26.5.2",
     "jest-cli": "^26.5.2",
+    "lnk": "^1.1.0",
     "lodash-es": "4.17.15",
     "prettier": "^2.1.2",
     "prismjs": "1.21.0",

--- a/publish-docs.js
+++ b/publish-docs.js
@@ -132,6 +132,7 @@ function build() {
                 /="\/build/g,
                 /="\/style/g,
                 /="\/assets/g,
+                /="\/node_modules/g,
                 /\/kompendium.json/g,
             ],
             to: [
@@ -139,6 +140,7 @@ function build() {
                 `="/versions/${version}/build`,
                 `="/versions/${version}/style`,
                 `="/versions/${version}/assets`,
+                `="/versions/${version}/node_modules`,
                 `/versions/${version}/kompendium.json`,
             ],
         };

--- a/rollup-plugin-link-node-modules.js
+++ b/rollup-plugin-link-node-modules.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-undef */
+const lnk = require('lnk');
+const fs = require('fs');
+
+const TIMEOUT = 500;
+
+module.exports = function linkNodeModules() {
+    return {
+        name: 'link-node-modules',
+        generateBundle: async () => {
+            while (!fs.existsSync('www')) {
+                await new Promise((resolve) => setTimeout(resolve, TIMEOUT));
+            }
+
+            if (!fs.existsSync('www/node_modules')) {
+                lnk(['node_modules'], 'www');
+            }
+        },
+    };
+};

--- a/src/index.html
+++ b/src/index.html
@@ -15,10 +15,18 @@
     <link href="/style/color-palette-extended.css" rel="stylesheet" />
     <link href="/build/lime-elements.css" rel="stylesheet" />
     <script type="module" src="/build/lime-elements.esm.js"></script>
+    <script>
+        const config = {
+            iconPath: 'node_modules/@lundalogik/lime-icons8'
+        };
+        const element = document.createElement('limel-config');
+        element.config = config;
+        document.body.append(element);
+    </script>
 
-    <link href="/assets/kompendium/kompendium/kompendium.css" rel="stylesheet" />
-    <script type="module" src="/assets/kompendium/kompendium/kompendium.esm.js"></script>
-    <script nomodule src="/assets/kompendium/kompendium/kompendium.js"></script>
+    <link href="/node_modules/kompendium/dist/kompendium/kompendium.css" rel="stylesheet" />
+    <script type="module" src="/node_modules/kompendium/dist/kompendium/kompendium.esm.js"></script>
+    <script nomodule src="/node_modules/kompendium/dist/kompendium/kompendium.js"></script>
 
 
     <kompendium-app path="/kompendium.json"></kompendium-app>

--- a/stencil.config.docs.ts
+++ b/stencil.config.docs.ts
@@ -23,12 +23,12 @@ export const config: Config = {
             copy: [
                 { src: 'style/color-palette-extended.css' },
                 {
-                    src: '../node_modules/@lundalogik/lime-icons8/assets/',
-                    dest: 'assets/',
+                    src: '../node_modules/@lundalogik/lime-icons8',
+                    dest: 'node_modules/@lundalogik/lime-icons8',
                 },
                 {
-                    src: '../node_modules/kompendium/dist/',
-                    dest: 'assets/kompendium/',
+                    src: '../node_modules/kompendium/',
+                    dest: 'node_modules/kompendium/',
                 },
             ],
         },

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,6 +2,7 @@ import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
 import { kompendium } from 'kompendium';
 import guides from './guides';
+import linkNodeModules from './rollup-plugin-link-node-modules';
 
 export const config: Config = {
     hashFileNames: false,
@@ -23,17 +24,7 @@ export const config: Config = {
             type: 'www',
             serviceWorker: null,
             dir: 'www',
-            copy: [
-                { src: 'style/color-palette-extended.css' },
-                {
-                    src: '../node_modules/@lundalogik/lime-icons8/assets/',
-                    dest: 'assets/',
-                },
-                {
-                    src: '../node_modules/kompendium/dist/',
-                    dest: 'assets/kompendium/',
-                },
-            ],
+            copy: [{ src: 'style/color-palette-extended.css' }],
         },
     ],
     commonjs: {
@@ -44,7 +35,7 @@ export const config: Config = {
             ],
         },
     },
-    plugins: [sass()],
+    plugins: [sass(), linkNodeModules()],
     tsconfig: './tsconfig.dev.json',
     globalStyle: 'src/global/core-styles.scss',
     testing: {


### PR DESCRIPTION
Just copying the icons takes 30+ seconds on my machine when starting the dev-server. This PR creates a symlink to node_modules instead to speed things up a bit


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
