### PR TITLE
perf(linear-progress): remove `buffer-dots` and thus their always…

### DIFF
--- a/src/components/linear-progress/linear-progress.tsx
+++ b/src/components/linear-progress/linear-progress.tsx
@@ -72,7 +72,6 @@ export class LinearProgress {
             >
                 <div class="mdc-linear-progress__buffer">
                     <div class="mdc-linear-progress__buffer-bar"></div>
-                    <div class="mdc-linear-progress__buffer-dots"></div>
                 </div>
                 <div class="mdc-linear-progress__bar mdc-linear-progress__primary-bar">
                     <span class="mdc-linear-progress__bar-inner" />


### PR DESCRIPTION
… running animations

fix: https://github.com/Lundalogik/crm-feature/issues/2346

The `mdc-linear-progress__buffer-dots` is from a feature that
we do not use. However, their div was present, and their animation
was always running, affecting the performance.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
