### PR TITLE
Create a duplicate of limel-list, called limel-menu-list, only used by limel-menu

### DIFF
--- a/src/components/menu-list/menu-list-item.types.ts
+++ b/src/components/menu-list/menu-list-item.types.ts
@@ -1,6 +1,4 @@
-import { ListSeparator, MenuListItem } from '@limetech/lime-elements';
-
-export interface ListItem<T = any> {
+export interface MenuListItem<T = any> {
     /**
      * Text to display in the list item.
      */
@@ -40,4 +38,8 @@ export interface ListItem<T = any> {
      * List of actions to display as a menu at the end of the item
      */
     actions?: Array<MenuListItem | ListSeparator>;
+}
+
+export interface ListSeparator {
+    separator: true;
 }

--- a/src/components/menu-list/menu-list-renderer-config.ts
+++ b/src/components/menu-list/menu-list-renderer-config.ts
@@ -1,0 +1,9 @@
+import { IconSize, MenuListType } from '@limetech/lime-elements';
+
+export interface MenuListRendererConfig {
+    isMenu?: boolean;
+    isOpen?: boolean;
+    badgeIcons?: boolean;
+    type?: MenuListType;
+    iconSize?: IconSize;
+}

--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -1,0 +1,349 @@
+import { MenuListItem, ListSeparator, MenuItem } from '@limetech/lime-elements';
+import { h } from '@stencil/core';
+import { CheckboxTemplate } from '../checkbox/checkbox.template';
+import { MenuListRendererConfig } from './menu-list-renderer-config';
+import { RadioButtonTemplate } from './radio-button/radio-button.template';
+
+export class MenuListRenderer {
+    private defaultConfig: MenuListRendererConfig = {
+        isOpen: true,
+        badgeIcons: false,
+    };
+
+    private config: MenuListRendererConfig;
+
+    private hasIcons: boolean;
+    private twoLines: boolean;
+    private avatarList: boolean;
+    private commandKey: boolean;
+
+    private applyTabIndexToItemAtIndex: number;
+
+    public render(
+        items: Array<MenuListItem | ListSeparator | MenuItem>,
+        config: MenuListRendererConfig = {}
+    ) {
+        items = items || [];
+        this.config = { ...this.defaultConfig, ...config };
+
+        this.twoLines = items.some((item) => {
+            return 'secondaryText' in item && !!item.secondaryText;
+        });
+
+        this.commandKey = items.some((item) => {
+            return 'commandText' in item && !!item.commandText;
+        });
+
+        this.hasIcons = items.some((item) => {
+            return 'icon' in item && !!item.icon;
+        });
+
+        this.avatarList = this.config.badgeIcons && this.hasIcons;
+        const selectableListTypes = ['selectable', 'radio', 'checkbox', 'menu'];
+
+        let role;
+        switch (this.config.type) {
+            case 'checkbox':
+                role = 'group';
+                break;
+            case 'radio':
+                role = 'radiogroup';
+                break;
+            default:
+                role = this.config.type === 'menu' ? 'menu' : 'listbox';
+        }
+
+        this.applyTabIndexToItemAtIndex =
+            this.getIndexForWhichToApplyTabIndex(items);
+
+        const classNames = {
+            'mdc-deprecated-list': true,
+            'mdc-deprecated-list--two-line': this.twoLines,
+            selectable: selectableListTypes.includes(this.config.type),
+            'mdc-deprecated-list--avatar-list': this.avatarList,
+            'list--compact':
+                this.twoLines &&
+                this.commandKey &&
+                ['small', 'x-small'].includes(this.config.iconSize),
+        };
+
+        return (
+            <ul
+                class={classNames}
+                aria-hidden={(this.config.type === 'menu').toString()}
+                role={role}
+                aria-orientation="vertical"
+            >
+                {items.map(this.renderMenuListItem)}
+            </ul>
+        );
+    }
+
+    /**
+     * Determine which MenuListItem should have the `tab-index` attribute set,
+     * and return the index at which that MenuListItem is located in `items`.
+     * Returns `undefined` if no item should have the attribute set.
+     * See https://github.com/material-components/material-components-web/tree/e66a43a75fef4f9179e24856649518e15e279a04/packages/mdc-list#accessibility
+     *
+     * @param {Array<MenuListItem | ListSeparator | MenuItems>} items the items of the list, including any `ListSeparator`:s
+     * @returns {number} the index as per the description
+     */
+    private getIndexForWhichToApplyTabIndex = (
+        items: Array<MenuListItem | ListSeparator | MenuItem>
+    ) => {
+        let result;
+        for (let i = 0, max = items.length; i < max; i += 1) {
+            if ('separator' in items[i]) {
+                // Ignore ListSeparator
+            } else {
+                const item = items[i] as MenuListItem<any>;
+                if (item.selected) {
+                    result = i;
+                    break;
+                }
+
+                if (result === undefined && !item.disabled) {
+                    result = i;
+                    // Do NOT break, as any later item with
+                    // `selected=true` should get the tab-index instead!
+                }
+            }
+        }
+
+        return result;
+    };
+
+    /**
+     * Render a single list item
+     *
+     * @param {MenuListItem | ListSeparator | MenuItems} item the item to render
+     * @param {number} index the index the item had in the `items` array
+     * @returns {HTMLElement} the list item
+     */
+    private renderMenuListItem = (
+        item: MenuListItem | ListSeparator | MenuItem,
+        index: number
+    ) => {
+        if ('separator' in item) {
+            return <li class="mdc-deprecated-list-divider" role="separator" />;
+        }
+
+        if (['radio', 'checkbox'].includes(this.config.type)) {
+            return this.renderVariantMenuListItem(this.config, item, index);
+        }
+
+        const classNames = {
+            'mdc-deprecated-list-item': true,
+            'mdc-deprecated-list-item--disabled': item.disabled,
+            'mdc-deprecated-list-item--selected': item.selected,
+        };
+
+        const attributes: { tabindex?: string } = {};
+        if (index === this.applyTabIndexToItemAtIndex) {
+            attributes.tabindex = '0';
+        }
+
+        return (
+            <li
+                class={classNames}
+                role={this.config.type === 'menu' ? 'menuitem' : ''}
+                aria-disabled={item.disabled ? 'true' : 'false'}
+                aria-selected={item.selected ? 'true' : 'false'}
+                data-index={index}
+                {...attributes}
+            >
+                {item.icon ? this.renderIcon(this.config, item) : null}
+                {this.renderText(item)}
+                {this.twoLines && this.avatarList ? this.renderDivider() : null}
+                {this.renderActionMenu(item.actions)}
+            </li>
+        );
+    };
+
+    /**
+     * Render the text of the list item
+     *
+     * @param {MenuListItem | MenuItem} item the list item
+     * @returns {HTMLElement | string} the text for the list item
+     */
+    private renderText = (item: MenuListItem | MenuItem) => {
+        if (this.isSimpleItem(item)) {
+            return (
+                <span class="mdc-deprecated-list-item__text">{item.text}</span>
+            );
+        }
+
+        return (
+            <div class="mdc-deprecated-list-item__text">
+                <div class="mdc-deprecated-list-item__primary-command-text">
+                    <div class="mdc-deprecated-list-item__primary-text">
+                        {item.text}
+                    </div>
+                    {this.renderCommandText(item)}
+                </div>
+                <div class="mdc-deprecated-list-item__secondary-text">
+                    {item.secondaryText}
+                </div>
+            </div>
+        );
+    };
+
+    private renderCommandText = (item: MenuListItem | MenuItem) => {
+        if (!('commandText' in item)) {
+            return;
+        }
+
+        return (
+            <div class="mdc-deprecated-list-item__command-text">
+                {item.commandText}
+            </div>
+        );
+    };
+
+    private isSimpleItem = (item: MenuListItem | MenuItem): boolean => {
+        if ('commandText' in item) {
+            return false;
+        }
+
+        if ('secondaryText' in item) {
+            return false;
+        }
+
+        return true;
+    };
+
+    /**
+     * Render an icon for a list item
+     *
+     * @param {MenuListRendererConfig} config the config object, passed on from the `renderMenuListItem` function
+     * @param {MenuListItem} item the list item
+     * @returns {HTMLElement} the icon element
+     */
+    private renderIcon = (
+        config: MenuListRendererConfig,
+        item: MenuListItem
+    ) => {
+        const style: any = {};
+        if (item.iconColor) {
+            if (config.badgeIcons) {
+                style['--icon-background-color'] = item.iconColor;
+            } else {
+                style.color = item.iconColor;
+            }
+        }
+
+        return (
+            <limel-icon
+                badge={config.badgeIcons}
+                class="mdc-deprecated-list-item__graphic"
+                name={item.icon}
+                style={style}
+                size={config.iconSize}
+            />
+        );
+    };
+
+    private renderDivider = () => {
+        const classes = {
+            'mdc-deprecated-list-divider': true,
+            'mdc-deprecated-list-divider--inset': true,
+        };
+        if (this.config.iconSize) {
+            classes[this.config.iconSize] = true;
+        }
+
+        return <hr class={classes} />;
+    };
+
+    private renderActionMenu = (
+        actions: Array<MenuListItem | ListSeparator>
+    ) => {
+        if (!actions || actions.length === 0) {
+            return;
+        }
+
+        return (
+            <limel-menu
+                class="mdc-deprecated-list-item__meta"
+                items={actions}
+                openDirection="left"
+            >
+                <limel-icon slot="trigger" name="menu_2" size="small" />
+            </limel-menu>
+        );
+    };
+
+    private renderVariantMenuListItem = (
+        config: MenuListRendererConfig,
+        item: MenuListItem,
+        index: number
+    ) => {
+        let itemTemplate;
+        if (config.type === 'radio') {
+            itemTemplate = (
+                <RadioButtonTemplate
+                    id={`c_${index}`}
+                    checked={item.selected}
+                    disabled={item.disabled}
+                />
+            );
+        } else if (config.type === 'checkbox') {
+            itemTemplate = (
+                <CheckboxTemplate
+                    id={`c_${index}`}
+                    checked={item.selected}
+                    disabled={item.disabled}
+                />
+            );
+        }
+
+        const classNames = {
+            'mdc-deprecated-list-item': true,
+            'mdc-deprecated-list-item--disabled': item.disabled,
+            'mdc-deprecated-list-item__text': !item.secondaryText,
+        };
+
+        const attributes: { tabindex?: string } = {};
+        if (index === this.applyTabIndexToItemAtIndex) {
+            attributes.tabindex = '0';
+        }
+
+        return (
+            <li
+                class={classNames}
+                role={config.type}
+                aria-checked={item.selected ? 'true' : 'false'}
+                aria-disabled={item.disabled ? 'true' : 'false'}
+                data-index={index}
+                {...attributes}
+            >
+                {this.renderVariantMenuListItemContent(
+                    config,
+                    item,
+                    itemTemplate
+                )}
+            </li>
+        );
+    };
+
+    private renderVariantMenuListItemContent = (
+        config: MenuListRendererConfig,
+        item: MenuListItem | MenuItem,
+        itemTemplate: any
+    ) => {
+        if (this.hasIcons) {
+            return [
+                item.icon ? this.renderIcon(config, item) : null,
+                this.renderText(item),
+                <div class="mdc-deprecated-list-item__meta">
+                    {itemTemplate}
+                </div>,
+            ];
+        }
+
+        return [
+            <div class="mdc-deprecated-list-item__graphic">{itemTemplate}</div>,
+            this.renderText(item),
+        ];
+    };
+}

--- a/src/components/menu-list/menu-list.e2e.ts
+++ b/src/components/menu-list/menu-list.e2e.ts
@@ -1,0 +1,280 @@
+import { MenuListItem, ListSeparator } from '@limetech/lime-elements';
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('limel-menu-list', () => {
+    let page;
+    let limelList;
+    let innerList;
+    beforeEach(async () => {
+        page = await newE2EPage({
+            html: '<limel-menu-list></limel-menu-list>',
+        });
+        limelList = await page.find('limel-menu-list');
+        innerList = await page.find('limel-menu-list>>>ul');
+    });
+
+    describe('without items', () => {
+        it('renders an empty listbox', () => {
+            expect(innerList).toHaveClass('mdc-deprecated-list');
+            expect(innerList).toEqualAttribute('role', 'listbox');
+            expect(innerList.children).toHaveLength(0);
+        });
+    });
+
+    describe('with an item', () => {
+        let items: Array<MenuListItem | ListSeparator>;
+        beforeEach(async () => {
+            items = [{ text: 'item 1' }];
+            await limelList.setProperty('items', items);
+            await page.waitForChanges();
+        });
+        it('renders the item', () => {
+            expect(innerList.children).toHaveLength(1);
+            expect(innerList.children[0]).toHaveClass(
+                'mdc-deprecated-list-item'
+            );
+        });
+        it('does not render a menu-item', () => {
+            expect(innerList.children[0]).not.toEqualAttribute(
+                'role',
+                'menuitem'
+            );
+        });
+        it('sets tabindex to 0', () => {
+            expect(innerList.children[0]).toEqualAttribute('tabindex', '0');
+        });
+        it('sets the aria-disabled to false', () => {
+            expect(innerList.children[0]).toEqualAttribute(
+                'aria-disabled',
+                'false'
+            );
+        });
+        it('displays the correct text', () => {
+            expect(innerList.children[0]).toEqualText('item 1');
+        });
+    });
+
+    describe('with a disabled item', () => {
+        let items: Array<MenuListItem | ListSeparator>;
+        beforeEach(async () => {
+            items = [{ text: 'item 1', disabled: true }];
+            await limelList.setProperty('items', items);
+            await page.waitForChanges();
+        });
+        it('renders the item', () => {
+            expect(innerList.children).toHaveLength(1);
+            expect(innerList.children[0]).toHaveClass(
+                'mdc-deprecated-list-item'
+            );
+        });
+        it('does not set tabindex', () => {
+            expect(innerList.children[0]).not.toHaveAttribute('tabindex');
+        });
+        it('sets the aria-disabled to true', () => {
+            expect(innerList.children[0]).toEqualAttribute(
+                'aria-disabled',
+                'true'
+            );
+        });
+        it('displays the correct text', () => {
+            expect(innerList.children[0]).toEqualText('item 1');
+        });
+    });
+
+    describe('with multiple items', () => {
+        let items: Array<MenuListItem | ListSeparator>;
+        beforeEach(async () => {
+            items = [
+                { text: 'item 1' },
+                { separator: true },
+                { text: 'item 3' },
+                {
+                    text: 'item 4',
+                    disabled: true,
+                },
+                { text: 'item 5' },
+            ];
+            await limelList.setProperty('items', items);
+            await page.waitForChanges();
+        });
+        it('renders the items', () => {
+            expect(innerList.children).toHaveLength(5);
+        });
+        it('can render separators', () => {
+            expect(innerList.children[1]).toHaveClass(
+                'mdc-deprecated-list-divider'
+            );
+            expect(innerList.children[1]).not.toHaveClass(
+                'mdc-deprecated-list-item'
+            );
+            expect(innerList.children[1]).toEqualAttribute('role', 'separator');
+        });
+        it('gives each item the correct index', () => {
+            expect(innerList.children[0]).toEqualAttribute('data-index', '0');
+            // The separator doesn't get a data-index attribute,
+            // but it *does* increment the index.
+            expect(innerList.children[2]).toEqualAttribute('data-index', '2');
+            expect(innerList.children[3]).toEqualAttribute('data-index', '3');
+            expect(innerList.children[4]).toEqualAttribute('data-index', '4');
+        });
+    });
+
+    describe('with at least one item with secondary text', () => {
+        let items: Array<MenuListItem | ListSeparator>;
+        beforeEach(async () => {
+            items = [
+                { text: 'item 1' },
+                { separator: true },
+                {
+                    text: 'item 3',
+                    secondaryText: 'some info',
+                },
+                {
+                    text: 'item 4',
+                    disabled: true,
+                },
+                { text: 'item 5' },
+            ];
+            await limelList.setProperty('items', items);
+            await page.waitForChanges();
+        });
+        it('renders a list with two-line items', () => {
+            expect(innerList).toHaveClass('mdc-deprecated-list--two-line');
+        });
+        it('renders items withOUT secondary text as single line', () => {
+            expect(innerList.children[0].children).toHaveLength(1);
+            expect(innerList.children[0]).toEqualText('item 1');
+        });
+        it('renders items WITH secondary text as two lines', () => {
+            expect(innerList.children[2].children).toHaveLength(1);
+            expect(innerList.children[2].children[0]).toHaveClass(
+                'mdc-deprecated-list-item__text'
+            );
+            expect(innerList.children[2].children[0].children).toHaveLength(2);
+            expect(innerList.children[2].children[0].children[0]).toEqualText(
+                'item 3'
+            );
+            expect(
+                innerList.children[2].children[0].children[0].children[0]
+            ).toHaveClass('mdc-deprecated-list-item__primary-text');
+            expect(innerList.children[2].children[0].children[1]).toEqualText(
+                'some info'
+            );
+            expect(innerList.children[2].children[0].children[1]).toHaveClass(
+                'mdc-deprecated-list-item__secondary-text'
+            );
+        });
+        it('can render separators', () => {
+            expect(innerList.children[1]).toHaveClass(
+                'mdc-deprecated-list-divider'
+            );
+            expect(innerList.children[1]).not.toHaveClass(
+                'mdc-deprecated-list-item'
+            );
+            expect(innerList.children[1]).toEqualAttribute('role', 'separator');
+        });
+        it('gives each item the correct index', () => {
+            expect(innerList.children[0]).toEqualAttribute('data-index', '0');
+            // The separator doesn't get a data-index attribute,
+            // but it *does* increment the index.
+            expect(innerList.children[2]).toEqualAttribute('data-index', '2');
+            expect(innerList.children[3]).toEqualAttribute('data-index', '3');
+            expect(innerList.children[4]).toEqualAttribute('data-index', '4');
+        });
+    });
+
+    describe('when the attribute `type`', () => {
+        describe('is not set', () => {
+            it('is not selectable', () => {
+                expect(innerList).not.toHaveClass('selectable');
+            });
+        });
+
+        describe('is set as `selectable`', () => {
+            let items;
+            beforeEach(async () => {
+                page = await newE2EPage({
+                    html: '<limel-menu-list type="selectable"></limel-menu-list>',
+                });
+                limelList = await page.find('limel-menu-list');
+                innerList = await page.find('limel-menu-list>>>ul');
+                items = [{ text: 'item 1' }];
+                await limelList.setProperty('items', items);
+                await page.waitForChanges();
+            });
+            it('is selectable', () => {
+                expect(innerList).toHaveClass('selectable');
+            });
+            it('has the value `selectable`', async () => {
+                const propValue = await limelList.getProperty('type');
+                expect(propValue).toBe('selectable');
+            });
+            describe('the `change` event', () => {
+                let spy;
+                beforeEach(async () => {
+                    spy = await page.spyOnEvent('change');
+                });
+                describe('when an item is selected', () => {
+                    let item;
+                    beforeEach(async () => {
+                        item = await innerList.find('li');
+                        await item.click();
+                        await page.waitForTimeout(20); // Give the event a chance to bubble.
+                    });
+                    it('is emitted', () => {
+                        expect(spy).toHaveReceivedEventTimes(1);
+                    });
+                    it('passes the selected item as the event details', () => {
+                        expect(spy).toHaveReceivedEventDetail({
+                            ...items[0],
+                            selected: true,
+                        });
+                    });
+                });
+            });
+        });
+        describe('is set as `menu`', () => {
+            let items;
+            beforeEach(async () => {
+                page = await newE2EPage({
+                    html: '<limel-menu-list type="menu"></limel-menu-list>',
+                });
+                limelList = await page.find('limel-menu-list');
+                innerList = await page.find('limel-menu-list>>>ul');
+                items = [{ text: 'item 1' }];
+                await limelList.setProperty('items', items);
+                await page.waitForChanges();
+            });
+            it('is selectable', () => {
+                expect(innerList).toHaveClass('selectable');
+            });
+            it('has the value `menu`', async () => {
+                const propValue = await limelList.getProperty('type');
+                expect(propValue).toBe('menu');
+            });
+            describe('the `change` event', () => {
+                let spy;
+                beforeEach(async () => {
+                    spy = await page.spyOnEvent('change');
+                });
+                describe('when an item is selected', () => {
+                    let item;
+                    beforeEach(async () => {
+                        item = await innerList.find('li');
+                        await item.click();
+                        await page.waitForTimeout(20); // Give the event a chance to bubble.
+                    });
+                    it('is emitted', () => {
+                        expect(spy).toHaveReceivedEventTimes(1);
+                    });
+                    it('passes the selected item as the event details but as not selected', () => {
+                        expect(spy).toHaveReceivedEventDetail({
+                            ...items[0],
+                            selected: false,
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -1,0 +1,244 @@
+@use '../../style/internal/z-index';
+@use '../../style/functions';
+@use '../../style/mixins';
+
+@use '../../style/internal/lime-theme';
+
+@use '@material/list';
+@use '@material/menu';
+@use '@material/ripple';
+
+$list-border-radius: 0.375rem; // 6px
+
+/**
+ * @prop --icon-background-color: Color to use for icon background when `badgeIcons=true`.
+ * @prop --icon-color: Color to use for icon. Defaults to grey when `badgeIcons=false`. Defaults to white when `badgeIcons=true`.
+ * @prop --list-grid-max-width: Maximum width of a list that has `has-grid-layout` class. Defaults to `100%`.
+ * @prop --list-grid-item-max-width: Maximum width of items in a list that has `has-grid-layout` class. Defaults to `10rem`.
+ * @prop --list-grid-item-min-width: Minimum width of items in a list that has `has-grid-layout` class. Defaults to `7.5rem`.
+ * @prop --list-grid-gap: Distance between items in a list that has `has-grid-layout` class. Defaults to `0.75rem`.
+ */
+
+:host {
+    display: block;
+}
+
+:host([hidden]) {
+    display: none;
+}
+
+@include list.deprecated-core-styles;
+
+.mdc-menu {
+    max-height: 70vh; // force tall menus render inside the viewport when menu is at the bottom of the screen
+}
+
+.mdc-deprecated-list {
+    --mdc-theme-text-icon-on-background: var(
+        --icon-color,
+        rgb(var(--contrast-900))
+    );
+    padding: 0;
+    border-radius: $list-border-radius;
+
+    .mdc-deprecated-list-item {
+        z-index: z-index.$list-mdc-list-item; // in Chrome on Windows, menus flicker when they have a scroll bar and user hovers on them. We may be able to remove this in future versions of Chrome. Kia 2021-May-12
+
+        &.mdc-deprecated-list-item--disabled {
+            cursor: not-allowed;
+
+            limel-icon {
+                opacity: 0.38; // similar to `mdc-deprecated-list-item__text` when disabled
+            }
+        }
+
+        &:first-child {
+            border-top-left-radius: $list-border-radius;
+            border-top-right-radius: $list-border-radius;
+        }
+        &:last-child {
+            border-bottom-right-radius: $list-border-radius;
+            border-bottom-left-radius: $list-border-radius;
+        }
+    }
+
+    &.selectable
+        .mdc-deprecated-list-item:not(.mdc-deprecated-list-item--disabled) {
+        cursor: pointer;
+    }
+
+    .mdc-deprecated-list-item__meta {
+        // the action menu on the right side a list item
+        line-height: 100%;
+        margin-right: -0.5rem;
+    }
+
+    &.mdc-deprecated-list--avatar-list {
+        position: relative;
+
+        limel-icon.mdc-deprecated-list-item__graphic {
+            background-color: var(
+                --icon-background-color,
+                rgb(var(--contrast-900))
+            );
+            color: var(--icon-color, rgba(var(--color-white), 0.88));
+            margin-right: functions.pxToRem(12);
+            margin-left: functions.pxToRem(-4);
+        }
+
+        hr.mdc-deprecated-list-divider {
+            position: absolute;
+            bottom: 0;
+
+            &.mdc-deprecated-list-divider--inset {
+                --icon-width: #{functions.pxToRem(41)};
+                --icon-right-padding: #{functions.pxToRem(16)};
+                --list-right-padding: #{functions.pxToRem(16)};
+                margin-left: calc(
+                    var(--icon-width) + var(--icon-right-padding)
+                );
+                width: calc(
+                    100% - var(--icon-width) - var(--icon-right-padding) -
+                        var(--list-right-padding)
+                );
+
+                &.x-small {
+                    --icon-width: #{functions.pxToRem(23)};
+                }
+
+                &.small {
+                    --icon-width: #{functions.pxToRem(30)};
+                }
+
+                &.medium {
+                    --icon-width: #{functions.pxToRem(40)};
+                }
+
+                &.large {
+                    --icon-width: #{functions.pxToRem(46)};
+                }
+            }
+        }
+
+        .mdc-deprecated-list-item:last-child hr.mdc-deprecated-list-divider {
+            display: none;
+        }
+    }
+
+    .mdc-deprecated-list-item[role='menuitem'] {
+        font-size: functions.pxToRem(13);
+
+        .mdc-deprecated-list-item__graphic {
+            margin-right: functions.pxToRem(14);
+        }
+    }
+
+    &.mdc-deprecated-list--two-line {
+        .mdc-deprecated-list-item__text {
+            padding: functions.pxToRem(8) 0;
+        }
+        .mdc-deprecated-list-item__primary-text {
+            margin-bottom: functions.pxToRem(4);
+        }
+    }
+
+    .mdc-deprecated-list-item__secondary-text,
+    .mdc-deprecated-list-item__primary-text,
+    .mdc-deprecated-list-item__command-text {
+        margin: 0;
+        &:before,
+        &:after {
+            display: none;
+        }
+    }
+
+    .mdc-deprecated-list-item__command-text {
+        color: rgb(var(--contrast-800));
+        margin-left: 0.7rem;
+    }
+
+    .mdc-deprecated-list-item__text {
+        align-self: center;
+        width: 100%;
+    }
+
+    .mdc-deprecated-list-item__primary-command-text {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: baseline;
+    }
+
+    // Tweaks to display the icon correctly in Edge
+    limel-icon.mdc-deprecated-list-item__graphic {
+        display: block;
+    }
+}
+
+.mdc-deprecated-list:not(.mdc-deprecated-list--avatar-list) {
+    limel-icon.mdc-deprecated-list-item__graphic {
+        // Tweaks to make icon lists align nicely with badge-icon lists.
+        &[size='x-small'] {
+            margin-right: functions.pxToRem(4);
+        }
+        &[size='small'] {
+            margin-right: functions.pxToRem(8);
+        }
+        &[size='medium'] {
+            margin-right: functions.pxToRem(8);
+        }
+        &[size='large'] {
+            margin-right: functions.pxToRem(12);
+        }
+    }
+}
+
+.mdc-deprecated-list-item.mdc-ripple-upgraded {
+    @include ripple.surface;
+    @include ripple.radius-bounded;
+    @include ripple.states;
+}
+
+@keyframes fade-out-focus-style {
+    0% {
+        opacity: 0.12; // What Material Design sets
+    }
+    100% {
+        opacity: 0; // What we like it to become, a moment after it gets focused
+    }
+}
+
+:not(.mdc-deprecated-list--non-interactive) {
+    > {
+        :not(.mdc-deprecated-list-item--disabled).mdc-deprecated-list-item {
+            &.mdc-ripple-upgraded--background-focused::before,
+            &:not(.mdc-ripple-upgraded):focus::before {
+                animation: fade-out-focus-style 1s ease forwards;
+            }
+            &:focus-visible {
+                box-shadow: var(--shadow-depth-8-focused);
+                border-radius: $list-border-radius;
+                z-index: z-index.$list--has-interactive-items--mdc-list-item--hover;
+
+                &:before {
+                    animation-duration: 0s !important;
+                }
+            }
+
+            &:before {
+                transition: opacity, background-color;
+                transition-duration: 0.2s;
+                transition-timing-function: ease;
+            }
+        }
+    }
+}
+
+@import '../checkbox/checkbox.scss';
+
+@import './radio-button/radio-button.scss';
+
+@import './partial-styles/custom-styles.scss';
+@import './partial-styles/enable-multiline-text.scss';
+@import './partial-styles/_has-grid-layout.scss';
+@import './partial-styles/_static-actions.scss';

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -1,0 +1,314 @@
+import {
+    IconSize,
+    MenuListItem,
+    ListSeparator,
+    MenuListType,
+} from '@limetech/lime-elements';
+import { MDCList, MDCListActionEvent } from '@material/list';
+import { MDCMenu, MDCMenuItemEvent } from '@material/menu';
+import { MDCRipple } from '@material/ripple';
+import { strings as listStrings } from '@material/list/constants';
+import { strings as menuStrings } from '@material/menu/constants';
+import {
+    Component,
+    Element,
+    Event,
+    EventEmitter,
+    h,
+    Host,
+    Prop,
+    Watch,
+} from '@stencil/core';
+import { MenuListRenderer } from './menu-list-renderer';
+import { MenuListRendererConfig } from './menu-list-renderer-config';
+
+const { ACTION_EVENT } = listStrings;
+const { SELECTED_EVENT } = menuStrings;
+
+/**
+ * @private
+ */
+@Component({
+    tag: 'limel-menu-list',
+    shadow: true,
+    styleUrl: 'menu-list.scss',
+})
+export class MenuList {
+    /**
+     * List of items to display
+     */
+    @Prop()
+    public items: Array<MenuListItem | ListSeparator>;
+
+    /**
+     * Set to `true` if the list should display larger icons with a background
+     */
+    @Prop()
+    public badgeIcons: boolean;
+
+    /**
+     * Size of the icons in the list
+     */
+    @Prop()
+    public iconSize: IconSize = 'small';
+
+    /**
+     * The type of the list, omit to get a regular list. Available types are:
+     * `selectable`: regular list with single selection.
+     * `radio`: radio button list with single selection.
+     * `checkbox`: checkbox list with multiple selection.
+     * `menu`: menu list with single selection.
+     */
+    @Prop()
+    public type: MenuListType;
+
+    /**
+     * By default, lists will display 3 lines of text, and then truncate the rest.
+     * Consumers can increase or decrease this number by specifying
+     * `maxLinesSecondaryText`. If consumer enters zero or negative
+     * numbers we default to 1; and if they type decimals we round up.
+     */
+    // eslint-disable-next-line no-magic-numbers
+    @Prop() maxLinesSecondaryText: number = 3;
+
+    @Element()
+    private element: HTMLLimelMenuListElement;
+
+    private config: MenuListRendererConfig;
+    private MenuListRenderer = new MenuListRenderer();
+    private mdcList: MDCList;
+    private mdcMenu: MDCMenu;
+    private multiple: boolean;
+    private selectable: boolean;
+
+    /**
+     * Fired when a new value has been selected from the list. Only fired if selectable is set to true
+     */
+    @Event()
+    private change: EventEmitter<MenuListItem | MenuListItem[]>;
+
+    /**
+     * Fired when an action has been selected from the action menu of a list item
+     */
+    @Event()
+    protected select: EventEmitter<MenuListItem | MenuListItem[]>;
+
+    public connectedCallback() {
+        this.setup();
+    }
+
+    public disconnectedCallback() {
+        this.teardown();
+    }
+
+    public componentDidLoad() {
+        this.setup();
+    }
+
+    public render() {
+        this.config = {
+            badgeIcons: this.badgeIcons,
+            type: this.type,
+            iconSize: this.iconSize,
+        };
+        let maxLinesSecondaryText = +this.maxLinesSecondaryText?.toFixed();
+        if (this.maxLinesSecondaryText < 1) {
+            maxLinesSecondaryText = 1;
+        }
+
+        const html = this.MenuListRenderer.render(this.items, this.config);
+
+        if (this.type === 'menu') {
+            return <div class="mdc-menu mdc-menu-surface">{html}</div>;
+        }
+
+        return (
+            <Host
+                style={{
+                    '--maxLinesSecondaryText': `${maxLinesSecondaryText}`,
+                }}
+            >
+                {html}
+            </Host>
+        );
+    }
+
+    @Watch('type')
+    protected handleType() {
+        this.setupListeners();
+    }
+
+    @Watch('items')
+    protected itemsChanged() {
+        if (!this.mdcList) {
+            return;
+        }
+
+        const MenuListItems = this.items.filter(this.isMenuListItem);
+
+        if (!this.multiple) {
+            this.mdcList.selectedIndex = MenuListItems.findIndex(
+                (item: MenuListItem) => item.selected
+            );
+
+            return;
+        }
+
+        this.mdcList.selectedIndex = MenuListItems.filter(
+            (item: MenuListItem) => item.selected
+        ).map((item: MenuListItem) => MenuListItems.indexOf(item));
+    }
+
+    private setup = () => {
+        if (this.type === 'menu') {
+            this.setupMenu();
+        } else {
+            this.setupList();
+        }
+
+        this.setupListeners();
+    };
+
+    private setupList = () => {
+        const element = this.element.shadowRoot.querySelector(
+            '.mdc-deprecated-list'
+        );
+        if (!element) {
+            return;
+        }
+
+        this.mdcList = new MDCList(element);
+        this.mdcList.listElements.forEach((item) => new MDCRipple(item));
+    };
+
+    private setupMenu = () => {
+        const element = this.element.shadowRoot.querySelector('.mdc-menu');
+        if (!element) {
+            return;
+        }
+
+        this.mdcMenu = new MDCMenu(element);
+        this.mdcMenu.hasTypeahead = true;
+        this.mdcMenu.wrapFocus = true;
+        this.mdcMenu.items.forEach((item) => new MDCRipple(item));
+    };
+
+    private setupListeners = () => {
+        if (this.type === 'menu') {
+            this.setupMenuListeners();
+        } else {
+            this.setupListListeners();
+        }
+    };
+
+    private setupListListeners = () => {
+        if (!this.mdcList) {
+            return;
+        }
+
+        this.mdcList.unlisten(ACTION_EVENT, this.handleAction);
+
+        this.selectable = ['selectable', 'radio', 'checkbox', 'menu'].includes(
+            this.type
+        );
+        this.multiple = this.type === 'checkbox';
+
+        if (!this.selectable) {
+            return;
+        }
+
+        this.mdcList.listen(ACTION_EVENT, this.handleAction);
+        this.mdcList.singleSelection = !this.multiple;
+    };
+
+    private setupMenuListeners = () => {
+        if (!this.mdcMenu) {
+            return;
+        }
+
+        this.mdcMenu.unlisten(SELECTED_EVENT, this.handleMenuSelect);
+        this.selectable = true;
+        this.mdcMenu.listen(SELECTED_EVENT, this.handleMenuSelect);
+    };
+
+    private teardown = () => {
+        this.mdcList?.unlisten(ACTION_EVENT, this.handleAction);
+        this.mdcList?.destroy();
+
+        this.mdcMenu?.unlisten(SELECTED_EVENT, this.handleMenuSelect);
+        this.mdcMenu?.destroy();
+    };
+
+    private handleAction = (event: MDCListActionEvent) => {
+        if (!this.multiple) {
+            this.handleSingleSelect(event.detail.index);
+
+            return;
+        }
+
+        this.handleMultiSelect(event.detail.index);
+    };
+
+    private handleMenuSelect = (event: MDCMenuItemEvent) => {
+        this.handleSingleSelect(event.detail.index);
+    };
+
+    private handleSingleSelect = (index: number) => {
+        const MenuListItems = this.items.filter(
+            this.isMenuListItem
+        ) as MenuListItem[];
+        if (MenuListItems[index].disabled) {
+            return;
+        }
+
+        const selectedItem: MenuListItem = MenuListItems.find(
+            (item: MenuListItem) => {
+                return !!item.selected;
+            }
+        );
+
+        if (selectedItem) {
+            this.change.emit({ ...selectedItem, selected: false });
+        }
+
+        if (MenuListItems[index] !== selectedItem) {
+            if (this.type === 'menu') {
+                this.change.emit({ ...MenuListItems[index], selected: false });
+
+                return;
+            }
+
+            this.change.emit({ ...MenuListItems[index], selected: true });
+        }
+    };
+
+    private handleMultiSelect = (index: number) => {
+        const MenuListItems = this.items.filter(
+            this.isMenuListItem
+        ) as MenuListItem[];
+        if (MenuListItems[index].disabled) {
+            return;
+        }
+
+        const selectedItems: MenuListItem[] = MenuListItems.filter(
+            (item: MenuListItem, listIndex: number) => {
+                if (listIndex === index) {
+                    // This is the item that was selected or deselected,
+                    // so we negate its previous selection status.
+                    return !item.selected;
+                }
+
+                // This is an item that didn't change, so we keep its selection status.
+                return item.selected;
+            }
+        ).map((item: MenuListItem) => {
+            return { ...item, selected: true };
+        });
+
+        this.change.emit(selectedItems);
+    };
+
+    private isMenuListItem = (item: MenuListItem): boolean => {
+        return !('separator' in item);
+    };
+}

--- a/src/components/menu-list/menu-list.types.ts
+++ b/src/components/menu-list/menu-list.types.ts
@@ -1,0 +1,7 @@
+/**
+ * The type of the list, omit to get a regular list. Available types are:
+ * `selectable`: regular list with single selection.
+ * `radio`: radio button list with single selection.
+ * `checkbox`: checkbox list with multiple selection.
+ */
+export type MenuListType = 'selectable' | 'radio' | 'checkbox' | 'menu';

--- a/src/components/menu-list/partial-styles/_has-grid-layout.scss
+++ b/src/components/menu-list/partial-styles/_has-grid-layout.scss
@@ -1,0 +1,34 @@
+:host(.has-grid-layout) {
+    --gap: var(--list-grid-gap, 0.75rem);
+    padding: var(--gap);
+
+    // Prettier's linting doesn't like the `grid-template-columns` below
+    /* prettier-ignore */
+    .mdc-deprecated-list {
+        display: grid;
+        grid-gap: var(--gap);
+        grid-template-columns: repeat(
+            auto-fit,
+            minmax(
+                min(100%, max(calc(var(--list-grid-item-max-width, 10rem) - var(--gap)), var(--list-grid-item-min-width, 7.5rem))), 1fr)
+            );
+        max-width: var(--list-grid-max-width, 100%);
+
+    }
+
+    .mdc-deprecated-list-divider {
+        grid-column: 1/-1; // makes the divider span through all columns
+    }
+
+    .mdc-deprecated-list-item {
+        border-radius: functions.pxToRem(4);
+        background-color: rgb(var(--contrast-100));
+    }
+
+    .mdc-deprecated-list--avatar-list {
+        limel-icon {
+            margin-right: functions.pxToRem(4);
+            margin-left: functions.pxToRem(-8);
+        }
+    }
+}

--- a/src/components/menu-list/partial-styles/_static-actions.scss
+++ b/src/components/menu-list/partial-styles/_static-actions.scss
@@ -1,0 +1,32 @@
+// This is used in limel-picker only for now
+
+:host(.static-actions-list) {
+    z-index: z-index.$list-static-actions-list;
+    background-color: var(--mdc-theme-surface);
+}
+
+:host(.has-position-sticky) {
+    position: sticky;
+    box-shadow: 0 0 functions.pxToRem(12) functions.pxToRem(8)
+        var(--mdc-theme-surface);
+}
+
+:host(.has-position-sticky.is-on-top) {
+    top: 0;
+}
+
+:host(.has-position-sticky.is-at-bottom) {
+    bottom: 0;
+}
+
+:host(.is-on-top) {
+    border-bottom: 1px solid rgb(var(--contrast-400));
+    margin-bottom: functions.pxToRem(8);
+    padding-bottom: functions.pxToRem(4);
+}
+
+:host(.is-at-bottom) {
+    border-top: 1px solid rgb(var(--contrast-400));
+    margin-top: functions.pxToRem(8);
+    padding-top: functions.pxToRem(4);
+}

--- a/src/components/menu-list/partial-styles/custom-styles.scss
+++ b/src/components/menu-list/partial-styles/custom-styles.scss
@@ -1,0 +1,38 @@
+@use '../../../style/internal/z-index';
+@use '../../../style/mixins';
+
+$background-color-of-odd-interactive-items: rgb(var(--contrast-100));
+$background-color-of-even-interactive-items: rgb(var(--contrast-200));
+$background-color-of-interactive-items-hovered: rgb(var(--contrast-100));
+
+:host(.has-striped-rows) {
+    .mdc-deprecated-list {
+        border: 1px solid rgb(var(--contrast-400));
+    }
+
+    .mdc-deprecated-list-item {
+        &:nth-child(even) {
+            background-color: $background-color-of-even-interactive-items;
+        }
+        &:nth-child(odd) {
+            background-color: $background-color-of-odd-interactive-items;
+        }
+    }
+}
+
+:host(.has-interactive-items) {
+    .mdc-deprecated-list-item {
+        &:not(.mdc-deprecated-list-item--disabled) {
+            @include mixins.is-flat-clickable();
+
+            &:hover {
+                z-index: z-index.$list--has-interactive-items--mdc-list-item--hover;
+                background-color: $background-color-of-interactive-items-hovered;
+
+                &:before {
+                    background-color: $background-color-of-interactive-items-hovered;
+                }
+            }
+        }
+    }
+}

--- a/src/components/menu-list/partial-styles/enable-multiline-text.scss
+++ b/src/components/menu-list/partial-styles/enable-multiline-text.scss
@@ -1,0 +1,20 @@
+// We want to display all texts in multiple lines, which means overriding MDC's
+// default styles first. MDC offers possibility to have max three-line lists.
+// But MDC Web does not currently support three-line lists.
+
+:host {
+    --line-height-of-secondary-text: 1.2rem;
+}
+
+.mdc-deprecated-list-item {
+    height: auto !important; // `!important` because MD adds different fixed `height`s to different lists, such as `mdc-list--two-line` or `mdc-list--avatar-list` and we don't want to overwride them all separately
+    min-height: 3rem; // in MD, `3rem` is the default `height`.
+
+    .mdc-deprecated-list-item__secondary-text {
+        line-height: var(--line-height-of-secondary-text);
+        white-space: normal;
+        display: -webkit-box;
+        -webkit-line-clamp: var(--maxLinesSecondaryText);
+        -webkit-box-orient: vertical;
+    }
+}

--- a/src/components/menu-list/radio-button/radio-button.scss
+++ b/src/components/menu-list/radio-button/radio-button.scss
@@ -1,0 +1,12 @@
+@use '@material/form-field';
+@use '@material/radio';
+
+@include form-field.core-styles;
+
+.mdc-form-field {
+    display: flex;
+
+    .mdc-radio {
+        @include radio.ink-color(primary);
+    }
+}

--- a/src/components/menu-list/radio-button/radio-button.template.tsx
+++ b/src/components/menu-list/radio-button/radio-button.template.tsx
@@ -1,0 +1,42 @@
+import { FunctionalComponent, h } from '@stencil/core';
+
+interface RadioButtonTemplateProps {
+    disabled?: boolean;
+    id: string;
+    checked?: boolean;
+    onChange?: (event: Event) => void;
+    label?: string;
+}
+
+export const RadioButtonTemplate: FunctionalComponent<RadioButtonTemplateProps> =
+    (props) => {
+        return (
+            <div class="mdc-form-field">
+                <div
+                    class={`
+                        mdc-radio
+                        ${props.disabled ? 'mdc-radio--disabled' : ''}
+                    `}
+                >
+                    <input
+                        class="mdc-radio__native-control"
+                        type="radio"
+                        id={props.id}
+                        checked={props.checked}
+                        disabled={props.disabled}
+                        onChange={props.onChange}
+                    />
+                    <div class="mdc-radio__background">
+                        <div class="mdc-radio__outer-circle" />
+                        <div class="mdc-radio__inner-circle" />
+                    </div>
+                </div>
+                <label
+                    class={`${props.disabled ? 'disabled' : ''}`}
+                    htmlFor={props.id}
+                >
+                    {props.label}
+                </label>
+            </div>
+        );
+    };

--- a/src/components/menu/menu.e2e.ts
+++ b/src/components/menu/menu.e2e.ts
@@ -1,10 +1,10 @@
-import { ListItem, ListSeparator } from '@limetech/lime-elements';
+import { MenuListItem, ListSeparator } from '@limetech/lime-elements';
 import { newE2EPage, E2EPage, E2EElement } from '@stencil/core/testing';
 
 describe('limel-menu', () => {
     let page: E2EPage;
     let limelMenu: HTMLLimelMenuElement & E2EElement;
-    let items: Array<ListItem | ListSeparator>;
+    let items: Array<MenuListItem | ListSeparator>;
     beforeEach(async () => {
         page = await newE2EPage({
             html: `
@@ -121,7 +121,7 @@ describe('limel-menu', () => {
         describe('when selected', () => {
             let list;
             beforeEach(async () => {
-                list = await page.find('limel-list');
+                list = await page.find('limel-menu-list');
                 await list.click();
                 await page.waitForChanges();
             });

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -1,4 +1,4 @@
-import { ListItem, ListSeparator } from '@limetech/lime-elements';
+import { MenuListItem, ListSeparator } from '@limetech/lime-elements';
 import {
     Component,
     Event,
@@ -94,12 +94,12 @@ export class Menu {
      * Is emitted when a menu item is selected.
      */
     @Event()
-    private select: EventEmitter<ListItem | ListItem[]>;
+    private select: EventEmitter<MenuListItem | MenuListItem[]>;
 
     @Element()
     private host: HTMLLimelMenuElement;
 
-    private list: HTMLLimelListElement;
+    private list: HTMLLimelMenuListElement;
 
     private portalId: string;
 
@@ -156,7 +156,7 @@ export class Menu {
                         onDismiss={this.onClose}
                         style={cssProperties}
                     >
-                        <limel-list
+                        <limel-menu-list
                             class={{
                                 'has-grid-layout has-interactive-items':
                                     this.gridLayout,
@@ -224,7 +224,7 @@ export class Menu {
     };
 
     private onListChange = (event) => {
-        this.items = this.items.map((item: ListItem) => {
+        this.items = this.items.map((item: MenuListItem) => {
             if (item === event.detail) {
                 return event.detail;
             }
@@ -268,7 +268,7 @@ export class Menu {
         return zipObject(propertyNames, values);
     }
 
-    private setListElement = (element: HTMLLimelListElement) => {
+    private setListElement = (element: HTMLLimelMenuListElement) => {
         this.list = element;
     };
 
@@ -276,9 +276,9 @@ export class Menu {
         const activeElement = this.list.shadowRoot.activeElement as HTMLElement;
         activeElement?.blur();
 
-        const listItems = this.items.filter(this.isListItem);
+        const MenuListItems = this.items.filter(this.isMenuListItem);
         const selectedIndex = Math.max(
-            listItems.findIndex((item) => item.selected),
+            MenuListItems.findIndex((item) => item.selected),
             0
         );
         const menuElements: HTMLElement[] = Array.from(
@@ -287,7 +287,9 @@ export class Menu {
         menuElements[selectedIndex]?.focus();
     };
 
-    private isListItem(item: ListItem | ListSeparator): item is ListItem {
+    private isMenuListItem(
+        item: MenuListItem | ListSeparator
+    ): item is MenuListItem {
         return !('separator' in item);
     }
 }

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,8 +1,8 @@
-import { ListItem } from '../list/list-item.types';
+import { MenuListItem } from '../menu-list/menu-list-item.types';
 
 export type OpenDirection = 'left' | 'right';
 
-export interface MenuItem<T = any> extends ListItem<T> {
+export interface MenuItem<T = any> extends MenuListItem<T> {
     /**
      * The additional supporting text is used for shortcut commands and displayed in the list item.
      */

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -12,6 +12,8 @@ export * from './components/input-field/input-field.types';
 export * from './components/list/list-item.types';
 export * from './components/list/list.types';
 export * from './components/menu/menu.types';
+export * from './components/menu-list/menu-list-item.types';
+export * from './components/menu-list/menu-list.types';
 export * from './components/picker/searcher.types';
 export * from './components/progress-flow/progress-flow.types';
 export * from './components/select/option.types';


### PR DESCRIPTION
**EDIT:** _To clarify, the idea here is to initially make the smallest possible change that completely separates limel-menu from limel-list, so that no future changes made to limel-menu will cause changes to limel-list. This means a lot of duplicated code in this PR, and a lot of dead code too. That will be cleaned up in successive PRs._

This is the first step (step 2 is here: #1417) that will allow us to remove all menu-specific code from limel-list, and all code not necessary for use with limel-menu from limel-menu-list.

Later, it might be possible to make limel-menu-list part of the limel-menu component, but that's an issue for a later step.

To make the changes easier to follow, I've split the change into several steps:
1. The first commit only duplicates the whole folder `src/components/list` into `src/components/menu-list` (except for the examples, which won't be used), and renames the files, prefixing each of them with `menu-`.
2. The second commit changes the names of the components, interfaces, etc.
3. This commit is just changes the linter made because of differences in line lengths caused by step 2.
4. Made the docs page for the new component private.

I've marked commit 2 and 3 as fixups, because I think we really only need this split for the review. But if someone thinks it would be useful to keep the commits separate in the permanent history, that's ok with me too 🙂

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
