### PR TITLE
style(eslint): disallow multiline ternary operator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
         'jsdoc/no-undefined-types': 'off',
         'jsdoc/check-tag-names': 'off',
         'max-classes-per-file': ['error', 1],
+        'multiline-ternary': ['error', 'never'],
         'no-bitwise': 'error',
         'no-caller': 'error',
         'no-console': 'error',

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -565,9 +565,7 @@ export class ChipSet {
             >
                 {chip.icon ? this.renderIcon(chip) : null}
                 {this.renderLabel(chip)}
-                {chip.removable && !this.readonly && !this.disabled
-                    ? this.renderChipRemoveButton()
-                    : null}
+                {this.renderChipRemoveButton(chip)}
             </div>,
         ];
     }
@@ -617,7 +615,11 @@ export class ChipSet {
         );
     }
 
-    private renderChipRemoveButton() {
+    private renderChipRemoveButton(chip: Chip) {
+        if (!chip.removable || this.readonly || this.disabled) {
+            return;
+        }
+
         const svgData = `<svg style="height:100%;width:100%;" width="32" height="32" x="0px" y="0px" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
     <line fill="none" id="svg_1" stroke="currentColor" stroke-width="2" x1="8" x2="24" y1="8" y2="24"/>
     <line fill="none" id="svg_2" stroke="currentColor" stroke-width="2" x1="24" x2="8" y1="8" y2="24"/>

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -129,12 +129,15 @@ export class Dialog {
         this.mdcDialog.listen('MDCDialog:closed', this.handleMdcClosed);
         this.mdcDialog.listen('MDCDialog:closing', this.handleMdcClosing);
 
-        this.mdcDialog.scrimClickAction = this.closingActions.scrimClick
-            ? 'close'
-            : '';
-        this.mdcDialog.escapeKeyAction = this.closingActions.escapeKey
-            ? 'close'
-            : '';
+        this.mdcDialog.scrimClickAction = '';
+        if (this.closingActions.scrimClick) {
+            this.mdcDialog.scrimClickAction = 'close';
+        }
+
+        this.mdcDialog.escapeKeyAction = '';
+        if (this.closingActions.escapeKey) {
+            this.mdcDialog.escapeKeyAction = 'close';
+        }
     }
 
     public disconnectedCallback() {

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -159,18 +159,20 @@ export class File {
     }
 
     private get chipArray() {
-        return this.value
-            ? [
-                  {
-                      ...DEFAULT_FILE_CHIP,
-                      text: this.value.filename,
-                      id: this.value.id,
-                      icon: this.value.icon || DEFAULT_ICON,
-                      iconFillColor: this.value.iconColor,
-                      iconBackgroundColor: this.value.iconBackgroundColor,
-                  },
-              ]
-            : [];
+        if (!this.value) {
+            return [];
+        }
+
+        return [
+            {
+                ...DEFAULT_FILE_CHIP,
+                text: this.value.filename,
+                id: this.value.id,
+                icon: this.value.icon || DEFAULT_ICON,
+                iconFillColor: this.value.iconColor,
+                iconBackgroundColor: this.value.iconBackgroundColor,
+            },
+        ];
     }
 
     private handleKeyDown(event: KeyboardEvent) {

--- a/src/components/input-field/examples/input-field-number.tsx
+++ b/src/components/input-field/examples/input-field-number.tsx
@@ -32,6 +32,11 @@ export class InputFieldNumberExample {
     }
 
     public render() {
+        let formatLabel = 'Format number';
+        if (this.formatNumber) {
+            formatLabel = 'Unformat number';
+        }
+
         return [
             <limel-input-field
                 label="Number Field Label"
@@ -46,11 +51,7 @@ export class InputFieldNumberExample {
             <p>
                 <limel-flex-container justify="end">
                     <limel-button
-                        label={
-                            this.formatNumber
-                                ? 'Unformat number'
-                                : 'Format number'
-                        }
+                        label={formatLabel}
                         onClick={this.toggleFormatting}
                     />
                     <limel-button

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -262,6 +262,10 @@ export class InputField {
             'mdc-text-field--with-trailing-icon': !!this.getTrailingIcon(),
             'mdc-text-field--with-leading-icon': !!this.leadingIcon,
         };
+        const labelClassList = {
+            'mdc-floating-label': true,
+            'mdc-floating-label--float-above': !!this.value || this.isFocused,
+        };
 
         return [
             <div class={classList}>
@@ -284,17 +288,7 @@ export class InputField {
                 <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading"></div>
                     <div class="mdc-notched-outline__notch">
-                        <label
-                            class={`
-                            mdc-floating-label
-                            ${
-                                this.value || this.isFocused
-                                    ? 'mdc-floating-label--float-above'
-                                    : ''
-                            }
-                        `}
-                            htmlFor="input-element"
-                        >
+                        <label class={labelClassList} htmlFor="input-element">
                             {this.label}
                         </label>
                     </div>
@@ -427,20 +421,12 @@ export class InputField {
             return;
         }
 
-        return (
-            <p
-                class={`
-            mdc-text-field-helper-text
-            ${
-                this.isInvalid()
-                    ? 'mdc-text-field-helper-text--validation-msg'
-                    : ''
-            }
-        `}
-            >
-                {this.helperText}
-            </p>
-        );
+        const classList = {
+            'mdc-text-field-helper-text': true,
+            'mdc-text-field-helper-text--validation-msg': this.isInvalid(),
+        };
+
+        return <p class={classList}>{this.helperText}</p>;
     }
 
     private renderCharacterCounter() {
@@ -574,11 +560,12 @@ export class InputField {
             return;
         }
 
-        const renderValue = this.formatNumber
-            ? new Intl.NumberFormat(navigator.language).format(
-                  Number(this.value)
-              )
-            : this.value;
+        let renderValue = this.value;
+        if (this.formatNumber) {
+            renderValue = new Intl.NumberFormat(navigator.language).format(
+                Number(this.value)
+            );
+        }
 
         return <span class="formatted-input">{renderValue}</span>;
     }

--- a/src/components/linear-progress/linear-progress.tsx
+++ b/src/components/linear-progress/linear-progress.tsx
@@ -56,15 +56,13 @@ export class LinearProgress {
     }
 
     public render() {
+        const classList = {
+            'mdc-linear-progress': true,
+            'mdc-linear-progress--indeterminate': this.indeterminate,
+        };
+
         return (
-            <div
-                role="progressbar"
-                class={`mdc-linear-progress ${
-                    this.indeterminate
-                        ? 'mdc-linear-progress--indeterminate'
-                        : ''
-                }`}
-            >
+            <div role="progressbar" class={classList}>
                 <div class="mdc-linear-progress__buffer" />
                 <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
                     <span class="mdc-linear-progress__bar-inner" />

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -163,9 +163,10 @@ export class Picker {
     }
 
     public async componentWillUpdate() {
-        this.chipSetEditMode = !this.chipSet
-            ? false
-            : await this.chipSet.getEditMode();
+        this.chipSetEditMode = false;
+        if (this.chipSet) {
+            this.chipSetEditMode = await this.chipSet.getEditMode();
+        }
     }
 
     public render() {

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -1,6 +1,11 @@
 import { Component, Element, h, Prop, Watch } from '@stencil/core';
 import { OpenDirection } from '../menu/menu.types';
-import { createPopper, Instance, OptionsGeneric } from '@popperjs/core';
+import {
+    createPopper,
+    Instance,
+    OptionsGeneric,
+    Placement,
+} from '@popperjs/core';
 import { FlipModifier } from '@popperjs/core/lib/modifiers/flip';
 
 /**
@@ -172,10 +177,13 @@ export class Portal {
         }
 
         if (this.inheritParentWidth) {
-            this.container.style.width =
-                hostWidth > 0
-                    ? `${hostWidth}px`
-                    : `${this.getContentWidth(this.container)}px`;
+            const containerWidth = this.getContentWidth(this.container);
+            let width = containerWidth;
+            if (hostWidth > 0) {
+                width = hostWidth;
+            }
+
+            this.container.style.width = `${width}px`;
         }
 
         Object.keys(this.containerStyle).forEach((property) => {
@@ -212,19 +220,22 @@ export class Portal {
     private createPopperConfig(): Partial<
         OptionsGeneric<Partial<FlipModifier>>
     > {
+        let placement: Placement = 'bottom-start';
+        let flipPlacement: Placement = 'top-start';
+
+        if (this.openDirection === 'left') {
+            placement = 'bottom-end';
+            flipPlacement = 'top-end';
+        }
+
         return {
             strategy: this.position,
-            placement:
-                this.openDirection === 'left' ? 'bottom-end' : 'bottom-start',
+            placement: placement,
             modifiers: [
                 {
                     name: 'flip',
                     options: {
-                        fallbackPlacements: [
-                            this.openDirection === 'left'
-                                ? 'top-end'
-                                : 'top-start',
-                        ],
+                        fallbackPlacements: [flipPlacement],
                     },
                 },
             ],

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -163,7 +163,7 @@ export class Portal {
     }
 
     private styleContainer() {
-        const rect: any = this.host.getBoundingClientRect();
+        const hostWidth = this.host.getBoundingClientRect().width;
 
         if (this.visible) {
             this.container.style.display = 'block';
@@ -173,8 +173,8 @@ export class Portal {
 
         if (this.inheritParentWidth) {
             this.container.style.width =
-                rect.width > 0
-                    ? `${rect.width}px`
+                hostWidth > 0
+                    ? `${hostWidth}px`
                     : `${this.getContentWidth(this.container)}px`;
         }
 
@@ -188,9 +188,9 @@ export class Portal {
             return null;
         }
 
-        const rect = element.getBoundingClientRect();
-        if (rect.width !== 0) {
-            return rect.width;
+        const width = element.getBoundingClientRect().width;
+        if (width !== 0) {
+            return width;
         }
 
         const elementContent = element.querySelector('*');

--- a/src/components/select/select.e2e.ts
+++ b/src/components/select/select.e2e.ts
@@ -267,22 +267,22 @@ describe('limel-select (native)', () => {
                         expect(d).toEqual(expectedValue);
                     }
                 );
-                it.skip(
-                    expectFloating
-                        ? 'label is floating'
-                        : 'label is not floating',
-                    () => {
-                        if (expectFloating) {
-                            expect(label).toHaveClass(
-                                'mdc-floating-label--float-above'
-                            );
-                        } else {
-                            expect(label).not.toHaveClass(
-                                'mdc-floating-label--float-above'
-                            );
-                        }
+                let name = 'label is not floating';
+                if (expectFloating) {
+                    name = 'label is floating';
+                }
+
+                it.skip(name, () => {
+                    if (expectFloating) {
+                        expect(label).toHaveClass(
+                            'mdc-floating-label--float-above'
+                        );
+                    } else {
+                        expect(label).not.toHaveClass(
+                            'mdc-floating-label--float-above'
+                        );
                     }
-                );
+                });
             }
         });
     });


### PR DESCRIPTION
It's far too easy to abuse the ternary operator to make multiline statements in the code that is hard to read. I suggest we add an ESLint rule to not allow them at all

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
