### PR TITLE
fix(date-picker): clearing a required date field with backspace sets …

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -349,6 +349,10 @@ export class DatePicker {
     }
 
     private handleInputElementChange(event) {
+        if (event.detail === '') {
+            this.clearValue();
+        }
+
         event.stopPropagation();
     }
 


### PR DESCRIPTION
…the date field to invailid

fix Lundalogik/crm-feature#1912

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
