### PR TITLE
fix(popover): do not emit close event when clicking inside nested portals

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
 import { zipObject } from 'lodash-es';
+import { portalContains } from '../portal/contains';
 
 /**
  * A popover is an impermanent layer that is displayed on top of other content
@@ -135,7 +136,7 @@ export class Popover {
 
     private globalClickListener(event: MouseEvent) {
         const element: HTMLElement = event.target as HTMLElement;
-        const clickedInside = Boolean(element.closest(`#${this.portalId}`));
+        const clickedInside = portalContains(this.host, element);
         if (this.open && !clickedInside) {
             this.close.emit();
         }

--- a/src/components/portal/contains.spec.ts
+++ b/src/components/portal/contains.spec.ts
@@ -1,0 +1,86 @@
+import { portalContains } from './contains';
+
+describe('portalContains', () => {
+    let element: HTMLElement;
+    let child: HTMLElement;
+
+    beforeEach(async () => {
+        class TestComponent extends HTMLElement {
+            constructor() {
+                super();
+                this.attachShadow({ mode: 'open' });
+            }
+        }
+        customElements.define('test-component', TestComponent);
+        await customElements.whenDefined('test-component');
+    });
+
+    describe('when child is a descendant', () => {
+        beforeEach(() => {
+            element = document.createElement('span');
+            child = document.createElement('span');
+
+            element.appendChild(child);
+        });
+
+        it('returns true', () => {
+            expect(portalContains(element, child)).toBe(true);
+        });
+    });
+
+    describe('when child is not a descendant', () => {
+        beforeEach(() => {
+            element = document.createElement('span');
+            child = document.createElement('span');
+        });
+
+        it('returns false', () => {
+            expect(portalContains(element, child)).toBe(false);
+        });
+    });
+
+    describe('when child is a descendant in a shadowRoot', () => {
+        beforeEach(() => {
+            element = document.createElement('test-component');
+            child = document.createElement('span');
+
+            element.shadowRoot.appendChild(child);
+        });
+
+        it('returns true', () => {
+            expect(portalContains(element, child)).toBe(true);
+        });
+    });
+
+    describe('when child is a descendant in a portal', () => {
+        beforeEach(async () => {
+            // This test duplicates some of the implementation from the
+            // limel-portal component. The reason behind this is because the
+            // `assignedElements` method does not seem to exist when running
+            // the tests, so the portal content will never be moved to the
+            // portal container. This mock implementation is so that we can
+            // still test that the `portalContains` still works when elements
+            // are inside a portal
+
+            element = document.createElement('test-component');
+            const portal = document.createElement('div');
+            element.shadowRoot.appendChild(portal);
+
+            const container = document.createElement('div');
+            container.classList.add('limel-portal--container');
+            Object.assign(container, {
+                portalSource: portal,
+            });
+
+            const containerContent = document.createElement('test-component');
+            container.appendChild(containerContent);
+
+            child = document.createElement('span');
+            containerContent.shadowRoot.appendChild(child);
+        });
+
+        it('returns true', () => {
+            expect(portalContains(element, child)).toBe(true);
+        });
+    });
+});

--- a/src/components/portal/contains.ts
+++ b/src/components/portal/contains.ts
@@ -1,0 +1,38 @@
+/**
+ * Check if an element is a descendant of another
+ *
+ * If the child element is a descendant of a limel-portal, this function will
+ * go back through the portal and check the original tree recursively
+ *
+ * @param {HTMLElement} element the parent element
+ * @param {HTMLElement} child the child element to check
+ *
+ * @returns {boolean} `true` if child is a descendant of element, taking
+ * portals into account
+ */
+export function portalContains(
+    element: HTMLElement,
+    child: HTMLElement
+): boolean {
+    if (element.contains(child) || element.shadowRoot?.contains(child)) {
+        return true;
+    }
+
+    const parent = findParent(child);
+    if (!parent) {
+        return false;
+    }
+
+    return portalContains(element, parent);
+}
+
+function findParent(element: HTMLElement) {
+    const portal: any = element.closest('.limel-portal--container');
+    if (portal) {
+        return portal.portalSource;
+    }
+
+    const rootNode = element.getRootNode() as ShadowRoot;
+
+    return rootNode.host;
+}

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -141,6 +141,9 @@ export class Portal {
         this.container = document.createElement('div');
         this.container.setAttribute('id', this.containerId);
         this.container.setAttribute('class', 'limel-portal--container');
+        Object.assign(this.container, {
+            portalSource: this.host,
+        });
 
         content.forEach((element: HTMLElement) => {
             this.container.appendChild(element);


### PR DESCRIPTION
If the popover contains e.g. a limel-select, the dropdown of the select will be placed inside a
limel-portal while the popover content is inside another portal. Clicking inside the select dropdown
should not emit a close event, se we have to go back through all the portals to the source element
tree when deciding if the event should be emitted or not.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
