### PR TITLE
fix(tooltip): capital letters at shortcuts

### DIFF
--- a/src/components/tooltip/examples/tooltip.tsx
+++ b/src/components/tooltip/examples/tooltip.tsx
@@ -14,7 +14,7 @@ export class TooltipExample {
             <limel-button icon="search" id="tooltip-example" />,
             <limel-tooltip
                 label="Search"
-                helperLabel="alt+f"
+                helperLabel="alt + F"
                 elementId="tooltip-example"
             />,
         ];


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1400

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
