### PR TITLE
Improve docs for limel-form and limel-table

### DIFF
--- a/src/components/form/examples/custom-component-form.tsx
+++ b/src/components/form/examples/custom-component-form.tsx
@@ -4,6 +4,31 @@ import { schema } from './custom-component-schema';
 /**
  * Custom form component
  *
+ * You can specify a custom component to use for any property in your form. This
+ * is done under the `lime` key in the schema, following the
+ * [LimeSchemaOptions](#/type/LimeSchemaOptions/) specification, for example:
+ *
+ * ```ts
+ * const schema = {
+ *     type: 'object',
+ *     properties: {
+ *         hero: {
+ *             type: 'integer',
+ *             title: 'Hero',
+ *             lime: {
+ *                 component: {
+ *                     name: 'my-useful-hero-picker',
+ *                 },
+ *             },
+ *         },
+ *     },
+ * };
+ * ```
+ *
+ * While you can, in principle, use any component in a form, your custom form
+ * components should implement the [FormComponent](#/type/FormComponent/)
+ * interface.
+ *
  * @link custom-component-schema.ts
  * @link custom-component-picker.tsx
  */

--- a/src/components/table/examples/table-custom-components.tsx
+++ b/src/components/table/examples/table-custom-components.tsx
@@ -6,6 +6,25 @@ import { capitalize } from 'lodash-es';
 /**
  * Custom components
  *
+ * You can specify a custom component to use for any column in your table. This
+ * is done under the `component` key in the schema, following the
+ * [TableComponentDefinition](#/type/TableComponentDefinition/) specification,
+ * for example:
+ *
+ * ```ts
+ * const columns = [
+ *     {
+ *         title: 'Food',
+ *         field: 'food',
+ *         component: { name: 'my-fancy-food-displayer' },
+ *     },
+ * ];
+ * ```
+ *
+ * While you can, in principle, use any component in a table, your custom table
+ * components should implement the [TableComponent](#/type/TableComponent/)
+ * interface.
+ *
  * @link birds.ts
  * @link table-food.tsx
  */

--- a/src/components/table/examples/table-header-menu.tsx
+++ b/src/components/table/examples/table-header-menu.tsx
@@ -5,6 +5,11 @@ import { persons, Person } from './persons';
 /**
  * Column header menu
  *
+ * You can also add custom components to the header cell of a column. In
+ * contrast to custom components used elsewhere in the table, custom components
+ * used in the header do not replace the entire content of the cell. Instead,
+ * they appear in a slot next to the column sorting icon.
+ *
  * @link persons.ts
  * @link header-menu.tsx
  */

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -498,8 +498,8 @@ export class Table {
     render() {
         return (
             <div id="tabulator-container">
-                {/* Toggle style instead of removing the loader 
-                    because removing the element will cause a rerender, breaking the 
+                {/* Toggle style instead of removing the loader
+                    because removing the element will cause a rerender, breaking the
                     tabulator table */}
                 <div
                     id="tabulator-loader"

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -18,12 +18,12 @@ const FIRST_PAGE = 1;
 /**
  * @exampleComponent limel-example-table
  * @exampleComponent limel-example-table-custom-components
+ * @exampleComponent limel-example-table-header-menu
  * @exampleComponent limel-example-table-movable-columns
  * @exampleComponent limel-example-table-local
  * @exampleComponent limel-example-table-remote
  * @exampleComponent limel-example-table-activate-row
  * @exampleComponent limel-example-table-default-sorted
- * @exampleComponent limel-example-table-header-menu
  * @exampleComponent limel-example-table-low-density
  */
 @Component({


### PR DESCRIPTION
The interfaces for custom components, both for limel-form and for limel-table, have been too easy to miss. This PR adds descriptions to the relevant examples, including links to the documentation for the relevant interfaces.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
