### PR TITLE
fix: pass z-index to datepicker portal

### DIFF
--- a/src/components/date-picker/date-picker.scss
+++ b/src/components/date-picker/date-picker.scss
@@ -1,5 +1,10 @@
 @import '../../style/internal/variables';
 
+// Note! The `--dropdown-z-index` property is used from `date-picker.tsx`.
+/**
+ * @prop --dropdown-z-index: z-index of the dropdown menu.
+ */
+
 div.container {
     position: relative;
 }

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -3,6 +3,7 @@ import {
     h,
     Prop,
     State,
+    Element,
     EventEmitter,
     Event,
     Watch,
@@ -115,6 +116,9 @@ export class DatePicker {
     @Event()
     private change: EventEmitter<Date>;
 
+    @Element()
+    private host: HTMLLimelDatePickerElement;
+
     @State()
     private formattedValue: string;
 
@@ -185,6 +189,10 @@ export class DatePicker {
             );
         }
 
+        const dropdownZIndex = getComputedStyle(this.host).getPropertyValue(
+            '--dropdown-z-index'
+        );
+
         return (
             <div class="container">
                 <limel-input-field
@@ -204,6 +212,7 @@ export class DatePicker {
                 <limel-portal
                     containerId={this.portalId}
                     visible={this.showPortal}
+                    containerStyle={{ 'z-index': dropdownZIndex }}
                 >
                     <limel-flatpickr-adapter
                         format={this.internalFormat}


### PR DESCRIPTION
Copy of fix from #1137 but for limel-date-picker.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
