### PR TITLE
fix(table): make column headers of a empty tables clickable

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -125,4 +125,5 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
     color: rgb(var(--contrast-800));
     font-weight: bold;
     font-size: functions.pxToRem(20);
+    pointer-events: none;
 }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -119,6 +119,7 @@ $tabulator-arrow-color-active: rgb($tabulator-arrow-color-active-raw-value);
 
 #tabulator-loader {
     background-color: rgba(var(--contrast-100), 0.6);
+    cursor: wait;
 }
 
 #tabulator-empty-text {


### PR DESCRIPTION
When a table is empty, the `tabulator-empty-text` div is rendered.
It covered the headers and therefore blocked any clicks.
With `pointer-events: none;` we let clicks go through.

fix https://github.com/Lundalogik/crm-feature/issues/2333

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
