### PR TITLE
fix(popover): prevent triggering of default link actions which are…

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -137,6 +137,7 @@ export class Popover {
         const clickedInside = portalContains(this.host, element);
         if (this.open && !clickedInside) {
             event.stopPropagation();
+            event.preventDefault();
             this.close.emit();
         }
     }


### PR DESCRIPTION
… below an open popover

While the popover was open, if you clicked on a link (accidentally)
the link would react (call, email, site).

fix: https://github.com/Lundalogik/crm-feature/issues/2276

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
