### PR TITLE
fix(input-field): fix missing label when prefilled and placed in dialog or collapsible-section

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -204,6 +204,7 @@ export class InputField {
         this.onKeyDown = this.onKeyDown.bind(this);
         this.handleCompletionChange = this.handleCompletionChange.bind(this);
         this.onKeyDownForList = this.onKeyDownForList.bind(this);
+        this.layout = this.layout.bind(this);
     }
 
     public connectedCallback() {
@@ -227,12 +228,16 @@ export class InputField {
         this.completionsList = [...this.completions].map((item) => {
             return { text: item };
         });
+
+        window.addEventListener('resize', this.layout, { passive: true });
     }
 
     public disconnectedCallback() {
         if (this.mdcTextField) {
             this.mdcTextField.destroy();
         }
+
+        window.removeEventListener('resize', this.layout);
     }
 
     public componentDidUpdate() {
@@ -304,6 +309,10 @@ export class InputField {
         if (newValue !== this.mdcTextField.value) {
             this.mdcTextField.value = newValue || '';
         }
+    }
+
+    private layout() {
+        this.mdcTextField?.layout();
     }
 
     private renderTextArea() {


### PR DESCRIPTION
When limel-input-field of type `textarea` had a value, and was hidden at the time of creation (e.g.
when placed inside a limel-dialog or limel-collapsible-section), the label would be missing. This
fixes that problem.

fix #950

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
