### PR TITLE
chore: fix weird imports in examples

### DIFF
--- a/src/components/button-group/examples/button-group-composite.tsx
+++ b/src/components/button-group/examples/button-group-composite.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, State } from '@stencil/core';
-import { Button } from 'src/components/button/button.types';
+import { Button } from '../../button/button.types';
 
 /**
  * Composite

--- a/src/components/chip-set/examples/chip-set-composite.tsx
+++ b/src/components/chip-set/examples/chip-set-composite.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, State } from '@stencil/core';
-import { Languages } from 'src/components/date-picker/date.types';
+import { Languages } from '../../date-picker/date.types';
 import { Chip } from '../chip.types';
 
 /**

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, EventEmitter, Event } from '@stencil/core';
 import { FormComponent } from '@limetech/lime-elements';
-import { ListItem } from 'src/components/list/list-item.types';
+import { ListItem } from '../../list/list-item.types';
 
 @Component({
     tag: 'limel-example-custom-picker',

--- a/src/components/form/examples/props-factory-picker.tsx
+++ b/src/components/form/examples/props-factory-picker.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, EventEmitter, Event } from '@stencil/core';
 import { FormComponent } from '@limetech/lime-elements';
-import { ListItem } from 'src/components/list/list-item.types';
+import { ListItem } from '../../list/list-item.types';
 
 @Component({
     tag: 'limel-example-props-factory-picker',

--- a/src/components/table/examples/header-menu.tsx
+++ b/src/components/table/examples/header-menu.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
-import { ListItem } from 'src/components/list/list-item.types';
+import { ListItem } from '../../list/list-item.types';
 
 @Component({
     tag: 'limel-example-header-menu',


### PR DESCRIPTION
There were some imports with weird paths, and they caused the build in
`lime-webclient/frontend/admin/` to fail when you had linked a local dev-build.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
