### PR TITLE
feat(file): display icon of most common filetypes on chip

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -637,6 +637,7 @@ export class ChipSet {
                 style={style}
                 size="small"
                 badge={true}
+                title={chip.iconTitle}
             />
         );
     }

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -20,6 +20,11 @@ export interface Chip<T = any> {
     iconFillColor?: string;
 
     /**
+     * `title` attribute of the icon
+     */
+    iconTitle?: string;
+
+    /**
      * Background color of the icon. Overrides `--icon-background-color`.
      */
     iconBackgroundColor?: string;

--- a/src/components/file/examples/file-composite.tsx
+++ b/src/components/file/examples/file-composite.tsx
@@ -19,7 +19,7 @@ export class FileCompositeExample {
         label: 'Attach a file',
         value: {
             id: '123',
-            filename: 'picture.jpg',
+            filename: 'document.pdf',
         } as FileInfo,
     };
 

--- a/src/components/file/examples/file-custom-icon.tsx
+++ b/src/components/file/examples/file-custom-icon.tsx
@@ -3,6 +3,11 @@ import { Component, h, State } from '@stencil/core';
 
 /**
  * Custom icon and color
+ * This component automatically visualizes the file type, based on the extension
+ * of the selected file. The visualization is done by displaying a colorful icon
+ * along with the filename, for the most common file types.
+ *
+ * However, you can also customize the icon and its fill color & background color.
  */
 @Component({
     tag: 'limel-example-file-custom-icon',

--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -10,7 +10,7 @@ import { Component, h, State } from '@stencil/core';
 })
 export class FileExample {
     @State()
-    private value: FileInfo = { filename: 'picture.jpg', id: 123 };
+    private value: FileInfo = { filename: 'letter.docx', id: 123 };
 
     @State()
     private required = false;

--- a/src/components/file/file-metadata.ts
+++ b/src/components/file/file-metadata.ts
@@ -1,0 +1,59 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { getIconForFile } from './icons';
+import { getIconFillColorForFile } from './icon-fill-colors';
+import { getIconBackgroundColorForFile } from './icon-background-colors';
+
+export function getFileIcon(file: FileInfo) {
+    if (file?.icon) {
+        return file.icon;
+    }
+
+    const extension = getExtension(file);
+    if (!extension) {
+        return;
+    }
+
+    return getIconForFile(extension);
+}
+
+export function getFileColor(file: FileInfo) {
+    if (file?.iconColor) {
+        return file.iconColor;
+    }
+
+    const extension = getExtension(file);
+    if (!extension) {
+        return;
+    }
+
+    return getIconFillColorForFile(extension);
+}
+
+export function getFileBackgroundColor(file: FileInfo) {
+    if (file?.iconBackgroundColor) {
+        return file.iconBackgroundColor;
+    }
+
+    const extension = getExtension(file);
+    if (!extension) {
+        return;
+    }
+
+    return getIconBackgroundColorForFile(extension);
+}
+
+export function getFileExtensionTitle(file: FileInfo) {
+    if (file?.icon) {
+        return file.icon;
+    }
+
+    return getExtension(file);
+}
+
+export function getExtension(file: FileInfo) {
+    if (!file) {
+        return;
+    }
+
+    return file.filename.split('.').pop();
+}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -9,6 +9,12 @@ import {
     Prop,
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
+import {
+    getFileBackgroundColor,
+    getFileColor,
+    getFileExtensionTitle,
+    getFileIcon,
+} from './file-metadata';
 
 const CHIP_SET_TAG_NAME = 'limel-chip-set';
 const DEFAULT_FILE_CHIP: Chip = {
@@ -16,7 +22,6 @@ const DEFAULT_FILE_CHIP: Chip = {
     text: null,
     removable: true,
 };
-const DEFAULT_ICON = 'note';
 
 /**
  * This component lets end-users select a *single* file from their device
@@ -193,10 +198,11 @@ export class File {
                 ...DEFAULT_FILE_CHIP,
                 text: this.value.filename,
                 id: this.value.id,
-                icon: this.value.icon || DEFAULT_ICON,
-                iconFillColor: this.value.iconColor,
-                iconBackgroundColor: this.value.iconBackgroundColor,
+                icon: getFileIcon(this.value),
+                iconFillColor: getFileColor(this.value),
+                iconBackgroundColor: getFileBackgroundColor(this.value),
                 href: this.value.href,
+                iconTitle: getFileExtensionTitle(this.value),
             },
         ];
     }

--- a/src/components/file/icon-background-colors.ts
+++ b/src/components/file/icon-background-colors.ts
@@ -1,0 +1,134 @@
+const DEFAULT_ICON_BACKGROUND_COLOR = 'rgba(var(--color-gray-lighter), 0.4)';
+const CALENDAR_ICON_BACKGROUND_COLOR = 'rgba(var(--color-cyan-lighter), 0.4)';
+const EMAIL_ICON_BACKGROUND_COLOR = 'rgba(var(--color-gray-lighter), 0.4)';
+const HTML_ICON_BACKGROUND_COLOR = 'rgba(var(--color-blue-lighter), 0.4)';
+const TEXT_ICON_BACKGROUND_COLOR = 'rgba(var(--color-yellow-lighter), 0.4)';
+const EXCEL_ICON_BACKGROUND_COLOR = 'rgba(var(--color-green-lighter), 0.4)';
+const POWERPOINT_ICON_BACKGROUND_COLOR =
+    'rgba(var(--color-coral-lighter), 0.4)';
+const WORD_ICON_BACKGROUND_COLOR = 'rgba(var(--color-sky-lighter), 0.4)';
+const IMAGE_ICON_BACKGROUND_COLOR = 'rgba(var(--color-lime-lighter), 0.4)';
+const VECTOR_GRAPHIC_ICON_BACKGROUND_COLOR =
+    'rgba(var(--color-magenta-lighter), 0.4)';
+const PRESENTATION_BACKGROUND_COLOR = 'rgba(var(--color-blue-lighter), 0.4)';
+const DOCUMENT_ICON_BACKGROUND_COLOR = 'rgba(var(--color-orange-lighter), 0.4)';
+const SPREADSHEET_ICON_BACKGROUND_COLOR =
+    'rgba(var(--color-green-lighter), 0.4)';
+const AUDIO_ICON_BACKGROUND_COLOR = 'rgba(var(--color-indigo-lighter), 0.4)';
+const VIDEO_ICON_BACKGROUND_COLOR = 'rgba(var(--color-red-lighter), 0.4)';
+const COMPRESSED_ICON_BACKGROUND_COLOR =
+    'rgba(var(--color-orange-lighter), 0.4)';
+const MESSAGE_ICON_BACKGROUND_COLOR = 'rgba(var(--color-yellow-lighter), 0.4)';
+const PDF_ICON_BACKGROUND_COLOR = 'rgba(var(--color-red-lighter), 0.4)';
+const DATA_ICON_BACKGROUND_COLOR = 'rgba(var(--color-glaucous-lighter), 0.4)';
+
+const filetypeBackgroundColorTable: Record<string, string> = {
+    // Message
+    msg: MESSAGE_ICON_BACKGROUND_COLOR,
+
+    // Calendar
+    ics: CALENDAR_ICON_BACKGROUND_COLOR,
+    ical: CALENDAR_ICON_BACKGROUND_COLOR,
+    icalendar: CALENDAR_ICON_BACKGROUND_COLOR,
+
+    // Email
+    ifb: CALENDAR_ICON_BACKGROUND_COLOR,
+    email: EMAIL_ICON_BACKGROUND_COLOR,
+    eml: EMAIL_ICON_BACKGROUND_COLOR,
+    oft: EMAIL_ICON_BACKGROUND_COLOR,
+    ost: EMAIL_ICON_BACKGROUND_COLOR,
+    emlx: EMAIL_ICON_BACKGROUND_COLOR,
+
+    // Web
+    html: HTML_ICON_BACKGROUND_COLOR,
+    xml: HTML_ICON_BACKGROUND_COLOR,
+
+    // Editable text
+    txt: TEXT_ICON_BACKGROUND_COLOR,
+    rtf: TEXT_ICON_BACKGROUND_COLOR,
+
+    // Editable document
+    dot: WORD_ICON_BACKGROUND_COLOR,
+    doc: WORD_ICON_BACKGROUND_COLOR,
+    docx: WORD_ICON_BACKGROUND_COLOR,
+    dotx: WORD_ICON_BACKGROUND_COLOR,
+    docm: WORD_ICON_BACKGROUND_COLOR,
+    dotm: WORD_ICON_BACKGROUND_COLOR,
+    odt: DOCUMENT_ICON_BACKGROUND_COLOR,
+    pages: DOCUMENT_ICON_BACKGROUND_COLOR,
+
+    // Portable document
+    pdf: PDF_ICON_BACKGROUND_COLOR,
+
+    // Presentation
+    ppt: POWERPOINT_ICON_BACKGROUND_COLOR,
+    pot: POWERPOINT_ICON_BACKGROUND_COLOR,
+    pps: POWERPOINT_ICON_BACKGROUND_COLOR,
+    pptx: POWERPOINT_ICON_BACKGROUND_COLOR,
+    pptm: POWERPOINT_ICON_BACKGROUND_COLOR,
+    potx: POWERPOINT_ICON_BACKGROUND_COLOR,
+    potm: POWERPOINT_ICON_BACKGROUND_COLOR,
+    ppam: POWERPOINT_ICON_BACKGROUND_COLOR,
+    ppsx: POWERPOINT_ICON_BACKGROUND_COLOR,
+    ppsm: POWERPOINT_ICON_BACKGROUND_COLOR,
+    sldx: POWERPOINT_ICON_BACKGROUND_COLOR,
+    sldm: POWERPOINT_ICON_BACKGROUND_COLOR,
+    odp: PRESENTATION_BACKGROUND_COLOR,
+    key: PRESENTATION_BACKGROUND_COLOR,
+
+    // Spreadsheet
+    xls: EXCEL_ICON_BACKGROUND_COLOR,
+    xlsx: EXCEL_ICON_BACKGROUND_COLOR,
+    csv: DEFAULT_ICON_BACKGROUND_COLOR,
+    numbers: SPREADSHEET_ICON_BACKGROUND_COLOR,
+
+    // Image
+    bmp: IMAGE_ICON_BACKGROUND_COLOR,
+    jpg: IMAGE_ICON_BACKGROUND_COLOR,
+    jpeg: IMAGE_ICON_BACKGROUND_COLOR,
+    heic: IMAGE_ICON_BACKGROUND_COLOR,
+    png: IMAGE_ICON_BACKGROUND_COLOR,
+    gif: IMAGE_ICON_BACKGROUND_COLOR,
+
+    // Editable image
+    psd: PRESENTATION_BACKGROUND_COLOR,
+    ai: DOCUMENT_ICON_BACKGROUND_COLOR,
+
+    // Vector graphic
+    svg: VECTOR_GRAPHIC_ICON_BACKGROUND_COLOR,
+    svgz: VECTOR_GRAPHIC_ICON_BACKGROUND_COLOR,
+    ep: VECTOR_GRAPHIC_ICON_BACKGROUND_COLOR,
+    eps: VECTOR_GRAPHIC_ICON_BACKGROUND_COLOR,
+    sketch: VECTOR_GRAPHIC_ICON_BACKGROUND_COLOR,
+
+    // Audio
+    mp3: AUDIO_ICON_BACKGROUND_COLOR,
+    wav: AUDIO_ICON_BACKGROUND_COLOR,
+    wma: AUDIO_ICON_BACKGROUND_COLOR,
+    ogg: AUDIO_ICON_BACKGROUND_COLOR,
+
+    // Video
+    flv: VIDEO_ICON_BACKGROUND_COLOR,
+    h264: VIDEO_ICON_BACKGROUND_COLOR,
+    mov: VIDEO_ICON_BACKGROUND_COLOR,
+    mp4: VIDEO_ICON_BACKGROUND_COLOR,
+    mwv: VIDEO_ICON_BACKGROUND_COLOR,
+
+    // Compressed:
+    zip: COMPRESSED_ICON_BACKGROUND_COLOR,
+    '7z': COMPRESSED_ICON_BACKGROUND_COLOR,
+    rar: COMPRESSED_ICON_BACKGROUND_COLOR,
+
+    // Data
+    json: DATA_ICON_BACKGROUND_COLOR,
+    yaml: DATA_ICON_BACKGROUND_COLOR,
+    sql: DATA_ICON_BACKGROUND_COLOR,
+    db: DATA_ICON_BACKGROUND_COLOR,
+    dbf: DATA_ICON_BACKGROUND_COLOR,
+};
+
+export function getIconBackgroundColorForFile(extension: string): string {
+    return (
+        filetypeBackgroundColorTable[extension] || DEFAULT_ICON_BACKGROUND_COLOR
+    );
+}

--- a/src/components/file/icon-fill-colors.ts
+++ b/src/components/file/icon-fill-colors.ts
@@ -1,0 +1,128 @@
+const DEFAULT_ICON_FILL_COLOR = 'rgb(var(--color-gray-dark))';
+const CALENDAR_ICON_FILL_COLOR = 'rgb(var(--color-cyan-dark))';
+const EMAIL_ICON_FILL_COLOR = 'rgb(var(--color-gray-dark))';
+const HTML_ICON_FILL_COLOR = 'rgb(var(--color-blue-dark))';
+const TEXT_ICON_FILL_COLOR = 'rgb(var(--color-yellow-darker))';
+const EXCEL_ICON_FILL_COLOR = 'rgb(var(--color-green-dark))';
+const POWERPOINT_ICON_FILL_COLOR = 'rgb(var(--color-coral-dark))';
+const WORD_ICON_FILL_COLOR = 'rgb(var(--color-sky-dark))';
+const IMAGE_ICON_FILL_COLOR = 'rgb(var(--color-lime-dark))';
+const VECTOR_GRAPHIC_FILL_COLOR = 'rgb(var(--color-magenta-dark))';
+const PRESENTATION_ICON_FILL_COLOR = 'rgb(var(--color-blue-dark))';
+const DOCUMENT_ICON_FILL_COLOR = 'rgb(var(--color-orange-dark))';
+const SPREADSHEET_ICON_FILL_COLOR = 'rgb(var(--color-green-dark))';
+const AUDIO_ICON_FILL_COLOR = 'rgb(var(--color-indigo-dark))';
+const VIDEO_ICON_FILL_COLOR = 'rgb(var(--color-red-dark))';
+const COMPRESSED_ICON_FILL_COLOR = 'rgb(var(--color-brown-default))';
+const MESSAGE_ICON_FILL_COLOR = 'rgb(var(--color-yellow-dark))';
+const PDF_ICON_FILL_COLOR = 'rgb(var(--color-red-dark))';
+const DATA_ICON_FILL_COLOR = 'rgb(var(--color-glaucous-dark))';
+
+const filetypeFillColorTable: Record<string, string> = {
+    // Message
+    msg: MESSAGE_ICON_FILL_COLOR,
+
+    // Calendar
+    ics: CALENDAR_ICON_FILL_COLOR,
+    ical: CALENDAR_ICON_FILL_COLOR,
+    icalendar: CALENDAR_ICON_FILL_COLOR,
+    ifb: CALENDAR_ICON_FILL_COLOR,
+
+    // Email
+    email: EMAIL_ICON_FILL_COLOR,
+    eml: EMAIL_ICON_FILL_COLOR,
+    oft: EMAIL_ICON_FILL_COLOR,
+    ost: EMAIL_ICON_FILL_COLOR,
+    emlx: EMAIL_ICON_FILL_COLOR,
+
+    // Web
+    html: HTML_ICON_FILL_COLOR,
+    xml: HTML_ICON_FILL_COLOR,
+
+    // Editable text
+    txt: TEXT_ICON_FILL_COLOR,
+    rtf: TEXT_ICON_FILL_COLOR,
+
+    // Editable document
+    dot: WORD_ICON_FILL_COLOR,
+    doc: WORD_ICON_FILL_COLOR,
+    docx: WORD_ICON_FILL_COLOR,
+    dotx: WORD_ICON_FILL_COLOR,
+    docm: WORD_ICON_FILL_COLOR,
+    dotm: WORD_ICON_FILL_COLOR,
+    odt: DOCUMENT_ICON_FILL_COLOR,
+    pages: DOCUMENT_ICON_FILL_COLOR,
+
+    // Portable document
+    pdf: PDF_ICON_FILL_COLOR,
+
+    // Presentation
+    ppt: POWERPOINT_ICON_FILL_COLOR,
+    pot: POWERPOINT_ICON_FILL_COLOR,
+    pps: POWERPOINT_ICON_FILL_COLOR,
+    pptx: POWERPOINT_ICON_FILL_COLOR,
+    pptm: POWERPOINT_ICON_FILL_COLOR,
+    potx: POWERPOINT_ICON_FILL_COLOR,
+    potm: POWERPOINT_ICON_FILL_COLOR,
+    ppam: POWERPOINT_ICON_FILL_COLOR,
+    ppsx: POWERPOINT_ICON_FILL_COLOR,
+    ppsm: POWERPOINT_ICON_FILL_COLOR,
+    sldx: POWERPOINT_ICON_FILL_COLOR,
+    sldm: POWERPOINT_ICON_FILL_COLOR,
+    odp: PRESENTATION_ICON_FILL_COLOR,
+    key: PRESENTATION_ICON_FILL_COLOR,
+
+    // Spreadsheet
+    xls: EXCEL_ICON_FILL_COLOR,
+    xlsx: EXCEL_ICON_FILL_COLOR,
+    csv: DEFAULT_ICON_FILL_COLOR,
+    numbers: SPREADSHEET_ICON_FILL_COLOR,
+
+    // Image
+    bmp: IMAGE_ICON_FILL_COLOR,
+    jpg: IMAGE_ICON_FILL_COLOR,
+    jpeg: IMAGE_ICON_FILL_COLOR,
+    heic: IMAGE_ICON_FILL_COLOR,
+    png: IMAGE_ICON_FILL_COLOR,
+    gif: IMAGE_ICON_FILL_COLOR,
+
+    // Editable image
+    psd: PRESENTATION_ICON_FILL_COLOR,
+    ai: DOCUMENT_ICON_FILL_COLOR,
+
+    // Vector graphic
+    svg: VECTOR_GRAPHIC_FILL_COLOR,
+    svgz: VECTOR_GRAPHIC_FILL_COLOR,
+    ep: VECTOR_GRAPHIC_FILL_COLOR,
+    eps: VECTOR_GRAPHIC_FILL_COLOR,
+    sketch: VECTOR_GRAPHIC_FILL_COLOR,
+
+    // Audio
+    mp3: AUDIO_ICON_FILL_COLOR,
+    wav: AUDIO_ICON_FILL_COLOR,
+    wma: AUDIO_ICON_FILL_COLOR,
+    ogg: AUDIO_ICON_FILL_COLOR,
+
+    // Video
+    flv: VIDEO_ICON_FILL_COLOR,
+    h264: VIDEO_ICON_FILL_COLOR,
+    mov: VIDEO_ICON_FILL_COLOR,
+    mp4: VIDEO_ICON_FILL_COLOR,
+    mwv: VIDEO_ICON_FILL_COLOR,
+
+    // Compressed
+    zip: COMPRESSED_ICON_FILL_COLOR,
+    '7z': COMPRESSED_ICON_FILL_COLOR,
+    rar: COMPRESSED_ICON_FILL_COLOR,
+
+    // Data
+    json: DATA_ICON_FILL_COLOR,
+    yaml: DATA_ICON_FILL_COLOR,
+    sql: DATA_ICON_FILL_COLOR,
+    db: DATA_ICON_FILL_COLOR,
+    dbf: DATA_ICON_FILL_COLOR,
+};
+
+export function getIconFillColorForFile(extension: string): string {
+    return filetypeFillColorTable[extension] || DEFAULT_ICON_FILL_COLOR;
+}

--- a/src/components/file/icons.ts
+++ b/src/components/file/icons.ts
@@ -1,0 +1,129 @@
+const DEFAULT_ICON = 'file';
+const CALENDAR_ICON = 'tear_off_calendar';
+const EMAIL_ICON = 'email';
+const HTML_ICON = 'internet';
+const TEXT_ICON = 'text_box';
+const EXCEL_ICON = 'ms_excel_copyrighted';
+const WORD_ICON = 'ms_word_copyrighted';
+const POWERPOINT_ICON = 'ms_powerpoint_copyrighted';
+const IMAGE_ICON = 'picture';
+const PHOTO_ICON = 'camera';
+const VECTOR_GRAPHIC_ICON = 'vector';
+const PRESENTATION_ICON = 'presentation_filled';
+const DOCUMENT_ICON = 'overview_pages_2';
+const SPREADSHEET_ICON = 'data_sheet';
+const AUDIO_ICON = 'audio_wave';
+const VIDEO_ICON = 'video_file';
+const COMPRESSED_ICON = 'condom_package';
+const MESSAGE_ICON = 'ms_outlook_copyrighted';
+const DATA_ICON = 'database';
+
+const filetypeIconTable: Record<string, string> = {
+    // Message
+    msg: MESSAGE_ICON,
+
+    // Calendar
+    ics: CALENDAR_ICON,
+    ical: CALENDAR_ICON,
+    icalendar: CALENDAR_ICON,
+    ifb: CALENDAR_ICON,
+
+    // Email
+    email: EMAIL_ICON,
+    eml: EMAIL_ICON,
+    oft: EMAIL_ICON,
+    ost: EMAIL_ICON,
+    emlx: EMAIL_ICON,
+
+    // Web
+    html: HTML_ICON,
+    xml: HTML_ICON,
+
+    // Editable text
+    txt: TEXT_ICON,
+    rtf: TEXT_ICON,
+
+    // Editable document
+    dot: WORD_ICON,
+    doc: WORD_ICON,
+    docx: WORD_ICON,
+    dotx: WORD_ICON,
+    docm: WORD_ICON,
+    dotm: WORD_ICON,
+    odt: DOCUMENT_ICON,
+    pages: DOCUMENT_ICON,
+
+    // Portable document
+    pdf: 'PDF_2',
+
+    // Presentation
+    ppt: POWERPOINT_ICON,
+    pot: POWERPOINT_ICON,
+    pps: POWERPOINT_ICON,
+    pptx: POWERPOINT_ICON,
+    pptm: POWERPOINT_ICON,
+    potx: POWERPOINT_ICON,
+    potm: POWERPOINT_ICON,
+    ppam: POWERPOINT_ICON,
+    ppsx: POWERPOINT_ICON,
+    ppsm: POWERPOINT_ICON,
+    sldx: POWERPOINT_ICON,
+    sldm: POWERPOINT_ICON,
+    odp: PRESENTATION_ICON,
+    key: PRESENTATION_ICON,
+
+    // Spreadsheet
+    xls: EXCEL_ICON,
+    xlsx: EXCEL_ICON,
+    csv: SPREADSHEET_ICON,
+    numbers: SPREADSHEET_ICON,
+
+    // Image
+    jpg: PHOTO_ICON,
+    jpeg: PHOTO_ICON,
+    heic: PHOTO_ICON,
+    bmp: IMAGE_ICON,
+    png: IMAGE_ICON,
+    gif: IMAGE_ICON,
+
+    // Editable image
+    psd: 'adobe_photoshop_copyrighted',
+    ai: 'adobe_illustrator_copyrighted',
+
+    // Vector graphic
+    svg: VECTOR_GRAPHIC_ICON,
+    svgz: VECTOR_GRAPHIC_ICON,
+    ep: VECTOR_GRAPHIC_ICON,
+    eps: VECTOR_GRAPHIC_ICON,
+    sketch: VECTOR_GRAPHIC_ICON,
+
+    // Audio
+    mp3: AUDIO_ICON,
+    wav: AUDIO_ICON,
+    wma: AUDIO_ICON,
+    ogg: AUDIO_ICON,
+
+    // Video
+    avi: VIDEO_ICON,
+    flv: VIDEO_ICON,
+    h264: VIDEO_ICON,
+    mov: VIDEO_ICON,
+    mp4: VIDEO_ICON,
+    mwv: VIDEO_ICON,
+
+    // Compressed
+    zip: COMPRESSED_ICON,
+    '7z': COMPRESSED_ICON,
+    rar: COMPRESSED_ICON,
+
+    // Data
+    json: 'json',
+    yaml: DATA_ICON,
+    sql: DATA_ICON,
+    db: DATA_ICON,
+    dbf: DATA_ICON,
+};
+
+export function getIconForFile(extension: string): string {
+    return filetypeIconTable[extension] || DEFAULT_ICON;
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/hack-tuesday/issues/187
fix: https://github.com/Lundalogik/crm-feature/issues/2088

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
