### PR TITLE
feat(progress-flow): add alternative ui style

### DIFF
--- a/src/components/progress-flow/examples/progress-flow-alternative-ui.tsx
+++ b/src/components/progress-flow/examples/progress-flow-alternative-ui.tsx
@@ -1,0 +1,99 @@
+import { Component, h, State } from '@stencil/core';
+import { FlowItem } from '../progress-flow.types';
+
+/**
+ * Alternative UI
+ *
+ * You can render the component with an alternative layout which may be good for
+ * some use cases. To achive this, simply add the `has-detached-steps` to the
+ * component.
+ * :::tip
+ * This design is more suitable when the user is not expected to go through
+ * the process by manually clicking on each step.
+ *
+ * For example when you only want to visualize status of process when things are
+ * happening without user's direct engagement.
+ * :::
+ * :::note
+ * The `is-narrow` class does not affect this UI alternative.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-progress-flow-alternative-ui',
+    shadow: true,
+})
+export class ProgressFlowAlternativeUiExample {
+    @State()
+    private flowItems: FlowItem[] = [
+        {
+            value: 'placemend',
+            text: 'Order placed',
+            secondaryText: 'Yesterday, 19:37',
+            icon: 'add_shopping_cart',
+            selectedColor: 'rgb(var(--color-orange-default))',
+        },
+        {
+            value: 'payment',
+            text: 'Payment successful',
+            secondaryText: 'Credit card',
+            icon: 'money',
+            selectedColor: 'rgb(var(--color-green-default))',
+        },
+        {
+            value: 'confirmation',
+            text: 'Order confirmed',
+            secondaryText: 'Today, 07:15',
+            selected: true,
+            icon: 'ok',
+            selectedColor: 'rgb(var(--color-sky-default))',
+        },
+        {
+            value: 'process',
+            text: 'Order processed',
+            selectedColor: 'rgb(var(--color-teal-default))',
+            icon: 'packaging',
+        },
+        {
+            value: 'shipment',
+            text: 'Ready to pickup',
+            selectedColor: 'rgb(var(--color-teal-default))',
+            icon: 'agreement',
+        },
+        {
+            value: 'cancel',
+            text: 'Order cancelled',
+            isOffProgress: true,
+            icon: 'return_purchase',
+            iconColor: 'rgb(var(--color-red-dark))',
+            selectedColor: 'rgb(var(--color-red-dark))',
+        },
+        {
+            value: 'returned',
+            text: 'Package retuned',
+            isOffProgress: true,
+            icon: 'return',
+            iconColor: 'rgb(var(--color-coral-default))',
+            selectedColor: 'rgb(var(--color-coral-default))',
+        },
+    ];
+
+    public render() {
+        return (
+            <limel-progress-flow
+                flowItems={this.flowItems}
+                onChange={this.handleChange}
+                class="has-detached-steps"
+                readonly={true}
+            />
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FlowItem>) => {
+        this.flowItems = this.flowItems.map((item) => {
+            return {
+                ...item,
+                selected: item.value === event.detail?.value,
+            };
+        });
+    };
+}

--- a/src/components/progress-flow/progress-flow-item/partial-styles/_has-detached-steps.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_has-detached-steps.scss
@@ -1,0 +1,155 @@
+:host(.has-detached-steps) {
+    --selected-indicator-right: 0.5rem;
+    --step-height: 1.75rem;
+    padding-top: var(--step-height);
+
+    .flow-item {
+        align-items: center;
+        --step-background: var(
+            --progress-flow-step-background-color,
+            rgb(var(--contrast-400))
+        );
+
+        &:not(.selected) {
+            .step:not(.disabled) {
+                &:before {
+                    box-shadow: var(--button-shadow-normal);
+                }
+
+                &:hover {
+                    box-shadow: none;
+
+                    &:before {
+                        box-shadow: var(--button-shadow-hovered);
+                    }
+                }
+
+                &:active {
+                    &:before {
+                        box-shadow: var(--button-shadow-pressed);
+                    }
+                }
+            }
+        }
+    }
+
+    .step {
+        border-radius: var(--step-height);
+        background-color: transparent;
+        padding: 0 !important;
+
+        &:after {
+            // selected indicator
+            right: 0;
+            left: 0;
+            bottom: 0;
+            top: 0;
+            margin: auto;
+            height: calc(var(--step-height) + #{functions.pxToRem(8)});
+            width: calc(var(--step-height) + #{functions.pxToRem(8)});
+            border-width: functions.pxToRem(2);
+            border-style: solid;
+            background-color: transparent;
+            opacity: 0.5;
+        }
+
+        &:before {
+            transition: box-shadow 0.2s ease, background-color 0.2s ease;
+            content: '';
+            width: var(--step-height);
+            height: var(--step-height);
+            border-radius: var(--step-height);
+
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            margin: auto;
+        }
+    }
+
+    .divider {
+        width: 100%;
+        z-index: z-index.$limel-progress-flow-divider-has-detached-steps;
+        overflow: unset;
+        transform: unset;
+
+        &:after {
+            border: none;
+            height: functions.pxToRem(4);
+            border-radius: 0;
+
+            width: calc(100% - var(--step-height));
+            transform: translateX(calc(50% + (var(--step-height) / 5)));
+        }
+    }
+    .off-progress-item {
+        .icon {
+            margin-left: auto;
+        }
+    }
+
+    .icon {
+        position: absolute;
+        left: 0;
+        right: 0;
+        margin: auto;
+    }
+
+    .text,
+    .secondary-text {
+        padding: 0 functions.pxToRem(4);
+    }
+    .text {
+        transform: translateY(calc(-100% - #{functions.pxToRem(12)}));
+        font-size: functions.pxToRem(13);
+    }
+
+    .secondary-text {
+        padding-left: 0;
+        opacity: 0.6;
+    }
+
+    //  colors
+    .flow-item {
+        .step {
+            &:before {
+                background-color: var(--step-background);
+            }
+        }
+
+        &.selected {
+            .step {
+                color: var(--step-text);
+
+                .divider:after {
+                    background-image: linear-gradient(
+                        to right,
+                        var(--step-background--selected),
+                        var(--step-background)
+                    );
+                }
+
+                &:after {
+                    // selected indicator
+                    border-color: var(--step-background--selected);
+                }
+
+                &:before {
+                    background-color: var(--step-background--selected);
+                }
+            }
+        }
+
+        &.passed {
+            .step {
+                color: var(--step-text);
+
+                &:before {
+                    background-color: var(--step-background--passed);
+                }
+            }
+        }
+    }
+}

--- a/src/components/progress-flow/progress-flow-item/partial-styles/_has-detached-steps.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_has-detached-steps.scss
@@ -38,22 +38,8 @@
         background-color: transparent;
         padding: 0 !important;
 
-        &:after {
-            // selected indicator
-            right: 0;
-            left: 0;
-            bottom: 0;
-            top: 0;
-            margin: auto;
-            height: calc(var(--step-height) + #{functions.pxToRem(8)});
-            width: calc(var(--step-height) + #{functions.pxToRem(8)});
-            border-width: functions.pxToRem(2);
-            border-style: solid;
-            background-color: transparent;
-            opacity: 0.5;
-        }
-
         &:before {
+            //  circle
             transition: box-shadow 0.2s ease, background-color 0.2s ease;
             content: '';
             width: var(--step-height);
@@ -67,20 +53,27 @@
             left: 0;
             margin: auto;
         }
+
+        &:after {
+            // lock icon
+            right: 0;
+            left: 0;
+            bottom: 0;
+            top: 0;
+            margin: auto;
+        }
     }
 
     .divider {
         width: 100%;
-        z-index: z-index.$limel-progress-flow-divider-has-detached-steps;
+        left: 0;
         overflow: unset;
         transform: unset;
 
         &:after {
             border: none;
-            height: functions.pxToRem(4);
+            height: 0.25rem;
             border-radius: 0;
-
-            width: calc(100% - var(--step-height));
             transform: translateX(calc(50% + (var(--step-height) / 5)));
         }
     }
@@ -99,7 +92,7 @@
 
     .text,
     .secondary-text {
-        padding: 0 functions.pxToRem(4);
+        padding: 0 0.25rem;
     }
     .text {
         transform: translateY(calc(-100% - #{functions.pxToRem(12)}));
@@ -113,6 +106,9 @@
 
     //  colors
     .flow-item {
+        .icon {
+            --icon-background-color: var(--step-background);
+        }
         .step {
             &:before {
                 background-color: var(--step-background);
@@ -120,6 +116,10 @@
         }
 
         &.selected {
+            .icon {
+                --icon-background-color: var(--step-background--selected);
+            }
+
             .step {
                 color: var(--step-text);
 
@@ -143,6 +143,10 @@
         }
 
         &.passed {
+            .icon {
+                --icon-background-color: var(--step-background--passed);
+            }
+
             .step {
                 color: var(--step-text);
 

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
@@ -181,3 +181,4 @@ $limel-progress-flow-divider: 1;
 
 @import './partial-styles/_selected-indicator';
 @import './partial-styles/_colors';
+@import './partial-styles/_has-detached-steps';

--- a/src/components/progress-flow/progress-flow.tsx
+++ b/src/components/progress-flow/progress-flow.tsx
@@ -16,6 +16,7 @@ import { FlowItem } from './progress-flow.types';
  * @exampleComponent limel-example-progress-flow-colors-css
  * @exampleComponent limel-example-progress-flow-off-progress-steps
  * @exampleComponent limel-example-progress-flow-narrow
+ * @exampleComponent limel-example-progress-flow-alternative-ui
  */
 @Component({
     tag: 'limel-progress-flow',


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Safari
- [ ] Firefox

Mobile:
- [ ] Chrome on Android
- [ ] iOS
