### PR TITLE
ci(release.yml): revert back to running on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Create and Publish Full Release
 on:
-  schedule:
-    # Run at 02:00 UTC every night.
-    - cron: "0 2 * * *"
+  push:
+    branches:
+      - main
   # workflow_dispatch makes it possible to trigger the run manually
   workflow_dispatch:
 


### PR DESCRIPTION
I realised running nightly does not help for avoiding new commits on `next`, since
we would still have to do the merge from `next` to `main` at a time when no new
commits would be added to `next` between the merge and the release. So scheduling
the release to run nightly actually just made the problem worse 🤦.

Partially reverts 93c54ae59.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
