### PR TITLE
fix(dialog): query host element before renderFooter is called

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -100,6 +100,7 @@ export class Dialog {
 
     public componentWillLoad() {
         this.id = createRandomString();
+        this.showFooter = !!this.host.querySelector('[slot="button"]');
     }
 
     public componentDidLoad() {
@@ -111,8 +112,6 @@ export class Dialog {
         if (!element) {
             return;
         }
-
-        this.showFooter = !!this.host.querySelector('[slot="button"]');
 
         this.mdcDialog = new MDCDialog(element);
         if (this.open) {


### PR DESCRIPTION
The check for a slot named button now actually works and is called before renderFooter, which was
not the case in the initial implementation.

`<footer>` is always there in the current implementation and breakpoints shows that `renderFooter` gets called before `initialize`, thus always showing the footer element.

The breakpoint also showed that `initialize` was called from `componentDidLoad` and this fix moves the query for the slot named `button` to `componentWillLoad` which makes the feature work as intended.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
