### PR TITLE
docs(form): add example for `propsFactory`

### DIFF
--- a/src/components/form/examples/props-factory-form.tsx
+++ b/src/components/form/examples/props-factory-form.tsx
@@ -1,0 +1,57 @@
+import { Component, h, State } from '@stencil/core';
+import { schema } from './props-factory-schema';
+
+/**
+ * Using `propsFactory`
+ *
+ * @link props-factory-schema.ts
+ * @link props-factory-picker.tsx
+ */
+@Component({
+    tag: 'limel-example-props-factory-form',
+    shadow: true,
+})
+export class PropsFactoryFormExample {
+    @State()
+    private formData: object = {
+        hero: 1001,
+    };
+
+    private anObjectToInject = {
+        someProp: 'The object was successfully injected!',
+    };
+    private aStringToInject = 'The string was successfully injected!';
+
+    constructor() {
+        this.propsFactory = this.propsFactory.bind(this);
+        this.handleFormChange = this.handleFormChange.bind(this);
+    }
+
+    public render() {
+        return [
+            <limel-form
+                onChange={this.handleFormChange}
+                value={this.formData}
+                schema={schema}
+                propsFactory={this.propsFactory}
+            />,
+            <limel-example-value value={this.formData} />,
+        ];
+    }
+
+    private propsFactory(subSchema: Record<string, any>) {
+        if (
+            subSchema.lime?.component?.name ===
+            'limel-example-props-factory-picker'
+        ) {
+            return {
+                injectedObject: this.anObjectToInject,
+                injectedString: this.aStringToInject,
+            };
+        }
+    }
+
+    private handleFormChange(event: CustomEvent<object>) {
+        this.formData = event.detail;
+    }
+}

--- a/src/components/form/examples/props-factory-picker.tsx
+++ b/src/components/form/examples/props-factory-picker.tsx
@@ -1,0 +1,127 @@
+import { Component, h, Prop, EventEmitter, Event } from '@stencil/core';
+import { FormComponent } from '@limetech/lime-elements';
+import { ListItem } from 'src/components/list/list-item.types';
+
+@Component({
+    tag: 'limel-example-props-factory-picker',
+    shadow: true,
+})
+export class PropsFactoryPickerExample implements FormComponent<number> {
+    /**
+     * An object injected using `propsFactory`
+     */
+    @Prop()
+    public injectedObject: { someProp: string };
+
+    /**
+     * A string injected using `propsFactory`
+     */
+    @Prop()
+    public injectedString: string;
+
+    /**
+     * The value of the property
+     */
+    @Prop()
+    public value: number;
+
+    /**
+     * Label to display next to the input field
+     */
+    @Prop()
+    public label: string;
+
+    /**
+     * Set to `true` if a value is required
+     */
+    @Prop()
+    public required: boolean;
+
+    /**
+     * Set to `true` if the value is readonly
+     */
+    @Prop()
+    public readonly: boolean;
+
+    /**
+     * Set to `true` if input should be disabled
+     */
+    @Prop()
+    public disabled: boolean;
+
+    /**
+     * Emitted when the value is changed
+     */
+    @Event()
+    public change: EventEmitter<number>;
+
+    private heroes: Array<ListItem<number>> = [
+        {
+            text: 'Superman',
+            value: 1001,
+            icon: 'superman',
+            iconColor: 'var(--lime-deep-red)',
+        },
+        {
+            text: 'Squirrel Girl',
+            value: 1002,
+            icon: 'squirrel',
+            iconColor: 'var(--lime-orange)',
+        },
+        {
+            text: 'Captain America',
+            value: 1003,
+            icon: 'captain_america',
+            iconColor: 'var(--lime-blue)',
+        },
+        {
+            text: 'Black Widow',
+            value: 1004,
+            icon: 'spider',
+            iconColor: 'var(--lime-dark-grey)',
+        },
+    ];
+
+    constructor() {
+        this.handleChange = this.handleChange.bind(this);
+        this.search = this.search.bind(this);
+    }
+
+    public componentWillLoad() {
+        console.log(
+            'propsFactory-picker - this.injectedObject.someProp:',
+            this.injectedObject.someProp
+        );
+        console.log(
+            'propsFactory-picker - this.injectedString:',
+            this.injectedString
+        );
+    }
+
+    private handleChange(event: CustomEvent<ListItem<number>>) {
+        event.stopPropagation();
+        this.change.emit(event.detail?.value);
+    }
+
+    private async search(query: string): Promise<ListItem[]> {
+        return this.heroes.filter((hero) => {
+            return hero.text.toLowerCase().includes(query.toLowerCase());
+        });
+    }
+
+    public render() {
+        const value = this.heroes.find((hero) => hero.value === this.value);
+
+        return (
+            <limel-picker
+                label={this.label}
+                value={value}
+                disabled={this.disabled}
+                readonly={this.readonly}
+                required={this.required}
+                onChange={this.handleChange}
+                searcher={this.search}
+            />
+        );
+    }
+}

--- a/src/components/form/examples/props-factory-schema.ts
+++ b/src/components/form/examples/props-factory-schema.ts
@@ -1,0 +1,14 @@
+export const schema = {
+    type: 'object',
+    properties: {
+        hero: {
+            type: 'integer',
+            title: 'Hero',
+            lime: {
+                component: {
+                    name: 'limel-example-props-factory-picker',
+                },
+            },
+        },
+    },
+};

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -30,6 +30,7 @@ import { isInteger } from './validators';
  * @exampleComponent limel-example-list-form
  * @exampleComponent limel-example-dynamic-form
  * @exampleComponent limel-example-custom-component-form
+ * @exampleComponent limel-example-props-factory-form
  * @exampleComponent limel-example-form-layout
  * @exampleComponent limel-example-form-span-fields
  */


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
