### PR TITLE
feat(select): make `readonly` and `disabled` visually distinct

### DIFF
--- a/src/components/select/examples/select-multiple.tsx
+++ b/src/components/select/examples/select-multiple.tsx
@@ -16,6 +16,9 @@ export class SelectMultipleExample {
     public disabled = false;
 
     @State()
+    public readonly = false;
+
+    @State()
     public required = false;
 
     private options: Option[] = [
@@ -32,6 +35,7 @@ export class SelectMultipleExample {
                     value={this.value}
                     options={this.options}
                     disabled={this.disabled}
+                    readonly={this.readonly}
                     required={this.required}
                     onChange={this.changeHandler}
                     multiple={true}
@@ -42,6 +46,11 @@ export class SelectMultipleExample {
                             checked={this.disabled}
                             label="Disabled"
                             onChange={this.setDisabled}
+                        />
+                        <limel-checkbox
+                            checked={this.readonly}
+                            label="Readonly"
+                            onChange={this.setReadonly}
                         />
                         <limel-checkbox
                             checked={this.required}
@@ -62,6 +71,11 @@ export class SelectMultipleExample {
     private setDisabled = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
     };
 
     private setRequired = (event: CustomEvent<boolean>) => {

--- a/src/components/select/examples/select-multiple.tsx
+++ b/src/components/select/examples/select-multiple.tsx
@@ -24,12 +24,6 @@ export class SelectMultipleExample {
         { text: 'Leia Organo', value: 'leia' },
     ];
 
-    constructor() {
-        this.onChange = this.onChange.bind(this);
-        this.toggleEnabled = this.toggleEnabled.bind(this);
-        this.toggleRequired = this.toggleRequired.bind(this);
-    }
-
     public render() {
         return (
             <section>
@@ -39,20 +33,20 @@ export class SelectMultipleExample {
                     options={this.options}
                     disabled={this.disabled}
                     required={this.required}
-                    onChange={this.onChange}
+                    onChange={this.changeHandler}
                     multiple={true}
                 />
                 <p>
                     <limel-flex-container justify="end">
                         <limel-checkbox
-                            label="Disabled"
-                            onChange={this.toggleEnabled}
                             checked={this.disabled}
+                            label="Disabled"
+                            onChange={this.setDisabled}
                         />
                         <limel-checkbox
-                            label="Required"
-                            onChange={this.toggleRequired}
                             checked={this.required}
+                            label="Required"
+                            onChange={this.setRequired}
                         />
                     </limel-flex-container>
                 </p>
@@ -61,15 +55,17 @@ export class SelectMultipleExample {
         );
     }
 
-    private onChange(event: CustomEvent<Option[]>) {
+    private changeHandler = (event: CustomEvent<Option[]>) => {
         this.value = event.detail;
-    }
+    };
 
-    private toggleEnabled() {
-        this.disabled = !this.disabled;
-    }
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
 
-    private toggleRequired() {
-        this.required = !this.required;
-    }
+    private setRequired = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.required = event.detail;
+    };
 }

--- a/src/components/select/examples/select.tsx
+++ b/src/components/select/examples/select.tsx
@@ -12,16 +12,14 @@ export class SelectExample {
     @State()
     public disabled = false;
 
+    @State()
+    public required = false;
+
     private options: Option[] = [
         { text: 'Luke Skywalker', value: 'luke' },
         { text: 'Han Solo', value: 'han', disabled: true },
         { text: 'Leia Organo', value: 'leia' },
     ];
-
-    constructor() {
-        this.onChange = this.onChange.bind(this);
-        this.toggleEnabled = this.toggleEnabled.bind(this);
-    }
 
     public render() {
         return (
@@ -32,13 +30,20 @@ export class SelectExample {
                     value={this.value}
                     options={this.options}
                     disabled={this.disabled}
-                    onChange={this.onChange}
+                    required={this.required}
+                    onChange={this.changeHandler}
                 />
                 <p>
                     <limel-flex-container justify="end">
-                        <limel-button
-                            onClick={this.toggleEnabled}
-                            label={this.disabled ? 'Enable' : 'Disable'}
+                        <limel-checkbox
+                            checked={this.disabled}
+                            label="Disabled"
+                            onChange={this.setDisabled}
+                        />
+                        <limel-checkbox
+                            checked={this.required}
+                            label="Required"
+                            onChange={this.setRequired}
                         />
                     </limel-flex-container>
                 </p>
@@ -47,11 +52,17 @@ export class SelectExample {
         );
     }
 
-    private onChange(event) {
+    private changeHandler = (event) => {
         this.value = event.detail;
-    }
+    };
 
-    private toggleEnabled() {
-        this.disabled = !this.disabled;
-    }
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private setRequired = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.required = event.detail;
+    };
 }

--- a/src/components/select/examples/select.tsx
+++ b/src/components/select/examples/select.tsx
@@ -13,6 +13,9 @@ export class SelectExample {
     public disabled = false;
 
     @State()
+    public readonly = false;
+
+    @State()
     public required = false;
 
     private options: Option[] = [
@@ -30,6 +33,7 @@ export class SelectExample {
                     value={this.value}
                     options={this.options}
                     disabled={this.disabled}
+                    readonly={this.readonly}
                     required={this.required}
                     onChange={this.changeHandler}
                 />
@@ -39,6 +43,11 @@ export class SelectExample {
                             checked={this.disabled}
                             label="Disabled"
                             onChange={this.setDisabled}
+                        />
+                        <limel-checkbox
+                            checked={this.readonly}
+                            label="Readonly"
+                            onChange={this.setReadonly}
                         />
                         <limel-checkbox
                             checked={this.required}
@@ -59,6 +68,11 @@ export class SelectExample {
     private setDisabled = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
     };
 
     private setRequired = (event: CustomEvent<boolean>) => {

--- a/src/components/select/partial-styles/_readonly.scss
+++ b/src/components/select/partial-styles/_readonly.scss
@@ -1,0 +1,11 @@
+.limel-select.mdc-select {
+    &.limel-select--readonly {
+        .limel-select-trigger {
+            cursor: default;
+            opacity: 1;
+        }
+        .mdc-select__dropdown-icon {
+            display: none;
+        }
+    }
+}

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -6,6 +6,7 @@
 @import '@limetech/mdc-floating-label/mdc-floating-label';
 
 @import '../../style/mixins';
+@import './partial-styles/_readonly.scss';
 
 // Note! The `--dropdown-z-index` property is used from `select.tsx`.
 /**

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -4,6 +4,7 @@ import { isMultiple } from '../../util/multiple';
 
 interface SelectTemplateProps {
     disabled?: boolean;
+    readonly?: boolean;
     required?: boolean;
     invalid?: boolean;
     options: Option[];
@@ -45,6 +46,7 @@ export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = (
         'limel-select': true,
         'mdc-select': true,
         'mdc-select--disabled': props.disabled,
+        'limel-select--readonly': props.readonly,
         'limel-select--required': props.required,
         'limel-select--invalid': !isValid,
         'limel-select--empty': !hasValue,

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -40,17 +40,19 @@ import { SelectTemplate } from './select.template';
 })
 export class Select {
     /**
-     * Disables the select when `true`. Works exactly the same as
-     * `readonly`. If either property is `true`, the select will be
-     * disabled.
+     * Set to `true` to make the field disabled.
+     * and visually shows that the `select` component is editable but disabled.
+     * This tells the users that if certain requirements are met,
+     * the component may become interactable.
      */
     @Prop({ reflect: true })
     public disabled = false;
 
     /**
-     * Disables the select when `true`. Works exactly the same as
-     * `disabled`. If either property is `true`, the select will be
-     * disabled.
+     * Set to `true` to make the field read-only.
+     * This visualizes the component slightly differently.
+     * But shows no visual sign indicating that the component is disabled
+     * or can ever become interactable.
      */
     @Prop({ reflect: true })
     public readonly = false;
@@ -187,6 +189,7 @@ export class Select {
             <SelectTemplate
                 id={this.portalId}
                 disabled={this.disabled || this.readonly}
+                readonly={this.readonly}
                 required={this.required}
                 invalid={this.invalid}
                 label={this.label}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2160

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
