### PR TITLE
fix(table): don't show empty message when loading the table

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -106,7 +106,8 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
     font-size: functions.pxToRem(13);
 }
 
-#tabulator-loader {
+#tabulator-loader,
+#tabulator-empty-text {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -114,9 +115,18 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+#tabulator-loader {
     background-color: rgba(255, 255, 255, 0.5);
 
     limel-spinner {
         color: var(--lime-turquoise);
     }
+}
+
+#tabulator-empty-text {
+    color: rgb(var(--contrast-800));
+    font-weight: bold;
+    font-size: functions.pxToRem(20);
 }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -118,7 +118,7 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
 }
 
 #tabulator-loader {
-    background-color: rgba(255, 255, 255, 0.5);
+    background-color: rgba(var(--contrast-100), 0.6);
 }
 
 #tabulator-empty-text {

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -119,10 +119,6 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
 
 #tabulator-loader {
     background-color: rgba(255, 255, 255, 0.5);
-
-    limel-spinner {
-        color: var(--lime-turquoise);
-    }
 }
 
 #tabulator-empty-text {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -315,7 +315,6 @@ export class Table {
             dataFiltered: this.updateMaxPage,
             nestedFieldSeparator: false,
             ...columnOptions,
-            placeholder: this.emptyMessage,
         };
     }
 
@@ -521,6 +520,7 @@ export class Table {
                 >
                     <limel-spinner size="large" />
                 </div>
+                {this.renderEmptyMessage()}
                 <div
                     id="tabulator-table"
                     class={{
@@ -529,6 +529,20 @@ export class Table {
                         'has-movable-columns': this.movableColumns,
                     }}
                 />
+            </div>
+        );
+    }
+
+    private renderEmptyMessage() {
+        const showEmptyMessage =
+            !this.loading && !this.data.length && this.emptyMessage;
+
+        return (
+            <div
+                id="tabulator-empty-text"
+                style={{ display: showEmptyMessage ? 'flex' : 'none' }}
+            >
+                <span>{this.emptyMessage}</span>
             </div>
         );
     }


### PR DESCRIPTION
We could use tabulator's placeholder option and send in a DOM node instead of a string. However, I
think it is an easier solution not to use the placeholder option  and instead just render the empty
message in the render method.

fix Lundalogik/crm-feature#2326



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
