### PR TITLE
chore(package): upgrade Kompendium from v0.10.1 to v0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "jest": "^26.6.3",
         "jest-cli": "^26.6.3",
         "jsx-dom": "^7.0.4",
-        "kompendium": "^0.10.1",
+        "kompendium": "^0.10.2",
         "lodash-es": "^4.17.21",
         "material-components-web": "^11.0.0",
         "moment": "^2.29.1",
@@ -8100,9 +8100,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.1.tgz",
-      "integrity": "sha512-mtViWQenEey/3r5Kur/WUPm64faaeqIH/YbDcaB2wLBNqWd+Mf29aBEGK+OcwEIJkINy3kviV3jQOu3hdXd4Sg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.2.tgz",
+      "integrity": "sha512-8Y/6osW8EQ8fm1URVQBgnkL5UJhH67zwFEd29fXj2wCX1Lc/XzuJogR7IThOLoV5uyBagtW1V58JA20fKdwPcg==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -19330,9 +19330,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.1.tgz",
-      "integrity": "sha512-mtViWQenEey/3r5Kur/WUPm64faaeqIH/YbDcaB2wLBNqWd+Mf29aBEGK+OcwEIJkINy3kviV3jQOu3hdXd4Sg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.10.2.tgz",
+      "integrity": "sha512-8Y/6osW8EQ8fm1URVQBgnkL5UJhH67zwFEd29fXj2wCX1Lc/XzuJogR7IThOLoV5uyBagtW1V58JA20fKdwPcg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "jsx-dom": "^7.0.4",
-    "kompendium": "^0.10.1",
+    "kompendium": "^0.10.2",
     "lodash-es": "^4.17.21",
     "material-components-web": "^11.0.0",
     "moment": "^2.29.1",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
