### PR TITLE
feat(header): add support for `supporting-text`

### DIFF
--- a/src/components/header/examples/header.scss
+++ b/src/components/header/examples/header.scss
@@ -1,7 +1,8 @@
 :host(limel-example-header) {
     --header-background-color: rgb(var(--contrast-1100));
     --header-heading-color: rgb(var(--contrast-100));
-    --header-subheading-color: rgb(var(--color-red-lighter));
+    --header-subheading-color: rgb(var(--color-teal-lighter));
+    --header-supporting-text-color: rgb(var(--color-red-lighter));
     --header-icon-color: rgb(var(--color-red-light));
 }
 

--- a/src/components/header/examples/header.tsx
+++ b/src/components/header/examples/header.tsx
@@ -53,7 +53,8 @@ export class HeaderExample {
             <limel-header
                 icon="brake_warning"
                 heading="Useful information"
-                subheading="Oops... data couldn't be loaded!"
+                subheading="Note"
+                supportingText="Data couldn't be loaded!"
             >
                 {this.renderActions()}
             </limel-header>

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -5,6 +5,7 @@
  * @prop --header-background-color: Background color of header, defaults to `--contrast-300`.
  * @prop --header-heading-color: Color of heading text, defaults to `--contrast-1100`.
  * @prop --header-subheading-color: Color of subheading text, defaults to `--contrast-900`.
+ * @prop --header-supporting-text-color: Color of supporting text in subheading, defaults to `--header-subheading-color`.
  * @prop --header-icon-color: Color of header icon, defaults to `--contrast-1100`.
  * @prop --header-top-right-left-border-radius: Top-left and top-right border radius of header, defaults to `0.75rem`.
  * @prop --header-responsive-breakpoint: Defines the minimum allowed `width` of both information and actions areas in the header, defaults to `22rem`.
@@ -60,6 +61,14 @@
     color: var(--header-subheading-color, rgb(var(--contrast-900)));
     font-size: pxToRem(14);
     font-weight: lighter;
+}
+
+.information__headings__subheading__supporting-text {
+    color: var(--header-supporting-text-color, var(--header-subheading-color));
+    span {
+        margin: 0 pxToRem(8);
+        font-weight: bold;
+    }
 }
 
 .actions {

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -7,6 +7,7 @@
  * @prop --header-subheading-color: Color of subheading text, defaults to `--contrast-900`.
  * @prop --header-supporting-text-color: Color of supporting text in subheading, defaults to `--header-subheading-color`.
  * @prop --header-icon-color: Color of header icon, defaults to `--contrast-1100`.
+ * @prop --header-icon-background-color: Background color of header icon, defaults to `transparent`.
  * @prop --header-top-right-left-border-radius: Top-left and top-right border radius of header, defaults to `0.75rem`.
  * @prop --header-responsive-breakpoint: Defines the minimum allowed `width` of both information and actions areas in the header, defaults to `22rem`.
  */
@@ -38,6 +39,7 @@
 .information__icon {
     flex-shrink: 0;
     color: var(--header-icon-color, rgb(var(--contrast-1100)));
+    background-color: var(--header-icon-background-color, transparent);
 }
 
 .information__headings {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -20,8 +20,8 @@ import { Component, h, Prop } from '@stencil/core';
  * ## Layout
  * The vital information in a header is usually manifested in form of an icon,
  * and a heading. A subheading also could be added to provide supplementary
- * information.
- *
+ * information. There is also a third place for displaying supplementary information
+ * or "supporting text", which will be rendered as a part of the subheading.
  * Along with this information, headers can also include actions, controls, or
  * menus.
  *
@@ -70,6 +70,12 @@ export class Header {
     @Prop()
     public subheading: string;
 
+    /**
+     * An extra string of text to display along with with the Subheading
+     */
+    @Prop()
+    public supportingText: string;
+
     public render() {
         return [
             <div class="information">
@@ -91,6 +97,7 @@ export class Header {
                         title={this.subheading}
                     >
                         {this.subheading}
+                        {this.renderSupportingText()}
                     </h2>
                 </div>
             </div>,
@@ -98,5 +105,17 @@ export class Header {
                 <slot />
             </div>,
         ];
+    }
+
+    private renderSupportingText() {
+        if (!this.supportingText) {
+            return;
+        }
+
+        return (
+            <span class="information__headings__subheading__supporting-text">
+                <span>·</span> {this.supportingText}
+            </span>
+        );
     }
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1888

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
