### PR TITLE
fix(select): make selected-text truncate & prevent select to grow…

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -30,6 +30,7 @@
 
     .limel-select-trigger {
         display: inline-flex;
+        min-width: 0; // makes the limel-select__selected-text truncate and prevents the select to grow wider than its container
         height: $height-of-mdc-text-field;
 
         cursor: pointer;


### PR DESCRIPTION
wider than its container

fix: https://github.com/Lundalogik/lime-elements/issues/1060

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
