### PR TITLE
feat(flex-container): enable adding gap between flex items

### DIFF
--- a/src/components/flex-container/flex-container.scss
+++ b/src/components/flex-container/flex-container.scss
@@ -1,5 +1,6 @@
 :host(limel-flex-container) {
     display: flex;
+    gap: calc(var(--flex-container-gap, 0) * 1rem);
 }
 :host(limel-flex-container[hidden]) {
     display: none;

--- a/src/components/flex-container/flex-container.tsx
+++ b/src/components/flex-container/flex-container.tsx
@@ -39,6 +39,11 @@ export class FlexContainer {
     @Prop({ reflect: true })
     public reverse = false;
 
+    /**
+     * Accepts numbers and adds that number as a gap (in `rem`) between items
+     */
+    // FIXME: we need to render an inline style in the DOM, like this: `style="--flex-container-gap: {gap}"`
+
     public render() {
         return <slot />;
     }


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1251

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
