### PR TITLE
feat(style): make Lime's percentage colors universally available

### DIFF
--- a/src/components/slider/partial-styles/percentage-color.scss
+++ b/src/components/slider/partial-styles/percentage-color.scss
@@ -5,18 +5,6 @@
 }
 
 :host(.displays-percentage-colors) {
-    --color-percent--0: rgb(var(--color-gray-default));
-    --color-percent--0to10: rgb(var(--color-red-dark));
-    --color-percent--10to20: rgb(var(--color-red-default));
-    --color-percent--20to30: rgb(var(--color-coral-default));
-    --color-percent--30to40: rgb(var(--color-orange-default));
-    --color-percent--40to50: rgb(var(--color-amber-default));
-    --color-percent--50to60: rgb(var(--color-yellow-default));
-    --color-percent--60to70: rgb(var(--color-grass-default));
-    --color-percent--70to80: rgb(var(--color-lime-default));
-    --color-percent--80to90: rgb(var(--color-teal-default));
-    --color-percent--90to100: rgb(var(--color-teal-dark));
-
     .slider.lime-slider--readonly {
         --mdc-theme-on-surface: var(--mdc-theme-primary);
     }

--- a/src/style/colors.scss
+++ b/src/style/colors.scss
@@ -12,4 +12,16 @@
     --lime-magenta: #{brand-colors.$lime-magenta};
     --lime-light-grey: #{brand-colors.$lime-light-grey};
     --lime-dark-grey: #{brand-colors.$lime-dark-grey};
+
+    --color-percent--0: rgb(var(--color-gray-default));
+    --color-percent--0to10: rgb(var(--color-red-dark));
+    --color-percent--10to20: rgb(var(--color-red-default));
+    --color-percent--20to30: rgb(var(--color-coral-default));
+    --color-percent--30to40: rgb(var(--color-orange-default));
+    --color-percent--40to50: rgb(var(--color-amber-default));
+    --color-percent--50to60: rgb(var(--color-yellow-default));
+    --color-percent--60to70: rgb(var(--color-grass-default));
+    --color-percent--70to80: rgb(var(--color-lime-default));
+    --color-percent--80to90: rgb(var(--color-teal-default));
+    --color-percent--90to100: rgb(var(--color-teal-dark));
 }


### PR DESCRIPTION
This way, any component –internal or external– that needs to visualize
a percentage using Lime Technologies' color conventions
can do so by reusing our CSS variable names.

This PR is needed for https://github.com/Lundalogik/crm-feature/issues/2338

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
