### PR TITLE
chore(style): remove unused mixin for `label--float-above`

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -288,10 +288,11 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
         }
 
         .mdc-floating-label {
-            padding-left: $leading-icon-space;
-            max-width: calc(100% - #{$leading-icon-space});
-            &.lime-floating-label--float-above {
-                padding-left: 0;
+            &:not(.lime-floating-label--float-above) {
+                left: $leading-icon-space;
+            }
+            &.mdc-floating-label--float-above {
+                left: functions.pxToRem(4);
             }
         }
     }

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -26,6 +26,7 @@
 
 @include shared_input-select-picker.outlined-style-overrides;
 @include shared_input-select-picker.floating-label-overrides;
+@include shared_input-select-picker.cropped-label-hack;
 @include shared_input-select-picker.disabled-overrides;
 @include shared_input-select-picker.readonly-overrides;
 @include shared_input-select-picker.leading-icon;

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -59,12 +59,6 @@ $cropped-label-hack--font-size: 0.875rem; //14px
     letter-spacing: 0.009375em;
 }
 
-@mixin label--float-above() {
-    // transform: translateY(-2.38rem) scale(0.75);
-    // font-size: functions.pxToRem(16); // See comments in `cropped-label-hack` below
-    // font-size: 0.875rem;
-}
-
 @mixin cropped-label-hack {
     // Some font size applied to `label--float-above` causes the labels to get cut off
     // when an empty field gets focused
@@ -83,9 +77,6 @@ $cropped-label-hack--font-size: 0.875rem; //14px
             // This is why I don't like this hack.
         }
     }
-
-    // NOTE: if we ever remove this hack, we must also update the mixin above
-    // (`label--float-above`)
 }
 
 @mixin looks-like-helper-line {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2295


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
