### PR TITLE
RFC: stop global clickjacking in popover and menu

### DIFF
--- a/src/components/menu-surface/menu-surface.tsx
+++ b/src/components/menu-surface/menu-surface.tsx
@@ -38,6 +38,13 @@ export class MenuSurface {
     public allowClicksElement: HTMLElement;
 
     /**
+     * True if the propagation of the click event,
+     * when clicking outside the menu, should be stopped.
+     */
+    @Prop()
+    public stopPropagation = true;
+
+    /**
      * Emitted when the menu surface is dismissed and should be closed
      */
     @Event()
@@ -52,6 +59,7 @@ export class MenuSurface {
         this.handleDocumentClick = this.handleDocumentClick.bind(this);
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleResize = this.handleResize.bind(this);
+        this.stopEvent = this.stopEvent.bind(this);
     }
 
     public connectedCallback() {
@@ -174,8 +182,10 @@ export class MenuSurface {
     }
 
     private stopEvent(event) {
-        event.stopPropagation();
-        event.preventDefault();
+        if (this.stopPropagation) {
+            event.stopPropagation();
+            event.preventDefault();
+        }
     }
 
     private handleKeyDown(event: KeyboardEvent) {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -51,6 +51,13 @@ export class Menu {
     public open = false;
 
     /**
+     * True if the propagation of the click event,
+     * when clicking outside the menu, should be stopped.
+     */
+    @Prop()
+    public stopPropagation = true;
+
+    /**
      * Defines whether the menu should show badges.
      */
     @Prop({ reflect: true })
@@ -107,6 +114,7 @@ export class Menu {
                     <limel-menu-surface
                         open={this.open}
                         onDismiss={this.onClose}
+                        stopPropagation={this.stopPropagation}
                     >
                         <limel-list
                             items={this.items}
@@ -140,7 +148,10 @@ export class Menu {
     };
 
     private onTriggerClick = (event: MouseEvent) => {
-        event.stopPropagation();
+        if (this.stopPropagation) {
+            event.stopPropagation();
+        }
+
         if (this.disabled) {
             return;
         }

--- a/src/components/popover/examples/popover-click-issue.tsx
+++ b/src/components/popover/examples/popover-click-issue.tsx
@@ -1,0 +1,126 @@
+import { Component, h, State } from '@stencil/core';
+
+@Component({
+    tag: 'limel-example-popover-click-issue',
+    shadow: true,
+})
+export class PopoverClickIssueExample {
+    @State()
+    private isPopoverOneOpen = false;
+
+    @State()
+    private isPopoverTwoOpen = false;
+
+    @State()
+    private isMenuOpen = false;
+
+    @State()
+    private stopPropagation = true;
+
+    constructor() {
+        this.openPopoverOne = this.openPopoverOne.bind(this);
+        this.onPopoverOneClose = this.onPopoverOneClose.bind(this);
+        this.openPopoverTwo = this.openPopoverTwo.bind(this);
+        this.onPopoverTwoClose = this.onPopoverTwoClose.bind(this);
+        this.openMenu = this.openMenu.bind(this);
+    }
+
+    public render() {
+        return [
+            <p>
+                When using stopPropagation when clicking outside an open menu or
+                popover the user is required to perform an extra click to first
+                close the open menu/popover and then click the other trigger
+                again to open the next, unlike how one would expect it to work.
+            </p>,
+            <p>
+                The clickjacking in popover and menu is performed to avoid
+                closing an open dialog when clicking outside the dialog when
+                also having a menu/popover open. This causes this unwanted
+                behavior and should probably be replaced with something else
+                that checks the target of the click and then decides whether or
+                not to use <code>event.stopPropagation()</code>.
+            </p>,
+            <p>
+                With the checkbox ticked, only one click is needed to close one
+                popover/menu and open another one.
+            </p>,
+            <limel-checkbox
+                onChange={(ev: CustomEvent<boolean>) =>
+                    (this.stopPropagation = !ev.detail)
+                }
+                checked={!this.stopPropagation}
+                label="Stop clickjacking"
+            />,
+            <limel-flex-container>
+                <limel-popover
+                    stopPropagation={this.stopPropagation}
+                    open={this.isPopoverOneOpen}
+                    onClose={this.onPopoverOneClose}
+                >
+                    <limel-button
+                        slot="trigger"
+                        primary={true}
+                        label="Popover one"
+                        onClick={this.openPopoverOne}
+                    />
+                    <p style={{ margin: '0.5rem 1rem' }} tabindex="0">
+                        Content
+                    </p>
+                </limel-popover>
+                <limel-popover
+                    stopPropagation={this.stopPropagation}
+                    open={this.isPopoverTwoOpen}
+                    onClose={this.onPopoverTwoClose}
+                >
+                    <limel-button
+                        slot="trigger"
+                        primary={true}
+                        label="Popover two"
+                        onClick={this.openPopoverTwo}
+                    />
+                    <p style={{ margin: '0.5rem 1rem' }} tabindex="0">
+                        Content
+                    </p>
+                </limel-popover>
+                <limel-menu
+                    stopPropagation={this.stopPropagation}
+                    open={this.isMenuOpen}
+                    items={[{ text: 'Menu item', value: 'v' }]}
+                >
+                    <limel-button
+                        slot="trigger"
+                        primary={true}
+                        label="Menu"
+                        onClick={this.openMenu}
+                    />
+                </limel-menu>
+            </limel-flex-container>,
+        ];
+    }
+
+    private openPopoverOne() {
+        console.log('opening popover one');
+        this.isPopoverOneOpen = true;
+    }
+
+    private onPopoverOneClose() {
+        console.log('closing popover one');
+        this.isPopoverOneOpen = false;
+    }
+
+    private openPopoverTwo() {
+        console.log('opening popover two');
+        this.isPopoverTwoOpen = true;
+    }
+
+    private onPopoverTwoClose() {
+        console.log('closing popover two');
+        this.isPopoverTwoOpen = false;
+    }
+
+    private openMenu() {
+        console.log('opening menu');
+        this.isMenuOpen = true;
+    }
+}

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -60,6 +60,7 @@ import { portalContains } from '../portal/contains';
  *
  * @slot - Content to put inside the surface
  * @exampleComponent limel-example-popover
+ * @exampleComponent limel-example-popover-click-issue
  * @private
  */
 @Component({
@@ -73,6 +74,13 @@ export class Popover {
      */
     @Prop()
     public open = false;
+
+    /**
+     * True if the propagation of the click event,
+     * when clicking outside the popover, should be stopped.
+     */
+    @Prop()
+    public stopPropagation = true;
 
     /**
      * Emits an event when the component is closing
@@ -129,7 +137,10 @@ export class Popover {
         const element: HTMLElement = event.target as HTMLElement;
         const clickedInside = portalContains(this.host, element);
         if (this.open && !clickedInside) {
-            event.stopPropagation();
+            if (this.stopPropagation) {
+                event.stopPropagation();
+            }
+
             this.close.emit();
         }
     }


### PR DESCRIPTION
When using our popover and menu components, the click from the user is killed when the component is open.
So for example, if a filter popover is open in the table view, the user can no longer single-click to open a record because the popover steals the first click to close it.

The same goes for the menu component where we have documented the reasons for having this clickjacking.

```
  // When the menu surface is open, we want to stop the `click` event from propagating
  // when clicking outside the surface itself. This is to prevent any dialog that might
  // be open from closing, etc. However, when dragging a scrollbar no `click` event is emitted,
  // only mousedown and mouseup. So we listen for `mousedown` and attach a one-time listener
  // for `click`, so we can capture and "kill" it.
```

IMHO, it would be better if we only stopped the propagation of the click when clicking outside a dialog when another portal is open.

To demonstrate the differences of using `event.stopPropagation()`, the published docs of this PR will contain an example where it can be turned off for popover and menu. Tick "Stop clickjacking" to get the wanted behavior.

So, what would be the best way to detect if we have an dialog open and should stop propagating the click event?
Could we check (in the click handlers in popover and menu) if the last opened portal is a dialog and only then use `event.stopPropagation()`? Or even better, could we place this in the dialog component and let it check if another portal have opened after the dialog was opened? So if there is a "newer" portal than the one for the current dialog when receiving the click, stop the event from also closing the dialog. 

Thoughts?