### PR TITLE
chore(package): update kompendium from v0.10.0 to v0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jest": "^26.6.3",
         "jest-cli": "^26.6.3",
         "jsx-dom": "^6.4.21",
-        "kompendium": "^0.10.0",
+        "kompendium": "^0.10.1",
         "lodash-es": "^4.17.21",
         "moment": "^2.29.1",
         "number-abbreviate": "^2.0.0",
@@ -7674,9 +7674,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.0.tgz",
-      "integrity": "sha512-M9LMfSL3WGAchnlGsbnNmeqm3F6lIXury5TrIFVKiDYOJFICxUj6MdEB2t3xPsOXFTsyOhr8uq0Fwb/YZ1Ytog==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.1.tgz",
+      "integrity": "sha512-mtViWQenEey/3r5Kur/WUPm64faaeqIH/YbDcaB2wLBNqWd+Mf29aBEGK+OcwEIJkINy3kviV3jQOu3hdXd4Sg==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -18345,9 +18345,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.0.tgz",
-      "integrity": "sha512-M9LMfSL3WGAchnlGsbnNmeqm3F6lIXury5TrIFVKiDYOJFICxUj6MdEB2t3xPsOXFTsyOhr8uq0Fwb/YZ1Ytog==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.1.tgz",
+      "integrity": "sha512-mtViWQenEey/3r5Kur/WUPm64faaeqIH/YbDcaB2wLBNqWd+Mf29aBEGK+OcwEIJkINy3kviV3jQOu3hdXd4Sg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "jsx-dom": "^6.4.21",
-    "kompendium": "^0.10.0",
+    "kompendium": "^0.10.1",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.1",
     "number-abbreviate": "^2.0.0",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
