### PR TITLE
fix(button): render it a perfect square when there is only an icon

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -37,7 +37,8 @@ button {
     }
 
     .mdc-button__icon.no-label {
-        margin: 0;
+        margin-right: pxToRem(-4);
+        margin-left: pxToRem(-4);
     }
 
     limel-icon {


### PR DESCRIPTION
and no label

fix: https://github.com/Lundalogik/crm-feature/issues/1973



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
