### PR TITLE
feat(form): add support for readonly property on form fields

### DIFF
--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -110,6 +110,7 @@ export class LimeElementsWidgetAdapter extends React.Component {
         const { name, events, extraProps } = this.props;
         const disabled = this.isDisabled();
         const value = this.getValue();
+        const readonly = this.isReadOnly();
 
         const newEvents = {
             change: this.props.widgetProps.onChange,
@@ -123,6 +124,7 @@ export class LimeElementsWidgetAdapter extends React.Component {
                 value: value,
                 label: this.getLabel(),
                 disabled: disabled,
+                readonly: readonly,
                 required: this.isRequired(),
                 invalid: this.isInvalid(),
                 'helper-text': this.getHelperText(),
@@ -133,12 +135,6 @@ export class LimeElementsWidgetAdapter extends React.Component {
     }
 
     private isDisabled() {
-        // We treat disabled and readonly the same here since the default
-        // lime-elements components does not have a readonly state
-        if (this.isReadOnly()) {
-            return true;
-        }
-
         const widgetProps = this.props.widgetProps;
         const options: LimeSchemaOptions = widgetProps.schema.lime;
 


### PR DESCRIPTION
fix: Lundalogik/crm-feature#2071



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
