### PR TITLE
ci(pr-checks.yml): split publishing of docs into separate job, so failure does not fail the ci job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,34 +60,34 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-  docs:
-    name: Publish Docs
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_USERNAME: lime-ci
-      GH_EMAIL: 617355+lime-ci@users.noreply.github.com
-      GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
-      CI: true
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.CREATE_RELEASE }}
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-        check-latest: true
-    - run: npm i -g npm
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
-    - run: git config --global user.email "$GH_EMAIL"
-    - run: git config --global user.name "$GH_USERNAME"
-    - run: npm run docs:publish -- --v=PR-${{ github.event.pull_request.number }}
-    - uses: actions/github-script@v3
-      with:
-        script: |
-          const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
-          await script({github, context});
+  # docs:
+  #   name: Publish Docs
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     GH_USERNAME: lime-ci
+  #     GH_EMAIL: 617355+lime-ci@users.noreply.github.com
+  #     GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
+  #     CI: true
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #     with:
+  #       token: ${{ secrets.CREATE_RELEASE }}
+  #   - uses: actions/setup-node@v2
+  #     with:
+  #       node-version: '14'
+  #       check-latest: true
+  #   - run: npm i -g npm
+  #   - name: npm install
+  #     run: |
+  #       GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
+  #       npm ci
+  #       rm .npmrc
+  #   - run: git config --global user.email "$GH_EMAIL"
+  #   - run: git config --global user.name "$GH_USERNAME"
+  #   - run: npm run docs:publish -- --v=PR-${{ github.event.pull_request.number }}
+  #   - uses: actions/github-script@v3
+  #     with:
+  #       script: |
+  #         const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
+  #         await script({github, context});

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,14 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_USERNAME: lime-ci
-      GH_EMAIL: 617355+lime-ci@users.noreply.github.com
-      GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
-      CI: true
     steps:
     - uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.CREATE_RELEASE }}
     - uses: actions/setup-node@v2
       with:
         node-version: '14'
@@ -44,15 +38,9 @@ jobs:
         GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
         npm ci
         rm .npmrc
+    - run: npm run build
     - run: npm test --if-present
-    - run: git config --global user.email "$GH_EMAIL"
-    - run: git config --global user.name "$GH_USERNAME"
-    - run: npm run docs:publish -- --v=PR-${{ github.event.pull_request.number }}
-    - uses: actions/github-script@v3
-      with:
-        script: |
-          const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
-          await script({github, context});
+    - run: npm run docs:build
 
   commitlint:
     name: Commitlint
@@ -71,3 +59,35 @@ jobs:
         uses: xt0rted/block-autosquash-commits-action@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  docs:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_USERNAME: lime-ci
+      GH_EMAIL: 617355+lime-ci@users.noreply.github.com
+      GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
+      CI: true
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.CREATE_RELEASE }}
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        check-latest: true
+    - run: npm i -g npm
+    - name: npm install
+      run: |
+        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
+        npm ci
+        rm .npmrc
+    - run: git config --global user.email "$GH_EMAIL"
+    - run: git config --global user.name "$GH_USERNAME"
+    - run: npm run docs:publish -- --v=PR-${{ github.event.pull_request.number }}
+    - uses: actions/github-script@v3
+      with:
+        script: |
+          const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
+          await script({github, context});


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
