### PR TITLE
fix(list): only apply badge effect to graphic

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -70,7 +70,7 @@ $list-border-radius: 0.375rem; // 6px
     &.mdc-deprecated-list--avatar-list {
         position: relative;
 
-        limel-icon {
+        limel-icon.mdc-deprecated-list-item__graphic {
             background-color: var(
                 --icon-background-color,
                 rgb(var(--contrast-900))

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -67,6 +67,12 @@ $list-border-radius: 0.375rem; // 6px
         cursor: pointer;
     }
 
+    .mdc-deprecated-list-item__meta {
+        // the action menu on the right side a list item
+        line-height: 100%;
+        margin-right: -0.5rem;
+    }
+
     &.mdc-deprecated-list--avatar-list {
         position: relative;
 


### PR DESCRIPTION
fixes #1370, Lundalogik/limepkg-workorder-list#38

Tested with modified "list with actions" example to get the combination action menu + badge icons.

```typescript
    public render() {
        return (
            <limel-list
                badgeIcons={true}
                iconSize="large"
                items={this.items}
                onSelect={this.onSelectAction}
            />
        );
    }
```

**Before**

<img width="451" alt="Screen Shot 2021-09-29 at 19 44 07" src="https://user-images.githubusercontent.com/435885/135322452-97cb7df1-bbb3-4503-beb5-a8e1d12e1b2d.png">

**After**

<img width="447" alt="Screen Shot 2021-09-29 at 19 45 00" src="https://user-images.githubusercontent.com/435885/135322450-e3d95f82-7de9-42b2-aa9c-8716ce1af86e.png">

Also, margins of the action menu icon are unaffected even when using something different than the default icon size.

<img width="473" alt="Screen Shot 2021-09-29 at 19 48 39" src="https://user-images.githubusercontent.com/435885/135322446-f70ec82c-1881-4e33-ad27-5c8d625c5de6.png">
<img width="469" alt="Screen Shot 2021-09-29 at 19 45 58" src="https://user-images.githubusercontent.com/435885/135322448-852f0f1a-a010-4f1d-9343-89b5a424458e.png">

UPDATE:
Also makes sure that action menu is vertically centered (ty @Kiarokh @mjlime).

Before and after:
<img width="1130" alt="Screen Shot 2021-09-30 at 11 32 55" src="https://user-images.githubusercontent.com/435885/135427319-0c699d02-11e7-45ef-954c-5ea0feb5af02.png">


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
