### PR TITLE
fix(collapsible-section): disallow user selection of headings in 

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -56,6 +56,8 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    user-select: none; // mostly to improve experience on Android, where tapping on sections selects the text too
 }
 
 .section__header__actions {


### PR DESCRIPTION
collapsible sections

fix: https://github.com/Lundalogik/crm-feature/issues/1622

Mostly improves experience on Android, where tapping on sections selects the text too

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
