### PR TITLE
fix(input-field): fix cut-off label for input fields with leading icon

### DIFF
--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -62,7 +62,10 @@ $cropped-label-hack--font-size: 0.875rem; //14px
 @mixin cropped-label-hack {
     // Some font size applied to `label--float-above` causes the labels to get cut off
     // when an empty field gets focused
-    .mdc-text-field--outlined.mdc-notched-outline--upgraded.mdc-text-field--textarea,
+    .mdc-text-field--outlined.mdc-text-field--with-leading-icon.mdc-notched-outline--upgraded,
+    .mdc-text-field--outlined.mdc-text-field--with-leading-icon
+        .mdc-notched-outline--upgraded,
+    .mdc-text-field--outlined.mdc-text-field--textarea.mdc-notched-outline--upgraded,
     .mdc-text-field--outlined.mdc-text-field--textarea
         .mdc-notched-outline--upgraded,
     .mdc-text-field--outlined.mdc-notched-outline--upgraded,


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2348

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
