### PR TITLE
fix(tabs): add missing interface for tab-panel components

### DIFF
--- a/src/components/tab-panel/examples/tab-panel-content.tsx
+++ b/src/components/tab-panel/examples/tab-panel-content.tsx
@@ -7,7 +7,7 @@ import {
     State,
     Watch,
 } from '@stencil/core';
-import { Tab } from '@limetech/lime-elements';
+import { Tab, TabPanelComponent } from '@limetech/lime-elements';
 
 const LOAD_TIME = 1000;
 
@@ -16,7 +16,7 @@ const LOAD_TIME = 1000;
     shadow: true,
     styleUrl: 'tab-panel-content.scss',
 })
-export class TabPanelContentExample {
+export class TabPanelContentExample implements TabPanelComponent {
     /**
      * The tab that this component belongs to
      */
@@ -27,7 +27,7 @@ export class TabPanelContentExample {
      * Emitted when the vote button is clicked to update the badge in the tab
      */
     @Event()
-    private changeTab: EventEmitter<Tab>;
+    public changeTab: EventEmitter<Tab>;
 
     @State()
     private votes = 0;

--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -15,7 +15,8 @@ import { dispatchResizeEvent } from '../../util/dispatch-resize-event';
  * The `limel-tab-panel` component uses the `limel-tab-bar` component together
  * with custom slotted components and will display the content for the currently
  * active tab. Each slotted component must have an id equal to the id of the
- * corresponding tab it belongs to.
+ * corresponding tab it belongs to. These components should implement the
+ * [TabPanelComponent](#/type/TabPanelComponent/) interface.
  *
  * The `limel-tab-panel` component will automatically set each tab configuration
  * on the corresponding slotted component as a property named `tab` so that the

--- a/src/components/tab-panel/tab-panel.types.ts
+++ b/src/components/tab-panel/tab-panel.types.ts
@@ -1,0 +1,18 @@
+import { EventEmitter } from '@stencil/core';
+import { Tab } from '../tab-bar/tab.types';
+
+/**
+ * Interface for components rendered inside a `limel-tab-panel`
+ */
+export interface TabPanelComponent {
+    /**
+     * The tab that the component belongs to
+     */
+    tab: Tab;
+
+    /**
+     * Emit when the tab is updated for some reason, e.g. changing the text,
+     * icon or badge
+     */
+    changeTab?: EventEmitter<Tab>;
+}

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -17,4 +17,5 @@ export * from './components/progress-flow/progress-flow.types';
 export * from './components/select/option.types';
 export * from './components/spinner/spinner.types';
 export * from './components/tab-bar/tab.types';
+export * from './components/tab-panel/tab-panel.types';
 export * from './components/table/table.types';


### PR DESCRIPTION
fix #1264



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
