### PR TITLE
For sliders, make `readonly` and `disabled` visually distinct

### DIFF
--- a/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
+++ b/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
@@ -15,6 +15,12 @@ import { Component, h, State } from '@stencil/core';
 })
 export class SliderMultiplierPercentageColorsExample {
     @State()
+    private disabled = false;
+
+    @State()
+    private readonly = false;
+
+    @State()
     private value = 0.25;
 
     private factor = 100;
@@ -32,8 +38,22 @@ export class SliderMultiplierPercentageColorsExample {
                     factor={this.factor}
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
+                    disabled={this.disabled}
+                    readonly={this.readonly}
                     onChange={this.changeHandler}
                 />
+                <limel-flex-container justify="end">
+                    <limel-checkbox
+                        checked={this.disabled}
+                        label="Disabled"
+                        onChange={this.setDisabled}
+                    />
+                    <limel-checkbox
+                        checked={this.readonly}
+                        label="Readonly"
+                        onChange={this.setReadonly}
+                    />
+                </limel-flex-container>
                 <limel-example-value value={this.value} />
             </section>
         );
@@ -41,5 +61,15 @@ export class SliderMultiplierPercentageColorsExample {
 
     private changeHandler = (event: CustomEvent<number>) => {
         this.value = event.detail;
+    };
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
     };
 }

