### PR TITLE
fix(list): border radius on all corners when only 1 item is displayed

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -9,6 +9,8 @@
 
 @import '../../style/mixins';
 
+$list-border-radius: 0.375rem; // 6px
+
 /**
  * @prop --icon-background-color: Color to use for icon background when `badgeIcons=true`.
  * @prop --icon-color: Color to use for icon. Defaults to grey when `badgeIcons=false`. Defaults to white when `badgeIcons=true`.
@@ -60,7 +62,7 @@
 .mdc-list {
     --mdc-theme-text-icon-on-background: var(--icon-color, rgb(157, 157, 157));
     padding: 0;
-    border-radius: pxToRem(6);
+    border-radius: $list-border-radius;
 
     .mdc-list-item {
         &.mdc-list-item--disabled {
@@ -72,10 +74,12 @@
         }
 
         &:first-child {
-            border-radius: pxToRem(6) pxToRem(6) pxToRem(0) pxToRem(0);
+            border-top-left-radius: $list-border-radius;
+            border-top-right-radius: $list-border-radius;
         }
         &:last-child {
-            border-radius: pxToRem(0) pxToRem(0) pxToRem(6) pxToRem(6);
+            border-bottom-right-radius: $list-border-radius;
+            border-bottom-left-radius: $list-border-radius;
         }
     }
 


### PR DESCRIPTION
fixes this problem, where top corners didn't get correct radius:
<img width="100%" alt="Screen Shot 2020-12-11 at 14 37 41" src="https://user-images.githubusercontent.com/35954987/108056701-e5808880-7051-11eb-8d77-cf95cd6913de.png">

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
