### PR TITLE
Input fields emit null instead of undefined

### DIFF
--- a/src/components/form/widgets/date-picker.ts
+++ b/src/components/form/widgets/date-picker.ts
@@ -48,7 +48,7 @@ export class DatePicker extends React.Component {
         }
 
         if (!event.detail) {
-            props.onChange(undefined);
+            props.onChange(null);
 
             return;
         }

--- a/src/components/form/widgets/input-field.ts
+++ b/src/components/form/widgets/input-field.ts
@@ -38,8 +38,9 @@ export class InputField extends React.Component {
     }
 
     private handleChange(event: CustomEvent<string>) {
-        const props = this.props;
         event.stopPropagation();
+        const props = this.props;
+
         if (!props.onChange) {
             return;
         }

--- a/src/components/form/widgets/input-field.ts
+++ b/src/components/form/widgets/input-field.ts
@@ -40,14 +40,19 @@ export class InputField extends React.Component {
     private handleChange(event: CustomEvent<string>) {
         event.stopPropagation();
         const props = this.props;
+        const type = getInputType(props.schema);
 
         if (!props.onChange) {
             return;
         }
 
-        let value;
-        if (event.detail !== '') {
+        let value: string;
+        if (event.detail || typeof event.detail === 'number') {
             value = event.detail;
+        } else if (type === 'number') {
+            value = null;
+        } else {
+            value = '';
         }
 
         props.onChange(value);


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1960
## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
