### PR TITLE
feat(chip-set): make clear all chips button's label translatable

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -1,4 +1,4 @@
-import { Chip } from '@limetech/lime-elements';
+import { Chip, Languages } from '@limetech/lime-elements';
 import {
     MDCChipInteractionEvent,
     MDCChipSelectionEvent,
@@ -17,6 +17,7 @@ import {
     Watch,
 } from '@stencil/core';
 import { handleKeyboardEvent } from './chip-set-input-helpers';
+import translate from '../../global/translations';
 
 const SELECTED_CHIP_CLASS = 'mdc-chip--selected';
 
@@ -111,6 +112,13 @@ export class ChipSet {
     public delimiter: string = null;
 
     /**
+     * Defines the language for translations.
+     * Will translate the translatable strings on the components. For example, the clear all chips label.
+     */
+    @Prop()
+    public language: Languages = 'en';
+
+    /**
      * Dispatched when a chip is interacted with
      */
     @Event()
@@ -158,7 +166,7 @@ export class ChipSet {
     private mdcChipSet: MDCChipSet;
     private mdcTextField: MDCTextField;
     private handleKeyDown = handleKeyboardEvent;
-    private clearAllLabel = 'Clear chips';
+    private clearAllChipsLabel: string;
 
     constructor() {
         this.renderChip = this.renderChip.bind(this);
@@ -216,6 +224,13 @@ export class ChipSet {
     @Method()
     public async emptyInput() {
         this.syncEmptyInput();
+    }
+
+    public componentWillLoad() {
+        this.clearAllChipsLabel = translate.get(
+            'chip-set.clear-all',
+            this.language
+        );
     }
 
     public componentDidLoad() {
@@ -664,8 +679,8 @@ export class ChipSet {
                 class="mdc-text-field__icon clear-all-button"
                 tabindex="0"
                 role="button"
-                title={this.clearAllLabel}
-                aria-label={this.clearAllLabel}
+                title={this.clearAllChipsLabel}
+                aria-label={this.clearAllChipsLabel}
             />
         );
     }

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -2,4 +2,5 @@ export default {
     'date-picker.month.heading': 'Måned',
     'date-picker.quarter.heading': 'Kvartal',
     'date-picker.year.heading': 'År',
+    'chip-set.clear-all': 'Ryd alle',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -2,4 +2,5 @@ export default {
     'date-picker.month.heading': 'Month',
     'date-picker.quarter.heading': 'Quarter',
     'date-picker.year.heading': 'Year',
+    'chip-set.clear-all': 'Clear all',
 };

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -2,4 +2,5 @@ export default {
     'date-picker.month.heading': 'Kuukausi',
     'date-picker.quarter.heading': 'Vuosineljännes',
     'date-picker.year.heading': 'Vuosi',
+    'chip-set.clear-all': 'Tyhjennä kaikki',
 };

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -2,4 +2,5 @@ export default {
     'date-picker.month.heading': 'Maand',
     'date-picker.quarter.heading': 'Kwartaal',
     'date-picker.year.heading': 'Jaar',
+    'chip-set.clear-all': 'Alles wissen',
 };

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -2,4 +2,5 @@ export default {
     'date-picker.month.heading': 'Måned',
     'date-picker.quarter.heading': 'Kvartal',
     'date-picker.year.heading': 'År',
+    'chip-set.clear-all': 'Fjern alle',
 };

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -2,4 +2,5 @@ export default {
     'date-picker.month.heading': 'Månad',
     'date-picker.quarter.heading': 'Kvartal',
     'date-picker.year.heading': 'År',
+    'chip-set.clear-all': 'Rensa alla',
 };


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
