### PR TITLE
fix(menu): pass css props defined for menu to portal

### DIFF
--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -2,10 +2,6 @@
 @use '@material/elevation';
 @use '@material/menu';
 
-/**
- * @prop --menu-surface-width: Width of the menu surface. Defaults to `auto`
- */
-
 :host {
     display: block;
 }

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -1,8 +1,10 @@
 @use '../../style/functions';
 
 // Note! The `--dropdown-z-index` property is used from `menu.tsx`.
+
 /**
- * @prop --dropdown-z-index: z-index of the dropdown menu.
+ * @prop --dropdown-z-index: `z-index` of the dropdown menu.
+ * @prop --menu-surface-width: Width of the menu surface. Defaults to `auto`
  */
 
 :host {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -8,6 +8,7 @@ import {
     Element,
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
+import { zipObject } from 'lodash-es';
 import { OpenDirection } from './menu.types';
 
 /**
@@ -105,6 +106,7 @@ export class Menu {
     }
 
     public render() {
+        const cssProperties = this.getCssProperties();
         const dropdownZIndex = getComputedStyle(this.host).getPropertyValue(
             '--dropdown-z-index'
         );
@@ -128,6 +130,7 @@ export class Menu {
                     <limel-menu-surface
                         open={this.open}
                         onDismiss={this.onClose}
+                        style={cssProperties}
                     >
                         <limel-list
                             items={this.items}
@@ -197,5 +200,15 @@ export class Menu {
         }
 
         return portalPosition;
+    }
+
+    private getCssProperties() {
+        const propertyNames = ['--menu-surface-width'];
+        const style = getComputedStyle(this.host);
+        const values = propertyNames.map((property) => {
+            return style.getPropertyValue(property);
+        });
+
+        return zipObject(propertyNames, values);
     }
 }


### PR DESCRIPTION
We offer the possibility of tweaking `--menu-surface-width`
for `limel-menu`. But this was not working, because `limel-menu-surface`
would go into `limel-portal--container`;
and no defined variable would follow.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
