### PR TITLE
fix(menu): remove export of deleted interface

### DIFF
--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -12,7 +12,6 @@ export * from './components/input-field/input-field.types';
 export * from './components/list/list-item.types';
 export * from './components/list/list.types';
 export * from './components/menu/menu.types';
-export * from './components/menu-list/menu-list-item.types';
 export * from './components/menu-list/menu-list.types';
 export * from './components/picker/searcher.types';
 export * from './components/progress-flow/progress-flow.types';


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
