### PR TITLE
fix(dialog): replace `heading` with `limel-header`

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -20,6 +20,11 @@ slot[name='header'] {
 
 :host {
     --dialog-background-color: rgb(var(--contrast-100));
+    --header-heading-color: var(--dialog-heading-title-color);
+    --header-subheading-color: var(--dialog-heading-subtitle-color);
+    --header-supporting-text-color: var(--dialog-heading-supporting-text-color);
+    --header-icon-color: var(--dialog-heading-icon-color);
+    --header-icon-background-color: var(--dialog-heading-icon-background-color);
 }
 
 .mdc-dialog {
@@ -48,74 +53,6 @@ slot[name='header'] {
         height: var(--dialog-height, auto);
         background-color: var(--dialog-background-color);
         box-shadow: var(--shadow-depth-64);
-    }
-
-    .mdc-dialog__title {
-        font-size: pxToRem(16);
-        line-height: 1.4;
-        margin: 0;
-        font-weight: 500;
-        font-style: normal;
-        color: var(
-            --dialog-heading-title-color,
-            var(--mdc-theme-text-primary-on-background)
-        );
-        &:before {
-            height: 1rem; // Kia: Not sure what `:before` is used for, but it's default MD height is 2.5rem, which makes the header very tall.
-        }
-    }
-
-    .mdc-dialog__title,
-    .dialog__heading {
-        padding: pxToRem(12);
-        background-color: rgb(var(--contrast-300));
-    }
-
-    .dialog__heading {
-        display: flex;
-        align-items: center;
-        flex-shrink: 0;
-
-        limel-icon {
-            margin-right: pxToRem(12);
-            color: var(--dialog-heading-icon-color, #{$mdc-theme-secondary});
-
-            &[badge] {
-                background-color: var(
-                    --dialog-heading-icon-background-color,
-                    #{$mdc-theme-secondary}
-                );
-                color: var(
-                    --dialog-heading-icon-color,
-                    #{$mdc-theme-on-secondary}
-                );
-            }
-        }
-
-        .dialog__title {
-            font-weight: 500;
-            margin: 0;
-            color: var(
-                --dialog-heading-title-color,
-                var(--mdc-theme-text-primary-on-background)
-            );
-        }
-
-        .dialog__subtitle {
-            margin: 0;
-            color: var(
-                --dialog-heading-subtitle-color,
-                var(--mdc-theme-text-secondary-on-background)
-            );
-        }
-
-        .dialog__supporting-text {
-            margin: 0;
-            color: var(
-                --dialog-heading-supporting-text-color,
-                var(--mdc-theme-text-secondary-on-background)
-            );
-        }
     }
 }
 

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -231,8 +231,7 @@ export class Dialog {
 
     private renderHeading() {
         if (this.isBadgeHeading(this.heading)) {
-            const { title, subtitle, supportingText, icon, badgeIcon } =
-                this.heading;
+            const { title, subtitle, supportingText, icon } = this.heading;
 
             return (
                 <limel-header

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -235,33 +235,15 @@ export class Dialog {
                 this.heading;
 
             return (
-                <div class="dialog__heading">
-                    <limel-icon
-                        size="large"
-                        name={icon}
-                        badge={badgeIcon !== false}
-                    />
-                    <div>
-                        {
-                            <h2 class="mdc-typography--headline2 dialog__title">
-                                {title}
-                            </h2>
-                        }
-                        {subtitle ? (
-                            <h3 class="mdc-typography--subtitle1 dialog__subtitle">
-                                {subtitle}
-                            </h3>
-                        ) : null}
-                        {supportingText ? (
-                            <h3 class="mdc-typography--subtitle1 dialog__supporting-text">
-                                {supportingText}
-                            </h3>
-                        ) : null}
-                    </div>
-                </div>
+                <limel-header
+                    icon={icon}
+                    heading={title}
+                    subheading={subtitle}
+                    supportingText={supportingText}
+                ></limel-header>
             );
         } else if (typeof this.heading === 'string') {
-            return <h2 class="mdc-dialog__title">{this.heading.trim()}</h2>;
+            return <limel-header heading={this.heading}></limel-header>;
         }
 
         return null;

--- a/src/components/dialog/dialog.types.ts
+++ b/src/components/dialog/dialog.types.ts
@@ -3,5 +3,8 @@ export interface DialogHeading {
     subtitle?: string;
     supportingText?: string;
     icon: string;
+    /**
+     * @deprecated
+     */
     badgeIcon?: boolean;
 }

--- a/src/components/dialog/examples/dialog-heading.scss
+++ b/src/components/dialog/examples/dialog-heading.scss
@@ -1,6 +1,7 @@
 :host(limel-example-dialog-heading) {
     --dialog-width: 40rem;
-    --dialog-heading-supporting-text-color: rgb(var(--color-orange-dark));
+    --dialog-heading-subtitle-color: rgb(var(--contrast-1200));
+    --dialog-heading-icon-color: rgb(var(--color-white));
 
     limel-input-field {
         margin-bottom: 1rem;
@@ -8,31 +9,27 @@
 
     limel-dialog {
         &.company {
-            --dialog-heading-icon-color: rgb(var(--color-sky-default));
             --dialog-heading-icon-background-color: rgb(
                 var(--color-sky-default)
             );
         }
 
         &.person {
-            --dialog-heading-icon-color: rgb(var(--color-orange-default));
             --dialog-heading-icon-background-color: rgb(
                 var(--color-orange-default)
             );
         }
 
         &.deal {
-            --dialog-heading-icon-color: rgb(var(--color-green-default));
             --dialog-heading-icon-background-color: rgb(
                 var(--color-green-default)
             );
         }
 
         &.todo {
+            --header-heading-color: rgb(var(--color-teal-dark));
+            --dialog-heading-supporting-text-color: rgb(var(--color-red-dark));
             --dialog-heading-icon-color: rgb(var(--color-teal-default));
-            --dialog-heading-icon-background-color: rgb(
-                var(--color-teal-default)
-            );
         }
     }
 }

--- a/src/components/dialog/examples/dialog-heading.scss
+++ b/src/components/dialog/examples/dialog-heading.scss
@@ -34,9 +34,5 @@
                 var(--color-teal-default)
             );
         }
-
-        &.badge {
-            --dialog-heading-icon-color: rgb(var(--color-white));
-        }
     }
 }

--- a/src/components/dialog/examples/dialog-heading.tsx
+++ b/src/components/dialog/examples/dialog-heading.tsx
@@ -27,9 +27,6 @@ export class DialogHeadingExample {
     @State()
     private icon: Option;
 
-    @State()
-    private badge: boolean = true;
-
     private icons: Option[] = [
         {
             text: 'Company',
@@ -59,11 +56,9 @@ export class DialogHeadingExample {
             subtitle: this.subtitle,
             supportingText: this.supportingText,
             icon: this.icon.value,
-            badgeIcon: this.badge,
         };
         const classNames = {
             [this.icon.text.toLowerCase()]: true,
-            badge: this.badge,
         };
 
         return [
@@ -102,11 +97,6 @@ export class DialogHeadingExample {
                     value={this.icon}
                     onChange={this.handleIconChange}
                 />
-                <limel-checkbox
-                    label="Badge"
-                    checked={this.badge}
-                    onChange={this.handleBadgeChange}
-                />
 
                 <limel-button
                     label="Ok"
@@ -140,9 +130,5 @@ export class DialogHeadingExample {
 
     private handleIconChange = (event: CustomEvent<Option>) => {
         this.icon = event.detail;
-    };
-
-    private handleBadgeChange = (event: CustomEvent<boolean>) => {
-        this.badge = event.detail;
-    };
+    }
 }

--- a/src/components/dialog/examples/dialog-heading.tsx
+++ b/src/components/dialog/examples/dialog-heading.tsx
@@ -130,5 +130,5 @@ export class DialogHeadingExample {
 
     private handleIconChange = (event: CustomEvent<Option>) => {
         this.icon = event.detail;
-    }
+    };
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -79,12 +79,7 @@ export class Header {
     public render() {
         return [
             <div class="information">
-                <limel-icon
-                    class="information__icon"
-                    badge={true}
-                    size="large"
-                    name={this.icon}
-                />
+                {this.renderIcon()}
                 <div class="information__headings">
                     <h1
                         class="information__headings__heading"
@@ -105,6 +100,21 @@ export class Header {
                 <slot />
             </div>,
         ];
+    }
+
+    private renderIcon() {
+        if (!this.icon) {
+            return;
+        }
+
+        return (
+            <limel-icon
+                class="information__icon"
+                badge={true}
+                size="large"
+                name={this.icon}
+            />
+        );
     }
 
     private renderSupportingText() {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1908

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
