### PR TITLE
fix(select): give more space to label by reducing dropdown-icon's margin

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -93,6 +93,10 @@
 
         position: relative;
         bottom: unset;
+        margin: {
+            left: 0;
+            right: functions.pxToRem(4);
+        }
     }
 
     .limel-select-trigger,


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1365

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
