### PR TITLE
ci(semantic-release): use `release` instead of `no ci` in release commits

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   semantic-release:
     name: Run Semantic Release
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!contains(github.event.head_commit.message, '[release]')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/release.config.js
+++ b/release.config.js
@@ -16,7 +16,14 @@ module.exports = {
         ],
         '@semantic-release/changelog',
         '@semantic-release/npm',
-        '@semantic-release/git',
+        [
+            '@semantic-release/git',
+            {
+                message:
+                    // eslint-disable-next-line no-template-curly-in-string
+                    'chore(release): ${nextRelease.version} [release]\n\n${nextRelease.notes}',
+            },
+        ],
         '@semantic-release/github',
     ],
     npmPublish: true,


### PR DESCRIPTION
Including `[no ci]` will prevent GitHub Actions from running the workflow
at all. But we want to run the release workflow even if the last commit
happens to be a pre-release commit. So we use `[release]` instead of
`[no ci]`. That way, the workflow will run, and we can skip or run stuff
depending on what workflow we're in.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
