### PR TITLE
fix(input-field): prevent labels getting cut off when input field is focused

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -10,6 +10,7 @@
 
 @import './partial-styles/trailing-icon.scss';
 @import './partial-styles/outlined-style-overrides.scss';
+@import './partial-styles/cropped-label-hack';
 
 /**
  * @prop --textarea-height: Height of the field when type is set to `textarea`

--- a/src/components/input-field/partial-styles/_cropped-label-hack.scss
+++ b/src/components/input-field/partial-styles/_cropped-label-hack.scss
@@ -1,0 +1,19 @@
+// Some font size applied to `label--float-above` causes the labels to get cut off
+// when an empty field gets focused
+
+.mdc-text-field--outlined.mdc-notched-outline--upgraded,
+.mdc-text-field--outlined .mdc-notched-outline--upgraded {
+    .mdc-floating-label--float-above {
+        //font-size: 1rem; This is what we get from MD now, which causes the miscalculations
+        font-size: 0.875rem;
+        // of course this is `14px` and the other one is `16px`.
+        // Unfortunately MD scales the floating label down, by applying a
+        // `transform` & `scale(0.75)` which is probably why they had to increase
+        // the font-size, to make it more readable.
+        // This is why I don't like this hack.
+    }
+}
+
+// NOTE: if we ever remove this hack, we must also update a mixin
+// called: `@mixin label--float-above()`
+// located in: style/internal/shared_input-select-picker.scss

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -42,7 +42,8 @@ $height-of-helper-text-pseudo-before: 0.75rem; // There is strange a pseudo befo
 
 @mixin label--float-above() {
     transform: translateY(-2.38rem) scale(0.75);
-    font-size: pxToRem(16);
+    // font-size: pxToRem(16); // See comments in: /input-field/partial-styles/_cropped-label-hack.scss
+    font-size: 0.875rem;
 }
 
 @mixin looks-like-helper-line {


### PR DESCRIPTION
fix: Lundalogik/crm-feature#1671

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
