### PR TITLE
fix(form): custom form components can be set to readonly in schema

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -213,7 +213,7 @@ export class SchemaField extends React.Component<FieldProps> {
             ...factoryProps,
             value: this.getValue(),
             required: this.isRequired(),
-            readonly: readonly,
+            readonly: readonly || schema.readOnly,
             disabled: disabled,
             invalid: this.isInvalid(),
             label: this.getLabel(),


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
