### PR TITLE
fix(table): don't scroll table to the left after each reload

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -213,7 +213,7 @@ export class Table {
                 return;
             }
 
-            this.tabulator.setData(this.data);
+            this.tabulator.replaceData(this.data);
         });
     }
 
@@ -358,7 +358,7 @@ export class Table {
         if (abortRequest) {
             setTimeout(() => {
                 this.updateMaxPage();
-                this.tabulator.setData(this.data);
+                this.tabulator.replaceData(this.data);
             });
 
             return false;

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -351,6 +351,20 @@ export class Table {
         };
     }
 
+    /*
+     * The ajaxRequesting callback is triggered when ever an ajax request is made.
+     *
+     * Tabulator is requesting data with an AJAX request even though it has been
+     * given data when it was created.
+     *
+     * It seems unnecessary for us to emit the `load` event as well when this
+     * happens, since we can just initialize the table with the data that has been
+     * given to us. Therefore, we abort the request if:
+     *
+     *  * its the first time this method is called and,
+     *  * data has been sent in to the component as a prop
+     *
+     */
     private handleAjaxRequesting() {
         const abortRequest = this.firstRequest && !!this.data?.length;
         this.firstRequest = false;


### PR DESCRIPTION
fix: Lundalogik/crm-feature#2027



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
