### PR TITLE
fix(input-field): debounce changes to input, to avoid lost characters in some consumer applications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2464,6 +2464,21 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@stencil/sass": "^1.3.2",
     "@types/html-escaper": "^3.0.0",
     "@types/jest": "^26.0.14",
+    "@types/lodash-es": "^4.17.4",
     "@types/prismjs": "^1.16.1",
     "@types/puppeteer": "^3.0.2",
     "@types/react": "^16.9.51",


### PR DESCRIPTION
Note to reviewer: This needs to be tested in the Lime CRM web client, because the input field hasn't been lagging when running in the docs.

fix: Lundalogik/crm-feature#1719

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
