### PR TITLE
docs(button): fix broken link to Design Guidelines section of docs

### DIFF
--- a/src/components/button/examples/button-reduce-presence.tsx
+++ b/src/components/button/examples/button-reduce-presence.tsx
@@ -9,7 +9,7 @@ import { Component, h, State } from '@stencil/core';
  * remains visible while the loading animation is ongoing. When the animation is
  * done and the checkmark has been shown, the button will hide.
  *
- * Read more in the [Design Guidelines](/#/DesignGuidelines/decluttering.md)
+ * Read more in the [Design Guidelines](#/DesignGuidelines/decluttering.md/)
  */
 @Component({
     tag: 'limel-example-button-reduce-presence',


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
