### PR TITLE
docs(popover): fix wrong property name in example

### DIFF
--- a/src/components/popover/examples/popover.scss
+++ b/src/components/popover/examples/popover.scss
@@ -1,3 +1,3 @@
 :host(limel-example-popover) {
-    --popover-header-background-color: rgb(var(--contrast-1300));
+    --popover-body-background-color: rgb(var(--contrast-200));
 }


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
