### PR TITLE
chore(package): update dev-dependency on lime-icons8 from v2.1.0 to v2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1736,8 +1736,9 @@
       }
     },
     "@lundalogik/lime-icons8": {
-      "version": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.1.0/96ebb4a7165fc618dba53568ab04db5fb9803a58d19e936965415e14dd224256",
-      "integrity": "sha512-+VIV5GuqaYcOxsrhjIHd1MxBezrkpaYPcIpQUPn/6Mp+PwJnaAi53O4g+8HtJn0MNcmHSJ7vBBAVVkJ2J1GyBg==",
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.2.1/0d9dc34ddea732f7e7e6d5a9db5216635cc64791b6afbd11c7a5c4616ab30784",
+      "integrity": "sha512-vN9VRGZ/yIiowG387jyzgv1P5Wsn/UsqEMdPBlw7JelqiCz2hXKn9sMEwDJj6x2FATQB1F+9xGQpXXurQOOiyA==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",
     "@lundalogik/cz-conventional-changelog": "^3.1.0",
-    "@lundalogik/lime-icons8": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.1.0/96ebb4a7165fc618dba53568ab04db5fb9803a58d19e936965415e14dd224256",
+    "@lundalogik/lime-icons8": "^2.2.1",
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/exec": "5.0.0",
     "@semantic-release/git": "9.0.0",


### PR DESCRIPTION
This just updates the dev-dependency, which is used to provide icons for the published
documentation. In production, the consumer of lime-elements is responsible for providing the icons.

fix: Lundalogik/crm-feature#1788

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
