### PR TITLE
fix(input-field): prevent `formatted-input` of type `number` from rem…

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -49,10 +49,16 @@
         .mdc-floating-label {
             color: $label-color;
         }
+        .mdc-text-field__input {
+            color: $input-text-color;
+        }
     }
     &.mdc-text-field--disabled {
         .mdc-floating-label {
             color: $label-color-disabled;
+        }
+        .mdc-text-field__input {
+            color: $input-text-color-disabled;
         }
     }
 }
@@ -78,6 +84,7 @@
     position: absolute;
 
     display: none;
+    color: $input-text-color;
 }
 
 :not(.mdc-text-field--focused):not(.mdc-text-field--invalid) {
@@ -132,6 +139,18 @@ input.mdc-text-field__input {
         top: 0;
         bottom: 0;
         margin: auto;
+    }
+}
+
+.mdc-text-field {
+    &:not(.mdc-text-field--disabled) .mdc-text-field-character-counter,
+    &:not(.mdc-text-field--disabled)
+        + .mdc-text-field-helper-line
+        .mdc-text-field-character-counter,
+    &:not(.mdc-text-field--disabled)
+        + .mdc-text-field-helper-line
+        .mdc-text-field-helper-text {
+        color: $helper-text-color;
     }
 }
 

--- a/src/components/input-field/partial-styles/_readonly.scss
+++ b/src/components/input-field/partial-styles/_readonly.scss
@@ -1,10 +1,15 @@
 .mdc-text-field {
     &.lime-text-field--readonly {
-        .mdc-text-field__input {
+        input.mdc-text-field__input {
             background-color: transparent;
+            color: $input-text-color;
         }
 
-        .mdc-text-field__input,
+        .formatted-input {
+            color: $input-text-color;
+            opacity: 1;
+        }
+
         label.mdc-floating-label {
             color: $label-color;
         }

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -8,8 +8,12 @@ $background-color-normal: rgba(var(--contrast-200), 0.5);
 $background-color-hovered: rgba(var(--contrast-200), 1);
 $background-color-focused: rgba(var(--contrast-100), 0.8);
 $background-color-disabled: transparent;
+
 $label-color: rgba(var(--contrast-1200), 1);
 $label-color-disabled: rgba(var(--contrast-1200), 0.5);
+$input-text-color: rgba(var(--contrast-1400), 1);
+$input-text-color-disabled: rgba(var(--contrast-1400), 0.5);
+$helper-text-color: $label-color;
 
 $height-of-mdc-text-field: 3.5rem; //This is written directly in rem, beucase the vaiable used to calculate things elsewhere
 $height-of-mdc-helper-text-block: 0.9375rem;


### PR DESCRIPTION
…aining transparent in `readonly`
fix: https://github.com/Lundalogik/crm-feature/issues/2147


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
