### PR TITLE
docs(input-field): improve description for focus-example

### DIFF
--- a/src/components/input-field/examples/input-field-focus.tsx
+++ b/src/components/input-field/examples/input-field-focus.tsx
@@ -12,7 +12,7 @@ import { Component, h, State } from '@stencil/core';
 })
 export class InputFieldFocusExample {
     @State()
-    private value;
+    private value: string;
 
     private inputField: HTMLLimelInputFieldElement;
 
@@ -37,7 +37,7 @@ export class InputFieldFocusExample {
         ];
     }
 
-    private changeHandler(event) {
+    private changeHandler(event: CustomEvent<string>) {
         this.value = event.detail;
     }
 

--- a/src/components/input-field/examples/input-field-focus.tsx
+++ b/src/components/input-field/examples/input-field-focus.tsx
@@ -1,9 +1,19 @@
 import { Component, h, State } from '@stencil/core';
 
 /**
- * How to set focus on input fields
+ * Setting focus programmatically
  *
- * The `tabindex` must be set to be able to set focus on the input field.
+ * To set focus programmatically, call `.focus()` on the `limel-input-field`
+ * element. Note that, for this to work, the `tabindex` property must be set
+ * on the `limel-input-field`.
+ *
+ * - `tabindex="0"` means that the element should be focusable in sequential
+ * keyboard navigation, after any positive tabindex values and its order is
+ * defined by the document's source order.
+ * - A _positive value_ means the element should be focusable in sequential
+ * keyboard navigation, with its order defined by the value of the number.
+ *
+ * Read more on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex).
  */
 @Component({
     tag: 'limel-example-input-field-focus',


### PR DESCRIPTION
Also add some missing typings (in separate commit).

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
