### PR TITLE
WIP trying to find the reason readonly doesn't work for limel-picker inside limel-form

### DIFF
--- a/src/components/form/adapters/base-adapter.ts
+++ b/src/components/form/adapters/base-adapter.ts
@@ -66,6 +66,16 @@ export class LimeElementsAdapter extends React.Component<any, any> {
     ) {
         super(props);
 
+        if (props.elementProps) {
+            if (props.elementProps.formInfo?.schema?.disabled || props.elementProps.formInfo?.schema?.lime?.component?.props?.disabled) {
+                props.elementProps.disabled = true;
+            }
+
+            if (props.elementProps.formInfo?.schema?.readonly || props.elementProps.formInfo?.schema?.lime?.component?.props?.readonly) {
+                props.elementProps.readonly = true;
+            }
+        }
+
         this.state = {
             prevEvents: {},
         };

--- a/src/components/form/adapters/base-adapter.ts
+++ b/src/components/form/adapters/base-adapter.ts
@@ -67,11 +67,19 @@ export class LimeElementsAdapter extends React.Component<any, any> {
         super(props);
 
         if (props.elementProps) {
-            if (props.elementProps.formInfo?.schema?.disabled || props.elementProps.formInfo?.schema?.lime?.component?.props?.disabled) {
+            if (
+                props.elementProps.formInfo?.schema?.disabled ||
+                props.elementProps.formInfo?.schema?.lime?.component?.props
+                    ?.disabled
+            ) {
                 props.elementProps.disabled = true;
             }
 
-            if (props.elementProps.formInfo?.schema?.readonly || props.elementProps.formInfo?.schema?.lime?.component?.props?.readonly) {
+            if (
+                props.elementProps.formInfo?.schema?.readonly ||
+                props.elementProps.formInfo?.schema?.lime?.component?.props
+                    ?.readonly
+            ) {
                 props.elementProps.readonly = true;
             }
         }


### PR DESCRIPTION
The `readonly` and `disabled` props for `limel-picker` works just fine when the component is used directly, but when used inside `limel-form`, those properties are not passed on to the component, regardless of whether the properties are set on the "root" of the field config, or in the `lime.component.props` section.

So far I've edited the limel-form examples to show only a single example with a single picker, and I've added loads of console.logs, to be able to see where the props "disappear".

As can be seen in the following screenshot, when `baseAdapter` renders the custom component, properties are available under `elementProps.schema`, but they have not been set at the root level of `elementProps`. I'm not quite sure were would be the best place to add them…? Maybe in the constructor on lines 60 to 76 in `base-adapter.ts`, before the call to `super` on line 67? 

![image](https://user-images.githubusercontent.com/154725/108987588-c0b09480-7693-11eb-9418-533ea5aecd8e.png)

fix: Lundalogik/crm-feature#1854

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
