### PR TITLE
fix(flex-container): make action buttons slot work nicely in `limel-dialog`

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -161,3 +161,10 @@ slot[name='header'] {
     /* Opera doesn't support this in the shorthand */
     background-attachment: local, local, scroll, scroll;
 }
+
+slot[name='button'] {
+    display: flex;
+    gap: 0.5rem; // Makes sure buttons get some default distance
+    width: 100%;
+    justify-content: flex-end;
+}

--- a/src/components/dialog/examples/dialog-closing-actions.tsx
+++ b/src/components/dialog/examples/dialog-closing-actions.tsx
@@ -49,12 +49,12 @@ export class DialogClosingActionsExample {
             <limel-button
                 primary={true}
                 label="Open"
-                onClick={this.triggerOnClick}
+                onClick={this.openDialog}
             />,
             <limel-dialog
                 open={this.isOpen}
                 closingActions={{ escapeKey: false, scrimClick: false }}
-                onClose={this.onClose}
+                onClose={this.closeDialog}
             >
                 <p>
                     This dialog doesn't close by clicking the scrim or pressing
@@ -62,22 +62,22 @@ export class DialogClosingActionsExample {
                 </p>
                 <limel-button
                     label="I understand"
-                    onClick={this.okOnClick}
+                    onClick={this.handleConfirmClick}
                     slot="button"
                 />
             </limel-dialog>,
         ];
     }
 
