### PR TITLE
feat(select): enable adding icons to select options

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -63,6 +63,14 @@
     border-radius: pxToRem(6);
 
     .mdc-list-item {
+        &.mdc-list-item--disabled {
+            cursor: not-allowed;
+
+            limel-icon {
+                opacity: 0.38; // similar to `mdc-list-item__text` when disabled
+            }
+        }
+
         &:first-child {
             border-radius: pxToRem(6) pxToRem(6) pxToRem(0) pxToRem(0);
         }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -161,10 +161,16 @@
     limel-icon.mdc-list-item__graphic {
         // Tweaks to make icon lists align nicely with badge-icon lists.
         &[size='x-small'] {
-            margin-right: pxToRem(24);
+            margin-right: pxToRem(4);
         }
         &[size='small'] {
-            margin-right: pxToRem(26);
+            margin-right: pxToRem(8);
+        }
+        &[size='medium'] {
+            margin-right: pxToRem(8);
+        }
+        &[size='large'] {
+            margin-right: pxToRem(12);
         }
     }
 }

--- a/src/components/select/examples/select-narrow.tsx
+++ b/src/components/select/examples/select-narrow.tsx
@@ -31,9 +31,21 @@ export class SelectExample {
     };
 
     private options: Option[] = [
-        { text: 'Luke Skywalker', value: 'luke' },
-        { text: 'Han Solo', value: 'han' },
-        { text: 'Leia Organo', value: 'leia' },
+        {
+            text: 'Luke Skywalker',
+            value: 'luke',
+            icon: 'businessman',
+        },
+        {
+            text: 'Han Solo',
+            value: 'han',
+            icon: 'human_head',
+        },
+        {
+            text: 'Leia Organo',
+            value: 'leia',
+            icon: 'businesswoman',
+        },
     ];
 
     constructor() {

--- a/src/components/select/examples/select-with-icons.tsx
+++ b/src/components/select/examples/select-with-icons.tsx
@@ -1,0 +1,70 @@
+import { Option } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+/**
+ * Select with icons for options
+ */
+@Component({
+    shadow: true,
+    tag: 'limel-example-select-with-icons',
+})
+export class SelectExample {
+    @State()
+    public value: Option;
+
+    private options: Option[] = [
+        {
+            text: 'Batman',
+            value: 'bat',
+            icon: 'batman_old',
+            iconColor: 'rgb(var(--color-black))',
+        },
+        {
+            text: 'Iron Man',
+            value: 'iron',
+            disabled: true,
+            icon: 'iron_man',
+            iconColor: 'rgb(var(--color-coral-default))',
+        },
+        {
+            text: 'Spider-Man',
+            value: 'spider',
+            icon: 'spiderman_head',
+            iconColor: 'rgb(var(--color-red-default))',
+        },
+        {
+            text: 'Superman',
+            value: 'super',
+            icon: 'superman',
+            iconColor: 'rgb(var(--color-blue-default))',
+        },
+        {
+            text: 'Wonder Woman',
+            value: 'wonder',
+            icon: 'wonder_woman',
+            iconColor: 'rgb(var(--color-yellow-darker))',
+        },
+    ];
+
+    constructor() {
+        this.onChange = this.onChange.bind(this);
+    }
+
+    public render() {
+        return (
+            <section>
+                <limel-select
+                    label="Favorite hero"
+                    helperText="If you see a lack of diversity, it's our icon-provider's fault"
+                    value={this.value}
+                    options={this.options}
+                    onChange={this.onChange}
+                />
+                <limel-example-value value={this.value} />
+            </section>
+        );
+    }
+
+    private onChange(event) {
+        this.value = event.detail;
+    }
+}

--- a/src/components/select/option.types.ts
+++ b/src/components/select/option.types.ts
@@ -25,4 +25,14 @@ export interface Option<T extends string = string> {
      * Set to `true` to make this option disabled and not possible to select.
      */
     disabled?: boolean;
+
+    /**
+     * Displays an icon beside the name of the option.
+     */
+    icon?: string;
+
+    /**
+     * Adds a color to the icon.
+     */
+    iconColor?: string;
 }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -17,14 +17,26 @@
     display: none;
 }
 
-.limel-select__selected-text {
-    @include looks-like-input-label;
-    @include truncate-text;
+.limel-select__selected-option {
+    display: flex;
+    align-items: center;
+
     box-sizing: border-box;
     outline: none;
 
     padding: 0 pxToRem(16);
     align-self: center;
+    min-width: 0; // makes it truncate and prevents the select to grow wider than its container
+}
+
+.limel-select__selected-option__icon {
+    margin-right: pxToRem(8);
+    flex-shrink: 0;
+}
+
+.limel-select__selected-option__text {
+    @include looks-like-input-label;
+    @include truncate-text;
 }
 
 .limel-select {
@@ -33,7 +45,6 @@
     .limel-select-trigger {
         display: inline-flex;
         align-items: center;
-        min-width: 0; // makes the limel-select__selected-text truncate and prevents the select to grow wider than its container
         height: 100%;
 
         cursor: pointer;
@@ -79,7 +90,7 @@
     }
 
     .limel-select-trigger,
-    .limel-select__selected-text {
+    .limel-select__selected-option {
         width: 100%;
     }
 
@@ -151,7 +162,7 @@ select.limel-select__native-control {
         }
     }
 
-    .limel-select__selected-text {
+    .limel-select__selected-option {
         padding: 0 pxToRem(12);
     }
 }

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -80,8 +80,11 @@ const SelectValue: FunctionalComponent<
             class={containerClassList}
             onKeyPress={props.onTriggerPress}
         >
-            <div class="limel-select__selected-text">
-                {getSelectedText(props.value)}
+            <div class="limel-select__selected-option">
+                {getSelectedIcon(props.value)}
+                <span class="limel-select__selected-option__text">
+                    {getSelectedText(props.value)}
+                </span>
             </div>
             <i class="mdc-select__dropdown-icon" />
             <label class={labelClassList}>{props.label}</label>
@@ -195,6 +198,8 @@ function createMenuItems(
             selected: selected,
             disabled: disabled,
             value: option,
+            icon: option.icon,
+            iconColor: option.iconColor,
         };
     });
 }
@@ -209,4 +214,24 @@ function getSelectedText(value: Option | Option[]): string {
     }
 
     return value.text;
+}
+
+function getSelectedIcon(value: any) {
+    if (!value || !value.icon) {
+        return '';
+    }
+
+    const style: any = {};
+    if (value.iconColor) {
+        style.color = value.iconColor;
+    }
+
+    return (
+        <limel-icon
+            class="limel-select__selected-option__icon"
+            name={value.icon}
+            size="medium"
+            style={style}
+        />
+    );
 }

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -24,6 +24,7 @@ import { SelectTemplate } from './select.template';
 
 /**
  * @exampleComponent limel-example-select
+ * @exampleComponent limel-example-select-with-icons
  * @exampleComponent limel-example-select-multiple
  * @exampleComponent limel-example-select-initially-empty
  * @exampleComponent limel-example-select-initially-empty-required


### PR DESCRIPTION
according to size rhythm guidelines
fix: https://github.com/Lundalogik/crm-feature/issues/1790
## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [x] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
