### PR TITLE
ch(release.yml): run release nightly instead of on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
 name: Create and Publish Full Release
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Run at 02:00 UTC every night.
+    - cron: "0 2 * * *"
+  # workflow_dispatch makes it possible to trigger the run manually
+  workflow_dispatch:
+
 jobs:
   semantic-release:
     name: Run Semantic Release


### PR DESCRIPTION
Because we prefer not to get new commits on `next` between the time we merge `next`
into `main`, and the time the created release commit is merged back to `next`, this
commit changes the release workflow from running on push to running nightly. We also
add a workflow_dispatch trigger.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
