### PR TITLE
fix(shadows): add shadow styles to use for `focused` elements

### DIFF
--- a/src/components/popover-surface/popover-surface.scss
+++ b/src/components/popover-surface/popover-surface.scss
@@ -1,4 +1,5 @@
 @import '../../style/functions';
+@import '../../style/internal/variables';
 
 .limel-popover-surface {
     position: relative;
@@ -11,8 +12,44 @@
 
     border-radius: var(--popover-border-radius, pxToRem(12));
     box-shadow: var(--shadow-depth-16);
-    background-color: var(
-        --popover-body-background-color,
-        rgb(var(--contrast-100))
-    );
+
+    backdrop-filter: blur(pxToRem(5));
+
+    &:after {
+        // allows using `--popover-body-background-color` while
+        // getting the blurred backdrop effect
+        transition: opacity 0.4s ease;
+        pointer-events: none;
+
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: $limel-popover-before--z-index;
+
+        opacity: 0.7;
+
+        border-radius: var(--popover-border-radius, pxToRem(12));
+        background-color: var(
+            --popover-body-background-color,
+            rgb(var(--contrast-100))
+        );
+    }
+
+    &:focus,
+    &:focus-within {
+        outline: none;
+
+        &:after {
+            opacity: 1;
+        }
+    }
+
+    &:focus-visible {
+        // only when non-pointer input is being used,
+        // e.g. tabbed into using keyboard
+        box-shadow: var(--shadow-depth-16-focused);
+    }
 }

--- a/src/components/popover-surface/popover-surface.tsx
+++ b/src/components/popover-surface/popover-surface.tsx
@@ -25,7 +25,7 @@ export class PopoverSurface {
     }
 
     public render() {
-        return <div class="limel-popover-surface" tabindex="-1" />;
+        return <div class="limel-popover-surface" tabindex="0" />;
     }
 
     private appendElement() {

--- a/src/components/popover/examples/popover.tsx
+++ b/src/components/popover/examples/popover.tsx
@@ -23,7 +23,9 @@ export class PopoverExample {
                     label="Click me!"
                     onClick={this.openPopover}
                 />
-                <p style={{ margin: '0.5rem 1rem' }}>Content</p>
+                <p style={{ margin: '0.5rem 1rem' }} tabindex="0">
+                    Content
+                </p>
             </limel-popover>,
         ];
     }

--- a/src/style/internal/z-index-variables.scss
+++ b/src/style/internal/z-index-variables.scss
@@ -8,3 +8,4 @@ $limel-list--has-interactive-items--mdc-list-item--hover--z-index: 1 !default;
 $limel-slider--thumb-container--z-index: 1 !default;
 $limel-tab-bar--active-tab--z-index: 2 !default;
 $limel-table--has-interactive-rows--selectable-row--hover--z-index: 1 !default;
+$limel-popover-before--z-index: -1 !default;

--- a/src/style/shadows.scss
+++ b/src/style/shadows.scss
@@ -1,5 +1,8 @@
 @import './functions';
 @import './mixins';
+@import './internal/mdc-variables';
+
+$visualise-focused-state: 0 0 0 #{pxToRem(2)} var(--mdc-theme-primary);
 
 :root {
     // Good for buttons and clickables such as select dropdowns, or slider grabbers
@@ -23,8 +26,12 @@
     // Good for Command bars, Command dropdowns, Context menus
     --shadow-depth-8: 0 #{pxToRem(3.2)} #{pxToRem(7.2)} 0 rgba(0, 0, 0, 0.132),
         0 #{pxToRem(0.6)} #{pxToRem(1.8)} 0 rgba(0, 0, 0, 0.108);
-
-    // Like above but light source is below the element, good for bottom bars, etc...
+    // Same as above, but when element is focused
+    --shadow-depth-8-focused: 0 #{pxToRem(3.2)} #{pxToRem(7.2)} 0
+            rgba(0, 0, 0, 0.132),
+        0 #{pxToRem(0.6)} #{pxToRem(1.8)} 0 rgba(0, 0, 0, 0.108),
+        #{$visualise-focused-state};
+    // Same as above, but light source is below the element, good for bottom bars, etc...
     --shadow-depth-8-reversed: 0 #{pxToRem(-3.2)} #{pxToRem(7.2)} 0
             rgba(0, 0, 0, 0.132),
         0 #{pxToRem(-0.6)} #{pxToRem(1.8)} 0 rgba(0, 0, 0, 0.108);
@@ -33,7 +40,19 @@
     --shadow-depth-16: 0 #{pxToRem(6.4)} #{pxToRem(14.4)} 0 rgba(0, 0, 0, 0.132),
         0 #{pxToRem(1.2)} #{pxToRem(3.6)} 0 rgba(0, 0, 0, 0.108);
 
+    // Same as above, but when element is focused
+    --shadow-depth-16-focused: 0 #{pxToRem(6.4)} #{pxToRem(14.4)} 0
+            rgba(0, 0, 0, 0.132),
+        0 #{pxToRem(1.2)} #{pxToRem(3.6)} 0 rgba(0, 0, 0, 0.108),
+        #{$visualise-focused-state};
+
     // Good for Pop up dialogs
     --shadow-depth-64: 0 #{pxToRem(25.6)} #{pxToRem(57.6)} 0 rgba(0, 0, 0, 0.22),
         0 #{pxToRem(4.8)} #{pxToRem(14.4)} 0 rgba(0, 0, 0, 0.18);
+
+    // Same as above, but when element is focused
+    --shadow-depth-64-focused: 0 #{pxToRem(25.6)} #{pxToRem(57.6)} 0
+            rgba(0, 0, 0, 0.22),
+        0 #{pxToRem(4.8)} #{pxToRem(14.4)} 0 rgba(0, 0, 0, 0.18),
+        #{$visualise-focused-state};
 }


### PR DESCRIPTION
makes most sense when used with `:focus-visible`
fix: https://github.com/Lundalogik/crm-feature/issues/1868
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
