### PR TITLE
fix(chip-set): update `--icon-color` default value to `rgb(var(--contrast-1100))`

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -8,7 +8,7 @@
 
 /**
  * @prop --icon-background-color: Background color of the icon. Defaults to transparent.
- * @prop --icon-color: Color of the icon. Defaults to 54% black.
+ * @prop --icon-color: Color of the icon. Defaults to `rgb(var(--contrast-1100))`.
  * @prop --background-color: Background color of the field when type is set to input.
  * @prop --background-color-disabled: Background color of the field when type is set to input and the component is disabled or readonly.
  * @prop --input-chip-set-selected-chip-color: Color of the highlight around selected chips in input chip-sets.
@@ -69,7 +69,7 @@ $height-of-chip-set-input: pxToRem(36);
 limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     background-color: var(--icon-background-color, transparent);
     margin: 0 !important;
-    color: var(--icon-color, rgba(0, 0, 0, 0.54));
+    color: var(--icon-color, rgb(var(--contrast-1100)));
 }
 
 .mdc-chip-set {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -25,6 +25,7 @@ const SELECTED_CHIP_CLASS = 'mdc-chip--selected';
  * @exampleComponent limel-example-chip-set-choice
  * @exampleComponent limel-example-chip-set-filter
  * @exampleComponent limel-example-chip-set-input
+ * @exampleComponent limel-example-chip-icon-color
  */
 @Component({
     tag: 'limel-chip-set',

--- a/src/components/chip-set/examples/chip-icon-colors.tsx
+++ b/src/components/chip-set/examples/chip-icon-colors.tsx
@@ -1,0 +1,46 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Chip Icon Color
+ *
+ * The color and background color of each chip's icon can be individually
+ * configured.
+ */
+@Component({
+    tag: 'limel-example-chip-icon-color',
+    shadow: true,
+})
+export class ChipIconColorExample {
+    public render() {
+        return [
+            <limel-chip-set
+                value={[
+                    {
+                        id: 1,
+                        text: 'Badger',
+                        icon: 'badger',
+                    },
+                    {
+                        id: 2,
+                        text: 'Elephant',
+                        icon: 'elephant',
+                        iconFillColor: 'rgb(var(--color-magenta-default))',
+                    },
+                    {
+                        id: 3,
+                        text: 'Caterpillar',
+                        icon: 'caterpillar',
+                        iconBackgroundColor: 'rgb(var(--color-orange-default))',
+                    },
+                    {
+                        id: 4,
+                        text: 'Fish',
+                        icon: 'fish',
+                        iconFillColor: 'rgb(var(--color-yellow-light))',
+                        iconBackgroundColor: 'rgb(var(--color-indigo-darker))',
+                    },
+                ]}
+            />,
+        ];
+    }
+}

--- a/src/components/chip-set/examples/chip-set-input.scss
+++ b/src/components/chip-set/examples/chip-set-input.scss
@@ -1,7 +1,4 @@
 limel-chip-set[type='input'] {
-    --icon-background-color: rgb(173, 173, 173);
-    --icon-color: white;
-
     flex-grow: 1;
     flex-shrink: 1;
     max-width: calc(100% - 7rem);

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -49,11 +49,6 @@ export class ChipSetInputExample {
             this.createChip('Fish'),
         ];
 
-        this.value[0].iconColor = 'var(--lime-red)';
-        this.value[1].iconColor = 'var(--lime-orange)';
-        this.value[2].iconColor = 'var(--lime-green)';
-        this.value[3].iconColor = 'var(--lime-blue)';
-
         this.chipSetOnChange = this.chipSetOnChange.bind(this);
         this.onInteract = this.onInteract.bind(this);
         this.onInput = this.onInput.bind(this);


### PR DESCRIPTION
Strong dominant colors make chips or buttons look like CTAs (Call To Action elements). This should be avoided and colors should be used to communicate meaningful messages or attract attention where needed.

Default styles should be neutral.

fix: https://github.com/Lundalogik/crm-feature/issues/1886

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
