### PR TITLE
fix(icon-button): visualize focus state when navigating with keyboard

### DIFF
--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -33,3 +33,12 @@
         @include is-elevated-clickable;
     }
 }
+
+.mdc-icon-button {
+    &:focus-visible {
+        // only when non-pointer input is being used,
+        // e.g. tabbed into using keyboard
+        box-shadow: var(--shadow-depth-8-focused);
+        border-radius: 50%;
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1878

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
