### PR TITLE
fix(chip-set): fix broken focus highlighting for keyboard navigation

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -39,7 +39,7 @@ $height-of-chip-set-input: pxToRem(36);
             }
         }
 
-        span[role='button'],
+        a[role='button'],
         span[role='checkbox'] {
             &:focus-visible {
                 &:after {


### PR DESCRIPTION
fix: Lundalogik/crm-feature#2231

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
