### PR TITLE
fix(input): cursor jumps to end of input when rapidly typing

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -235,12 +235,8 @@ export class InputField {
         this.handleCloseMenu = this.handleCloseMenu.bind(this);
         this.setFocus = this.setFocus.bind(this);
 
-        const debounceTimeout = 100;
-        this.changeEmitter = debounce(this.changeEmitter, debounceTimeout, {
-            leading: false,
-            maxWait: 300,
-            trailing: true,
-        });
+        const debounceTimeout = 300;
+        this.changeEmitter = debounce(this.changeEmitter, debounceTimeout);
 
         this.portalId = createRandomString();
     }


### PR DESCRIPTION
When adding text in the middle of an existing string in the input field the cursor sometimes jumps
to the end of the input.

fix #1255



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [x] Chrome
- [x] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
