### PR TITLE
fix(picker): show delimiter only when multiple is true

### DIFF
--- a/src/components/picker/examples/picker-multiple.tsx
+++ b/src/components/picker/examples/picker-multiple.tsx
@@ -37,6 +37,9 @@ export class PickerMultipleExample {
     @State()
     private disabled: boolean = false;
 
+    @State()
+    private delimiter: string = null;
+
     public render() {
         return [
             <limel-picker
@@ -49,6 +52,7 @@ export class PickerMultipleExample {
                 required={this.required}
                 readonly={this.readonly}
                 disabled={this.disabled}
+                delimiter={this.delimiter}
             />,
             <p>
                 <limel-flex-container justify="end">
@@ -66,6 +70,11 @@ export class PickerMultipleExample {
                         label="Required"
                         onChange={this.setRequired}
                         checked={this.required}
+                    />
+                    <limel-checkbox
+                        label="Use delimiters"
+                        onChange={this.useDelimiters}
+                        checked={this.delimiter !== null}
                     />
                 </limel-flex-container>
             </p>,
@@ -114,5 +123,9 @@ export class PickerMultipleExample {
 
     private setRequired = (event: CustomEvent<boolean>) => {
         this.required = event.detail;
+    };
+
+    private useDelimiters = (event: CustomEvent<boolean>) => {
+        this.delimiter = event.detail ? '&' : null;
     };
 }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -107,7 +107,7 @@ export class Picker {
     public multiple: boolean = false;
 
     /**
-     * Sets delimiters between chips.
+     * Sets delimiters between chips. Works only when `multiple` is `true`.
      */
     @Prop({ reflect: true })
     public delimiter: string = null;
@@ -243,7 +243,7 @@ export class Picker {
                 leadingIcon={this.leadingIcon}
                 value={this.chips}
                 disabled={this.disabled}
-                delimiter={this.delimiter}
+                delimiter={this.renderDelimiter()}
                 readonly={this.readonly}
                 required={this.required}
                 searchLabel={this.searchLabel}
@@ -276,6 +276,14 @@ export class Picker {
             newValue,
             SEARCH_DEBOUNCE
         );
+    }
+
+    private renderDelimiter() {
+        if (this.multiple) {
+            return this.delimiter;
+        }
+
+        return null;
     }
 
     private createChips(value: ListItem | ListItem[]): Chip[] {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2332 

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
