### PR TITLE
fix(table): correctly calculate height of tables 

### DIFF
--- a/src/components/table/partial-styles/tabulator-paginator.scss
+++ b/src/components/table/partial-styles/tabulator-paginator.scss
@@ -53,11 +53,14 @@
     }
 }
 
+$height-of-tabulator-header: pxToRem(34);
+$height-of-tabulator-paginator: pxToRem(36);
+
 .tabulator:not(.has-pagination) {
     &:not(.has-aggregation) {
         .tabulator-tableHolder {
-            height: 100% !important;
-            max-height: 100% !important;
+            height: calc(100% - #{$height-of-tabulator-header}) !important;
+            max-height: calc(100% - #{$height-of-tabulator-header}) !important;
         }
     }
     &.has-aggregation {
@@ -65,15 +68,13 @@
             height: calc(
                 100% -
                     (
-                        34px /*height of tabulator header */ + 36px
-                            /*height of tabulator paginator */
+                        #{$height-of-tabulator-header} + #{$height-of-tabulator-paginator}
                     )
             ) !important;
             max-height: calc(
                 100% -
                     (
-                        34px /*height of tabulator header */ + 36px
-                            /*height of tabulator paginator */
+                        #{$height-of-tabulator-header} + #{$height-of-tabulator-paginator}
                     )
             ) !important;
         }


### PR DESCRIPTION
tables which don't have aggregation & pagination bars

fix: https://github.com/Lundalogik/crm-feature/issues/1695

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
