### PR TITLE
fix(flatpickr-adapter): fix bad contrast in month select in Firefox

### DIFF
--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.scss
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.scss
@@ -140,6 +140,10 @@ $datepickerTextOnThemeColor: var(
 
         select {
             color: $datepickerTextOnThemeColor;
+
+            option {
+                color: initial;
+            }
         }
 
         input {


### PR DESCRIPTION
The problem was that the text color of the options in the select menu was set to white. Firefox uses
white background in a select menu. Now we don't override the default color of the select options.

fix Lundalogik/crm-feature#1770

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
