### PR TITLE
fix(input-field): render empty `readonly` field with a `–` value & `--float-above` label

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -294,12 +294,14 @@ export class InputField {
 
         const labelClassList = {
             'mdc-floating-label': true,
-            'mdc-floating-label--float-above': !!this.value || this.isFocused,
+            'mdc-floating-label--float-above':
+                !!this.value || this.isFocused || this.readonly,
         };
 
         return [
             <div class={this.getContainerClassList()}>
                 {this.renderFormattedNumber()}
+                {this.renderEmptyValueForReadonly()}
                 {this.renderInput(properties)}
                 {this.renderTextarea(properties)}
                 <div class="mdc-notched-outline">
@@ -445,6 +447,11 @@ export class InputField {
         );
     }
 
+    private renderEmptyValueForReadonly() {
+        if (this.readonly && !this.value) {
+            return <span class="formatted-input">–</span>;
+        }
+    }
     private renderHelperText() {
         if (this.helperText === null || this.helperText === undefined) {
             return;

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -74,7 +74,8 @@ const SelectValue: FunctionalComponent<
     };
     const labelClassList = {
         'mdc-floating-label': true,
-        'mdc-floating-label--float-above': props.hasValue || props.isOpen,
+        'mdc-floating-label--float-above':
+            props.hasValue || props.isOpen || props.readonly,
         'mdc-floating-label--active': props.isOpen,
     };
 
@@ -88,7 +89,7 @@ const SelectValue: FunctionalComponent<
             <div class="limel-select__selected-option">
                 {getSelectedIcon(props.value)}
                 <span class="limel-select__selected-option__text">
-                    {getSelectedText(props.value)}
+                    {getSelectedText(props.value, props.readonly)}
                 </span>
             </div>
             <ShowIcon {...props} isValid={props.isValid} />
@@ -225,7 +226,11 @@ function createMenuItems(
     });
 }
 
-function getSelectedText(value: Option | Option[]): string {
+function getSelectedText(value: Option | Option[], readonly: boolean): string {
+    if (!value && readonly) {
+        return '–';
+    }
+
     if (!value) {
         return '';
     }


### PR DESCRIPTION
This helps keeping the UI consistent and clean,
specially when many `readonly` input fields with and without values are
juxtaposed with each other.

fix https://github.com/Lundalogik/crm-feature/issues/2230

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
