### PR TITLE
fix(table): correct alignment for custom components in column header

### DIFF
--- a/src/components/table/examples/header-menu.scss
+++ b/src/components/table/examples/header-menu.scss
@@ -1,0 +1,3 @@
+:host {
+    line-height: 0;
+}

--- a/src/components/table/examples/header-menu.tsx
+++ b/src/components/table/examples/header-menu.tsx
@@ -4,6 +4,7 @@ import { ListItem } from 'src/components/list/list-item.types';
 @Component({
     tag: 'limel-example-header-menu',
     shadow: true,
+    styleUrl: 'header-menu.scss',
 })
 export class HeaderMenu {
     @Prop()

--- a/src/components/table/examples/table-header-menu.tsx
+++ b/src/components/table/examples/table-header-menu.tsx
@@ -10,8 +10,8 @@ import { persons, Person } from './persons';
  */
 @Component({
     tag: 'limel-example-table-header-menu',
-    styleUrl: 'table.scss',
     shadow: true,
+    styleUrl: 'table.scss',
 })
 export class TableExampleHeadermenu {
     private tableData: Person[] = persons;

--- a/src/components/table/partial-styles/header-component.scss
+++ b/src/components/table/partial-styles/header-component.scss
@@ -1,6 +1,7 @@
 .lime-col-title__custom-component {
     width: 100%;
     display: flex;
+    align-items: center;
 }
 .title-component-text {
     @include truncate-text();


### PR DESCRIPTION
fix: Lundalogik/crm-feature#1806

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
