### PR TITLE
fix(input-field): fix don't render completions if completion list is …

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -664,7 +664,7 @@ export class InputField {
     }
 
     private renderAutocompleteList() {
-        if (this.type === 'textarea') {
+        if (this.type === 'textarea' || !this.completions.length) {
             return;
         }
 


### PR DESCRIPTION
…empty

If the completion list is rendered and opened, but empty. The first click outside the list will
stillclose the list. This means that the user, for example, needs to click on a button two times to
click on the button. The completion list should therefore not be rendered if it is not necessary.

fix Lundalogik/crm-feature#1910

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
