### PR TITLE
fix(tab-bar): prevent unintended clicks on the last tab

### DIFF
--- a/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
+++ b/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
@@ -60,15 +60,15 @@
     position: relative;
     overflow: hidden;
 
-    &.scroll-left .scroll-fade.left,
-    &.scroll-left .scroll-button.left,
-    &.scroll-right .scroll-fade.right,
-    &.scroll-right .scroll-button.right {
+    &.can-scroll-left .scroll-fade.left,
+    &.can-scroll-left .scroll-button.left,
+    &.can-scroll-right .scroll-fade.right,
+    &.can-scroll-right .scroll-button.right {
         transform: translate3d(0, 0, 0);
     }
 
-    &.scroll-left:not(.scroll-right) .scroll-button.right,
-    &.scroll-right:not(.scroll-left) .scroll-button.left {
+    &.can-scroll-left:not(.can-scroll-right) .scroll-button.right,
+    &.can-scroll-right:not(.can-scroll-left) .scroll-button.left {
         opacity: 0.5;
         transition-delay: 0.5s;
     }

--- a/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
+++ b/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
@@ -19,9 +19,9 @@
         left: 0;
         background: linear-gradient(
             270deg,
-            rgba(246, 246, 247, 0) 0%,
-            rgba(246, 246, 247, 0.8) 40%,
-            rgba(246, 246, 247, 0.8) 100%
+            rgba($tab-background-color, 0) 0%,
+            rgba($tab-background-color, 0.8) 40%,
+            rgba($tab-background-color, 0.8) 100%
         );
     }
 
@@ -30,15 +30,15 @@
         right: 0;
         background: linear-gradient(
             90deg,
-            rgba(246, 246, 247, 0) 0%,
-            rgba(246, 246, 247, 0.8) 40%,
-            rgba(246, 246, 247, 0.8) 100%
+            rgba($tab-background-color, 0) 0%,
+            rgba($tab-background-color, 0.8) 40%,
+            rgba($tab-background-color, 0.8) 100%
         );
     }
 }
 
 .scroll-button {
-    --icon-background-color: #ffffff;
+    --icon-background-color: rgb(var(--contrast-100));
     top: pxToRem(4);
 
     &.left {
@@ -82,5 +82,5 @@
 .mdc-tab-scroller__scroll-content {
     padding: pxToRem(8) $tab-active-outer-edge-curve-size 0
         $tab-active-outer-edge-curve-size;
-    background-color: $tab-background-color;
+    background-color: rgb($tab-background-color);
 }

--- a/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
+++ b/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
@@ -1,0 +1,86 @@
+.scroll-fade,
+.scroll-button {
+    position: absolute;
+    transition: {
+        property: transform;
+        duration: 0.3s;
+        timing-function: ease-out;
+    }
+}
+
+.scroll-fade {
+    top: 0;
+    height: 100%;
+    width: pxToRem($tab-scroller-fade-width);
+    pointer-events: none;
+
+    &.left {
+        transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
+        left: 0;
+        background: linear-gradient(
+            270deg,
+            rgba(246, 246, 247, 0) 0%,
+            rgba(246, 246, 247, 0.8) 40%,
+            rgba(246, 246, 247, 0.8) 100%
+        );
+    }
+
+    &.right {
+        transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
+        right: 0;
+        background: linear-gradient(
+            90deg,
+            rgba(246, 246, 247, 0) 0%,
+            rgba(246, 246, 247, 0.8) 40%,
+            rgba(246, 246, 247, 0.8) 100%
+        );
+    }
+}
+
+.scroll-button {
+    --icon-background-color: #ffffff;
+    top: pxToRem(4);
+
+    &.left {
+        transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
+        left: pxToRem(4);
+    }
+
+    &.right {
+        transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
+        right: pxToRem(4);
+    }
+
+    &:hover {
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+.mdc-tab-scroller {
+    position: relative;
+    overflow: hidden;
+
+    &.scroll-left .scroll-fade.left,
+    &.scroll-left .scroll-button.left,
+    &.scroll-right .scroll-fade.right,
+    &.scroll-right .scroll-button.right {
+        transform: translate3d(0, 0, 0);
+    }
+
+    &.scroll-left:not(.scroll-right) .scroll-button.right,
+    &.scroll-right:not(.scroll-left) .scroll-button.left {
+        opacity: 0.5;
+        transition-delay: 0.5s;
+    }
+}
+
+.mdc-tab-scroller__scroll-area--scroll {
+    scrollbar-width: none; // This hides the scrollbars appearing under the tab bar in Firefox
+    -ms-overflow-style: none; // Same as above for IE 11
+}
+
+.mdc-tab-scroller__scroll-content {
+    padding: pxToRem(8) $tab-active-outer-edge-curve-size 0
+        $tab-active-outer-edge-curve-size;
+    background-color: $tab-background-color;
+}

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -33,67 +33,79 @@ $tab-scroller-fade-width: 65;
     }
 }
 
+.scroll-fade,
+.scroll-button {
+    position: absolute;
+    transition: {
+        property: transform;
+        duration: 0.3s;
+        delay: 0.5s;
+        timing-function: ease-out;
+    }
+}
+
+.scroll-fade {
+    top: 0;
+    height: 100%;
+    width: pxToRem($tab-scroller-fade-width);
+    pointer-events: none;
+
+    &.left {
+        transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
+        left: 0;
+        background: linear-gradient(
+            270deg,
+            rgba(246, 246, 247, 0) 0%,
+            rgba(246, 246, 247, 0.8) 40%,
+            rgba(246, 246, 247, 0.8) 100%
+        );
+    }
+
+    &.right {
+        transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
+        right: 0;
+        background: linear-gradient(
+            90deg,
+            rgba(246, 246, 247, 0) 0%,
+            rgba(246, 246, 247, 0.8) 40%,
+            rgba(246, 246, 247, 0.8) 100%
+        );
+    }
+}
+
+.scroll-button {
+    --icon-background-color: #ffffff;
+    top: pxToRem(4);
+
+    &.left {
+        transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
+        left: pxToRem(4);
+    }
+
+    &.right {
+        transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
+        right: pxToRem(4);
+    }
+
+    &:hover {
+        transform: translate3d(0, 0, 0);
+    }
+}
+
 .mdc-tab-scroller {
     position: relative;
     overflow: hidden;
-
-    .scroll-fade,
-    .scroll-button {
-        position: absolute;
-        transition-property: transform;
-        transition-duration: 250ms;
-        transition-timing-function: ease-out;
-    }
-
-    .scroll-fade {
-        top: 0;
-        height: 100%;
-        width: pxToRem($tab-scroller-fade-width);
-        pointer-events: none;
-
-        &.left {
-            transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
-            left: 0;
-            background: linear-gradient(
-                270deg,
-                rgba(246, 246, 247, 0) 0%,
-                rgba(246, 246, 247, 0.8) 40%,
-                rgba(246, 246, 247, 0.8) 100%
-            );
-        }
-
-        &.right {
-            transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
-            right: 0;
-            background: linear-gradient(
-                90deg,
-                rgba(246, 246, 247, 0) 0%,
-                rgba(246, 246, 247, 0.8) 40%,
-                rgba(246, 246, 247, 0.8) 100%
-            );
-        }
-    }
-
-    .scroll-button {
-        --icon-background-color: #ffffff;
-        top: pxToRem(4);
-
-        &.left {
-            transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
-            left: pxToRem(4);
-        }
-
-        &.right {
-            transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
-            right: pxToRem(4);
-        }
-    }
 
     &.scroll-left .scroll-fade.left,
     &.scroll-left .scroll-button.left,
     &.scroll-right .scroll-fade.right,
     &.scroll-right .scroll-button.right {
         transform: translate3d(0, 0, 0);
+    }
+
+    &.scroll-left:not(.scroll-right) .scroll-button.right,
+    &.scroll-right:not(.scroll-left) .scroll-button.left {
+        opacity: 0.5;
     }
 }
 

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -4,12 +4,12 @@
 @import '@limetech/mdc-tab-indicator/mdc-tab-indicator';
 @import '@limetech/mdc-tab/mdc-tab';
 
-$tab-content-background-color: #fff;
-$tab-background-color: #f6f6f7;
+$tab-content-background-color: rgb(var(--contrast-100));
+$tab-background-color: var(--contrast-300);
 $tab-border-radius: pxToRem(10);
 $tab-active-outer-edge-curve-size: pxToRem(12);
 $tab-separator-width: pxToRem(2);
-$tab-separator-background-color: #e8e8ea;
+$tab-separator-background-color: rgb(var(--contrast-600));
 $tab-scroller-fade-width: 65;
 
 @import './partial-styles/tab-bar-scroller.scss';

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -12,6 +12,8 @@ $tab-separator-width: pxToRem(2);
 $tab-separator-background-color: #e8e8ea;
 $tab-scroller-fade-width: 65;
 
+@import './partial-styles/tab-bar-scroller.scss';
+
 :host {
     display: block;
     position: relative;
@@ -31,93 +33,6 @@ $tab-scroller-fade-width: 65;
     .mdc-tab-indicator__content {
         border: none;
     }
-}
-
-.scroll-fade,
-.scroll-button {
-    position: absolute;
-    transition: {
-        property: transform;
-        duration: 0.3s;
-        delay: 0.5s;
-        timing-function: ease-out;
-    }
-}
-
-.scroll-fade {
-    top: 0;
-    height: 100%;
-    width: pxToRem($tab-scroller-fade-width);
-    pointer-events: none;
-
-    &.left {
-        transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
-        left: 0;
-        background: linear-gradient(
-            270deg,
-            rgba(246, 246, 247, 0) 0%,
-            rgba(246, 246, 247, 0.8) 40%,
-            rgba(246, 246, 247, 0.8) 100%
-        );
-    }
-
-    &.right {
-        transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
-        right: 0;
-        background: linear-gradient(
-            90deg,
-            rgba(246, 246, 247, 0) 0%,
-            rgba(246, 246, 247, 0.8) 40%,
-            rgba(246, 246, 247, 0.8) 100%
-        );
-    }
-}
-
-.scroll-button {
-    --icon-background-color: #ffffff;
-    top: pxToRem(4);
-
-    &.left {
-        transform: translate3d(pxToRem(0 - $tab-scroller-fade-width), 0, 0);
-        left: pxToRem(4);
-    }
-
-    &.right {
-        transform: translate3d(pxToRem($tab-scroller-fade-width), 0, 0);
-        right: pxToRem(4);
-    }
-
-    &:hover {
-        transform: translate3d(0, 0, 0);
-    }
-}
-
-.mdc-tab-scroller {
-    position: relative;
-    overflow: hidden;
-
-    &.scroll-left .scroll-fade.left,
-    &.scroll-left .scroll-button.left,
-    &.scroll-right .scroll-fade.right,
-    &.scroll-right .scroll-button.right {
-        transform: translate3d(0, 0, 0);
-    }
-
-    &.scroll-left:not(.scroll-right) .scroll-button.right,
-    &.scroll-right:not(.scroll-left) .scroll-button.left {
-        opacity: 0.5;
-    }
-}
-
-.mdc-tab-scroller__scroll-area--scroll {
-    scrollbar-width: none; // This hides the scrollbars appearing under the tab bar in Firefox
-    -ms-overflow-style: none; // Same as above for IE 11
-}
-
-.mdc-tab-scroller__scroll-content {
-    padding: pxToRem(8) $tab-active-outer-edge-curve-size 0
-        $tab-active-outer-edge-curve-size;
-    background-color: $tab-background-color;
 }
 
 .mdc-tab__ripple {

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -104,7 +104,7 @@ export class TabBar {
                         </div>
                     </div>
                     <div class="scroll-fade left" />
-                    <div class="scroll-button left" tab-index="-1">
+                    <div class="scroll-button left">
                         <limel-icon-button
                             icon="angle_left"
                             elevated={true}

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -106,8 +106,8 @@ export class TabBar {
                 <div
                     class={{
                         'mdc-tab-scroller': true,
-                        'scroll-left': this.canScrollLeft,
-                        'scroll-right': this.canScrollRight,
+                        'can-scroll-left': this.canScrollLeft,
+                        'can-scroll-right': this.canScrollRight,
                     }}
                 >
                     <div class="mdc-tab-scroller__scroll-area mdc-tab-scroller__scroll-area--scroll">

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -122,6 +122,7 @@ export class TabBar {
                             elevated={true}
                             tabindex="-1"
                             aria-hidden="true"
+                            disabled={!this.canScrollLeft}
                             onClick={this.handleLeftScrollClick}
                         />
                     </div>
@@ -132,6 +133,7 @@ export class TabBar {
                             elevated={true}
                             tabindex="-1"
                             aria-hidden="true"
+                            disabled={!this.canScrollRight}
                             onClick={this.handleRightScrollClick}
                         />
                     </div>

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -6,6 +6,7 @@ import {
     Element,
     EventEmitter,
     Event,
+    State,
     Watch,
 } from '@stencil/core';
 import { MDCTabBar, MDCTabBarActivatedEvent } from '@limetech/mdc-tab-bar';
@@ -59,9 +60,14 @@ export class TabBar {
     @Element()
     private host: HTMLLimelTabBarElement;
 
+    @State()
+    private canScrollLeft = false;
+
+    @State()
+    private canScrollRight = false;
+
     private mdcTabBar: MDCTabBar;
     private setupMdc = false;
-    private scrollerElement: HTMLElement;
     private scrollArea: HTMLElement;
     private scrollContent: HTMLElement;
 
@@ -97,7 +103,13 @@ export class TabBar {
     public render() {
         return (
             <div class="mdc-tab-bar" role="tablist">
-                <div class="mdc-tab-scroller">
+                <div
+                    class={{
+                        'mdc-tab-scroller': true,
+                        'scroll-left': this.canScrollLeft,
+                        'scroll-right': this.canScrollRight,
+                    }}
+                >
                     <div class="mdc-tab-scroller__scroll-area mdc-tab-scroller__scroll-area--scroll">
                         <div class="mdc-tab-scroller__scroll-content">
                             {this.tabs.map(this.renderTab)}
@@ -153,7 +165,6 @@ export class TabBar {
         }
 
         this.mdcTabBar = new MDCTabBar(element);
-        this.scrollerElement = element.querySelector('.mdc-tab-scroller');
         this.scrollArea = element.querySelector(
             '.mdc-tab-scroller__scroll-area'
         );
@@ -172,7 +183,9 @@ export class TabBar {
         };
 
         this.setupListeners();
-        this.handleScroll();
+
+        // Use timeout to avoid Stencil warning about re-renders. /Ads
+        setTimeout(this.handleScroll, 0);
     }
 
     private tearDown() {
@@ -220,15 +233,15 @@ export class TabBar {
         );
 
         if (scrollLeft > HIDE_SCROLL_BUTTONS_WHEN_SCROLLED_LESS_THAN_PX) {
-            this.scrollerElement.classList.add('scroll-left');
+            this.canScrollLeft = true;
         } else {
-            this.scrollerElement.classList.remove('scroll-left');
+            this.canScrollLeft = false;
         }
 
         if (scrollRight > HIDE_SCROLL_BUTTONS_WHEN_SCROLLED_LESS_THAN_PX) {
-            this.scrollerElement.classList.add('scroll-right');
+            this.canScrollRight = true;
         } else {
-            this.scrollerElement.classList.remove('scroll-right');
+            this.canScrollRight = false;
         }
     }
 


### PR DESCRIPTION
This happens when clicking fast on the `left` or `right` scroller buttons.
Now they stay in place while user hovers, but look kind of disabled.
They also disappear with a delay.
They're still clickable though, but that's because we can't access
the styles of `limel-icon-button` from outside.


fix: https://github.com/Lundalogik/crm-feature/issues/1862

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [x] Edge
- [x] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
