### PR TITLE
fix(collapsible-section): make `--body-padding` work only on the sides

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -4,7 +4,7 @@
  * @prop --closed-header-background-color: background color for header when closed
  * @prop --open-header-background-color: background color for header when open
  * @prop --body-background-color: background color for body
- * @prop --body-padding: padding for body
+ * @prop --body-padding: space around content of the body
  */
 
 :host {
@@ -91,7 +91,8 @@
 .section__body {
     animation: fade-in-section__body 0.3s ease-in forwards;
     background-color: var(--body-background-color, #ffffff);
-    padding: var(--body-padding, pxToRem(20));
+    padding-left: var(--body-padding, pxToRem(20));
+    padding-right: var(--body-padding, pxToRem(20));
     margin-bottom: pxToRem(24);
     border-radius: 0 0 var(--border-radius-of-header)
         var(--border-radius-of-header);

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -1,5 +1,9 @@
 @import '../../style/internal/mdc-variables';
 
+/**
+ * @prop --form-body-padding: space around content of the form
+ */
+
 .limel-form-array-item--simple {
     display: flex;
     align-items: center;
@@ -14,6 +18,7 @@
     --gap: 1rem;
     display: grid;
     gap: var(--gap);
+    padding: var(--form-body-padding, pxToRem(16));
 }
 
 .limel-form-layout--grid {
@@ -21,6 +26,7 @@
     --min-height-of-one-row: 4.71rem;
     display: grid;
     gap: var(--gap);
+    padding: var(--form-body-padding, pxToRem(16));
 
     // Using `minmax(0, 1fr)` below, instead of just `1fr` ensures that
     // components that are wider than their column don't make the column grow


### PR DESCRIPTION


Due to layout design,  content of collapsible sections
do not need to have distance with the header.
At the bottom, there is already space as margin.
fix: https://github.com/Lundalogik/lime-elements/issues/1069

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
