### PR TITLE
fix(button): prevent icons from shrinking when button is squeezed

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -66,6 +66,10 @@ button {
         position: absolute;
     }
 
+    .mdc-button__icon {
+        flex-shrink: 0;
+    }
+
     .mdc-button__icon.no-label {
         margin-right: functions.pxToRem(-4);
         margin-left: functions.pxToRem(-4);


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2252 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
