### PR TITLE
fix(chip-set): visualize keyboard navigation for chips

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -46,7 +46,7 @@
         &:focus-visible {
             + label {
                 &:after {
-                    // visualizes keyboard navigation
+                    // visualizes keyboard navigation on Chrome & Firefox
                     // only when non-pointer input is being used,
                     // e.g. tabbed into using keyboard
                     content: '';

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -38,6 +38,26 @@ $height-of-chip-set-input: pxToRem(36);
                 padding-left: pxToRem(12);
             }
         }
+
+        span[role='button'],
+        span[role='checkbox'] {
+            &:focus-visible {
+                &:after {
+                    // visualizes keyboard navigation on Chrome & Firefox
+                    // only when non-pointer input is being used,
+                    // e.g. tabbed into using keyboard
+                    content: '';
+                    display: block;
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    bottom: 0;
+                    left: 0;
+                    border-radius: pxToRem(60);
+                    box-shadow: var(--shadow-depth-8-focused);
+                }
+            }
+        }
     }
 
     &:hover {

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -230,6 +230,11 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     .has-chips:not(.mdc-text-field--disabled):hover &,
     .has-chips:not(.mdc-text-field--disabled).mdc-text-field--focused & {
         opacity: 1;
+        outline: none;
+    }
+
+    &:focus-visible {
+        box-shadow: var(--shadow-depth-8-focused);
     }
 
     :not(.has-chips) &,


### PR DESCRIPTION
Visualizes keyboard navigation on Chrome & Firefox
only when non-pointer input is being used,
e.g. tabbed into using keyboard

fix: https://github.com/Lundalogik/crm-feature/issues/1967

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
