### PR TITLE
feat(form): allow collapsible-sections to be loaded either open or closed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
                 functions: 'never',
                 objects: 'always-multiline',
                 imports: 'always-multiline',
+                exports: 'always-multiline',
             },
         ],
         curly: 'error',

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -126,6 +126,13 @@ export interface LimeSchemaOptions {
     collapsible?: boolean;
 
     /**
+     * When `collapsible` is `true`, set this to `false` to make the
+     * collapsible section load in the open state.
+     * Defaults to `true`.
+     */
+    collapsed?: boolean;
+
+    /**
      * Will render the field using the specified component. The component
      * should implement the `FormComponent` interface
      */

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -173,7 +173,7 @@ export interface FormLayoutOptions<T = FormLayoutType.Default> {
     type: T;
 
     /**
-     * @deprecated use `colSpan` instead
+     * @deprecated use `GridLayoutOptions.colSpan` instead
      */
     span?: 'all';
 }

--- a/src/components/form/internal.types.ts
+++ b/src/components/form/internal.types.ts
@@ -1,0 +1,6 @@
+import { JSONSchema7 } from 'json-schema';
+import { LimeSchemaOptions } from './form.types';
+
+export interface LimeJSONSchema extends JSONSchema7 {
+    lime?: LimeSchemaOptions;
+}

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -1,8 +1,13 @@
 import React from 'react';
 import { FormLayoutOptions, FormLayoutType } from '../form.types';
+import { LimeJSONSchema } from '../internal.types';
 import { renderDescription, renderTitle } from './common';
 import { GridLayout } from './grid-layout';
-import { ObjectFieldProperty, ObjectFieldTemplateProps } from './types';
+import {
+    LimeObjectFieldTemplateProps,
+    ObjectFieldProperty,
+    ObjectFieldTemplateProps,
+} from './types';
 
 export const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
     const id = props.idSchema.$id;
@@ -27,11 +32,14 @@ function renderFieldWithTitle(props: ObjectFieldTemplateProps) {
     );
 }
 
-function renderCollapsibleField(props: ObjectFieldTemplateProps) {
+function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
+    const defaultOpen = !isCollapsed(props.schema);
+
     return React.createElement(
         'limel-collapsible-section',
         {
             header: props.title,
+            'is-open': defaultOpen,
         },
         renderDescription(props.description),
         renderProperties(props.properties, props.schema)
@@ -82,4 +90,8 @@ function renderGridLayout(
 
 function isCollapsible(schema: any) {
     return !!schema.lime?.collapsible;
+}
+
+function isCollapsed(schema: LimeJSONSchema) {
+    return schema.lime.collapsed !== false;
 }

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -3,13 +3,9 @@ import { FormLayoutOptions, FormLayoutType } from '../form.types';
 import { LimeJSONSchema } from '../internal.types';
 import { renderDescription, renderTitle } from './common';
 import { GridLayout } from './grid-layout';
-import {
-    LimeObjectFieldTemplateProps,
-    ObjectFieldProperty,
-    ObjectFieldTemplateProps,
-} from './types';
+import { LimeObjectFieldTemplateProps, ObjectFieldProperty } from './types';
 
-export const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
+export const ObjectFieldTemplate = (props: LimeObjectFieldTemplateProps) => {
     const id = props.idSchema.$id;
     if (id === 'root' || !isCollapsible(props.schema)) {
         return renderFieldWithTitle(props);
@@ -22,7 +18,7 @@ export const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
     return renderProperties(props.properties, props.schema);
 };
 
-function renderFieldWithTitle(props: ObjectFieldTemplateProps) {
+function renderFieldWithTitle(props: LimeObjectFieldTemplateProps) {
     return React.createElement(
         React.Fragment,
         {},
@@ -46,7 +42,10 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
     );
 }
 
-function renderProperties(properties: ObjectFieldProperty[], schema: any) {
+function renderProperties(
+    properties: ObjectFieldProperty[],
+    schema: LimeJSONSchema
+) {
     const layout: FormLayoutOptions = schema.lime?.layout;
 
     return renderLayout(properties, layout);
@@ -88,7 +87,7 @@ function renderGridLayout(
     );
 }
 
-function isCollapsible(schema: any) {
+function isCollapsible(schema: LimeJSONSchema) {
     return !!schema.lime?.collapsible;
 }
 

--- a/src/components/form/templates/types.ts
+++ b/src/components/form/templates/types.ts
@@ -1,10 +1,6 @@
 import { ObjectFieldTemplateProps, ArrayFieldTemplateProps } from '@rjsf/core';
 import { LimeJSONSchema } from '../internal.types';
-export {
-    FieldTemplateProps,
-    ObjectFieldTemplateProps,
-    ArrayFieldTemplateProps,
-} from '@rjsf/core';
+export { FieldTemplateProps, ArrayFieldTemplateProps } from '@rjsf/core';
 
 export type TemplateProps = ObjectFieldTemplateProps | ArrayFieldTemplateProps;
 

--- a/src/components/form/templates/types.ts
+++ b/src/components/form/templates/types.ts
@@ -1,4 +1,5 @@
 import { ObjectFieldTemplateProps, ArrayFieldTemplateProps } from '@rjsf/core';
+import { LimeJSONSchema } from '../internal.types';
 export {
     FieldTemplateProps,
     ObjectFieldTemplateProps,
@@ -11,6 +12,10 @@ export type TemplateProps = ObjectFieldTemplateProps | ArrayFieldTemplateProps;
 export type ObjectFieldProperty = ObjectFieldTemplateProps['properties'][0];
 
 export type ArrayFieldItem = ArrayFieldTemplateProps['items'][0];
+
+export interface LimeObjectFieldTemplateProps extends ObjectFieldTemplateProps {
+    schema: LimeJSONSchema;
+}
 
 export interface Runnable {
     run: (event: any) => void;

--- a/src/components/form/templates/types.ts
+++ b/src/components/form/templates/types.ts
@@ -3,7 +3,6 @@ import { LimeJSONSchema } from '../internal.types';
 export {
     FieldTemplateProps,
     ObjectFieldTemplateProps,
-    // eslint-disable-next-line comma-dangle
     ArrayFieldTemplateProps,
 } from '@rjsf/core';
 

--- a/src/components/form/widgets/types.ts
+++ b/src/components/form/widgets/types.ts
@@ -1,11 +1,6 @@
 import { WidgetProps as RjsfWidgetProps } from '@rjsf/core';
-import { JSONSchema7 } from 'json-schema';
-import { LimeSchemaOptions } from '../form.types';
+import { LimeJSONSchema } from '../internal.types';
 
 export interface WidgetProps extends RjsfWidgetProps {
     schema: LimeJSONSchema;
-}
-
-interface LimeJSONSchema extends JSONSchema7 {
-    lime?: LimeSchemaOptions;
 }


### PR DESCRIPTION
Add new property `collapsibleDefaultOpen` to interface `LimeSchemaOptions`.

fix: Lundalogik/crm-feature#1609

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
