### PR TITLE
fix(collapsible-section): add divider lines on headers

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -49,7 +49,6 @@
 }
 
 .section__header__title {
-    flex-grow: 1;
     justify-self: flex-start;
     padding-right: pxToRem(12);
 
@@ -58,6 +57,21 @@
     text-overflow: ellipsis;
 
     user-select: none; // mostly to improve experience on Android, where tapping on sections selects the text too
+}
+
+.section__header__divider-line {
+    transition: opacity 0.3s ease 0.3s;
+    flex-grow: 1;
+    height: pxToRem(2);
+    border-radius: pxToRem(1);
+    background-color: var(--header-stroke-color, #8c8c96);
+    margin-right: pxToRem(16);
+
+    opacity: 0;
+
+    section.open & {
+        opacity: 0.16;
+    }
 }
 
 .section__header__actions {

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -21,7 +21,7 @@
 }
 
 .section__header {
-    transition: background-color 0.2s ease, border-radius 0.1s ease;
+    transition: background-color 0.4s ease, border-radius 0.1s ease;
     cursor: pointer;
 
     align-items: center;

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -70,6 +70,7 @@ export class CollapsibleSection {
                     <h2 class="section__header__title mdc-typography mdc-typography--headline2">
                         {this.header}
                     </h2>
+                    <div class="section__header__divider-line" />
                     {this.renderActions()}
                 </header>
                 <div class="section__body">


### PR DESCRIPTION
only shown when sections are open, not when collapsed.
fix: https://github.com/Lundalogik/crm-feature/issues/1747

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
