### PR TITLE
fix(date-picker): ensure picker respects the `disabled` property

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -350,6 +350,10 @@ export class DatePicker {
     }
 
     private onInputClick(event) {
+        if (this.disabled) {
+            return;
+        }
+
         if (this.showPortal) {
             return;
         }


### PR DESCRIPTION
Ensure that you cannot open the picker when the input field is enabled

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
