### PR TITLE
fix(input): min and max property can be set to "0" on input field of …

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -405,11 +405,11 @@ export class InputField {
             props.step = this.step;
         }
 
-        if (this.type === 'number' && this.min) {
+        if (this.type === 'number' && Number.isInteger(this.min)) {
             props.min = this.min;
         }
 
-        if (this.type === 'number' && this.max) {
+        if (this.type === 'number' && Number.isInteger(this.max)) {
             props.max = this.max;
         }
 


### PR DESCRIPTION
…type "number"

fix #1259



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
