### PR TITLE
fix: scrollbar showing in progress flow component

### DIFF
--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
@@ -133,7 +133,7 @@
     z-index: z-index.$limel-progress-flow-divider;
     right: 0;
     transform: translateX(50%);
-    overflow-y: hidden;
+    overflow: hidden;
 
     &:after {
         position: absolute;


### PR DESCRIPTION
The -y causes a scrollbar to appear under certain circumstances related to size of the window and length of the string in the "button".

![image](https://user-images.githubusercontent.com/37209464/140272320-9eb19515-530a-45c2-82f3-aa0ac9c7ca18.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
