### PR TITLE
chore(package.json): add script `npm run test:watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:scss:prod": "prettier -c --end-of-line lf --ignore-path ./.gitignore **/*.scss",
     "start": "npm run watch",
     "test": "npm run test:spec && npm run test:e2e",
+    "test:watch": "cross-env-shell SASS_PATH=node_modules \"stencil test --spec --e2e --watch\"",
     "test:e2e": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e\"",
     "test:e2e:watch": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e --watch\"",
     "test:spec": "stencil test --spec",


### PR DESCRIPTION
You can now run `npm run test:watch` and have the watcher run _both_ spec and e2e tests 🥳

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
