### PR TITLE
input-field: fix small bug, add tests, refactor, add small feature to input-field

### DIFF
--- a/src/components/input-field/examples/input-field-showlink.tsx
+++ b/src/components/input-field/examples/input-field-showlink.tsx
@@ -61,6 +61,15 @@ export class InputFieldShowlinkExample {
                 type="url"
                 showLink
             />,
+            <limel-input-field
+                label="urlAsText"
+                value={this.urlValue}
+                required={this.required}
+                disabled={this.disabled}
+                onChange={this.urlChangeHandler}
+                type="urlAsText"
+                showLink
+            />,
             <p>
                 <limel-flex-container justify="end">
                     <limel-button

--- a/src/components/input-field/input-field.e2e.ts
+++ b/src/components/input-field/input-field.e2e.ts
@@ -1,0 +1,248 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+import { InputType } from './input-field.types';
+
+describe('limel-input-field', () => {
+    let page: E2EPage;
+    let limelInput: E2EElement;
+    let inputContainer: E2EElement;
+    let label: E2EElement;
+    let outline: E2EElement;
+
+    const types: Array<{ name: InputType; [key: string]: any }> = [
+        { name: 'email' },
+        { name: 'number' },
+        { name: 'password' },
+        { name: 'search' },
+        { name: 'tel' },
+        { name: 'text' },
+        { name: 'textarea', nativeSelector: 'limel-input-field>>>textarea' },
+        { name: 'url' },
+    ];
+
+    types.forEach((type) =>
+        describe(`with type="${type.name}"`, () => {
+            const expectedInputId = 'tf-input-element';
+            beforeEach(async () => {
+                page = await createPage(`
+                    <limel-input-field
+                        type="${type.name}"
+                        label="Test"
+                    ></limel-input-field>
+                `);
+                limelInput = await page.find('limel-input-field');
+                inputContainer = await page.find(
+                    'limel-input-field>>>div.mdc-text-field'
+                );
+            });
+            if (type.name === 'textarea') {
+                it('uses the `textarea` style', () => {
+                    expect(inputContainer).toHaveClass(
+                        'mdc-text-field--textarea'
+                    );
+                });
+            } else {
+                it('uses the `outlined` style', () => {
+                    expect(inputContainer).toHaveClass(
+                        'mdc-text-field--outlined'
+                    );
+                });
+            }
+
+            it('is NOT considered invalid', () => {
+                expect(inputContainer).not.toHaveClass(
+                    'mdc-text-field--invalid'
+                );
+            });
+            it('is NOT disabled', () => {
+                expect(inputContainer).not.toHaveClass(
+                    'mdc-text-field--disabled'
+                );
+            });
+            it('is NOT required', () => {
+                expect(inputContainer).not.toHaveClass(
+                    'mdc-text-field--required'
+                );
+            });
+            it('does NOT have a leading icon', () => {
+                expect(inputContainer).not.toHaveClass(
+                    'mdc-text-field--with-leading-icon'
+                );
+            });
+            it('does NOT have a trailing icon', () => {
+                expect(inputContainer).not.toHaveClass(
+                    'mdc-text-field--with-trailing-icon'
+                );
+            });
+            describe('the native input', () => {
+                let nativeInput: E2EElement;
+
+                beforeEach(async () => {
+                    const selector =
+                        type.nativeSelector || 'limel-input-field>>>input';
+                    nativeInput = await page.find(selector);
+                });
+                if (type.name === 'textarea') {
+                    it('uses a native textarea', () => {
+                        expect(nativeInput).toBeTruthy();
+                    });
+                } else {
+                    it(`has the type '${type.name}'`, () => {
+                        expect(nativeInput).toEqualAttribute('type', type.name);
+                    });
+                }
+
+                it('has the expected `id`', () => {
+                    expect(nativeInput).toEqualAttribute('id', expectedInputId);
+                });
+                it('has the class `mdc-text-field__input`', () => {
+                    expect(nativeInput).toHaveClass('mdc-text-field__input');
+                });
+            });
+            describe('the label', () => {
+                beforeEach(async () => {
+                    label = await page.find('limel-input-field>>>label');
+                });
+                it('is a "floating" label', () => {
+                    expect(label).toHaveClass('mdc-floating-label');
+                });
+                it('is NOT floating', () => {
+                    expect(label).not.toHaveClass(
+                        'mdc-floating-label--float-above'
+                    );
+                });
+                it('is linked to the native input', () => {
+                    expect(label).toEqualAttribute('for', expectedInputId);
+                });
+                describe('after focusing', () => {
+                    beforeEach(async () => {
+                        label.focus();
+                        await page.waitForChanges();
+                    });
+                    it('IS floating', () => {
+                        expect(label).toHaveClass(
+                            'mdc-floating-label--float-above'
+                        );
+                    });
+                });
+            });
+            describe('the outline', () => {
+                beforeEach(async () => {
+                    outline = await page.find(
+                        'limel-input-field>>>.mdc-notched-outline'
+                    );
+                });
+                it('has the expected structure', () => {
+                    expect(outline).toEqualHtml(`
+                    <div class="mdc-notched-outline mdc-notched-outline--upgraded">
+                        <div class="mdc-notched-outline__leading"></div>
+                        <div class="mdc-notched-outline__notch">
+                            <label for="tf-input-element" class="mdc-floating-label">
+                                Test
+                            </label>
+                        </div>
+                        <div class="mdc-notched-outline__trailing"></div>
+                    </div>
+                `);
+                });
+            });
+            describe('when invalid is set to true', () => {
+                beforeEach(async () => {
+                    limelInput.setAttribute('invalid', true);
+                    await page.waitForChanges();
+                });
+                it('IS invalid', () => {
+                    expect(inputContainer).toHaveClass(
+                        'mdc-text-field--invalid'
+                    );
+                });
+                if (type.name !== 'textarea') {
+                    it('has a trailing icon indicating the field is invalid', async () => {
+                        const limelIcon = await page.find(
+                            'limel-input-field>>>i.mdc-text-field__icon.trailing-icon>limel-icon'
+                        );
+                        expect(limelIcon).toBeTruthy();
+                        expect(limelIcon).toEqualAttribute(
+                            'name',
+                            'high_importance'
+                        );
+                    });
+                }
+            });
+            describe('when disabled is set to true', () => {
+                beforeEach(async () => {
+                    limelInput.setAttribute('disabled', true);
+                    await page.waitForChanges();
+                });
+                it('IS disabled', () => {
+                    expect(inputContainer).toHaveClass(
+                        'mdc-text-field--disabled'
+                    );
+                });
+            });
+            describe('when required is set to true', () => {
+                beforeEach(async () => {
+                    limelInput.setAttribute('required', true);
+                    await page.waitForChanges();
+                });
+                it('IS required', () => {
+                    expect(inputContainer).toHaveClass(
+                        'mdc-text-field--required'
+                    );
+                });
+            });
+            if (type.name !== 'textarea') {
+                describe('when leadingIcon is set', () => {
+                    beforeEach(async () => {
+                        limelInput.setAttribute('leading-icon', 'cat');
+                        await page.waitForChanges();
+                    });
+                    it('has the correct leading icon', async () => {
+                        const leadingIcon = await page.find(
+                            'limel-input-field>>>i.mdc-text-field__icon:not(.trailing-icon)>limel-icon'
+                        );
+                        expect(leadingIcon).toBeTruthy();
+                        expect(leadingIcon).toEqualAttribute('name', 'cat');
+                    });
+                });
+                describe('when trailingIcon is set', () => {
+                    beforeEach(async () => {
+                        limelInput.setAttribute('trailing-icon', 'dog');
+                        await page.waitForChanges();
+                    });
+                    it('has the correct trailing icon', async () => {
+                        const trailingIcon = await page.find(
+                            'limel-input-field>>>i.mdc-text-field__icon.trailing-icon>limel-icon'
+                        );
+                        expect(trailingIcon).toBeTruthy();
+                        expect(trailingIcon).toEqualAttribute('name', 'dog');
+                    });
+                });
+                describe('when leadingIcon and trailingIcon is set', () => {
+                    beforeEach(async () => {
+                        limelInput.setAttribute('leading-icon', 'cat');
+                        limelInput.setAttribute('trailing-icon', 'dog');
+                        await page.waitForChanges();
+                    });
+                    it('has the correct leading icon', async () => {
+                        const leadingIcon = await page.find(
+                            'limel-input-field>>>.mdc-text-field__icon:not(.trailing-icon)>limel-icon'
+                        );
+                        expect(leadingIcon).toBeTruthy();
+                        expect(leadingIcon).toEqualAttribute('name', 'cat');
+                    });
+                    it('has the correct trailing icon', async () => {
+                        const trailingIcon = await page.find(
+                            'limel-input-field>>>.mdc-text-field__icon.trailing-icon>limel-icon'
+                        );
+                        expect(trailingIcon).toBeTruthy();
+                        expect(trailingIcon).toEqualAttribute('name', 'dog');
+                    });
+                });
+            }
+        })
+    );
+});
+
+async function createPage(content: string) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -150,3 +150,10 @@ input.mdc-text-field__input {
         height: $height-of-helper-text-pseudo-before;
     }
 }
