### PR TITLE
fix(menu-surface): do not kill click events when clicking in an allowed element

### DIFF
--- a/src/components/menu-surface/menu-surface.tsx
+++ b/src/components/menu-surface/menu-surface.tsx
@@ -32,6 +32,12 @@ export class MenuSurface {
     public open = false;
 
     /**
+     * Clicks in this element should not be prevented when the menu surface is open
+     */
+    @Prop()
+    public allowClicksElement: HTMLElement;
+
+    /**
      * Emitted when the menu surface is dismissed and should be closed
      */
     @Event()
@@ -106,10 +112,28 @@ export class MenuSurface {
     }
 
     private handleDocumentClick(event) {
-        if (this.open && !isDescendant(event.target, this.host)) {
-            this.dismiss.emit();
-            this.preventClickEventPropagation();
+        const elementPath = event.path || [];
+
+        if (!this.open) {
+            return;
         }
+
+        if (isDescendant(event.target, this.host)) {
+            return;
+        }
+
+        if (this.allowClicksElement) {
+            const clickedInAllowedElement = elementPath.includes(
+                this.allowClicksElement
+            );
+
+            if (clickedInAllowedElement) {
+                return;
+            }
+        }
+
+        this.dismiss.emit();
+        this.preventClickEventPropagation();
     }
 
     private handleResize() {

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -349,6 +349,7 @@ export class Picker {
             >
                 <limel-menu-surface
                     open={!!content}
+                    allowClicksElement={this.host}
                     style={{
                         '--menu-surface-width': '100%',
                         'max-height': 'inherit',


### PR DESCRIPTION
fix #1062

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
