### PR TITLE
feat(picker): make delimiter of chip-set available in picker

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -107,6 +107,12 @@ export class Picker {
     public multiple: boolean = false;
 
     /**
+     * Sets delimiters between chips.
+     */
+    @Prop({ reflect: true })
+    public delimiter: string = null;
+
+    /**
      * True if the dropdown list should be displayed without cutting the content
      *
      * @deprecated This was used for a workaround, and isn't needed any
@@ -237,6 +243,7 @@ export class Picker {
                 leadingIcon={this.leadingIcon}
                 value={this.chips}
                 disabled={this.disabled}
+                delimiter={this.delimiter}
                 readonly={this.readonly}
                 required={this.required}
                 searchLabel={this.searchLabel}


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2103
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
