### PR TITLE
fix(table): center align loading spinner

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -21,6 +21,10 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
     display: block;
 }
 
+#tabulator-container {
+    position: relative;
+}
+
 #tabulator-container,
 #tabulator-table {
     @include lime-typography.base;


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2269

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
