### PR TITLE
Static actions picker

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -221,3 +221,4 @@ $list-border-radius: 0.375rem; // 6px
 @import './partial-styles/custom-styles.scss';
 @import './partial-styles/enable-multiline-text.scss';
 @import './partial-styles/_has-grid-layout.scss';
+@import './partial-styles/_static-actions.scss';

--- a/src/components/list/partial-styles/_static-actions.scss
+++ b/src/components/list/partial-styles/_static-actions.scss
@@ -1,0 +1,32 @@
+// This is used in limel-picker only for now
+
+:host(.static-actions-list) {
+    z-index: z-index.$list-static-actions-list;
+    background-color: var(--mdc-theme-surface);
+}
+
+:host(.has-position-sticky) {
+    position: sticky;
+    box-shadow: 0 0 functions.pxToRem(12) functions.pxToRem(8)
+        var(--mdc-theme-surface);
+}
+
+:host(.has-position-sticky.is-on-top) {
+    top: 0;
+}
+
+:host(.has-position-sticky.is-at-bottom) {
+    bottom: 0;
+}
+
+:host(.is-on-top) {
+    border-bottom: 1px solid rgb(var(--contrast-400));
+    margin-bottom: functions.pxToRem(8);
+    padding-bottom: functions.pxToRem(4);
+}
+
+:host(.is-at-bottom) {
+    border-top: 1px solid rgb(var(--contrast-400));
+    margin-top: functions.pxToRem(8);
+    padding-top: functions.pxToRem(4);
+}

