### PR TITLE
limel-menu: deprecate some old stuff

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -61,6 +61,10 @@ export class Menu {
 
     /**
      * Defines whether the menu should have a fixed position on the screen.
+     *
+     * @deprecated Fixed position was used to get around a bug in the placement
+     * of the menu. This bug has since been fixed, which makes this attribute
+     * obsolete.
      */
     @Prop()
     public fixed = false;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -22,6 +22,9 @@ import { OpenDirection } from './menu.types';
 export class Menu {
     /**
      * Is displayed on the default trigger button.
+     *
+     * @deprecated Use with default trigger has been deprecated.
+     * Please supply your own trigger element.
      */
     @Prop({ reflect: true })
     public label = '';
@@ -81,6 +84,15 @@ export class Menu {
 
     constructor() {
         this.portalId = createRandomString();
+    }
+
+    public componentDidLoad() {
+        if (!this.host.querySelector('[slot="trigger"]')) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                'Using limel-menu with the default trigger is deprecated. Please provide your own trigger element.'
+            );
+        }
     }
 
     public render() {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -11,7 +11,7 @@ import { createRandomString } from '../../util/random-string';
 import { OpenDirection } from './menu.types';
 
 /**
- * @slot trigger - Element to use as a trigger for the menu
+ * @slot trigger - Element to use as a trigger for the menu.
  * @exampleComponent limel-example-menu
  */
 @Component({


### PR DESCRIPTION
#### feat(menu): deprecate use of limel-menu without a consumer provided trigger element

The default button was unstyled and we wouldn't want anyone to use it. Additionally, supplying a
custom trigger element is trivial, so there's no reason not to expect the consumer to do so.
Further, the default element seems to have been rendered every time the component re-rendered, even
though it was never seen by the user. Ergo: kill it with fire!

#### feat(menu): deprecate property `fixed`

Fixed position was used to get around a bug in the placement of the menu. This bug has since been
fixed, which makes this attribute obsolete.

fix: #1201

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
