### PR TITLE
fix(portal): popper is updated when container height is updated

### DIFF
--- a/src/components/menu-surface/menu-surface.tsx
+++ b/src/components/menu-surface/menu-surface.tsx
@@ -41,7 +41,6 @@ export class MenuSurface {
     private host: HTMLLimelMenuSurfaceElement;
 
     private menuSurface: MDCMenuSurface;
-    private observer: IResizeObserver;
 
     constructor() {
         this.handleDocumentClick = this.handleDocumentClick.bind(this);
@@ -95,13 +94,6 @@ export class MenuSurface {
         window.addEventListener('resize', this.handleResize, {
             passive: true,
         });
-
-        if ('ResizeObserver' in window) {
-            const observer = new ResizeObserver(() => {
-                this.ensureMenuFitsInViewPort();
-            });
-            observer.observe(this.host);
-        }
     }
 
     private teardown() {
@@ -111,10 +103,6 @@ export class MenuSurface {
         });
         this.host.removeEventListener('keydown', this.handleKeyDown);
         window.removeEventListener('resize', this.handleResize);
-
-        if (this.observer) {
-            this.observer.unobserve(this.host);
-        }
     }
 
     private handleDocumentClick(event) {
@@ -175,31 +163,5 @@ export class MenuSurface {
             event.stopPropagation();
             this.dismiss.emit();
         }
-    }
-
-    private ensureMenuFitsInViewPort() {
-        this.host.style.height = 'auto';
-        setTimeout(() => {
-            const viewHeight = Math.max(
-                document.documentElement.clientHeight || 0,
-                window.innerHeight || 0
-            );
-            const { top, bottom } = this.host.getBoundingClientRect();
-            if (viewHeight > bottom && top > 0) {
-                // The surface is rendered inside the viewport :)
-                return;
-            }
-
-            // Set the height of the surface so that it fits either above or
-            // below the trigger, depending on where there is more space.
-            const spaceAboveTopOfSurface = Math.max(top, 0);
-            const spaceBelowTopOfSurface = Math.max(viewHeight - top, 0);
-            const extraCosmeticSpace = 16;
-            const maxHeight =
-                viewHeight -
-                Math.min(spaceAboveTopOfSurface, spaceBelowTopOfSurface) -
-                extraCosmeticSpace;
-            this.host.style.height = `${maxHeight}px`;
-        });
     }
 }

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -28,19 +28,4 @@ $menu-item-background-color: #ebebeb;
 
 .mdc-menu-surface--anchor {
     position: relative;
-
-    limel-portal {
-        &.limel-portal--fixed {
-            position: fixed;
-        }
-
-        &:not(.limel-portal--fixed) {
-            z-index: -999999;
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-        }
-    }
 }

--- a/src/components/picker/picker.scss
+++ b/src/components/picker/picker.scss
@@ -2,4 +2,9 @@
 
 :host {
     position: relative;
+    display: block;
+}
+
+:host([hidden]) {
+    display: none;
 }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -25,7 +25,6 @@ import { createRandomString } from '../../util/random-string';
 
 const SEARCH_DEBOUNCE = 500;
 const CHIP_SET_TAG_NAME = 'limel-chip-set';
-const ITEM_LIMIT_NO_SCROLL = 5;
 
 /**
  * @exampleComponent limel-example-picker
@@ -98,6 +97,10 @@ export class Picker {
 
     /**
      * True if the dropdown list should be displayed without cutting the content
+     *
+     * @deprecated This was used for a workaround, and isn't needed any
+     * longer. Setting it has no effect, and the property will be removed
+     * in the next major version.
      */
     @Prop()
     public displayFullList: boolean = false;
@@ -206,7 +209,7 @@ export class Picker {
                 emptyInputOnBlur={false}
                 {...props}
             />,
-            <div class="mdc-menu-surface--anchor">{this.renderDropdown()}</div>,
+            this.renderDropdown(),
         ];
     }
 
@@ -262,13 +265,8 @@ export class Picker {
      */
     private renderDropdown() {
         const content = this.getDropdownContent();
-        const styling = {};
 
-        if (this.isScrollableDropdown()) {
-            styling['max-height'] = '250px';
-        }
-
-        return this.renderPortal(content, styling);
+        return this.renderPortal(content);
     }
 
     private getDropdownContent() {
@@ -337,29 +335,20 @@ export class Picker {
         );
     }
 
-    private isScrollableDropdown() {
-        if (this.displayFullList) {
-            return false;
-        }
-
-        if (!this.items || !this.items.length) {
-            return false;
-        }
-
-        return this.items.length > ITEM_LIMIT_NO_SCROLL;
-    }
-
-    private renderPortal(content = null, styling = {}) {
+    private renderPortal(content = null) {
         return (
             <limel-portal
                 visible={!!content}
                 containerId={this.portalId}
-                containerStyle={styling}
                 inheritParentWidth={true}
             >
                 <limel-menu-surface
                     open={!!content}
-                    style={{ '--menu-surface-width': '100%' }}
+                    style={{
+                        '--menu-surface-width': '100%',
+                        'max-height': 'inherit',
+                        display: 'flex',
+                    }}
                 >
                     {content}
                 </limel-menu-surface>

--- a/src/components/portal/portal.scss
+++ b/src/components/portal/portal.scss
@@ -1,3 +1,11 @@
-:host(limel-portal) {
+:host(limel-portal:not(.limel-portal--fixed)) {
     display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    pointer-events: none;
+}
+:host(limel-portal.limel-portal--fixed) {
+    position: fixed;
 }

--- a/src/components/portal/portal.scss
+++ b/src/components/portal/portal.scss
@@ -9,3 +9,7 @@
 :host(limel-portal.limel-portal--fixed) {
     position: fixed;
 }
+
+:host([hidden]) {
+    display: none;
+}

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -7,6 +7,12 @@
 
 @import '../../style/mixins';
 
+:host {
+    display: block;
+    position: relative;
+    height: $height-of-mdc-text-field;
+}
+
 :host([hidden]) {
     display: none;
 }
@@ -25,12 +31,12 @@
 }
 
 .limel-select {
-    display: grid;
+    height: 100%;
 
     .limel-select-trigger {
         display: inline-flex;
         min-width: 0; // makes the limel-select__selected-text truncate and prevents the select to grow wider than its container
-        height: $height-of-mdc-text-field;
+        height: 100%;
 
         cursor: pointer;
         border-radius: pxToRem(5);

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -42,7 +42,6 @@ export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = (
     const classList = {
         'limel-select': true,
         'mdc-select': true,
-        'mdc-menu-surface--anchor': true,
         'mdc-select--disabled': props.disabled,
         'limel-select--required': props.required,
         'limel-select--invalid': !isValid,
@@ -127,7 +126,11 @@ const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
             <limel-menu-surface
                 open={props.isOpen}
                 onDismiss={props.close}
-                style={{ '--menu-surface-width': '100%' }}
+                style={{
+                    '--menu-surface-width': '100%',
+                    'max-height': 'inherit',
+                    display: 'flex',
+                }}
             >
                 <limel-list
                     items={items}


### PR DESCRIPTION
The popper needs to recalculate on which side the container should flip at when the container's
dimension changes

fix Lundalogik/crm-feature#1722
fix Lundalogik/crm-feature#1705

Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [x] Edge
- [x] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
