### PR TITLE
fix(select): better visualize `focused` with keyboard

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -58,12 +58,13 @@
 
         &:focus {
             outline: none;
-            .mdc-select__dropdown-icon {
-                box-shadow: var(--button-shadow-hovered);
-            }
+
             .mdc-floating-label {
                 color: var(--mdc-theme-primary);
             }
+        }
+        &:focus-visible {
+            box-shadow: var(--shadow-depth-8-focused) !important;
         }
 
         .mdc-floating-label {


### PR DESCRIPTION
requires: https://github.com/Lundalogik/lime-elements/pull/1179

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
