### PR TITLE
feat(popover): add consumer-overridable css property `--popover-z-index`

### DIFF
--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -2,6 +2,7 @@
  * @prop --popover-surface-width: Width of the popover surface. defaults to `auto`
  * @prop --popover-body-background-color: Background color of popover body, defaults to `--contrast-100`.
  * @prop --popover-border-radius: Border radius of popover, defaults to `0.75rem`.
+ * @prop --popover-z-index: z-index of the popover.
  */
 
 .trigger-anchor {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -111,11 +111,18 @@ export class Popover {
 
     public render() {
         const cssProperties = this.getCssProperties();
+        const popoverZIndex = getComputedStyle(this.host).getPropertyValue(
+            '--popover-z-index'
+        );
 
         return (
             <div class="trigger-anchor">
                 <slot name="trigger"></slot>
-                <limel-portal visible={this.open} containerId={this.portalId}>
+                <limel-portal
+                    visible={this.open}
+                    containerId={this.portalId}
+                    containerStyle={{ 'z-index': popoverZIndex }}
+                >
                     <limel-popover-surface
                         contentCollection={this.host.children}
                         style={cssProperties}

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
     <style>
         :root {
             --dialog-z-index: 110;
+            --popover-z-index: 115;
             --dropdown-z-index: 120;
         }
     </style>


### PR DESCRIPTION
Complimentary PR to #1137, adding CSS variable for the popover z-index so it renders correctly with other elements.

Before: Using popover with button as the trigger inside a limel-dialog shows the dialog on top of the popover
![before picture popover in dialog](https://user-images.githubusercontent.com/435885/112133547-18c3b380-8bcc-11eb-9762-5b3b4cf8c8a2.png)

After: Using popover with icon button as trigger inside a limel-dialog, where a limel-select is used as the popover content

![example popover in dialog](https://user-images.githubusercontent.com/435885/112134906-81f7f680-8bcd-11eb-99f0-370e537f71fb.png)


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
