### PR TITLE
fix(tab-bar): improve visualization of focus state

### DIFF
--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -35,6 +35,15 @@ $tab-scroller-fade-width: 65;
     }
 }
 
+.mdc-tab--active {
+    .mdc-ripple-upgraded--background-focused {
+        &:before {
+            background-color: transparent;
+            transition: background-color 1s ease;
+        }
+    }
+}
+
 .mdc-tab__ripple {
     box-sizing: border-box;
     border-radius: $tab-border-radius;
@@ -47,7 +56,7 @@ $tab-scroller-fade-width: 65;
 
     &:before,
     &:after {
-        transition: background-color 0.2s ease;
+        transition: background-color 0.5s ease;
     }
 }
 


### PR DESCRIPTION
Focused tab does not require an extra click outside of it to lose
its styles which indicate that it is `focused`

fix: https://github.com/Lundalogik/crm-feature/issues/1969

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
