### PR TITLE
feat(file): add accept prop to filter selectable file types

### DIFF
--- a/src/components/file/examples/file-accepted-types.tsx
+++ b/src/components/file/examples/file-accepted-types.tsx
@@ -1,0 +1,40 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+@Component({
+    tag: 'limel-example-file-accepted-types',
+    shadow: true,
+})
+export class FileAcceptedTypesExample {
+    @State()
+    private value: FileInfo = { filename: 'picture.jpg', id: 123 };
+
+    @State()
+    private required = false;
+
+    constructor() {
+        this.handleChange = this.handleChange.bind(this);
+        this.toggleRequired = this.toggleRequired.bind(this);
+    }
+
+    public render() {
+        return [
+            <limel-file
+                label="Attach only images (png, jpeg)"
+                onChange={this.handleChange}
+                required={this.required}
+                value={this.value}
+                accept="image/jpeg,image/png"
+            />,
+        ];
+    }
+
+    private handleChange(event: CustomEvent<FileInfo>) {
+        this.value = event.detail;
+        console.log('onChange', this.value);
+    }
+
+    private toggleRequired() {
+        this.required = !this.required;
+    }
+}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -49,6 +49,7 @@ const DEFAULT_ICON = 'note';
  *
  * @exampleComponent limel-example-file
  * @exampleComponent limel-example-file-custom-icon
+ * @exampleComponent limel-example-file-accepted-types
  */
 @Component({
     tag: 'limel-file',
@@ -79,6 +80,12 @@ export class File {
      */
     @Prop({ reflect: true })
     public disabled: boolean = false;
+
+    /**
+     * The [accepted file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers)
+     */
+    @Prop({ reflect: true })
+    public accept: string = '*';
 
     /**
      * Dispatched when a file is selected/deselected
@@ -145,6 +152,7 @@ export class File {
                 id={this.fileInputId}
                 onChange={this.handleFileChange}
                 type="file"
+                accept={this.accept}
             />,
             <limel-chip-set
                 disabled={this.disabled}


### PR DESCRIPTION
fix: #1174

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
