### PR TITLE
fix(table): prevent tall custom components break column headers UI

### DIFF
--- a/src/components/table/partial-styles/header-component.scss
+++ b/src/components/table/partial-styles/header-component.scss
@@ -14,4 +14,5 @@
 
 .title-component-slot  {
     flex-shrink: 0;
+    max-height: pxToRem(16);
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1859
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
