### PR TITLE
fix(form): an empty required text field is considered invalid

### DIFF
--- a/src/components/form/widgets/input-field.ts
+++ b/src/components/form/widgets/input-field.ts
@@ -52,7 +52,7 @@ export class InputField extends React.Component {
         } else if (type === 'number') {
             value = null;
         } else {
-            value = '';
+            value = props.required ? null : '';
         }
 
         props.onChange(value);


### PR DESCRIPTION
This fixes so that the form no longer considers it self as valid when a text field that is
required is set to empty

fix Lundalogik/crm-feature#2112

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
