### PR TITLE
chore(package): update kompendium from v0.8.8 to v0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jest": "^26.6.3",
         "jest-cli": "^26.6.3",
         "jsx-dom": "^6.4.21",
-        "kompendium": "^0.8.8",
+        "kompendium": "^0.9.0",
         "lodash-es": "^4.17.21",
         "moment": "^2.29.1",
         "number-abbreviate": "^2.0.0",
@@ -7674,9 +7674,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.8.8.tgz",
-      "integrity": "sha512-798rmcqtP+1mvy/ZOFagYOqGidjPmoumBtHHreJ3gHos1oigsBWPk2AwO0dei1WEQpr7pFWAJSV2sVhvhFHixQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.9.0.tgz",
+      "integrity": "sha512-2hT6Bc9OPT2WGlsm5spctpDVsKHcwF6Tx5G1KDEUXo3cNLieYF5YhAYn7DpjqW5v62yq8ItIF2dSLuWZDbNqAQ==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -18345,9 +18345,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.8.8.tgz",
-      "integrity": "sha512-798rmcqtP+1mvy/ZOFagYOqGidjPmoumBtHHreJ3gHos1oigsBWPk2AwO0dei1WEQpr7pFWAJSV2sVhvhFHixQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.9.0.tgz",
+      "integrity": "sha512-2hT6Bc9OPT2WGlsm5spctpDVsKHcwF6Tx5G1KDEUXo3cNLieYF5YhAYn7DpjqW5v62yq8ItIF2dSLuWZDbNqAQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "jsx-dom": "^6.4.21",
-    "kompendium": "^0.8.8",
+    "kompendium": "^0.9.0",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.1",
     "number-abbreviate": "^2.0.0",


### PR DESCRIPTION
# 🥵 [0.9.0](https://github.com/jgroth/kompendium/compare/v0.8.8...v0.9.0) (2021-07-09)


### Bug Fixes

* **nav:** only render chevron for nav items that have children ([0ee58af](https://github.com/jgroth/kompendium/commit/0ee58af4797600964dd587ec9b30fe60e10a5e98))


### Features

* **nav:** in narrow mode, clicking on a nav item with no children now closes the menu ([8688f34](https://github.com/jgroth/kompendium/commit/8688f348b51397eeeae823a15131e7187ed814c1)), closes [#29](https://github.com/jgroth/kompendium/issues/29)
* **nav:** in narrow mode, clicking outside the nav bar now closes it ([888114b](https://github.com/jgroth/kompendium/commit/888114bcdbf180a6e13d07378e6db7220068d886)), closes [#29](https://github.com/jgroth/kompendium/issues/29)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