-    private triggerOnClick = () => {
+    private openDialog = () => {
         this.isOpen = true;
     };
 
-    private okOnClick = () => {
+    private handleConfirmClick = () => {
         this.isOpen = false;
     };
 
-    private onClose = () => {
+    private closeDialog = () => {
         this.isOpen = false;
     };
 }

--- a/src/components/dialog/examples/dialog-closing-actions.tsx
+++ b/src/components/dialog/examples/dialog-closing-actions.tsx
@@ -44,12 +44,6 @@ export class DialogClosingActionsExample {
     @State()
     private isOpen = false;
 
-    constructor() {
-        this.triggerOnClick = this.triggerOnClick.bind(this);
-        this.onClose = this.onClose.bind(this);
-        this.okOnClick = this.okOnClick.bind(this);
-    }
-
     public render() {
         return [
             <limel-button
@@ -75,15 +69,15 @@ export class DialogClosingActionsExample {
         ];
     }
 
-    private triggerOnClick() {
+    private triggerOnClick = () => {
         this.isOpen = true;
-    }
+    };
 
-    private okOnClick() {
+    private okOnClick = () => {
         this.isOpen = false;
-    }
+    };
 
-    private onClose() {
+    private onClose = () => {
         this.isOpen = false;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog-closing-actions.tsx
+++ b/src/components/dialog/examples/dialog-closing-actions.tsx
@@ -33,9 +33,11 @@ export class DialogClosingActionsExample {
                     This dialog doesn't close by clicking the scrim or pressing
                     the escape key. Only the Ok-button triggers a close event.
                 </p>
-                <limel-flex-container justify="end" slot="button">
-                    <limel-button label="Ok" onClick={this.okOnClick} />
-                </limel-flex-container>
+                <limel-button
+                    label="I understand"
+                    onClick={this.okOnClick}
+                    slot="button"
+                />
             </limel-dialog>,
         ];
     }

--- a/src/components/dialog/examples/dialog-closing-actions.tsx
+++ b/src/components/dialog/examples/dialog-closing-actions.tsx
@@ -2,7 +2,40 @@ import { Component, h, State } from '@stencil/core';
 
 /**
  * Custom closing actions
+ *
+ * Action buttons in dialogs can be used to add a clear visual indication for
+ * the sighted users to realize that the dialog can be closed by pressing
+ * a button as well.
+ * This may sometimes be considered an unnecessary usage of action buttons for
+ * sighted users. Because majority of them users know that clicking or tapping
+ * outside the dialog closes it.
+ *
+ * Such buttons are usually labeled ***OK***, ***Dismiss*** or ***Close***.
+ *
+ * :::tip
+ * When to use action buttons for simple "close" actions?
+ * - In fullscreen dialogs where clicking outside to close is hard.
+ * - When big dialogs are opened on phones, which make tapping outside hard for users.
+ * - When designing with accessibility in mind, and for those users who
+ * use screen readers to navigate the user interface.
+ * :::
+ *
+ * But sometimes, depending on the importance of the message which is displayed,
+ * you have to choose to display a close button, and disable other means of
+ * dismissing the dialog.
+ *
+ * :::tip
+ * When to use custom closing actions?
+ * - To make sure that the user really reads and understands the dialog's content.
+ * - To make sure that the user does not accidentally click outside and close the dialog.
+ * :::
+ *
+ * For such cases, avoid generic labels like ***OK***, or ***Close*** which unconsciously
+ * motivate users to dismiss the message; and instead use more purposeful labels
+ * such as ***I understand***, ***Looks good!***, ***Continue***, and similar;
+ * like in the example below.
  */
+
 @Component({
     tag: 'limel-example-dialog-closing-actions',
     shadow: true,
@@ -31,7 +64,7 @@ export class DialogClosingActionsExample {
             >
                 <p>
                     This dialog doesn't close by clicking the scrim or pressing
-                    the escape key. Only the Ok-button triggers a close event.
+                    the escape key. Only the button triggers a close event.
                 </p>
                 <limel-button
                     label="I understand"

--- a/src/components/dialog/examples/dialog-form.scss
+++ b/src/components/dialog/examples/dialog-form.scss
@@ -1,5 +1,0 @@
-limel-flex-container {
-    limel-button:not(:first-child) {
-        margin-right: 0.625rem;
-    }
-}

--- a/src/components/dialog/examples/dialog-form.tsx
+++ b/src/components/dialog/examples/dialog-form.tsx
@@ -27,17 +27,6 @@ export class DialogFormExample {
     @State()
     private isConfirmationOpen = false;
 
-    constructor() {
-        this.openDialog = this.openDialog.bind(this);
-        this.closeDialog = this.closeDialog.bind(this);
-        this.onClosing = this.onClosing.bind(this);
-        this.nameOnChange = this.nameOnChange.bind(this);
-        this.ageOnChange = this.ageOnChange.bind(this);
-        this.closeConfirmation = this.closeConfirmation.bind(this);
-        this.onConfirmPositive = this.onConfirmPositive.bind(this);
-        this.onConfirmNegative = this.onConfirmNegative.bind(this);
-    }
-
     public render() {
         return [
             <limel-button
@@ -120,38 +109,38 @@ export class DialogFormExample {
         this.closeDialog();
     };
 
-    private openDialog() {
+    private openDialog = () => {
         this.isOpen = true;
-    }
+    };
 
-    private closeDialog() {
+    private closeDialog = () => {
         this.isOpen = false;
-    }
+    };
 
-    private onClosing() {
+    private onClosing = () => {
         console.log('dialog is closing now!');
         this.isConfirmationOpen = true;
-    }
+    };
 
-    private nameOnChange(event) {
+    private nameOnChange = (event) => {
         this.name = event.detail;
-    }
+    };
 
-    private ageOnChange(event) {
+    private ageOnChange = (event) => {
         this.age = event.detail;
-    }
+    };
 
-    private closeConfirmation() {
+    private closeConfirmation = () => {
         this.isConfirmationOpen = false;
-    }
+    };
 
-    private onConfirmPositive() {
+    private onConfirmPositive = () => {
         this.isConfirmationOpen = false;
         this.isOpen = false;
-    }
+    };
 
-    private onConfirmNegative() {
+    private onConfirmNegative = () => {
         this.isOpen = true;
         this.isConfirmationOpen = false;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog-form.tsx
+++ b/src/components/dialog/examples/dialog-form.tsx
@@ -10,7 +10,6 @@ const MAX_AGE = 50;
 @Component({
     tag: 'limel-example-dialog-form',
     shadow: true,
-    styleUrl: 'dialog-form.scss',
 })
 export class DialogFormExample {
     @State()
@@ -76,32 +75,34 @@ export class DialogFormExample {
                         <limel-slider unit="%" value={this.percentage} />
                     </p>
                 </form>
-                <limel-flex-container slot="button" reverse={true}>
-                    <limel-button
-                        primary={true}
-                        label="Save"
-                        disabled={!this.nameValid() || !this.ageValid()}
-                        onClick={this.submitForm}
-                    />
-                    <limel-button label="Cancel" onClick={this.closeDialog} />
-                </limel-flex-container>
+                <limel-button
+                    label="Cancel"
+                    onClick={this.closeDialog}
+                    slot="button"
+                />
+                <limel-button
+                    primary={true}
+                    label="Save"
+                    disabled={!this.nameValid() || !this.ageValid()}
+                    onClick={this.submitForm}
+                    slot="button"
+                />
             </limel-dialog>,
             <limel-dialog
                 open={this.isConfirmationOpen}
                 onClose={this.closeConfirmation}
             >
                 <p>Are you sure you want to close this? </p>
-                <limel-flex-container
-                    justify="end"
-                    reverse={true}
+                <limel-button
+                    label="No"
+                    onClick={this.onConfirmNegative}
                     slot="button"
-                >
-                    <limel-button
-                        label="Yes"
-                        onClick={this.onConfirmPositive}
-                    />
-                    <limel-button label="No" onClick={this.onConfirmNegative} />
-                </limel-flex-container>
+                />
+                <limel-button
+                    label="Yes"
+                    onClick={this.onConfirmPositive}
+                    slot="button"
+                />
             </limel-dialog>,
         ];
     }

--- a/src/components/dialog/examples/dialog-fullscreen.tsx
+++ b/src/components/dialog/examples/dialog-fullscreen.tsx
@@ -11,11 +11,6 @@ export class DialogSizeExample {
     @State()
     private isOpen = false;
 
-    constructor() {
-        this.openDialog = this.openDialog.bind(this);
-        this.closeDialog = this.closeDialog.bind(this);
-    }
-
     public render() {
         return [
             <limel-button
@@ -38,11 +33,11 @@ export class DialogSizeExample {
         ];
     }
 
-    private openDialog() {
+    private openDialog = () => {
         this.isOpen = true;
-    }
+    };
 
-    private closeDialog() {
+    private closeDialog = () => {
         this.isOpen = false;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog-fullscreen.tsx
+++ b/src/components/dialog/examples/dialog-fullscreen.tsx
@@ -29,9 +29,11 @@ export class DialogSizeExample {
                 onClose={this.closeDialog}
             >
                 <p>This dialog is fullscreen</p>
-                <limel-flex-container justify="end" slot="button">
-                    <limel-button label="Ok" onClick={this.closeDialog} />
-                </limel-flex-container>
+                <limel-button
+                    label="Ok"
+                    onClick={this.closeDialog}
+                    slot="button"
+                />
             </limel-dialog>,
         ];
     }

--- a/src/components/dialog/examples/dialog-heading.tsx
+++ b/src/components/dialog/examples/dialog-heading.tsx
@@ -118,13 +118,12 @@ export class DialogHeadingExample {
                     onChange={this.handleBadgeChange}
                 />
 
-                <limel-flex-container justify="end" slot="button">
-                    <limel-button
-                        label="Ok"
-                        primary={true}
-                        onClick={this.closeDialog}
-                    />
-                </limel-flex-container>
+                <limel-button
+                    label="Ok"
+                    primary={true}
+                    onClick={this.closeDialog}
+                    slot="button"
+                />
             </limel-dialog>,
         ];
     }

--- a/src/components/dialog/examples/dialog-heading.tsx
+++ b/src/components/dialog/examples/dialog-heading.tsx
@@ -50,16 +50,6 @@ export class DialogHeadingExample {
     ];
 
     constructor() {
-        this.openDialog = this.openDialog.bind(this);
-        this.closeDialog = this.closeDialog.bind(this);
-
-        this.handleTitleChange = this.handleTitleChange.bind(this);
-        this.handleSubtitleChange = this.handleSubtitleChange.bind(this);
-        this.handleSupportingTextChange =
-            this.handleSupportingTextChange.bind(this);
-        this.handleIconChange = this.handleIconChange.bind(this);
-        this.handleBadgeChange = this.handleBadgeChange.bind(this);
-
         this.icon = this.icons[0];
     }
 
@@ -128,31 +118,31 @@ export class DialogHeadingExample {
         ];
     }
 
-    private openDialog() {
+    private openDialog = () => {
         this.isOpen = true;
-    }
+    };
 
-    private closeDialog() {
+    private closeDialog = () => {
         this.isOpen = false;
-    }
+    };
 
-    private handleTitleChange(event: CustomEvent<string>) {
+    private handleTitleChange = (event: CustomEvent<string>) => {
         this.title = event.detail;
-    }
+    };
 
-    private handleSubtitleChange(event: CustomEvent<string>) {
+    private handleSubtitleChange = (event: CustomEvent<string>) => {
         this.subtitle = event.detail;
-    }
+    };
 
-    private handleSupportingTextChange(event: CustomEvent<string>) {
+    private handleSupportingTextChange = (event: CustomEvent<string>) => {
         this.supportingText = event.detail;
-    }
+    };
 
-    private handleIconChange(event: CustomEvent<Option>) {
+    private handleIconChange = (event: CustomEvent<Option>) => {
         this.icon = event.detail;
-    }
+    };
 
-    private handleBadgeChange(event: CustomEvent<boolean>) {
+    private handleBadgeChange = (event: CustomEvent<boolean>) => {
         this.badge = event.detail;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog-nested-close-events.tsx
+++ b/src/components/dialog/examples/dialog-nested-close-events.tsx
@@ -47,12 +47,11 @@ export class DialogNestedCloseEventsExample {
                 >
                     <p>Then close me again…</p>
                 </limel-collapsible-section>
-                <limel-flex-container justify="end" slot="button">
-                    <limel-button
-                        label="Ok"
-                        onClick={this.handleCloseOnDialog}
-                    />
-                </limel-flex-container>
+                <limel-button
+                    label="Ok"
+                    onClick={this.handleCloseOnDialog}
+                    slot="button"
+                />
             </limel-dialog>,
             <limel-flex-container justify="end">
                 <limel-switch

--- a/src/components/dialog/examples/dialog-nested-close-events.tsx
+++ b/src/components/dialog/examples/dialog-nested-close-events.tsx
@@ -25,14 +25,6 @@ export class DialogNestedCloseEventsExample {
     @State()
     private stopInnerCloseEvent = false;
 
-    constructor() {
-        this.openDialog = this.openDialog.bind(this);
-        this.handleCloseOnDialog = this.handleCloseOnDialog.bind(this);
-        this.handleStopEventChange = this.handleStopEventChange.bind(this);
-        this.handleCloseOnCollapsible =
-            this.handleCloseOnCollapsible.bind(this);
-    }
-
     public render() {
         return [
             <limel-button
@@ -63,24 +55,24 @@ export class DialogNestedCloseEventsExample {
         ];
     }
 
-    private openDialog() {
+    private openDialog = () => {
         this.isOpen = true;
-    }
+    };
 
-    private handleCloseOnDialog() {
+    private handleCloseOnDialog = () => {
         this.isOpen = false;
-    }
+    };
 
-    private handleCloseOnCollapsible(event: CustomEvent) {
+    private handleCloseOnCollapsible = (event: CustomEvent) => {
         if (this.stopInnerCloseEvent) {
             console.log('Stopping the inner `close` event.');
             event.stopPropagation();
         } else {
             console.log('NOT stopping the inner `close` event!');
         }
-    }
+    };
 
-    private handleStopEventChange(event: CustomEvent<boolean>) {
+    private handleStopEventChange = (event: CustomEvent<boolean>) => {
         this.stopInnerCloseEvent = event.detail;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog-size.tsx
+++ b/src/components/dialog/examples/dialog-size.tsx
@@ -100,9 +100,11 @@ export class DialogSizeExample {
                     libero vel fringilla porttitor, odio orci rutrum enim, sed
                     rhoncus quam risus eu neque.
                 </p>
-                <limel-flex-container justify="end" slot="button">
-                    <limel-button label="Ok" onClick={this.closeDialog} />
-                </limel-flex-container>
+                <limel-button
+                    label="Ok"
+                    onClick={this.closeDialog}
+                    slot="button"
+                />
             </limel-dialog>,
         ];
     }

--- a/src/components/dialog/examples/dialog-size.tsx
+++ b/src/components/dialog/examples/dialog-size.tsx
@@ -12,11 +12,6 @@ export class DialogSizeExample {
     @State()
     private isOpen = false;
 
-    constructor() {
-        this.openDialog = this.openDialog.bind(this);
-        this.closeDialog = this.closeDialog.bind(this);
-    }
-
     public render() {
         return [
             <limel-button
@@ -109,11 +104,11 @@ export class DialogSizeExample {
         ];
     }
 
-    private openDialog() {
+    private openDialog = () => {
         this.isOpen = true;
-    }
+    };
 
-    private closeDialog() {
+    private closeDialog = () => {
         this.isOpen = false;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog.tsx
+++ b/src/components/dialog/examples/dialog.tsx
@@ -8,11 +8,6 @@ export class DialogExample {
     @State()
     private isOpen = false;
 
-    constructor() {
-        this.openDialog = this.openDialog.bind(this);
-        this.closeDialog = this.closeDialog.bind(this);
-    }
-
     public render() {
         return [
             <limel-button
@@ -31,11 +26,11 @@ export class DialogExample {
         ];
     }
 
-    private openDialog() {
+    private openDialog = () => {
         this.isOpen = true;
-    }
+    };
 
-    private closeDialog() {
+    private closeDialog = () => {
         this.isOpen = false;
-    }
+    };
 }

--- a/src/components/dialog/examples/dialog.tsx
+++ b/src/components/dialog/examples/dialog.tsx
@@ -22,9 +22,11 @@ export class DialogExample {
             />,
             <limel-dialog open={this.isOpen} onClose={this.closeDialog}>
                 <p>This is a simple alert-dialog.</p>
-                <limel-flex-container justify="end" slot="button">
-                    <limel-button label="Ok" onClick={this.closeDialog} />
-                </limel-flex-container>
+                <limel-button
+                    label="Ok"
+                    onClick={this.closeDialog}
+                    slot="button"
+                />
             </limel-dialog>,
         ];
     }

--- a/src/components/flex-container/flex-container.scss
+++ b/src/components/flex-container/flex-container.scss
@@ -4,7 +4,6 @@
 :host(limel-flex-container[hidden]) {
     display: none;
 }
-
 :host(limel-flex-container[direction='horizontal']) {
     flex-direction: row;
 }
@@ -17,7 +16,6 @@
 :host(limel-flex-container[direction='vertical'][reverse]) {
     flex-direction: column-reverse;
 }
-
 :host(limel-flex-container[align='start']) {
     align-items: flex-start;
 }
@@ -30,7 +28,6 @@
 :host(limel-flex-container[align='stretch']) {
     align-items: stretch;
 }
-
 :host(limel-flex-container[justify='start']) {
     justify-content: flex-start;
 }

--- a/src/components/flex-container/flex-container.scss
+++ b/src/components/flex-container/flex-container.scss
@@ -46,3 +46,17 @@
 :host(limel-flex-container[justify='space-evenly']) {
     justify-content: space-evenly;
 }
+
+// Since consumers often copy/paste from examples of `limel-dialog` from the
+// documentations, they often put their buttons in a `limel-flex-container`
+// which is used in the footer slot of those examples with buttons.
+// So to prevent unwanted layout problems of buttons having no distance, we use
+// below code to target `limel-flex-container`s in those slots.
+:host(limel-flex-container[slot='button']) {
+    gap: 0.5rem; // Makes sure buttons get some default distance
+    width: 100%;
+    justify-content: flex-end;
+}
+:host(limel-flex-container[slot='button'][direction='horizontal'][reverse]) {
+    justify-content: flex-start;
+}


### PR DESCRIPTION
buttons are located in the footer slot.
fix https://github.com/Lundalogik/crm-feature/issues/2232

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
