### PR TITLE
fix(chip-set): make label truncate correctly when there is a leading icon

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -216,6 +216,10 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 
 // used only in chipsets that do not have input
 .chip-set__label {
+    @include mixins.truncate-text;
+    width: 120%; // `120%` instead of `100%`,
+    // because this class is always together with `mdc-floating-label--float-above`,
+    // which scales the label down. So there is more horizontal space to display the label in.
     top: functions.pxToRem(13);
     padding-left: functions.pxToRem(20);
 }

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -31,6 +31,7 @@
 @include shared_input-select-picker.leading-icon;
 
 $height-of-chip-set-input: functions.pxToRem(36);
+$leading-icon-space: functions.pxToRem(40);
 
 .mdc-chip {
     @include mixins.is-elevated-inset-clickable;
@@ -272,12 +273,14 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 .has-leading-icon {
     &:not(.has-chips) {
         .mdc-text-field__input {
-            padding-left: functions.pxToRem(40);
+            padding-left: $leading-icon-space;
         }
 
         .mdc-floating-label {
-            &:not(.lime-floating-label--float-above) {
-                padding-left: functions.pxToRem(40);
+            padding-left: $leading-icon-space;
+            max-width: calc(100% - #{$leading-icon-space});
+            &.lime-floating-label--float-above {
+                padding-left: 0;
             }
         }
     }


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
