### PR TITLE
fix(input-field): improve action for incomplete url:s, improve target for relative url:s

### DIFF
--- a/src/components/input-field/examples/input-field-showlink.tsx
+++ b/src/components/input-field/examples/input-field-showlink.tsx
@@ -1,4 +1,4 @@
-import { Component, h, State, Watch } from '@stencil/core';
+import { Component, h, State } from '@stencil/core';
 
 /**
  * With `showLink=true`
@@ -16,15 +16,6 @@ export class InputFieldShowlinkExample {
     private disabled = false;
 
     @State()
-    private emailInvalid = false;
-
-    @State()
-    private telInvalid = false;
-
-    @State()
-    private urlInvalid = false;
-
-    @State()
     private emailValue: string;
 
     @State()
@@ -34,7 +25,6 @@ export class InputFieldShowlinkExample {
     private urlValue: string;
 
     constructor() {
-        this.checkValidity = this.checkValidity.bind(this);
         this.emailChangeHandler = this.emailChangeHandler.bind(this);
         this.telChangeHandler = this.telChangeHandler.bind(this);
         this.urlChangeHandler = this.urlChangeHandler.bind(this);
@@ -48,7 +38,6 @@ export class InputFieldShowlinkExample {
                 label="Email Field"
                 value={this.emailValue}
                 required={this.required}
-                invalid={this.emailInvalid}
                 disabled={this.disabled}
                 onChange={this.emailChangeHandler}
                 type="email"
@@ -58,7 +47,6 @@ export class InputFieldShowlinkExample {
                 label="Phone Field"
                 value={this.telValue}
                 required={this.required}
-                invalid={this.telInvalid}
                 disabled={this.disabled}
                 onChange={this.telChangeHandler}
                 type="tel"
@@ -68,7 +56,6 @@ export class InputFieldShowlinkExample {
                 label="URL Field"
                 value={this.urlValue}
                 required={this.required}
-                invalid={this.urlInvalid}
                 disabled={this.disabled}
                 onChange={this.urlChangeHandler}
                 type="url"
@@ -92,26 +79,16 @@ export class InputFieldShowlinkExample {
         ];
     }
 
-    @Watch('required')
-    private checkValidity() {
-        this.emailInvalid = this.required && !this.emailValue;
-        this.telInvalid = this.required && !this.telValue;
-        this.urlInvalid = this.required && !this.urlValue;
-    }
-
     private emailChangeHandler(event: CustomEvent<string>) {
         this.emailValue = event.detail;
-        this.checkValidity();
     }
 
     private telChangeHandler(event: CustomEvent<string>) {
         this.telValue = event.detail;
-        this.checkValidity();
     }
 
     private urlChangeHandler(event: CustomEvent<string>) {
         this.urlValue = event.detail;
-        this.checkValidity();
     }
 
     private toggleEnabled() {

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../util/keycodes';
 import { InputType } from './input-field.types';
 import { ListItem } from '@limetech/lime-elements';
-import { getHref } from './link-helper';
+import { getHref, getTarget } from './link-helper';
 
 interface LinkProperties {
     href: string;
@@ -514,7 +514,7 @@ export class InputField {
                 break;
             default:
                 props.href = getHref(this.value);
-                props.target = '_blank';
+                props.target = getTarget(this.value);
         }
 
         return props;

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../util/keycodes';
 import { InputType } from './input-field.types';
 import { ListItem } from '@limetech/lime-elements';
+import { getHref } from './link-helper';
 
 interface LinkProperties {
     href: string;
@@ -512,7 +513,7 @@ export class InputField {
                 props.href = `tel:${this.value}`;
                 break;
             default:
-                props.href = `${this.value}`;
+                props.href = getHref(this.value);
                 props.target = '_blank';
         }
 

--- a/src/components/input-field/link-helper.spec.ts
+++ b/src/components/input-field/link-helper.spec.ts
@@ -1,0 +1,93 @@
+import { getTarget, getHref, prependProtocol } from './link-helper';
+
+describe('limeLinkHelper', () => {
+    let element;
+    let isValid;
+    beforeEach(() => {
+        element = {
+            checkValidity: () => isValid,
+        };
+        jest.spyOn(document, 'createElement').mockReturnValueOnce(element);
+    });
+    describe('when input is a relative link', () => {
+        it('is NOT prepended with http:// for links starting with one "/"', () => {
+            expect(getHref('/test/hej')).toEqual('/test/hej');
+        });
+        it('is NOT prepended with http:// for links starting with "#"', () => {
+            expect(getHref('#test/hej')).toEqual('#test/hej');
+        });
+    });
+
+    describe('when input begins with "//"', () => {
+        it('is NOT prepended with http://', () => {
+            expect(getHref('//test/hej')).toEqual('//test/hej');
+        });
+    });
+
+    describe('when input begins with "ftp:"', () => {
+        it('is NOT prepended with http://', () => {
+            expect(getHref('ftp://limetest@web')).toEqual('ftp://limetest@web');
+        });
+    });
+
+    describe('when input begins with "https"', () => {
+        it('is NOT prepended with http://', () => {
+            expect(getHref('https://limetest@web')).toEqual(
+                'https://limetest@web'
+            );
+        });
+    });
+
+    describe('getTarget"', () => {
+        describe('when url is a relative link', () => {
+            it('it returns _self as a target', () => {
+                expect(getTarget('#test/hej')).toEqual('_self');
+            });
+        });
+        describe('when url is not relative link "', () => {
+            const linksWithTargetBlank = [
+                {
+                    type: 'http',
+                    value: 'http://one.com',
+                },
+                {
+                    type: 'https',
+                    value: 'https://two.com',
+                },
+                {
+                    type: 'ftp',
+                    value: 'ftp://five.com',
+                },
+                {
+                    type: 'ftps',
+                    value: 'ftps://six.com',
+                },
+                {
+                    type: 'arbitrary',
+                    value: 'eight.com',
+                },
+            ];
+            linksWithTargetBlank.forEach((link) => {
+                it('it returns _blank as a target"', () => {
+                    expect(getTarget(link.value)).toEqual('_blank');
+                });
+            });
+        });
+    });
+    describe('prependProtocol', () => {
+        describe('with typical non-relative link missing protocol', () => {
+            it('prepends value with https://', () => {
+                isValid = true;
+                expect(prependProtocol('lime.tech')).toEqual(
+                    'https://lime.tech'
+                );
+            });
+        });
+        describe('with an empty string', () => {
+            it('does not alter input', () => {
+                isValid = false;
+                expect(prependProtocol('')).toEqual('');
+            });
+        });
+    });
+});

--- a/src/components/input-field/link-helper.ts
+++ b/src/components/input-field/link-helper.ts
@@ -1,0 +1,53 @@
+export function getHref(value: string) {
+    const href = value ? String(value.trim()) : '';
+    if (isValid(href)) {
+        return href;
+    }
+
+    return prependProtocol(href);
+}
+
+export function getTarget(value: string) {
+    const url = getHref(value);
+    if (isRelativeLink(url)) {
+        return '_self';
+    }
+
+    return '_blank';
+}
+
+export function prependProtocol(input: string) {
+    if (!input) {
+        return input;
+    }
+
+    return 'https://' + input;
+}
+
+function isValid(href: string) {
+    return (
+        hasKnownProtocol(href) ||
+        isRelativeLink(href) ||
+        hasRelativeProtocol(href)
+    );
+}
+
+function hasKnownProtocol(input: string) {
+    const knownProtocols = ['ftp', 'ftps', 'https', 'http'];
+
+    return knownProtocols.some((knownProtocol) => {
+        return input.indexOf(knownProtocol + '://') === 0;
+    });
+}
+
+function isRelativeLink(input: string) {
+    if (hasRelativeProtocol(input)) {
+        return false;
+    }
+
+    return input.startsWith('/') || input.startsWith('#');
+}
+
+function hasRelativeProtocol(input: string) {
+    return input.startsWith('//');
+}


### PR DESCRIPTION
I copied the lime-link-helper.service.ts file from the webclient repo that was used in the old card and did some small refactoring changes to it. ~~The type of the input-field cannot be url because then the full url is required. Therefore, it is set to type = 'text'.~~

fix Lundalogik/crm-feature#1628

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
