### PR TITLE
fix(collapsible-section): set delay for micro animations

### DIFF
--- a/src/components/collapsible-section/partial-styles/expand-icon.scss
+++ b/src/components/collapsible-section/partial-styles/expand-icon.scss
@@ -22,7 +22,7 @@
 
     &:first-of-type,
     &:last-of-type {
-        transition: opacity 0.2s ease, transform 0.4s ease;
+        transition: opacity 0.2s ease 0.1s, transform 0.4s ease 0.3s;
     }
 
     &:first-of-type {
@@ -52,8 +52,8 @@
 
             &:nth-of-type(2),
             &:nth-of-type(3) {
-                transition: opacity 0.5s ease 0.2s,
-                    transform 0.7s cubic-bezier(0.85, 0.11, 0.14, 1.35);
+                transition: opacity 0.5s ease 0.4s,
+                    transform 0.7s cubic-bezier(0.85, 0.11, 0.14, 1.35) 0.2s;
             }
 
             &:nth-of-type(2) {
@@ -72,6 +72,10 @@
 section.open {
     .section__header {
         .expand-icon__line {
+            &:first-of-type,
+            &:last-of-type {
+                transition: opacity 0.2s ease 0.1s, transform 0.4s ease 0.3s;
+            }
             &:first-of-type {
                 transform: rotate3d(0, 0, 1, 0deg);
             }
@@ -100,8 +104,8 @@ section.open {
             .expand-icon__line {
                 &:first-of-type,
                 &:last-of-type {
-                    transition: opacity 0.2s ease,
-                        transform 0.4s cubic-bezier(0.85, 0.11, 0.14, 1.35);
+                    transition: opacity 0.2s ease 0.4s,
+                        transform 0.4s cubic-bezier(0.85, 0.11, 0.14, 1.35) 0.2s;
                 }
 
                 &:first-of-type {


### PR DESCRIPTION
This will prevent immediately triggering too many animations while user is
moving  their cursor over sections (like in overview tab in object cards)

fix: https://github.com/Lundalogik/crm-feature/issues/1641

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
