### PR TITLE
fix(chip-set): emit startEdit event when text field gets focus

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -201,6 +201,7 @@ export class ChipSet {
         }
 
         this.host.shadowRoot.querySelector('input').focus();
+        this.startEdit.emit();
     }
 
     /**


### PR DESCRIPTION
fix #1064

This code was removed in this commit https://github.com/Lundalogik/lime-elements/commit/4e473a131dab790feb909ead0ed846795aa0ccf5

Is there any reason for us to consider that only one _startEdit_ event is sent?

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
