### PR TITLE
feat(collapsible-section): enable keyboard navigation and interaction

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -62,6 +62,13 @@
             rgb(var(--contrast-300))
         );
     }
+
+    &:focus {
+        outline: none;
+    }
+    &:focus-visible {
+        box-shadow: var(--shadow-depth-8-focused);
+    }
 }
 
 .section__header__title {

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -1,6 +1,14 @@
-import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
+import {
+    Component,
+    Event,
+    EventEmitter,
+    h,
+    Prop,
+    Element,
+} from '@stencil/core';
 import { dispatchResizeEvent } from '../../util/dispatch-resize-event';
 import { Action } from './action';
+import { ENTER, ENTER_KEY_CODE } from '../../util/keycodes';
 
 /**
  * @slot - Content to put inside the collapsible section
@@ -52,6 +60,9 @@ export class CollapsibleSection {
     @Event()
     private action: EventEmitter<Action>;
 
+    @Element()
+    private host: HTMLLimelCollapsibleSectionElement;
+
     constructor() {
         this.onClick = this.onClick.bind(this);
         this.renderActionButton = this.renderActionButton.bind(this);
@@ -60,7 +71,12 @@ export class CollapsibleSection {
     public render() {
         return (
             <section class={`${this.isOpen ? 'open' : ''}`}>
-                <header class="section__header" onClick={this.onClick}>
+                <header
+                    class="section__header"
+                    onClick={this.onClick}
+                    onKeyDown={this.handleKeyDown}
+                    tabindex="0"
+                >
                     <div class="section__header__expand-icon">
                         <div class="expand-icon__line"></div>
                         <div class="expand-icon__line"></div>
@@ -91,6 +107,18 @@ export class CollapsibleSection {
             this.close.emit();
         }
     }
+
+    private handleKeyDown = (event: KeyboardEvent) => {
+        const isEnter = event.key === ENTER || event.keyCode === ENTER_KEY_CODE;
+
+        if (isEnter) {
+            event.stopPropagation();
+            event.preventDefault();
+            const element = (this.host.shadowRoot.activeElement ||
+                document.activeElement) as HTMLElement;
+            element.click();
+        }
+    };
 
     private renderActions() {
         if (!this.actions) {


### PR DESCRIPTION
Users now can tab and select section headers,
and also press the ENTER key to open or closes a section

fix: https://github.com/Lundalogik/crm-feature/issues/1972

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
