### PR TITLE
chore(docs): make text colors in examples work better with the new Kompendium in dark mode

### DIFF
--- a/src/components/shadows/examples/shadow-examples.scss
+++ b/src/components/shadows/examples/shadow-examples.scss
@@ -16,7 +16,8 @@
 
     code {
         font-size: pxToRem(12);
-        background-color: rgb(var(--contrast-500));
+        background-color: rgb(var(--kompendium-contrast-500));
+        color: rgb(var(--kompendium-contrast-1100));
         padding: 0 pxToRem(4);
         border-radius: pxToRem(3);
         margin-top: pxToRem(12);

--- a/src/components/shadows/examples/surface-shadows-bad-usage.scss
+++ b/src/components/shadows/examples/surface-shadows-bad-usage.scss
@@ -18,6 +18,7 @@
     --header-top-right-left-border-radius: var(--example-border-radius);
     border-radius: var(--example-border-radius);
     background-color: rgb(var(--contrast-100));
+    color: rgb(var(--contrast-1100));
 }
 
 .box {

--- a/src/components/size/examples/size-edge-case.scss
+++ b/src/components/size/examples/size-edge-case.scss
@@ -9,6 +9,7 @@ $scale-factor: 3.5;
 #size-rhythm-edge-case-example {
     position: relative;
     background-color: rgb(var(--contrast-300));
+    color: rgb(var(--contrast-1100));
     border-radius: pxToRem(4);
     padding: pxToRem(40) 0 pxToRem(40) pxToRem(80);
     margin-bottom: pxToRem(20);

--- a/src/examples/example-value.scss
+++ b/src/examples/example-value.scss
@@ -17,8 +17,8 @@ code {
     display: inline-block;
     border-radius: pxToRem(3);
     padding: pxToRem(1) pxToRem(5);
-    color: rgb(var(--contrast-1300));
-    background-color: rgb(var(--contrast-600));
+    color: rgb(var(--kompendium-contrast-1300));
+    background-color: rgb(var(--kompendium-contrast-600));
 }
 
 pre > code {
@@ -29,11 +29,6 @@ pre > code {
     overflow: auto;
     white-space: pre-wrap;
 
-    color: rgb(var(--contrast-800));
-    background-color: rgb(var(--contrast-1600));
-
-    @include in(dark-mode) {
-        color: rgb(var(--contrast-1000));
-        background-color: rgb(var(--contrast-200));
-    }
+    color: rgb(var(--kompendium-contrast-800));
+    background-color: rgb(var(--kompendium-contrast-1600));
 }


### PR DESCRIPTION
Note: requires latest version of Kompendium

### before:
![image](https://user-images.githubusercontent.com/154725/118775526-51f46900-b887-11eb-938a-f2c8e4fa0e17.png)

### after:
![image](https://user-images.githubusercontent.com/35954987/118803341-870eb480-b8a3-11eb-98b5-228964be5d8b.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
