### PR TITLE
fix(checkbox): use default material design style for checked state

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -7,12 +7,11 @@
     display: flex;
 
     .mdc-checkbox {
-        @include mdc-checkbox-ink-color(primary);
         @include mdc-checkbox-container-colors(
             secondary,
             on-primary,
-            secondary,
-            on-primary
+            primary,
+            primary
         );
 
         &.mdc-checkbox--invalid {


### PR DESCRIPTION
this improves usability and makes it more
clear which box is checked

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
