### PR TITLE
docs(icon): remove weird indentation

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -14,8 +14,7 @@ import { IconSize } from './icon.types';
  *
  * ### Setup
  * To use **@lundalogik/lime-icons8**, the `/assets` folder from
- *
- * @lundalogik/lime-icons8** must be made available on the webserver.
+ * __@lundalogik/lime-icons8__ must be made available on the webserver.
  * To use a different icon set, the icons must be placed in a folder structure
  * that looks like this: `assets/icons/<name-of-icon>.svg`
  *
@@ -54,6 +53,7 @@ import { IconSize } from './icon.types';
  * Search for an icon and **click on it to copy its name to clipboard**.
  *
  * <limel-example-icon-finder />
+ *
  * @exampleComponent limel-example-icon
  * @exampleComponent limel-example-icon-background
  */


### PR DESCRIPTION
There was a weird indentation for a whole section in the documentation due to an incorrect line
break and use of the @ sign at the start of a row



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
