### PR TITLE
fix(collapsible-section): fix chopped letters in section-headers

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -1,4 +1,5 @@
 @import '../../style/internal/mdc-variables';
+@import '../../style/mixins';
 
 /**
  * @prop --closed-header-background-color: background color for header when closed
@@ -49,12 +50,11 @@
 }
 
 .section__header__title {
+    @include truncate-text;
+    line-height: normal;
+
     justify-self: flex-start;
     padding-right: pxToRem(12);
-
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
 
     user-select: none; // mostly to improve experience on Android, where tapping on sections selects the text too
 }


### PR DESCRIPTION
I think this bug was introduced by using `overflow:hidden` in fix(collapsible-section): use better default colors for header and body 7b7527fe02144a0b8561a7f0192cf3b569d5d569 . I don't know if there was a reason for adding overflow hidden but everything seems to work when remove it. 

fix Lundalogik/crm-feature#1739

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
