### PR TITLE
fix(tab-panel): emit resize event to trigger component re-layout when changing tabs

### DIFF
--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -9,6 +9,7 @@ import {
     Watch,
 } from '@stencil/core';
 import { Tab } from '../tab-bar/tab.types';
+import { dispatchResizeEvent } from '../../util/dispatch-resize-event';
 
 /**
  * The `limel-tab-panel` component uses the `limel-tab-bar` component together
@@ -133,6 +134,10 @@ export class TabPanel {
         });
 
         this.setTabStatus(event.detail);
+
+        // Content inside the newly activated tab may need to redraw once
+        // visible, so we use the resize event trick. /Ads
+        setTimeout(dispatchResizeEvent);
     }
 
     private getSlot(): HTMLSlotElement {


### PR DESCRIPTION
Content inside the newly activated tab may need to redraw once visible, so we use the resize event
trick.

fix: Lundalogik/crm-feature#1696
fix: Lundalogik/crm-feature#1697

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
