### PR TITLE
fix(dialog): UX issue with a button rendering

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -115,3 +115,9 @@ slot[name='button'] {
     width: 100%;
     justify-content: flex-end;
 }
+
+@media screen and (max-width: 760px) {
+    slot[name='button'] {
+        flex-direction: column-reverse;
+    }
+}

--- a/src/components/dialog/examples/dialog-action-buttons.scss
+++ b/src/components/dialog/examples/dialog-action-buttons.scss
@@ -5,11 +5,10 @@
 }
 
 .button {
-    &.justify-left {
-        // In a full width flex container that has `justify-content: flex-end;`,
+    &:first-of-type {
         // these styles will align the targeted button to the left.
-        justify-self: flex-start;
         margin-right: auto;
+        margin-top: 0;
     }
     &.primary--neutral {
         --lime-primary-color: rgb(var(--contrast-1100));
@@ -20,5 +19,16 @@
     }
     &.primary--danger {
         --lime-primary-color: rgb(var(--color-red-default));
+    }
+}
+
+@media screen and (max-width: 760px) {
+    .button {
+        &:first-of-type {
+            // these styles will add a gap between "back button" and "discard" in a mobile view
+            // and put all buttons in a column.
+            margin-top: 1rem;
+            margin-right: 0;
+        }
     }
 }

--- a/src/components/dialog/examples/dialog-action-buttons.tsx
+++ b/src/components/dialog/examples/dialog-action-buttons.tsx
@@ -61,7 +61,7 @@ export class DialogActionButtonsExample {
                 </div>
                 <limel-button
                     label="Back to editing"
-                    class="button back primary--neutral justify-left"
+                    class="button back primary--neutral"
                     icon="left_arrow"
                     onClick={this.closeDialog}
                     slot="button"


### PR DESCRIPTION
fix Lundalogik/lime-elements#1387

Mobile view: 
![image](https://user-images.githubusercontent.com/50618208/137282079-7a042547-f885-4c1f-9bf9-b774ec838511.png)

Desktop view:
![image](https://user-images.githubusercontent.com/50618208/137282677-89fb2ab0-cc7e-4db5-b617-d41ae6c5a2bf.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
