### PR TITLE
fix(switch): make switch keep correct styles when readonly is true or false

### DIFF
--- a/src/components/switch/examples/switch.tsx
+++ b/src/components/switch/examples/switch.tsx
@@ -36,7 +36,7 @@ export class SwitchExample {
                 />
                 <limel-checkbox
                     checked={this.value}
-                    label="Toggle checked"
+                    label="Selected"
                     onChange={this.setChecked}
                 />
             </limel-flex-container>,

--- a/src/components/switch/examples/switch.tsx
+++ b/src/components/switch/examples/switch.tsx
@@ -15,37 +15,33 @@ export class SwitchExample {
     private readonly = false;
 
     public render() {
-        return (
-            <section>
-                <div>
-                    <limel-switch
-                        label={`Current value: ${this.value.toString()}`}
-                        value={this.value}
-                        disabled={this.disabled}
-                        readonly={this.readonly}
-                        onChange={this.changeHandler}
-                    />
-                    <limel-flex-container justify="end">
-                        <limel-checkbox
-                            checked={this.disabled}
-                            label="Disabled"
-                            onChange={this.setDisabled}
-                        />
-                        <limel-checkbox
-                            checked={this.readonly}
-                            label="Readonly"
-                            onChange={this.setReadonly}
-                        />
-                        <limel-checkbox
-                            checked={this.value}
-                            label="Toggle checked"
-                            onChange={this.setChecked}
-                        />
-                    </limel-flex-container>
-                </div>
-                <limel-example-value value={this.value} />
-            </section>
-        );
+        return [
+            <limel-switch
+                label={`Current value: ${this.value.toString()}`}
+                value={this.value}
+                disabled={this.disabled}
+                readonly={this.readonly}
+                onChange={this.changeHandler}
+            />,
+            <limel-flex-container justify="end">
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Disabled"
+                    onChange={this.setDisabled}
+                />
+                <limel-checkbox
+                    checked={this.readonly}
+                    label="Readonly"
+                    onChange={this.setReadonly}
+                />
+                <limel-checkbox
+                    checked={this.value}
+                    label="Toggle checked"
+                    onChange={this.setChecked}
+                />
+            </limel-flex-container>,
+            <limel-example-value value={this.value} />,
+        ];
     }
 
     private changeHandler = (event: CustomEvent<boolean>) => {

--- a/src/components/switch/partial-styles/_readonly.scss
+++ b/src/components/switch/partial-styles/_readonly.scss
@@ -1,14 +1,14 @@
-:host([readonly]) {
-    .mdc-switch {
-        opacity: 1;
+.mdc-switch {
+    opacity: 1;
 
+    &.lime-switch--readonly {
         .mdc-switch__track {
             opacity: 1;
             border: none;
         }
 
         .mdc-switch__thumb {
-            background-color: transparent;
+            background-color: transparent !important;
             border: none;
             box-shadow: none;
             &:after {

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -90,6 +90,7 @@ export class Switch {
                 class={{
                     'mdc-switch': true,
                     'mdc-switch--disabled': this.disabled || this.readonly,
+                    'lime-switch--readonly': this.readonly,
                 }}
             >
                 <div class="mdc-switch__track" />


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1257

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
