### PR TITLE
build(tsconfig): use specified tsconfig for production builds

### DIFF
--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -18,5 +18,6 @@ export const config: Config = {
         },
     },
     plugins: [sass()],
+    tsconfig: './tsconfig.dist.json',
     globalStyle: 'src/global/core-styles.scss',
 };

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "**/test/**",
+    "**/examples/**",
+    "**/dev-assets/**",
+    "**/*.spec.*",
+    "**/*.e2e.*",
+    "**/*.test-wrapper.*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,14 +20,5 @@
     "skipLibCheck": true,
     "typeRoots": ["types", "node_modules/@types"]
   },
-  "include": ["src", "types/jsx.d.ts"],
-  "exclude": [
-    "node_modules",
-    "**/test/**",
-    "**/examples/**",
-    "**/dev-assets/**",
-    "**/*.spec.*",
-    "**/*.e2e.*",
-    "**/*.test-wrapper.*"
-  ]
+  "include": ["src", "types/jsx.d.ts"]
 }


### PR DESCRIPTION
For some reason there were a lot of errors shown in VSCode for all the example components. The build
still worked, but it's annoying to have errors all over the file when writing new examples. It seems
VSCode used the production version of tsconfig instead of the dev one, so by specifying another file
for the production build we can use the default tsconfig for the whole project.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
