### PR TITLE
fix(popover): add forgotten border radius prop for popover

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -138,6 +138,7 @@ export class Popover {
         const propertyNames = [
             '--popover-surface-width',
             '--popover-body-background-color',
+            '--popover-border-radius',
         ];
         const style = getComputedStyle(this.host);
         const values = propertyNames.map((property) => {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1902
## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
