### PR TITLE
fix(form): allow fields to be rendered as read only

### DIFF
--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { WidgetProps } from '../widgets/types';
 import { LimeElementsAdapter } from './base-adapter';
 import { capitalize } from 'lodash-es';
+import { LimeSchemaOptions } from '../form.types';
 
 interface WidgetAdapterProps {
     name: string;
@@ -107,12 +108,11 @@ export class LimeElementsWidgetAdapter extends React.Component {
 
     render() {
         const { name, events, extraProps } = this.props;
-        const { disabled, onChange } = this.props.widgetProps;
-
+        const disabled = this.isDisabled();
         const value = this.getValue();
 
         const newEvents = {
-            change: onChange,
+            change: this.props.widgetProps.onChange,
             blur: this.handleBlur,
             ...events,
         };
@@ -130,5 +130,24 @@ export class LimeElementsWidgetAdapter extends React.Component {
             },
             events: newEvents,
         });
+    }
+
+    private isDisabled() {
+        // We treat disabled and readonly the same here since the default
+        // lime-elements components does not have a readonly state
+        if (this.isReadOnly()) {
+            return true;
+        }
+
+        const widgetProps = this.props.widgetProps;
+        const options: LimeSchemaOptions = widgetProps.schema.lime;
+
+        return widgetProps.disabled || options?.disabled;
+    }
+
+    private isReadOnly() {
+        const widgetProps = this.props.widgetProps;
+
+        return widgetProps.readonly;
     }
 }

--- a/src/components/form/examples/basic-schema.ts
+++ b/src/components/form/examples/basic-schema.ts
@@ -18,6 +18,12 @@ export const schema = {
             description: 'Enter your email address',
             format: 'email',
         },
+        home: {
+            type: 'string',
+            title: 'Home',
+            default: 'Earth',
+            readOnly: true,
+        },
         happiness: {
             type: 'number',
             title: 'Happiness',

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -136,6 +136,11 @@ export interface LimeSchemaOptions {
      * specified layout
      */
     layout?: FormLayoutOptions<any>;
+
+    /**
+     * Mark the field as disabled
+     */
+    disabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
According to react-jsonschema-form the difference between readonly and disabled fields is that the
text value of readonly fields can still be selected, while that is not possible for disabled fields.
None of the default lime-elements components that we map to the standard fields in the form have a
readonly state so we have to treat them the same for now and set the disabled state instead.

`readOnly` is part of the JSON schema specification and setting that will set the correct state as
expected. However, there is nothing in the specification that will allow something to be set as
disabled. Even though the standard components does not support both disabled and readonly, a custom
component could still support it since both are present on the `FormComponent` interface, e.g. the
limel-picker component has both those states. Since there is no standard way of specifying disabled
in the schema, we have to add it through the `lime` options we have created.

fix #1072

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
