### PR TITLE
Add `readonly` property alongside `disabled` for all input components

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -22,10 +22,18 @@ import { CheckboxTemplate } from './checkbox.template';
 })
 export class Checkbox {
     /**
-     * Disables the input field when `true`.
+     * Disables the checkbox when `true`. Works exactly the same as `readonly`.
+     * If either property is `true`, the checkbox will be disabled.
      */
     @Prop({ reflect: true })
     public disabled = false;
+
+    /**
+     * Disables the checkbox when `true`. Works exactly the same as `disabled`.
+     * If either property is `true`, the checkbox will be disabled.
+     */
+    @Prop({ reflect: true })
+    public readonly = false;
 
     /**
      * The checkbox label.
@@ -96,7 +104,7 @@ export class Checkbox {
     public render() {
         return (
             <CheckboxTemplate
-                disabled={this.disabled}
+                disabled={this.disabled || this.readonly}
                 label={this.label}
                 checked={this.checked}
                 required={this.required}

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -64,8 +64,10 @@ export class ChipSet {
     public disabled: boolean = false;
 
     /**
-     * For chip-sets of type `input`. Set to `true` to disable adding and removing chips,
-     * but allow interaction with existing chips in the set.
+     * For chip-sets of type `input`, set to `true` to disable adding and
+     * removing chips, but allow interaction with existing chips in the set.
+     * For any other types, setting either `readonly` or `disabled` disables
+     * the chip-set.
      */
     @Prop({ reflect: true })
     public readonly: boolean = false;
@@ -253,7 +255,7 @@ export class ChipSet {
 
         const classes = {
             'mdc-chip-set': true,
-            disabled: this.disabled,
+            disabled: this.disabled || this.readonly,
             'mdc-text-field--with-trailing-icon': true,
         };
         if (this.type) {

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -55,10 +55,20 @@ const nativeFormatForType = {
 })
 export class DatePicker {
     /**
-     * Disables the date picker when `true`.
+     * Disables the date picker when `true`. Works exactly the same as
+     * `readonly`. If either property is `true`, the date picker will be
+     * disabled.
      */
     @Prop()
     public disabled = false;
+
+    /**
+     * Disables the date picker when `true`. Works exactly the same as
+     * `disabled`. If either property is `true`, the date picker will be
+     * disabled.
+     */
+    @Prop()
+    public readonly = false;
 
     /**
      * Set to `true` to indicate that the current value of the date picker is
@@ -176,7 +186,7 @@ export class DatePicker {
             return (
                 <div class="container">
                     <limel-input-field
-                        disabled={this.disabled}
+                        disabled={this.disabled || this.readonly}
                         invalid={this.invalid}
                         label={this.label}
                         helperText={this.helperText}
@@ -196,7 +206,7 @@ export class DatePicker {
         return (
             <div class="container">
                 <limel-input-field
-                    disabled={this.disabled}
+                    disabled={this.disabled || this.readonly}
                     invalid={this.invalid}
                     label={this.label}
                     helperText={this.helperText}

--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -14,7 +14,7 @@ export class FileExample {
 
     constructor() {
         this.handleChange = this.handleChange.bind(this);
-        this.toggleRequired = this.toggleRequired.bind(this);
+        this.handleRequiredChange = this.handleRequiredChange.bind(this);
     }
 
     public render() {
@@ -27,9 +27,9 @@ export class FileExample {
             />,
             <limel-flex-container justify="end">
                 <limel-switch
-                    label="Toggle required"
+                    label="Required"
                     value={this.required}
-                    onChange={this.toggleRequired}
+                    onChange={this.handleRequiredChange}
                 />
             </limel-flex-container>,
         ];
@@ -40,7 +40,7 @@ export class FileExample {
         console.log('onChange', this.value);
     }
 
-    private toggleRequired() {
-        this.required = !this.required;
+    private handleRequiredChange(event: CustomEvent<boolean>) {
+        this.required = !!event.detail;
     }
 }

--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -12,9 +12,17 @@ export class FileExample {
     @State()
     private required = false;
 
+    @State()
+    private disabled = false;
+
+    @State()
+    private readonly = false;
+
     constructor() {
         this.handleChange = this.handleChange.bind(this);
         this.handleRequiredChange = this.handleRequiredChange.bind(this);
+        this.handleDisabledChange = this.handleDisabledChange.bind(this);
+        this.handleReadonlyChange = this.handleReadonlyChange.bind(this);
     }
 
     public render() {
@@ -24,12 +32,24 @@ export class FileExample {
                 onChange={this.handleChange}
                 required={this.required}
                 value={this.value}
+                disabled={this.disabled}
+                readonly={this.readonly}
             />,
             <limel-flex-container justify="end">
                 <limel-switch
                     label="Required"
                     value={this.required}
                     onChange={this.handleRequiredChange}
+                />
+                <limel-switch
+                    label="Disabled"
+                    value={this.disabled}
+                    onChange={this.handleDisabledChange}
+                />
+                <limel-switch
+                    label="Readonly"
+                    value={this.readonly}
+                    onChange={this.handleReadonlyChange}
                 />
             </limel-flex-container>,
         ];
@@ -42,5 +62,13 @@ export class FileExample {
 
     private handleRequiredChange(event: CustomEvent<boolean>) {
         this.required = !!event.detail;
+    }
+
+    private handleDisabledChange(event: CustomEvent<boolean>) {
+        this.disabled = !!event.detail;
+    }
+
+    private handleReadonlyChange(event: CustomEvent<boolean>) {
+        this.readonly = !!event.detail;
     }
 }

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -82,6 +82,13 @@ export class File {
     public disabled: boolean = false;
 
     /**
+     * Set to `true` to disable adding and removing files, but allow interaction
+     * with any already existing file.
+     */
+    @Prop({ reflect: true })
+    public readonly: boolean = false;
+
+    /**
      * The [accepted file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers)
      */
     @Prop({ reflect: true })
@@ -156,6 +163,7 @@ export class File {
             />,
             <limel-chip-set
                 disabled={this.disabled}
+                readonly={this.readonly}
                 label={this.label}
                 leadingIcon="upload_to_cloud"
                 onChange={this.handleChipSetChange}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -160,6 +160,7 @@ export class File {
                 onChange={this.handleFileChange}
                 type="file"
                 accept={this.accept}
+                disabled={this.disabled || this.readonly}
             />,
             <limel-chip-set
                 disabled={this.disabled}

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -54,10 +54,20 @@ interface LinkProperties {
 })
 export class InputField {
     /**
-     * Disables the input field when `true`.
+     * Disables the input field when `true`. Works exactly the same as
+     * `readonly`. If either property is `true`, the input field will be
+     * disabled.
      */
     @Prop({ reflect: true })
     public disabled = false;
+
+    /**
+     * Disables the input field when `true`. Works exactly the same as
+     * `disabled`. If either property is `true`, the input field will be
+     * disabled.
+     */
+    @Prop({ reflect: true })
+    public readonly = false;
 
     /**
      * Set to `true` to indicate that the current value of the input field is
@@ -279,7 +289,7 @@ export class InputField {
         properties.onFocus = this.onFocus;
         properties.onBlur = this.onBlur;
         properties.required = this.required;
-        properties.disabled = this.disabled;
+        properties.disabled = this.disabled || this.readonly;
 
         const labelClassList = {
             'mdc-floating-label': true,
@@ -325,7 +335,7 @@ export class InputField {
         const classList = {
             'mdc-text-field': true,
             'mdc-text-field--invalid': this.isInvalid(),
-            'mdc-text-field--disabled': this.disabled,
+            'mdc-text-field--disabled': this.disabled || this.readonly,
             'mdc-text-field--required': this.required,
             'mdc-text-field--with-trailing-icon': !!this.getTrailingIcon(),
         };
@@ -531,7 +541,7 @@ export class InputField {
             <a
                 {...linkProps}
                 class="mdc-text-field__icon trailing-icon"
-                tabindex={this.disabled ? '-1' : '0'}
+                tabindex={this.disabled || this.readonly ? '-1' : '0'}
                 role="button"
             >
                 <limel-icon name={icon} />

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -40,10 +40,20 @@ import { SelectTemplate } from './select.template';
 })
 export class Select {
     /**
-     * Disables the input field when `true`.
+     * Disables the select when `true`. Works exactly the same as
+     * `readonly`. If either property is `true`, the select will be
+     * disabled.
      */
     @Prop({ reflect: true })
     public disabled = false;
+
+    /**
+     * Disables the select when `true`. Works exactly the same as
+     * `disabled`. If either property is `true`, the select will be
+     * disabled.
+     */
+    @Prop({ reflect: true })
+    public readonly = false;
 
     /**
      * Set to `true` to indicate that the current value of the select is
@@ -176,7 +186,7 @@ export class Select {
         return (
             <SelectTemplate
                 id={this.portalId}
-                disabled={this.disabled}
+                disabled={this.disabled || this.readonly}
                 required={this.required}
                 invalid={this.invalid}
                 label={this.label}

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -22,10 +22,20 @@ import { getPercentageClass } from './getPercentageClass';
 })
 export class Slider {
     /**
-     * Set to `true` to disable the input
+     * Disables the slider when `true`. Works exactly the same as
+     * `readonly`. If either property is `true`, the slider will be
+     * disabled.
      */
     @Prop({ reflect: true })
     public disabled = false;
+
+    /**
+     * Disables the slider when `true`. Works exactly the same as
+     * `disabled`. If either property is `true`, the slider will be
+     * disabled.
+     */
+    @Prop({ reflect: true })
+    public readonly = false;
 
     /**
      * Default value: 1.
@@ -121,7 +131,7 @@ export class Slider {
     }
 
     public componentWillUpdate() {
-        this.mdcSlider.disabled = this.disabled;
+        this.mdcSlider.disabled = this.disabled || this.readonly;
     }
 
     public disconnectedCallback() {
@@ -154,7 +164,7 @@ export class Slider {
                         aria-valuemax={this.multiplyByFactor(this.valuemax)}
                         aria-valuenow={this.multiplyByFactor(this.getValue())}
                         aria-label={this.label}
-                        aria-disabled={this.disabled}
+                        aria-disabled={this.disabled || this.readonly}
                         data-step={this.step}
                     >
                         <div class="mdc-slider__track-container">

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -27,10 +27,20 @@ export class Switch {
     public label: string;
 
     /**
-     * Set to `true` to disable the switch
+     * Disables the switch when `true`. Works exactly the same as
+     * `disabled`. If either property is `true`, the switch will be
+     * disabled.
      */
     @Prop({ reflect: true })
     public disabled = false;
+
+    /**
+     * Disables the switch when `true`. Works exactly the same as
+     * `disabled`. If either property is `true`, the switch will be
+     * disabled.
+     */
+    @Prop({ reflect: true })
+    public readonly = false;
 
     /**
      * The value of the switch
@@ -76,10 +86,10 @@ export class Switch {
     public render() {
         return [
             <div
-                class={`
-                    mdc-switch
-                    ${this.disabled ? 'mdc-switch--disabled' : ''}
-                `}
+                class={{
+                    'mdc-switch': true,
+                    'mdc-switch--disabled': this.disabled || this.readonly,
+                }}
             >
                 <div class="mdc-switch__track" />
                 <div class="mdc-switch__thumb-underlay">
@@ -90,14 +100,14 @@ export class Switch {
                             id={this.fieldId}
                             role="switch"
                             onChange={this.onChange}
-                            disabled={this.disabled}
+                            disabled={this.disabled || this.readonly}
                             checked={this.value}
                         />
                     </div>
                 </div>
             </div>,
             <label
-                class={`${this.disabled ? 'disabled' : ''}`}
+                class={`${this.disabled || this.readonly ? 'disabled' : ''}`}
                 htmlFor={this.fieldId}
             >
                 <span class="label">{this.label}</span>


### PR DESCRIPTION
For most components, the properties do the same thing, and either can be used. In those cases, the addition of `readonly` is only to allow a more consistent interface between this and more complicated input components which do differentiate between the two.

For a few more complicated components, there is a difference between disabled and readonly, where readonly disallows changes to the value, but allows other interactions with the component, whereas disabled disallows all interaction.

This PR also includes a fix for a bug I found while making these changes to `limel-file`.

fix: #1195

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
