### PR TITLE
fix(button): make buttons with has-reduced-presence really disappear

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -85,18 +85,49 @@ button {
     }
 }
 
+$speed-of-reducing-presence: 0.3s;
+
+@keyframes reduced-presence {
+    0% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: scale(0.7);
+    }
+}
+
 :host(.has-reduced-presence) {
     button {
-        transition: opacity 300ms ease-in-out;
-
         &[disabled]:not(.loading):not(.just-loaded) {
-            opacity: 0;
+            animation: reduced-presence $speed-of-reducing-presence ease
+                forwards;
+            transition: padding $speed-of-reducing-presence ease,
+                min-width $speed-of-reducing-presence ease;
+            transition-delay: $speed-of-reducing-presence;
 
-            limel-icon,
+            padding: 0;
+            min-width: 0;
+            // we don't animate `min-height` and reset it to `0`, otherwise the
+            // button completely dissapear physically and can sometimes layout-shifts
+            // in the UI
+
             .label {
-                // Avoid fading in the label while
-                // simultaneously fading out the button.
+                transition: font-size 0.8s ease;
+                transition-delay: $speed-of-reducing-presence;
+                font-size: 0;
                 opacity: 0;
+            }
+            limel-icon,
+            limel-spinner,
+            svg {
+                transition: all $speed-of-reducing-presence ease;
+                transition-delay: $speed-of-reducing-presence;
+
+                opacity: 0;
+                width: 0;
+                height: 0;
             }
         }
     }


### PR DESCRIPTION
and do not occupy any visual width in the UI

fix: https://github.com/Lundalogik/crm-feature/issues/1890

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
