### PR TITLE
fix(tab-bar): reduce original letter spacing in MD tabs

### DIFF
--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -126,6 +126,7 @@ $tab-scroller-fade-width: 65;
 
 .mdc-tab {
     border-radius: 0;
+    letter-spacing: normal;
 }
 
 .mdc-tab {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1698
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
