### PR TITLE
fix(list): prevent flickering of scrollable menus

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -40,6 +40,8 @@ $list-border-radius: 0.375rem; // 6px
     border-radius: $list-border-radius;
 
     .mdc-list-item {
+        z-index: $limel-list-mdc-list-item--z-index; // in Chrome on Windows, menus flicker when they have a scroll bar and user hovers on them. We may be able to remove this in future versions of Chrome. Kia 2021-May-12
+
         &.mdc-list-item--disabled {
             cursor: not-allowed;
 

--- a/src/style/internal/z-index-variables.scss
+++ b/src/style/internal/z-index-variables.scss
@@ -10,3 +10,4 @@ $limel-tab-bar--active-tab--z-index: 2 !default;
 $limel-table--has-interactive-rows--selectable-row--hover--z-index: 1 !default;
 $limel-popover-before--z-index: -1 !default;
 $limel-button-group-radio-button-keyboard-focused--z-index: 1 !default;
+$limel-list-mdc-list-item--z-index: 0 !default;


### PR DESCRIPTION
in Chrome on Windows, menus flicker when they
have a scroll bar and user hovers on them.

fix https://github.com/Lundalogik/crm-feature/issues/2090

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [x] Chrome
- [x] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
