### PR TITLE
fix(input-field): add interactivity & more affordance to trailing icon

### DIFF
--- a/src/components/input-field/examples/input-field-icon-trailing.tsx
+++ b/src/components/input-field/examples/input-field-icon-trailing.tsx
@@ -3,7 +3,16 @@ import { Component, h, State } from '@stencil/core';
 /**
  * Input Field with Trailing Icon & Action
  *
- * A trailing icon can be added along with an action for that trailing icon.
+ * A trailing icon can be added to input fields along with an action
+ * for that trailing icon.
+ * :::note
+ * Use trailing icons only when you intend to have an action associated with them.
+ * Trailing icons of input fields will get an interactive visual effect when
+ * hovered to hint users that they are clickable.
+ *
+ * Therefore, a purely ornamental trailing icon that has this interactive effect
+ * will be confusing for users.
+ * :::
  */
 @Component({
     tag: 'limel-example-input-field-icon-trailing',

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -8,6 +8,8 @@
 @import '@limetech/mdc-elevation/mdc-elevation';
 @import '@limetech/mdc-menu-surface/mdc-menu-surface';
 
+@import './partial-styles/trailing-icon.scss';
+
 /**
  * @prop --textarea-height: Height of the field when type is set to `textarea`
  */

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -505,7 +505,7 @@ export class InputField {
         return (
             <a
                 {...linkProps}
-                class="mdc-text-field__icon"
+                class="mdc-text-field__icon trailing-icon"
                 tabindex={this.disabled ? '-1' : '0'}
                 role="button"
             >
@@ -519,7 +519,7 @@ export class InputField {
             <i
                 onKeyPress={this.handleIconKeyPress}
                 onClick={this.handleIconClick}
-                class="mdc-text-field__icon"
+                class="mdc-text-field__icon trailing-icon"
                 tabindex={this.isInvalid() ? '-1' : '0'}
                 role="button"
             >

--- a/src/components/input-field/partial-styles/trailing-icon.scss
+++ b/src/components/input-field/partial-styles/trailing-icon.scss
@@ -1,0 +1,35 @@
+.mdc-text-field--with-trailing-icon {
+    &:not(.mdc-text-field--disabled):not(.mdc-text-field--invalid) {
+        // `mdc-text-field--invalid` displays a (!) icon, which we don't want it to appear interactive
+        .trailing-icon {
+            transition: background-color 0.2s ease, box-shadow 0.3s ease;
+            border-radius: 50%;
+            padding: pxToRem(8);
+            right: pxToRem(8);
+
+            &:focus {
+                outline: none;
+            }
+
+            &:focus-visible {
+                box-shadow: 0 0 0 pxToRem(2) var(--mdc-theme-primary) !important; // has to be `!important` since we're using `box-shadow` insted of `outline` which is also used in `hover` mode
+            }
+        }
+
+        &:hover {
+            .trailing-icon {
+                box-shadow: var(--button-shadow-normal);
+                background-color: rgba(var(--contrast-100), 0.4);
+
+                &:hover {
+                    background-color: rgb(var(--contrast-100));
+                    box-shadow: var(--button-shadow-hovered);
+                }
+
+                &:active {
+                    box-shadow: var(--button-shadow-pressed);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1650
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
