### PR TITLE
fix(input-field): truncate `formatted-input` for type number

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -77,6 +77,8 @@
 
 .formatted-input {
     @include looks-like-input-label;
+    @include truncate-text;
+    width: calc(100% - #{pxToRem(20)});
 
     z-index: $limel-input-field--formatted-input--z-index;
     padding: 0 pxToRem(40) 0 pxToRem(16);


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2222

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