--- a/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
+++ b/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
@@ -21,10 +21,6 @@ export class SliderMultiplierPercentageColorsExample {
     private minValue = 0;
     private maxValue = 1;
 
-    constructor() {
-        this.onChange = this.onChange.bind(this);
-    }
-
     public render() {
         return (
             <section>
@@ -36,14 +32,14 @@ export class SliderMultiplierPercentageColorsExample {
                     factor={this.factor}
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
-                    onChange={this.onChange}
+                    onChange={this.changeHandler}
                 />
                 <limel-example-value value={this.value} />
             </section>
         );
     }
 
-    private onChange(event) {
+    private changeHandler = (event: CustomEvent<number>) => {
         this.value = event.detail;
-    }
+    };
 }

--- a/src/components/slider/examples/slider-multiplier.tsx
+++ b/src/components/slider/examples/slider-multiplier.tsx
@@ -15,10 +15,6 @@ export class SliderMultiplierExample {
     private minValue = 0;
     private maxValue = 1;
 
-    constructor() {
-        this.onChange = this.onChange.bind(this);
-    }
-
     public render() {
         return (
             <section>
@@ -29,14 +25,14 @@ export class SliderMultiplierExample {
                     factor={this.factor}
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
-                    onChange={this.onChange}
+                    onChange={this.changeHandler}
                 />
                 <limel-example-value value={this.value} />
             </section>
         );
     }
 
-    private onChange(event) {
+    private changeHandler = (event: CustomEvent<number>) => {
         this.value = event.detail;
-    }
+    };
 }

--- a/src/components/slider/examples/slider.tsx
+++ b/src/components/slider/examples/slider.tsx
@@ -14,11 +14,6 @@ export class SliderExample {
     private minValue = 15;
     private maxValue = 75;
 
-    constructor() {
-        this.onChange = this.onChange.bind(this);
-        this.toggleEnabled = this.toggleEnabled.bind(this);
-    }
-
     public render() {
         return (
             <section>
@@ -29,12 +24,13 @@ export class SliderExample {
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
                     disabled={this.disabled}
-                    onChange={this.onChange}
+                    onChange={this.changeHandler}
                 />
                 <limel-flex-container justify="end">
-                    <limel-button
-                        onClick={this.toggleEnabled}
-                        label={this.disabled ? 'Enable' : 'Disable'}
+                    <limel-checkbox
+                        checked={this.disabled}
+                        label="Disabled"
+                        onChange={this.setDisabled}
                     />
                 </limel-flex-container>
                 <limel-example-value value={this.value} />
@@ -42,11 +38,12 @@ export class SliderExample {
         );
     }
 
-    private onChange(event) {
+    private changeHandler = (event: CustomEvent<number>) => {
         this.value = event.detail;
-    }
+    };
 
-    private toggleEnabled() {
-        this.disabled = !this.disabled;
-    }
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
 }

--- a/src/components/slider/examples/slider.tsx
+++ b/src/components/slider/examples/slider.tsx
@@ -9,6 +9,9 @@ export class SliderExample {
     private disabled = false;
 
     @State()
+    private readonly = false;
+
+    @State()
     private value = 25;
 
     private minValue = 15;
@@ -24,6 +27,7 @@ export class SliderExample {
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
                     disabled={this.disabled}
+                    readonly={this.readonly}
                     onChange={this.changeHandler}
                 />
                 <limel-flex-container justify="end">
@@ -31,6 +35,11 @@ export class SliderExample {
                         checked={this.disabled}
                         label="Disabled"
                         onChange={this.setDisabled}
+                    />
+                    <limel-checkbox
+                        checked={this.readonly}
+                        label="Readonly"
+                        onChange={this.setReadonly}
                     />
                 </limel-flex-container>
                 <limel-example-value value={this.value} />
@@ -45,5 +54,10 @@ export class SliderExample {
     private setDisabled = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
     };
 }

--- a/src/components/slider/partial-styles/_readonly.scss
+++ b/src/components/slider/partial-styles/_readonly.scss
@@ -1,0 +1,22 @@
+.lime-slider--readonly {
+    .mdc-slider.mdc-slider--disabled {
+        .mdc-slider__track-container {
+            top: pxToRem(2);
+            height: pxToRem(16);
+            border-radius: 10rem;
+        }
+
+        .mdc-slider__pin,
+        .mdc-slider__track {
+            background-color: var(--lime-primary-color, $mdc-theme-primary);
+        }
+        .mdc-slider__pin-value-marker {
+            color: var(--lime-on-primary-color, $mdc-theme-on-primary);
+        }
+        .mdc-slider__pin {
+            height: 1rem;
+            margin-top: pxToRem(2);
+            font-size: pxToRem(14);
+        }
+    }
+}

--- a/src/components/slider/partial-styles/percentage-color.scss
+++ b/src/components/slider/partial-styles/percentage-color.scss
@@ -11,51 +11,53 @@
     --color-percent--80to90: rgb(var(--color-teal-default));
     --color-percent--90to100: rgb(var(--color-teal-dark));
 
-    .slider.percent-0 {
-        --lime-primary-color: var(--color-percent--0);
-    }
-    .slider.percent-0-10 {
-        --lime-primary-color: var(--color-percent--0to10);
-    }
-    .slider.percent-10-20 {
-        --lime-primary-color: var(--color-percent--10to20);
-    }
-    .slider.percent-20-30 {
-        --lime-primary-color: var(--color-percent--20to30);
-    }
-    .slider.percent-30-40 {
-        --lime-primary-color: var(--color-percent--30to40);
-    }
-    .slider.percent-40-50 {
-        --lime-primary-color: var(--color-percent--40to50);
-    }
-    .slider.percent-50-60 {
-        --lime-primary-color: var(--color-percent--50to60);
-    }
-    .slider.percent-60-70 {
-        --lime-primary-color: var(--color-percent--60to70);
-    }
-    .slider.percent-70-80 {
-        --lime-primary-color: var(--color-percent--70to80);
-    }
-    .slider.percent-80-90 {
-        --lime-primary-color: var(--color-percent--80to90);
-    }
-    .slider.percent-90-100 {
-        --lime-primary-color: var(--color-percent--90to100);
-    }
-
-    .slider.percent-30-40,
-    .slider.percent-40-50,
-    .slider.percent-70-80 {
-        .mdc-slider__pin-value-marker {
-            color: rgb(var(--color-gray-darker));
+    .slider,
+    .slider.lime-slider--readonly {
+        &.percent-0 {
+            --lime-primary-color: var(--color-percent--0);
         }
-    }
-    .slider.percent-50-60,
-    .slider.percent-60-70 {
-        .mdc-slider__pin-value-marker {
-            color: rgb(var(--color-gray-dark));
+        &.percent-0-10 {
+            --lime-primary-color: var(--color-percent--0to10);
+        }
+        &.percent-10-20 {
+            --lime-primary-color: var(--color-percent--10to20);
+        }
+        &.percent-20-30 {
+            --lime-primary-color: var(--color-percent--20to30);
+        }
+        &.percent-30-40 {
+            --lime-primary-color: var(--color-percent--30to40);
+        }
+        &.percent-40-50 {
+            --lime-primary-color: var(--color-percent--40to50);
+        }
+        &.percent-50-60 {
+            --lime-primary-color: var(--color-percent--50to60);
+        }
+        &.percent-60-70 {
+            --lime-primary-color: var(--color-percent--60to70);
+        }
+        &.percent-70-80 {
+            --lime-primary-color: var(--color-percent--70to80);
+        }
+        &.percent-80-90 {
+            --lime-primary-color: var(--color-percent--80to90);
+        }
+        &.percent-90-100 {
+            --lime-primary-color: var(--color-percent--90to100);
+        }
+        &.percent-30-40,
+        &.percent-40-50,
+        &.percent-70-80 {
+            .mdc-slider__pin-value-marker {
+                color: rgb(var(--color-gray-darker));
+            }
+        }
+        &.percent-50-60,
+        &.percent-60-70 {
+            .mdc-slider__pin-value-marker {
+                color: rgb(var(--color-gray-dark));
+            }
         }
     }
 }

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,6 +1,7 @@
 @import '../../style/internal/mdc-variables';
 @import '../../style/internal/shared_input-select-picker';
 @import './partial-styles/percentage-color.scss';
+@import './partial-styles/_readonly.scss';
 
 @import '@limetech/mdc-slider/mdc-slider';
 @import '@limetech/mdc-floating-label/mdc-floating-label';

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -22,17 +22,18 @@ import { getPercentageClass } from './getPercentageClass';
 })
 export class Slider {
     /**
-     * Disables the slider when `true`. Works exactly the same as
-     * `readonly`. If either property is `true`, the slider will be
-     * disabled.
+     * Disables the slider when `true`,
+     * and visually shows that the field is editable but disabled.
+     * This tells the users that if certain requirements are met,
+     * the slider may become interactable.
      */
     @Prop({ reflect: true })
     public disabled = false;
 
     /**
-     * Disables the slider when `true`. Works exactly the same as
-     * `disabled`. If either property is `true`, the slider will be
-     * disabled.
+     * Disables the slider when `true`. This visualizes the slider slightly differently.
+     * But shows no visual sign indicating that the slider field
+     * is disabled or can ever become interactable.
      */
     @Prop({ reflect: true })
     public readonly = false;
@@ -103,6 +104,7 @@ export class Slider {
 
     public constructor() {
         this.inputHandler = this.inputHandler.bind(this);
+        this.getContainerClassList = this.getContainerClassList.bind(this);
     }
 
     public connectedCallback() {
@@ -140,9 +142,17 @@ export class Slider {
         this.mdcSlider.destroy();
     }
 
+    private getContainerClassList() {
+        return {
+            slider: true,
+            'lime-slider--readonly': this.readonly,
+            [this.percentageClass]: true,
+        };
+    }
+
     public render() {
         return (
-            <div class={`slider ${this.percentageClass}`}>
+            <div class={this.getContainerClassList()}>
                 <label class="slider__label mdc-floating-label mdc-floating-label--float-above">
                     {this.label}
                 </label>


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
