### PR TITLE
fix(popover): prevent triggering of default link actions which are below an open popover

### DIFF
--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -1,3 +1,5 @@
+@use '../../style/internal/z-index';
+
 /**
  * @prop --popover-surface-width: Width of the popover surface. defaults to `auto`
  * @prop --popover-body-background-color: Background color of popover body, defaults to `--contrast-100`.
@@ -8,4 +10,18 @@
 .trigger-anchor {
     display: inline-block;
     position: relative;
+}
+
+.limel-popover-backdrop {
+    background: rgba(
+        cyan,
+        0.2
+    ); // this is for testing only, to make the div visible
+    border: 4px solid red; // this is for testing only, to make the div visible
+    z-index: var(--popover-z-index, z-index.$popover-backdrop-fallback);
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
 }

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -118,6 +118,7 @@ export class Popover {
         return (
             <div class="trigger-anchor">
                 <slot name="trigger"></slot>
+                {this.renderBackdrop()}
                 <limel-portal
                     visible={this.open}
                     containerId={this.portalId}
@@ -130,6 +131,14 @@ export class Popover {
                 </limel-portal>
             </div>
         );
+    }
+
+    private renderBackdrop() {
+        if (!this.open) {
+            return;
+        }
+
+        return <div class="limel-popover-backdrop" />;
     }
 
     private globalClickListener(event: MouseEvent) {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -137,6 +137,7 @@ export class Popover {
         const clickedInside = portalContains(this.host, element);
         if (this.open && !clickedInside) {
             event.stopPropagation();
+            event.preventDefault();
             this.close.emit();
         }
     }

--- a/src/style/internal/z-index.scss
+++ b/src/style/internal/z-index.scss
@@ -12,3 +12,4 @@ $table--has-interactive-rows--selectable-row--hover: 1 !default;
 $popover-before: -1 !default;
 $button-group-radio-button-keyboard-focused: 1 !default;
 $list-mdc-list-item: 0 !default;
+$popover-backdrop-fallback: 1 !default;


### PR DESCRIPTION
While the popover was open, if you clicked on a link (accidentally)
the link would react (call, email, site).

fix: https://github.com/Lundalogik/crm-feature/issues/1873 


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
