### PR TITLE
fix(chip-set): show delimiter directly after first chip

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -599,7 +599,6 @@ export class ChipSet {
 
     private renderInputChip(chip: Chip, index: number) {
         return [
-            this.renderDelimiter(index),
             <div
                 class={{
                     'mdc-chip': true,
@@ -614,6 +613,7 @@ export class ChipSet {
                 {this.renderLabel(chip)}
                 {this.renderChipRemoveButton(chip)}
             </div>,
+            this.renderDelimiter(),
         ];
     }
 
@@ -713,8 +713,8 @@ export class ChipSet {
         this.change.emit([]);
     }
 
-    private renderDelimiter(index: Number) {
-        if (index === 0 || !this.delimiter) {
+    private renderDelimiter() {
+        if (!this.delimiter) {
             return;
         }
 


### PR DESCRIPTION
Fix: https://github.com/Lundalogik/crm-feature/issues/1871
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
