### PR TITLE
fix(input-field): remove unnecessary validation when using `urlAsText`

### DIFF
--- a/src/components/input-field/input-field.e2e.ts
+++ b/src/components/input-field/input-field.e2e.ts
@@ -340,36 +340,6 @@ describe('limel-input-field', () => {
                 });
             })
         );
-
-        const invalidUrls = [
-            { input: 'justoneword' },
-            { input: 'some words with spaces' },
-        ];
-
-        invalidUrls.forEach((url) =>
-            describe(`with a value of '${url.input}'`, () => {
-                beforeEach(async () => {
-                    const nativeInput = await page.find(
-                        'limel-input-field>>>input'
-                    );
-                    nativeInput.focus();
-                    limelInput.setProperty('value', url.input);
-                    nativeInput.press('Tab');
-                    await page.waitForChanges();
-                });
-                it('IS considered invalid', () => {
-                    expect(inputContainer).toHaveClass(
-                        'mdc-text-field--invalid'
-                    );
-                });
-                it('has a trailing icon indicating the field is invalid', async () => {
-                    const icon = await page.find(
-                        'limel-input-field>>>.mdc-text-field__icon.trailing-icon>limel-icon'
-                    );
-                    expect(icon).toEqualAttribute('name', 'high_importance');
-                });
-            })
-        );
     });
 });
 

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -150,10 +150,3 @@ input.mdc-text-field__input {
         height: $height-of-helper-text-pseudo-before;
     }
 }
-
-.force-invalid {
-    // MDC will automatically remove the `mdc-text-field--invalid` class when
-    // the native validation passes. We sometimes need to be able to override
-    // that. /Ads
-    @extend .mdc-text-field--invalid;
-}

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -117,8 +117,9 @@ export class InputField {
      * built into the browser for many types of input fields. The native
      * validation for `url` is very strict, and does not allow relative urls,
      * nor any other formats that are not a "fully qualified" url. To allow
-     * such urls, use the type `urlAsText` instead. This will use `text` as the
-     * type for the native input element, and only apply minimal validation.
+     * such urls, use the type `urlAsText` instead. `urlAsText` works exactly
+     * like `text` in all regards, except that it enables use of the `showLink`
+     * property.
      */
     @Prop({ reflect: true })
     public type: InputType = 'text';
@@ -317,12 +318,9 @@ export class InputField {
     }
 
     private getContainerClassList() {
-        const forceInvalid = this.type === 'urlAsText' && this.isInvalid();
-
         const classList = {
             'mdc-text-field': true,
             'mdc-text-field--invalid': this.isInvalid(),
-            'force-invalid': forceInvalid,
             'mdc-text-field--disabled': this.disabled,
             'mdc-text-field--required': this.required,
             'mdc-text-field--with-trailing-icon': !!this.getTrailingIcon(),
@@ -460,25 +458,9 @@ export class InputField {
             return false;
         }
 
-        if (this.type === 'urlAsText' && this.isUrlInvalid(this.value)) {
-            return true;
-        }
-
         const element = this.getInputElement();
 
         return !(element && element.checkValidity());
-    }
-
-    private isUrlInvalid(url: string) {
-        if (!url) {
-            return false;
-        }
-
-        if (!url.includes('.') && url.substr(0, 1) !== '/') {
-            return true;
-        }
-
-        return false;
     }
 
     private getInputElement(): HTMLInputElement | HTMLTextAreaElement {


### PR DESCRIPTION
fix: #1128

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
