### PR TITLE
feat(package): upgrade @lundalogik/lime-icons8 from v2.4.0 to v2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@commitlint/config-conventional": "^13.1.0",
         "@lundalogik/cz-conventional-changelog": "^3.1.0",
-        "@lundalogik/lime-icons8": "^2.4.0",
+        "@lundalogik/lime-icons8": "^2.5.0",
         "@popperjs/core": "^2.9.3",
         "@rjsf/core": "^2.5.1",
         "@stencil/core": "^2.7.0",
@@ -1219,9 +1219,9 @@
       }
     },
     "node_modules/@lundalogik/lime-icons8": {
-      "version": "2.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.4.0/6cd9e874ececf499852fe4b2872166f4ae5242d6d9723467c51821b09f6adcc2",
-      "integrity": "sha512-d4WGRxS6Hxx5DhAV4RFkpsuF7iU+qo9KasiQ421HK0W/AxLEvAeCyU4cT8aGItI4uTaZ29eMP5keMROWhvGVrQ==",
+      "version": "2.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.5.0/785ef0580124d1ee465cc4377ff5a5f1c992712f85fd1fc7b397be35e800a047",
+      "integrity": "sha512-zEKKqNi0PE9SwwUddtiPrU2uh7RIC4wt/bLbCYW8e4C1FXMvc0cKm/ka36Bj0UAtknADGbMiXt2G3Htqcubrkw==",
       "dev": true,
       "license": "UNLICENSED"
     },
@@ -13592,9 +13592,9 @@
       }
     },
     "@lundalogik/lime-icons8": {
-      "version": "2.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.4.0/6cd9e874ececf499852fe4b2872166f4ae5242d6d9723467c51821b09f6adcc2",
-      "integrity": "sha512-d4WGRxS6Hxx5DhAV4RFkpsuF7iU+qo9KasiQ421HK0W/AxLEvAeCyU4cT8aGItI4uTaZ29eMP5keMROWhvGVrQ==",
+      "version": "2.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.5.0/785ef0580124d1ee465cc4377ff5a5f1c992712f85fd1fc7b397be35e800a047",
+      "integrity": "sha512-zEKKqNi0PE9SwwUddtiPrU2uh7RIC4wt/bLbCYW8e4C1FXMvc0cKm/ka36Bj0UAtknADGbMiXt2G3Htqcubrkw==",
       "dev": true
     },
     "@material/animation": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^13.1.0",
     "@lundalogik/cz-conventional-changelog": "^3.1.0",
-    "@lundalogik/lime-icons8": "^2.4.0",
+    "@lundalogik/lime-icons8": "^2.5.0",
     "@popperjs/core": "^2.9.3",
     "@rjsf/core": "^2.5.1",
     "@stencil/core": "^2.7.0",


### PR DESCRIPTION
This gives access to newly added logos of Lime Technologies,
as well as a few of Lime products, such as CRM, Go, and Elements;
which can now be used as `limel-icon`.



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