+
+.force-invalid {
+    // MDC will automatically remove the `mdc-text-field--invalid` class when
+    // the native validation passes. We sometimes need to be able to override
+    // that. /Ads
+    @extend .mdc-text-field--invalid;
+}

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -257,43 +257,43 @@ export class InputField {
     }
 
     public render() {
-        if (this.type === 'textarea') {
-            return this.renderTextArea();
-        }
+        const properties = this.getAdditionalProps();
+        properties.id = 'tf-input-element';
+        properties.class = 'mdc-text-field__input';
+        properties.onInput = this.handleChange;
+        properties.onFocus = this.onFocus;
+        properties.onBlur = this.onBlur;
+        properties.required = this.required;
+        properties.disabled = this.disabled;
 
-        const additionalProps = this.getAdditionalProps();
-        const classList = {
+        const containerClassList = {
             'mdc-text-field': true,
-            'mdc-text-field--outlined': true,
             'mdc-text-field--invalid': this.isInvalid(),
             'mdc-text-field--disabled': this.disabled,
             'mdc-text-field--required': this.required,
             'mdc-text-field--with-trailing-icon': !!this.getTrailingIcon(),
-            'mdc-text-field--with-leading-icon': !!this.leadingIcon,
         };
+
         const labelClassList = {
             'mdc-floating-label': true,
             'mdc-floating-label--float-above': !!this.value || this.isFocused,
         };
 
+        if (this.type === 'textarea') {
+            containerClassList['mdc-text-field--textarea'] = true;
+            containerClassList['has-helper-line'] =
+                !!this.helperText || !!this.maxlength;
+        } else {
+            containerClassList['mdc-text-field--outlined'] = true;
+            containerClassList['mdc-text-field--with-leading-icon'] = !!this
+                .leadingIcon;
+        }
+
         return [
-            <div class={classList}>
+            <div class={containerClassList}>
                 {this.renderFormattedNumber()}
-                <input
-                    class="mdc-text-field__input"
-                    id="tf-input-element"
-                    onInput={this.handleChange}
-                    onFocus={this.onFocus}
-                    onBlur={this.onBlur}
-                    required={this.required}
-                    disabled={this.disabled}
-                    type={this.type}
-                    pattern={this.pattern}
-                    onWheel={this.handleWheel}
-                    onKeyDown={this.onKeyDown}
-                    {...additionalProps}
-                    value={this.value}
-                />
+                {this.renderInput(properties)}
+                {this.renderTextarea(properties)}
                 <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading"></div>
                     <div class="mdc-notched-outline__notch">
@@ -309,9 +309,7 @@ export class InputField {
                 {this.renderIcons()}
             </div>,
             this.renderHelperLine(),
-            <div class="autocomplete-list-container">
-                {this.renderDropdown()}
-            </div>,
+            this.renderAutocompleteList(),
         ];
     }
 
@@ -326,57 +324,33 @@ export class InputField {
         }
     }
 
-    private layout() {
-        this.mdcTextField?.layout();
+    private renderInput(properties) {
+        if (this.type === 'textarea') {
+            return;
+        }
+
+        return (
+            <input
+                {...properties}
+                type={this.type}
+                pattern={this.pattern}
+                onWheel={this.handleWheel}
+                onKeyDown={this.onKeyDown}
+                value={this.value}
+            />
+        );
     }
 
-    private renderTextArea() {
-        const additionalProps = this.getAdditionalProps();
-        const classList = {
-            'mdc-text-field': true,
-            'mdc-text-field--textarea': true,
-            'mdc-text-field--disabled': this.disabled,
-            'mdc-text-field--with-trailing-icon': !!this.getTrailingIcon(),
-            'mdc-text-field--invalid': this.isInvalid(),
-            'mdc-text-field--required': this.required,
-            'has-helper-line': !!this.helperText || !!this.maxlength,
-        };
+    private renderTextarea(properties) {
+        if (this.type !== 'textarea') {
+            return;
+        }
 
-        const labelClassList = {
-            'mdc-floating-label': true,
-            'textarea-label': true,
-            'mdc-floating-label--float-above': !!this.value || this.isFocused,
-        };
+        return <textarea {...properties}>{this.value}</textarea>;
+    }
 
-        return [
-            <div class={classList}>
-                <textarea
-                    id="tf-input-element"
-                    class="mdc-text-field__input"
-                    onInput={this.handleChange}
-                    onFocus={this.onFocus}
-                    onBlur={this.onBlur}
-                    required={this.required}
-                    disabled={this.disabled}
-                    {...additionalProps}
-                >
-                    {this.value}
-                </textarea>
-                <div class="mdc-notched-outline">
-                    <div class="mdc-notched-outline__leading" />
-                    <div class="mdc-notched-outline__notch">
-                        <label
-                            htmlFor="tf-input-element"
-                            class={labelClassList}
-                        >
-                            {this.label}
-                        </label>
-                    </div>
-                    <div class="mdc-notched-outline__trailing" />
-                </div>
-            </div>,
-            this.renderHelperLine(),
-        ];
+    private layout() {
+        this.mdcTextField?.layout();
     }
 
     private getAdditionalProps() {
@@ -479,6 +453,10 @@ export class InputField {
     }
 
     private renderIcons() {
+        if (this.type === 'textarea') {
+            return;
+        }
+
         const html = [];
 
         if (this.leadingIcon) {
@@ -662,6 +640,18 @@ export class InputField {
         if (isForwardTab) {
             this.showCompletions = false;
         }
+    }
+
+    private renderAutocompleteList() {
+        if (this.type === 'textarea') {
+            return;
+        }
+
+        return (
+            <div class="autocomplete-list-container">
+                {this.renderDropdown()}
+            </div>
+        );
     }
 
     private renderDropdown() {

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -25,6 +25,7 @@ import {
 import { InputType } from './input-field.types';
 import { ListItem } from '@limetech/lime-elements';
 import { getHref, getTarget } from './link-helper';
+import { JSXBase } from '@stencil/core/internal';
 
 interface LinkProperties {
     href: string;
@@ -324,7 +325,9 @@ export class InputField {
         }
     }
 
-    private renderInput(properties) {
+    private renderInput(
+        properties: JSXBase.InputHTMLAttributes<HTMLInputElement>
+    ) {
         if (this.type === 'textarea') {
             return;
         }
@@ -341,7 +344,9 @@ export class InputField {
         );
     }
 
-    private renderTextarea(properties) {
+    private renderTextarea(
+        properties: JSXBase.TextareaHTMLAttributes<HTMLTextAreaElement>
+    ) {
         if (this.type !== 'textarea') {
             return;
         }

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -297,7 +297,10 @@ export class InputField {
                 <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading"></div>
                     <div class="mdc-notched-outline__notch">
-                        <label class={labelClassList} htmlFor="input-element">
+                        <label
+                            class={labelClassList}
+                            htmlFor="tf-input-element"
+                        >
                             {this.label}
                         </label>
                     </div>
@@ -348,7 +351,7 @@ export class InputField {
         return [
             <div class={classList}>
                 <textarea
-                    id="textarea"
+                    id="tf-input-element"
                     class="mdc-text-field__input"
                     onInput={this.handleChange}
                     onFocus={this.onFocus}
@@ -362,7 +365,10 @@ export class InputField {
                 <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading" />
                     <div class="mdc-notched-outline__notch">
-                        <label htmlFor="textarea" class={labelClassList}>
+                        <label
+                            htmlFor="tf-input-element"
+                            class={labelClassList}
+                        >
                             {this.label}
                         </label>
                     </div>

--- a/src/components/input-field/input-field.types.ts
+++ b/src/components/input-field/input-field.types.ts
@@ -11,4 +11,5 @@ export type InputType =
     | 'textarea'
     | 'time'
     | 'url'
+    | 'urlAsText'
     | 'week';


### PR DESCRIPTION
- fix(input-field): correctly link the label to the input or textarea element
- test(input-field): add tests for input-field
- refactor(input-field): duplicate less code
- refactor(input-field): add some missing typings
- feat(input-field): add `type='urlAsText'`, allowing urls that are not fully qualified

fix: #1071
fix: Lundalogik/crm-feature#1595

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS