### PR TITLE
fix: support legacy browsers again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1769,6 +1770,7 @@
       "integrity": "sha512-41P5BCXPEIT0BlZCxAXR5mLsBmPTWqGs93rnwN2BBVxxAFtGouRk8H8nVx5wE2UTU3dbpXd2GnUGXKAXffn7RA==",
       "dev": true,
       "dependencies": {
+        "@commitlint/load": ">6.1.1",
         "chalk": "^2.4.1",
         "commitizen": "^4.0.3",
         "conventional-commit-types": "^3.0.0",
@@ -3862,6 +3864,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4441,6 +4444,7 @@
       "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
       "dev": true,
       "dependencies": {
+        "@commitlint/load": ">6.1.1",
         "chalk": "^2.4.1",
         "commitizen": "^4.0.3",
         "conventional-commit-types": "^3.0.0",
@@ -4944,7 +4948,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5640,6 +5645,7 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
+        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -6253,6 +6259,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -7676,6 +7683,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -10350,6 +10358,7 @@
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       },
@@ -13359,6 +13368,7 @@
       "license": "ISC",
       "dependencies": {
         "debuglog": "^1.0.1",
+        "graceful-fs": "^4.1.2",
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
@@ -13377,6 +13387,7 @@
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
@@ -13806,9 +13817,13 @@
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
-        "safer-buffer": "^2.0.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "bin": {
         "sshpk-conv": "bin/sshpk-conv",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cm": "git-cz",
     "dev": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --docs\"",
     "watch": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --watch --docs --serve\"",
-    "watch:prod": "shx rm -rf www/ && cross-env-shell SASS_PATH=node_modules \"stencil build --watch\"",
+    "watch:prod": "shx rm -rf www/ && cross-env-shell SASS_PATH=node_modules \"stencil build --watch --docs --serve --config stencil.config.ts\"",
     "docs:build": "cross-env-shell NODE_ENV=prod SASS_PATH=node_modules \"stencil build --docs --config stencil.config.docs.ts\"",
     "docs:publish": "node publish-docs.js",
     "lint": "npm run lint:src && npm run lint:scss",

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -19,6 +19,18 @@ export const config: Config = {
         },
     },
     plugins: [sass()],
+    buildEs5: 'prod',
+    extras: {
+        /* See docs at https://stenciljs.com/docs/config-extras */
+        appendChildSlotFix: true,
+        cloneNodeFix: true,
+        cssVarsShim: true,
+        dynamicImportShim: true,
+        safari10: true,
+        scriptDataOpts: false,
+        shadowDomShim: true,
+        slotChildNodesFix: true,
+    },
     tsconfig: './tsconfig.dist.json',
     globalStyle: 'src/global/core-styles.scss',
 };

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -22,14 +22,11 @@ export const config: Config = {
     buildEs5: 'prod',
     extras: {
         /* See docs at https://stenciljs.com/docs/config-extras */
-        appendChildSlotFix: true,
-        cloneNodeFix: true,
         cssVarsShim: true,
         dynamicImportShim: true,
-        safari10: true,
-        scriptDataOpts: false,
+        scriptDataOpts: true,
         shadowDomShim: true,
-        slotChildNodesFix: true,
+        initializeNextTick: true,
     },
     tsconfig: './tsconfig.dist.json',
     globalStyle: 'src/global/core-styles.scss',

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -26,7 +26,6 @@ export const config: Config = {
         dynamicImportShim: true,
         scriptDataOpts: true,
         shadowDomShim: true,
-        initializeNextTick: true,
     },
     tsconfig: './tsconfig.dist.json',
     globalStyle: 'src/global/core-styles.scss',

--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -22,9 +22,7 @@ export const config: Config = {
     buildEs5: 'prod',
     extras: {
         /* See docs at https://stenciljs.com/docs/config-extras */
-        cssVarsShim: true,
         dynamicImportShim: true,
-        scriptDataOpts: true,
         shadowDomShim: true,
     },
     tsconfig: './tsconfig.dist.json',


### PR DESCRIPTION
Support for some older browsers was removed in lime-elements v29.0.0.
That support has now been added again.

fix: #1033

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