--- a/src/components/picker/actions.types.ts
+++ b/src/components/picker/actions.types.ts
@@ -1,0 +1,2 @@
+export type ActionPosition = 'top' | 'bottom';
+export type ActionScrollBehavior = 'sticky' | 'scroll';

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -1,0 +1,170 @@
+import { Action, ListItem, Option } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+import { ActionScrollBehavior, ActionPosition } from '../actions.types';
+
+const NETWORK_DELAY = 500;
+
+/**
+ * With static actions
+ *
+ * Static items can be added to the picker to enable triggering custom actions
+ * directly from the results dropdown list.
+ *
+ * :::tip
+ * A typical use case of such actions is scenarios in which the picker's search
+ * results or suggestions list does not include what the user wants to pick. By
+ * offering custom actions right in the list, we can enable users to add missing
+ * items.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-picker-static-actions',
+    shadow: true,
+})
+export class PickerStaticActionsExample {
+    private allItems: Array<ListItem<number>> = [
+        { text: 'Admiral Swiggins', value: 1 },
+        { text: 'Ayla', value: 2 },
+        { text: 'Clunk', value: 3 },
+        { text: 'Coco', value: 4 },
+        { text: 'Derpl', value: 5 },
+        { text: 'Froggy G', value: 6 },
+        { text: 'Gnaw', value: 7 },
+        { text: 'Lonestar', value: 8 },
+        { text: 'Leon', value: 9 },
+        { text: 'Raelynn', value: 10 },
+        { text: 'Skølldir', value: 11 },
+        { text: 'Voltar', value: 12 },
+        { text: 'Yuri', value: 13 },
+    ];
+
+    private actions: Array<ListItem<Action>> = [
+        {
+            text: 'Add a dog',
+            icon: 'dog',
+            iconColor: 'rgb(var(--color-orange-default))',
+            value: { id: 'dog' },
+        },
+        {
+            text: 'Add a cat',
+            icon: 'cat',
+            iconColor: 'rgb(var(--color-green-default))',
+            value: { id: 'cat' },
+        },
+    ];
+
+    private actionPositions: Array<Option<ActionPosition>> = [
+        { text: 'Bottom', value: 'bottom' },
+        { text: 'Top', value: 'top' },
+    ];
+
+    private actionScrollBehaviors: Array<Option<ActionScrollBehavior>> = [
+        { text: 'Sticky', value: 'sticky' },
+        { text: 'Scroll', value: 'scroll' },
+    ];
+
+    @State()
+    private selectedItem: ListItem<number> = null;
+
+    @State()
+    private lastUsedAction: Action = null;
+
+    @State()
+    private actionScrollBehavior: Option<ActionScrollBehavior> =
+        this.actionScrollBehaviors[0];
+
+    @State()
+    private actionPosition: Option<ActionPosition> = this.actionPositions[0];
+
+    constructor() {
+        this.search = this.search.bind(this);
+        this.onChange = this.onChange.bind(this);
+        this.onAction = this.onAction.bind(this);
+        this.setBehavior = this.setBehavior.bind(this);
+        this.setPosition = this.setPosition.bind(this);
+    }
+
+    public render() {
+        return [
+            <limel-picker
+                label="Select your favorite pet"
+                value={this.selectedItem}
+                searchLabel={'Search your awesomenaut'}
+                displayFullList={true}
+                searcher={this.search}
+                onChange={this.onChange}
+                onInteract={this.onInteract}
+                onAction={this.onAction}
+                actions={this.actions}
+                actionScrollBehavior={this.actionScrollBehavior?.value}
+                actionPosition={this.actionPosition?.value}
+            />,
+            <p>
+                <limel-flex-container justify="end">
+                    <limel-select
+                        style={{
+                            width: '12rem',
+                        }}
+                        label="Action Scroll Behavior"
+                        onChange={this.setBehavior}
+                        value={this.actionScrollBehavior}
+                        options={this.actionScrollBehaviors}
+                    />
+
+                    <limel-select
+                        style={{
+                            width: '10rem',
+                            'margin-left': '0.5rem',
+                        }}
+                        label="Action Position"
+                        onChange={this.setPosition}
+                        value={this.actionPosition}
+                        options={this.actionPositions}
+                    />
+                </limel-flex-container>
+            </p>,
+            <limel-example-value
+                label="Last pressed action"
+                value={this.lastUsedAction}
+            />,
+        ];
+    }
+
+    private search(query: string): Promise<ListItem[]> {
+        return new Promise((resolve) => {
+            if (query === '') {
+                resolve(this.allItems);
+            }
+
+            // Simulate some network delay
+            setTimeout(() => {
+                const filteredItems = this.allItems.filter((item) => {
+                    return item.text
+                        .toLowerCase()
+                        .includes(query.toLowerCase());
+                });
+                resolve(filteredItems);
+            }, NETWORK_DELAY);
+        });
+    }
+
+    private onChange(event: CustomEvent<ListItem<number>>) {
+        this.selectedItem = event.detail;
+    }
+
+    private onAction(event: CustomEvent<Action>) {
+        this.lastUsedAction = event.detail;
+    }
+
+    private onInteract(event) {
+        console.log('Value interacted with:', event.detail);
+    }
+
+    private setBehavior(event: CustomEvent<Option<ActionScrollBehavior>>) {
+        this.actionScrollBehavior = event.detail;
+    }
+
+    private setPosition(event: CustomEvent<Option<ActionPosition>>) {
+        this.actionPosition = event.detail;
+    }
+}

--- a/src/style/_theme-color-variables.scss
+++ b/src/style/_theme-color-variables.scss
@@ -28,4 +28,12 @@
         rgba(var(--contrast-1700), 0.54)
     );
     --lime-error-text-color: rgb(var(--color-red-darker));
+    --mdc-theme-surface: var(
+        --lime-surface-background-color,
+        rgb(var(--contrast-100))
+    );
+    --mdc-theme-on-surface: var(
+        --lime-on-surface-color,
+        var(--lime-text-primary-on-background-color)
+    );
 }

--- a/src/style/internal/z-index.scss
+++ b/src/style/internal/z-index.scss
@@ -7,6 +7,7 @@ $input-field--formatted-value: 1 !default;
 $input-field--input-with-formatted-value: 2 !default;
 $input-field--mdc-text-field__input--readonly: 1 !default;
 $list--has-interactive-items--mdc-list-item--hover: 1 !default;
+$list-static-actions-list: 1 !default;
 $tab-bar--active-tab: 2 !default;
 $table--has-interactive-rows--selectable-row--hover: 1 !default;
 $popover-before: -1 !default;


### PR DESCRIPTION
This PR is a part of a bigger feature that requires changes in multiple repos.
These are the PRs that belong together.

- ~[Lime webclient](https://github.com/Lundalogik/lime-webclient/pull/1839)~ replaced by [Lime webclient](https://github.com/Lundalogik/lime-webclient/pull/1845)
- [Lime core](https://github.com/Lundalogik/lime-core/pull/917)
- ~[Lime crm components](https://github.com/Lundalogik/lime-crm-components/pull/519)~ replaced by [Lime crm components](https://github.com/Lundalogik/lime-crm-components/pull/530)
- [Lime elements](https://github.com/Lundalogik/lime-elements/pull/1282) (Current)

**Background:**

fix: Lundalogik/crm-feature#2238

The wanted feature is to be able to create a new limeobject directly in the object form, both in create new dialog and the object overview form.

You should be able to configure in Lime admin what relation fields that enables this feature.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
