### PR TITLE
feat(picker): add leading icon to picker

### DIFF
--- a/src/components/picker/examples/picker-leading-icon-example.tsx
+++ b/src/components/picker/examples/picker-leading-icon-example.tsx
@@ -1,0 +1,125 @@
+import { ListItem } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+const NETWORK_DELAY = 500;
+
+/**
+ * With a "search" leading icon
+ */
+@Component({
+    tag: 'limel-example-picker-leading-icon',
+    shadow: true,
+})
+export class PickerLeadingIconExample {
+    private allItems: Array<ListItem<number>> = [
+        { text: 'Admiral Swiggins', value: 1 },
+        { text: 'Ayla', value: 2 },
+        { text: 'Clunk', value: 3 },
+        { text: 'Coco', value: 4 },
+        { text: 'Derpl', value: 5 },
+        { text: 'Froggy G', value: 6 },
+        { text: 'Gnaw', value: 7 },
+        { text: 'Lonestar', value: 8 },
+        { text: 'Leon', value: 9 },
+        { text: 'Raelynn', value: 10 },
+        { text: 'Skølldir', value: 11 },
+        { text: 'Voltar', value: 12 },
+        { text: 'Yuri', value: 13 },
+    ];
+
+    @State()
+    private selectedItem: ListItem<number>;
+
+    @State()
+    private required: boolean = false;
+
+    @State()
+    private readonly: boolean = false;
+
+    @State()
+    private disabled: boolean = false;
+
+    constructor() {
+        this.search = this.search.bind(this);
+        this.onChange = this.onChange.bind(this);
+        this.setDisabled = this.setDisabled.bind(this);
+        this.setReadonly = this.setReadonly.bind(this);
+        this.setRequired = this.setRequired.bind(this);
+    }
+
+    public render() {
+        return [
+            <limel-picker
+                label="Favorite awesomenaut"
+                leadingIcon="search"
+                value={this.selectedItem}
+                searcher={this.search}
+                onChange={this.onChange}
+                onInteract={this.onInteract}
+                required={this.required}
+                readonly={this.readonly}
+                disabled={this.disabled}
+            />,
+            <p>
+                <limel-flex-container justify="end">
+                    <limel-checkbox
+                        label="Disabled"
+                        onChange={this.setDisabled}
+                        checked={this.disabled}
+                    />
+                    <limel-checkbox
+                        label="Readonly"
+                        onChange={this.setReadonly}
+                        checked={this.readonly}
+                    />
+                    <limel-checkbox
+                        label="Required"
+                        onChange={this.setRequired}
+                        checked={this.required}
+                    />
+                </limel-flex-container>
+            </p>,
+            <p>
+                Value: <code>{JSON.stringify(this.selectedItem)}</code>
+            </p>,
+        ];
+    }
+
+    private search(query: string): Promise<ListItem[]> {
+        return new Promise((resolve) => {
+            if (query === '') {
+                resolve(this.allItems);
+            }
+
+            // Simulate some network delay
+            setTimeout(() => {
+                const filteredItems = this.allItems.filter((item) => {
+                    return item.text
+                        .toLowerCase()
+                        .includes(query.toLowerCase());
+                });
+                resolve(filteredItems);
+            }, NETWORK_DELAY);
+        });
+    }
+
+    private onChange(event: CustomEvent<ListItem<number>>) {
+        this.selectedItem = event.detail;
+    }
+
+    private onInteract(event) {
+        console.log('Value interacted with:', event.detail);
+    }
+
+    private setDisabled(event: CustomEvent<boolean>) {
+        this.disabled = event.detail;
+    }
+
+    private setReadonly(event: CustomEvent<boolean>) {
+        this.readonly = event.detail;
+    }
+
+    private setRequired(event: CustomEvent<boolean>) {
+        this.required = event.detail;
+    }
+}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -31,6 +31,7 @@ const CHIP_SET_TAG_NAME = 'limel-chip-set';
  * @exampleComponent limel-example-picker-multiple
  * @exampleComponent limel-example-picker-icons
  * @exampleComponent limel-example-picker-empty-suggestions
+ * @exampleComponent limel-example-picker-leading-icon
  */
 @Component({
     tag: 'limel-picker',
@@ -62,6 +63,12 @@ export class Picker {
      */
     @Prop()
     public searchLabel: string;
+
+    /**
+     * Leading icon to show to the far left in the text field
+     */
+    @Prop()
+    public leadingIcon: string;
 
     /**
      * A message to display when the search returned an empty result
@@ -196,6 +203,7 @@ export class Picker {
                 style={style}
                 type="input"
                 label={this.label}
+                leadingIcon={this.leadingIcon}
                 value={this.chips}
                 disabled={this.disabled}
                 readonly={this.readonly}


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
