### PR TITLE
fix(table): make col headers respect component's initial width

### DIFF
--- a/src/components/table/partial-styles/header-component.scss
+++ b/src/components/table/partial-styles/header-component.scss
@@ -2,8 +2,16 @@
     width: 100%;
     display: flex;
     align-items: center;
+    margin-right: pxToRem(20);
 }
+
 .title-component-text {
     @include truncate-text();
     flex-grow: 1;
+    flex-shrink: 1;
+    min-width: 0;
+}
+
+.title-component-slot  {
+    flex-shrink: 0;
 }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -1,5 +1,6 @@
 @import '../../../node_modules/tabulator-tables/src/scss/tabulator.scss';
 @import '../../style/mixins';
+@import '../../style/functions';
 @import '../../style/internal/variables';
 
 $table-header-background-color: #ededee;


### PR DESCRIPTION
Also make sure that their titles can truncate when
column header size has changed.
fix: https://github.com/Lundalogik/crm-feature/issues/1815

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
