### PR TITLE
fix(styles): define css variables once on `:root` instead of on every `:host`

### DIFF
--- a/src/global/core-styles.scss
+++ b/src/global/core-styles.scss
@@ -2,3 +2,35 @@
 
 @import '../style/colors.scss';
 @import '../style/shadows.scss';
+
+:root {
+    --mdc-theme-primary: var(
+        --lime-primary-color,
+        rgb(var(--color-teal-default))
+    );
+    --mdc-theme-secondary: var(
+        --lime-secondary-color,
+        rgb(var(--contrast-1100))
+    );
+    --mdc-theme-on-primary: var(
+        --lime-on-primary-color,
+        rgb(var(--contrast-100))
+    );
+    --mdc-theme-on-secondary: var(
+        --lime-on-secondary-color,
+        rgb(var(--contrast-100))
+    );
+    --mdc-theme-text-disabled-on-background: var(
+        --lime-text-disabled-on-background-color,
+        rgba(var(--contrast-1700), 0.38)
+    );
+    --mdc-theme-text-primary-on-background: var(
+        --lime-text-primary-on-background-color,
+        rgba(var(--contrast-1700), 0.87)
+    );
+    --mdc-theme-text-secondary-on-background: var(
+        --lime-text-secondary-on-background-color,
+        rgba(var(--contrast-1700), 0.54)
+    );
+    --lime-error-text-color: rgb(var(--color-red-darker));
+}

--- a/src/style/internal/mdc-variables.scss
+++ b/src/style/internal/mdc-variables.scss
@@ -37,38 +37,6 @@ $mdc-theme-text-secondary-on-background: rgba(0, 0, 0, 0.54);
 // $mdc-theme-text-disabled-on-dark: rgba(255, 255, 255, 0.5);
 // $mdc-theme-text-icon-on-dark: rgba(255, 255, 255, 0.5);
 
-:host {
-    --mdc-theme-primary: var(
-        --lime-primary-color,
-        rgb(var(--color-teal-default))
-    );
-    --mdc-theme-secondary: var(
-        --lime-secondary-color,
-        rgb(var(--contrast-1100))
-    );
-    --mdc-theme-on-primary: var(
-        --lime-on-primary-color,
-        rgb(var(--contrast-100))
-    );
-    --mdc-theme-on-secondary: var(
-        --lime-on-secondary-color,
-        rgb(var(--contrast-100))
-    );
-    --mdc-theme-text-disabled-on-background: var(
-        --lime-text-disabled-on-background-color,
-        rgba(var(--contrast-1700), 0.38)
-    );
-    --mdc-theme-text-primary-on-background: var(
-        --lime-text-primary-on-background-color,
-        rgba(var(--contrast-1700), 0.87)
-    );
-    --mdc-theme-text-secondary-on-background: var(
-        --lime-text-secondary-on-background-color,
-        rgba(var(--contrast-1700), 0.54)
-    );
-    --lime-error-text-color: rgb(var(--color-red-darker));
-}
-
 @import '@limetech/mdc-theme/mdc-theme';
 
 $mdc-typography-styles-headline1: (


### PR DESCRIPTION
Some css variables are not defined correctly. Move them to the global stylesheet file, and define
them on `:root` instead of `:host`.

fix: Lundalogik/crm-feature#2056

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
