### PR TITLE
valid decimal values in the form component is no longer reported as invalid

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -205,6 +205,7 @@ export class Form {
         const validator = new Ajv({
             unknownFormats: 'ignore',
             allErrors: true,
+            multipleOfPrecision: 2,
         }).addFormat('integer', isInteger);
         this.validator = validator.compile(this.schema);
     }


### PR DESCRIPTION
fix Lundalogik/lime-elements#1235



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
