### PR TITLE
docs(popover): explain how to pop on the correct side

### DIFF
--- a/src/components/popover/examples/popover.scss
+++ b/src/components/popover/examples/popover.scss
@@ -1,3 +1,5 @@
 :host(limel-example-popover) {
     --popover-header-background-color: rgb(var(--contrast-1300));
+    display: inline-block;
+    position: relative;
 }

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -39,6 +39,16 @@ import { portalContains } from '../portal/contains';
  * When a popover is displayed, interactions with other controls are blocked,
  * until user dismisses the popover.
  *
+ * :::warning
+ * In order for the popover to pop on the correct side of the element that
+ * triggers it, you need to wrap both of them in a container and make sure that
+ * the container:
+ * 1. is visually as big as the element that triggers the popover
+ * 1. has a `position` property specified (this normally can be `position: relative;`).
+ *
+ * Check the example to see how `:host` is displayed as `inline-block` to be as
+ * big as the button which is inside it.
+ * :::
  *
  * ## Layout
  * Popovers has only one slot in which you can import a custom web-component.


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1849
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
