### PR TITLE
docs(chip-set): do not use deprecated styles in example

### DIFF
--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -49,10 +49,10 @@ export class ChipSetInputExample {
             this.createChip('Fish'),
         ];
 
-        this.value[0].iconColor = 'var(--lime-red)';
-        this.value[1].iconColor = 'var(--lime-orange)';
-        this.value[2].iconColor = 'var(--lime-green)';
-        this.value[3].iconColor = 'var(--lime-blue)';
+        this.value[0].iconFillColor = 'var(--lime-yellow)';
+        this.value[1].iconBackgroundColor = 'var(--lime-orange)';
+        this.value[2].iconBackgroundColor = 'var(--lime-green)';
+        this.value[3].iconBackgroundColor = 'var(--lime-blue)';
 
         this.chipSetOnChange = this.chipSetOnChange.bind(this);
         this.onInteract = this.onInteract.bind(this);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/35954987/109803384-42b73500-7c21-11eb-9ce1-014130c7dd04.png)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
