### PR TITLE
chore(file-viewer): add new component

### DIFF
--- a/src/components/file-viewer/examples/file-viewer-custom-actions.tsx
+++ b/src/components/file-viewer/examples/file-viewer-custom-actions.tsx
@@ -1,0 +1,42 @@
+import { Component, h } from '@stencil/core';
+import { ListItem } from '@limetech/lime-elements';
+
+/**
+ * Adding custom actions
+ */
+@Component({
+    tag: 'limel-example-file-viewer-custom-actions',
+    shadow: true,
+})
+export class FileViewerCustomActionsExample {
+    public render() {
+        return (
+            <limel-file-viewer
+                url="https://filesamples.com/samples/document/docx/sample1.docx"
+                actions={this.actions}
+                onAction={this.handleAction}
+            />
+        );
+    }
+
+    private actions: ListItem[] = [
+        {
+            text: 'Show Alert',
+            icon: 'google_alerts_copyrighted',
+            value: 'action',
+        },
+        { text: 'Edit', icon: 'edit' },
+        { text: 'Download as PDF', icon: 'PDF_2' },
+        { text: 'Send for signing', icon: 'sign_up' },
+    ];
+
+    private handleAction = (event: CustomEvent<ListItem>) => {
+        if (event.detail.value === 'action') {
+            return this.showAlert();
+        }
+    };
+
+    private showAlert() {
+        alert('Hello! I am an alert box 😊');
+    }
+}

--- a/src/components/file-viewer/examples/file-viewer-filename.tsx
+++ b/src/components/file-viewer/examples/file-viewer-filename.tsx
@@ -1,0 +1,35 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Using the `filename` prop
+ * The component looks at the URL of the provided file, and based on how the
+ * URL ends, it can detect the extension and consequently choose the right way
+ * of rendering it in the browser.
+ *
+ * However, sometimes the URLs do not have the filename in them. In this case,
+ * it is vital to specify the filename, for the component to be able to render it.
+ *
+ * :::important
+ * Make sure the provided filename contains the correct extension!
+ * :::
+ *
+ * :::tip
+ * The filename that is specified will also be the filename that is used when the
+ * file is downloaded by clicking the download button on the File Viewer.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-file-viewer-filename',
+    shadow: true,
+})
+export class FileViewerFilenameExample {
+    public render() {
+        return (
+            <limel-file-viewer
+                url="https://avatars.githubusercontent.com/u/2682464?s=200&v=4"
+                alt="Lime's avatar on Github"
+                filename="lime-logo.png"
+            />
+        );
+    }
+}

--- a/src/components/file-viewer/examples/file-viewer-inbuilt-actions.tsx
+++ b/src/components/file-viewer/examples/file-viewer-inbuilt-actions.tsx
@@ -1,0 +1,44 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Using inbuilt actions
+ *
+ * The component offers a few inbuilt actions that enable users
+ * to download the file, open it in a new tab, or view it in fullscreen mode.
+ *
+ * :::note
+ * These action buttons do not get rendered for the office files,
+ * because the 3rd-party office viewers already offer the same features
+ * in their UI.
+ * :::
+ *
+ * :::important
+ * The download button will not work here in this example,
+ * due to the security policies of the web browsers.
+ * This is because the example files are not hosted in the same domain.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-file-viewer-inbuilt-actions',
+    shadow: true,
+    styleUrl: 'limel-example-file-viewer-inbuilt-actions.scss',
+})
+export class FileViewerInbuiltActionsExample {
+    public render() {
+        return [
+            <limel-file-viewer
+                url="https://www.lime-technologies.se/wp-content/uploads/2021/02/SummerParty-8-scaled.jpg"
+                allowFullscreen={true}
+                allowOpenInNewTab={true}
+                allowDownload={true}
+            />,
+            <limel-file-viewer
+                class="hosted-on-the-same-domain"
+                url="https://lundalogik.github.io/lime-elements/versions/next/favicon.svg"
+                allowFullscreen={true}
+                allowOpenInNewTab={true}
+                allowDownload={true}
+            />,
+        ];
+    }
+}

--- a/src/components/file-viewer/examples/file-viewer-office.tsx
+++ b/src/components/file-viewer/examples/file-viewer-office.tsx
@@ -1,0 +1,143 @@
+import { Component, State, h } from '@stencil/core';
+import { Option, LimelSelectCustomEvent } from '@limetech/lime-elements';
+import { OfficeViewer } from '../file-viewer.types';
+
+/**
+ * Office files
+ *
+ * There are many different software programs that can be used to create
+ * office files such as word processing documents, spreadsheets, and presentations.
+ * Web browsers do not natively support these formats for direct display.
+ *
+ * However, using the file-viewer component, you can easily display the content
+ * of office file types. The viewer relies on a few third-party technologies
+ * to render the file.
+ *
+ * By default, the component uses Microsoft Office Viewer, since it supports
+ * a wider range of file office formats. However, you can
+ * choose other viewers which are supported by this component.
+ *
+ * :::important
+ * 1. The file should be stored somewhere with a publicly accessible URL,
+ * otherwise the viewer cannot render them.
+ * 1. Once the file is viewed, it might get cached for a short while on the
+ * 3rd party servers –therefor remain publicly visible–,
+ * even if the original file deleted.
+ * 1. Files that are too large may not be rendered at all.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-file-viewer-office',
+    shadow: true,
+    styleUrl: 'file-viewer.scss',
+})
+export class FileViewerOfficeExample {
+    @State()
+    private selectedOfficeViewer: Option<OfficeViewer>;
+
+    private availableOfficeViewers: Array<Option<OfficeViewer>>;
+
+    private microsoftDocuments = [
+        {
+            title: 'Microsoft Word',
+            extension: '.docx',
+            url: 'https://filesamples.com/samples/document/docx/sample1.docx',
+        },
+        {
+            title: 'Microsoft PowerPoint',
+            extension: '.ppt',
+            url: 'https://filesamples.com/samples/document/ppt/sample1.ppt',
+        },
+        {
+            title: 'Microsoft Excel',
+            extension: '.xlsx',
+            url: 'https://filesamples.com/samples/document/xlsx/sample1.xlsx',
+        },
+    ];
+
+    private openDocuments = [
+        {
+            title: 'Text',
+            extension: '.odt',
+            url: 'https://filesamples.com/samples/document/odt/sample1.odt',
+        },
+        {
+            title: 'Spreadsheet',
+            extension: '.ods',
+            url: 'https://filesamples.com/samples/document/ods/sample1.ods',
+        },
+        {
+            title: 'Presentation',
+            extension: '.odp',
+            url: 'https://filesamples.com/samples/document/odp/sample1.odp',
+        },
+    ];
+
+    constructor() {
+        const officeViewers: OfficeViewer[] = [
+            'microsoft-office',
+            'google-drive',
+        ];
+        this.availableOfficeViewers = officeViewers.map((value) => {
+            return {
+                text: value as string,
+                value: value,
+            } as Option<OfficeViewer>;
+        });
+        this.selectedOfficeViewer = this.availableOfficeViewers.find(
+            (v) => v.value === 'microsoft-office'
+        );
+    }
+
+    public render() {
+        return [
+            <section>
+                <h1>Office files</h1>
+                <limel-select
+                    class="is-narrow"
+                    label="officeViewer"
+                    options={this.availableOfficeViewers}
+                    value={this.selectedOfficeViewer}
+                    onChange={this.handleNewSelection}
+                />
+            </section>,
+
+            <h2>Microsoft Office formats</h2>,
+            this.microsoftDocuments.map(this.renderMicrosoftDocuments),
+            <h2>OpenDocument formats</h2>,
+            this.openDocuments.map(this.renderOpenDocuments),
+        ];
+    }
+
+    private renderMicrosoftDocuments = (document: any) => {
+        return [
+            <h3>
+                {document.title}
+                <code>{document.extension}</code>
+            </h3>,
+            <limel-file-viewer
+                url={document.url}
+                officeViewer={this.selectedOfficeViewer?.value}
+            />,
+        ];
+    };
+
+    private renderOpenDocuments = (document: any) => {
+        return [
+            <h3>
+                {document.title}
+                <code>{document.extension}</code>
+            </h3>,
+            <limel-file-viewer
+                url={document.url}
+                officeViewer={this.selectedOfficeViewer?.value}
+            />,
+        ];
+    };
+
+    private handleNewSelection = (
+        event: LimelSelectCustomEvent<Option<OfficeViewer>>
+    ) => {
+        this.selectedOfficeViewer = event.detail;
+    };
+}

--- a/src/components/file-viewer/examples/file-viewer-with-picker.scss
+++ b/src/components/file-viewer/examples/file-viewer-with-picker.scss
@@ -1,0 +1,7 @@
+.view-here {
+    margin-top: 1.25rem;
+    padding: 0.75rem;
+    height: 40rem;
+
+    box-shadow: var(--shadow-depth-16);
+}

--- a/src/components/file-viewer/examples/file-viewer-with-picker.tsx
+++ b/src/components/file-viewer/examples/file-viewer-with-picker.tsx
@@ -1,0 +1,59 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * See an instant preview
+ * Select a file from your local machine using the file picker below,
+ * and `limel-file-viewer` component will display the file, if the format
+ * is supported.
+ */
+@Component({
+    tag: 'limel-example-file-viewer-with-picker',
+    shadow: true,
+    styleUrl: 'file-viewer-with-picker.scss',
+})
+export class FileViewerWithPickerExample {
+    @State()
+    private value: FileInfo;
+
+    @State()
+    private dataUrl: string = '';
+
+    public render() {
+        return [
+            <limel-file
+                label="Choose a file…"
+                onChange={this.handleChange}
+                value={this.value}
+            />,
+            <p>and view it below ↓</p>,
+            <div class="view-here">{this.renderFileViewer()}</div>,
+        ];
+    }
+
+    private renderFileViewer() {
+        if (!this.dataUrl) {
+            return;
+        }
+
+        return (
+            <limel-file-viewer
+                url={this.dataUrl}
+                filename={this.value?.filename}
+            />
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.value = event.detail;
+
+        if (!this.value?.fileContent) {
+            this.dataUrl = '';
+
+            return;
+        }
+
+        URL.revokeObjectURL(this.dataUrl);
+        this.dataUrl = URL.createObjectURL(this.value.fileContent);
+    };
+}

--- a/src/components/file-viewer/examples/file-viewer.scss
+++ b/src/components/file-viewer/examples/file-viewer.scss
@@ -1,0 +1,14 @@
+section {
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    align-items: center;
+
+    > * {
+        margin: 0;
+    }
+}
+
+limel-file-viewer {
+    margin: 0 0 4rem 0;
+}

--- a/src/components/file-viewer/examples/file-viewer.tsx
+++ b/src/components/file-viewer/examples/file-viewer.tsx
@@ -1,0 +1,58 @@
+import { Component, h } from '@stencil/core';
+/**
+ * Most common file types
+ *
+ * These are file formats that any web browser can display,
+ * without relying on any third-party plugins or additional
+ * plugins or extensions.
+ */
+@Component({
+    tag: 'limel-example-file-viewer',
+    shadow: true,
+    styleUrl: 'file-viewer.scss',
+})
+export class FileViewerExample {
+    private fileViewers = [
+        {
+            title: 'Image',
+            url: 'https://www.lime-technologies.se/wp-content/uploads/2021/02/SummerParty-8-scaled.jpg',
+            alt: 'Some of the people working at Lime Technologies',
+        },
+        {
+            title: 'Vector graphic',
+            url: 'https://lundalogik.github.io/lime-elements/versions/next/favicon.svg',
+            alt: 'Logo of Lime Elements',
+        },
+        {
+            title: 'PDF',
+            url: 'https://investors.lime-technologies.com/wp-content/uploads/2023/04/Sustainability-report-2022.pdf',
+        },
+        {
+            title: 'Text',
+            url: 'https://filesamples.com/samples/document/txt/sample1.txt',
+        },
+        {
+            title: 'Audio',
+            url: 'https://filesamples.com/samples/audio/wav/sample1.wav',
+        },
+        {
+            title: 'Video',
+            url: 'https://filesamples.com/samples/video/mp4/sample_960x540.mp4',
+        },
+        {
+            title: 'Unsupported file type',
+            url: 'https://filesamples.com/samples/font/bin/SourceCodePro-Regular.bin',
+        },
+    ];
+
+    public render() {
+        return this.fileViewers.map(this.renderFileViewer);
+    }
+
+    private renderFileViewer(fileViewer: any) {
+        return [
+            <h4>{fileViewer.title}</h4>,
+            <limel-file-viewer url={fileViewer.url} alt={fileViewer.alt} />,
+        ];
+    }
+}

--- a/src/components/file-viewer/examples/limel-example-file-viewer-inbuilt-actions.scss
+++ b/src/components/file-viewer/examples/limel-example-file-viewer-inbuilt-actions.scss
@@ -1,0 +1,10 @@
+:host(limel-example-file-viewer-inbuilt-actions) {
+    display: grid;
+    grid-template-columns: 1fr 30%;
+    gap: 2rem;
+}
+
+limel-file-viewer {
+    padding: 0.5rem;
+    border: 1px dashed rgb(var(--contrast-600));
+}

--- a/src/components/file-viewer/extension-mapping.spec.tsx
+++ b/src/components/file-viewer/extension-mapping.spec.tsx
@@ -1,0 +1,19 @@
+import { detectExtension } from './extension-mapping';
+
+describe('detectExtension', () => {
+    const testCases = [
+        { input: 'example.pdf', expected: 'pdf' },
+        { input: 'example.jpg', expected: 'image' },
+        { input: 'example.mp4', expected: 'video' },
+        { input: 'example.mp3', expected: 'audio' },
+        { input: 'example.txt', expected: 'text' },
+        { input: 'example.xyz', expected: 'unknown' },
+    ];
+
+    testCases.forEach((testCase) => {
+        it(`should detect ${testCase.expected} extension`, () => {
+            const result = detectExtension(testCase.input, '');
+            expect(result).toBe(testCase.expected);
+        });
+    });
+});

--- a/src/components/file-viewer/extension-mapping.tsx
+++ b/src/components/file-viewer/extension-mapping.tsx
@@ -1,0 +1,67 @@
+export function detectExtension(fileName, url): any {
+    const pathLike = fileName || url;
+    if (!pathLike) {
+        return 'unknown';
+    }
+
+    const extension = pathLike.split('.').pop().toLowerCase();
+    const extensionsToTypes = {
+        pdf: 'pdf',
+        jpg: 'image',
+        jpeg: 'image',
+        heic: 'image',
+        bmp: 'image',
+        png: 'image',
+        gif: 'image',
+        svg: 'image',
+        svgz: 'image',
+        ep: 'image',
+        eps: 'image',
+        avi: 'video',
+        flv: 'video',
+        h264: 'video',
+        mov: 'video',
+        mp4: 'video',
+        mwv: 'video',
+        mkv: 'video',
+        mp3: 'audio',
+        wav: 'audio',
+        wma: 'audio',
+        ogg: 'audio',
+        txt: 'text',
+        json: 'text',
+        html: 'text',
+        xml: 'text',
+        // Word
+        doc: 'office',
+        docx: 'office',
+        odt: 'office',
+        dot: 'office',
+        dotx: 'office',
+        docm: 'office', // not supported
+        dotm: 'office', // not yet tested
+        // Presentation
+        pot: 'office', // not tested
+        ppt: 'office',
+        pptx: 'office',
+        odp: 'office',
+        potx: 'office', // not supported
+        potm: 'office', // not supported
+        pps: 'office',
+        ppsx: 'office',
+        ppsm: 'office', // not supported
+        pptm: 'office', // not supported
+        ppam: 'office', // not tested
+        pages: 'office', // not supported (Apple)
+        // Spreadsheet
+        xls: 'office',
+        xlsx: 'office',
+        xlsm: 'office',
+        xlsb: 'office',
+        ods: 'office',
+        csv: 'office', // not supported
+        numbers: 'office', // not supported (Apple)
+    };
+
+    return extensionsToTypes[extension] || 'unknown';
+}

--- a/src/components/file-viewer/file-viewer.e2e.ts
+++ b/src/components/file-viewer/file-viewer.e2e.ts
@@ -1,0 +1,139 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+
+// Since we are currently using a pre-release of Stencil to get access
+// to Puppeteer, documentation is lacking.
+//
+// Methods and properties for E2EElement (v0.13.0-9):
+// https://github.com/ionic-team/stencil/blob/a0250ffcbf5a2c657475a05052eac3a4690809d2/src/testing/puppeteer/puppeteer-declarations.ts#L78
+//
+// Matchers (expect-methods) for E2EElement (v0.13.0-9):
+// https://github.com/ionic-team/stencil/blob/a0250ffcbf5a2c657475a05052eac3a4690809d2/src/declarations/testing.ts#L5
+
+describe('limel-file-viewer', () => {
+    let page: E2EPage;
+    let contentElement: E2EElement;
+
+    describe('with image', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-file-viewer url="cat.gif"></limel-file-viewer>
+            `);
+            contentElement = await page.find('limel-file-viewer>>>img');
+        });
+        it('displays the image given by url', () => {
+            expect(contentElement.getAttribute('src')).toEqualText('cat.gif');
+        });
+        it('shows button controls', async () => {
+            const buttons = await page.find('limel-file-viewer>>>div.buttons');
+            expect(buttons).toBeDefined();
+        });
+        it.skip('removes the image when url is cleared', async () => {
+            await page.$eval('limel-file-viewer', (el: any) => {
+                el.url = '';
+            });
+            await page.waitForChanges();
+
+            contentElement = await page.find('limel-file-viewer>>>img');
+
+            expect(contentElement).toBeNull();
+        });
+    });
+
+    describe('with pdf', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-file-viewer url="file.pdf"></limel-file-viewer>
+            `);
+            contentElement = await page.find('limel-file-viewer>>>object');
+        });
+        it('displays the pdf using the object element', () => {
+            expect(contentElement.getAttribute('data')).toEqualText('file.pdf');
+        });
+        it('does not show button controls', async () => {
+            const buttons = await page.find('limel-file-viewer>>>div.buttons');
+            expect(buttons).toBeNull();
+        });
+        it('has file not supported text as fallback', async () => {
+            const noSupportMessage = await contentElement.find('.no-support');
+            expect(noSupportMessage).toBeDefined();
+        });
+    });
+
+    describe('with text', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-file-viewer url="file.txt"></limel-file-viewer>
+            `);
+            contentElement = await page.find('limel-file-viewer>>>object');
+        });
+        it('displays the text file using the object element', () => {
+            expect(contentElement.getAttribute('data')).toEqualText('file.txt');
+        });
+        it('shows button controls', async () => {
+            const buttons = await page.find('limel-file-viewer>>>div.buttons');
+            expect(buttons).toBeDefined();
+        });
+        it('has file not supported text as fallback', async () => {
+            const noSupportMessage = await contentElement.find('.no-support');
+            expect(noSupportMessage).toBeDefined();
+        });
+    });
+
+    describe('with video', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-file-viewer url="file.mkv"></limel-file-viewer>
+            `);
+            contentElement = await page.find('limel-file-viewer>>>video');
+        });
+        it('displays the video using the video element', async () => {
+            const sourceElement = await contentElement.find('source');
+            expect(sourceElement.getAttribute('src')).toEqualText('file.mkv');
+        });
+        it('does not show button controls', async () => {
+            const buttons = await page.find('limel-file-viewer>>>div.buttons');
+            expect(buttons).toBeNull();
+        });
+        it('has file not supported text as fallback', async () => {
+            const noSupportMessage = await contentElement.find('.no-support');
+            expect(noSupportMessage).toBeDefined();
+        });
+    });
+
+    describe('with audio', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-file-viewer url="file.mp3"></limel-file-viewer>
+            `);
+            contentElement = await page.find('limel-file-viewer>>>audio');
+        });
+        it('displays the audio using the audio element', async () => {
+            const sourceElement = await contentElement.find('source');
+            expect(sourceElement.getAttribute('src')).toEqualText('file.mp3');
+        });
+        it('does not show button controls', async () => {
+            const buttons = await page.find('limel-file-viewer>>>div.buttons');
+            expect(buttons).toBeNull();
+        });
+        it('has file not supported text as fallback', async () => {
+            const noSupportMessage = await contentElement.find('.no-support');
+            expect(noSupportMessage).toBeDefined();
+        });
+    });
+
+    describe('without url', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-file-viewer></limel-file-viewer>
+            `);
+            contentElement = await page.find('limel-file-viewer>>>*');
+        });
+        it.skip('shows nothing', () => {
+            expect(contentElement).toBeNull();
+        });
+    });
+});
+
+async function createPage(content) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/file-viewer/file-viewer.scss
+++ b/src/components/file-viewer/file-viewer.scss
@@ -1,0 +1,91 @@
+@use '../../style/internal/variables';
+@use '../../style/internal/shared_input-select-picker';
+@use '../../style/mixins';
+
+$size-of-buttons: 2rem;
+
+:host {
+    isolation: isolate;
+    position: relative;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+img,
+video,
+audio,
+object,
+iframe {
+    max-height: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+iframe {
+    border: none;
+    width: 100%;
+    height: 100%;
+    min-height: 20rem; // makes sure to get minimum comfortable space for viewing office files, and Microsoft Office viewers toolbars
+}
+
+img {
+    min-width: 7rem;
+    object-fit: contain; // increases or decreases the size of the image to fill the box whilst preserving its aspect-ratio.
+}
+
+video {
+    width: 100%;
+    height: auto;
+}
+
+audio {
+    width: 100%;
+}
+
+object {
+    width: 100%;
+    height: 100%;
+}
+
+object[type='application/pdf'] {
+    min-height: 20rem;
+    // makes sure to get browsers' native controls for the PDF
+}
+
+object[type='text/plain'] {
+    border-radius: 0.25rem;
+    padding-right: $size-of-buttons;
+
+    overflow-y: auto;
+}
+
+@mixin plain-text-in-fullscreen {
+    background-color: rgb(var(--color-gray-darker));
+
+    object[type='text/plain'] {
+        max-width: 50rem;
+        max-height: calc(100% - 2rem);
+    }
+}
+
+:host(:fullscreen) {
+    @include plain-text-in-fullscreen;
+}
+:host(:-webkit-full-screen) {
+    // this is repetition of the previous block,
+    // but needed for Safari to work.
+    // Cannot write SCSS rules for `:host` using commas for some reason.
+    // e.g.: `:host(:fullscreen), :host(:-webkit-full-screen)`.
+    // So you have to repeat it sadly.
+    @include plain-text-in-fullscreen;
+}
+
+@import './partial-styles/ui-controls.scss';

--- a/src/components/file-viewer/file-viewer.spec.tsx
+++ b/src/components/file-viewer/file-viewer.spec.tsx
@@ -1,0 +1,42 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { FileViewer } from './file-viewer';
+
+describe('limel-file-viewer', () => {
+    const testCases = [
+        { url: 'example.jpg', type: 'image' },
+        { url: 'example.mp4', type: 'video' },
+        { url: 'example.mp3', type: 'audio' },
+        { url: 'example.txt', type: 'text' },
+        { url: 'example.xyz', type: 'unknown' },
+    ];
+
+    testCases.forEach((testCase) => {
+        it(`renders a ${testCase.type} viewer`, async () => {
+            const page = await newSpecPage({
+                components: [FileViewer],
+                html: `<limel-file-viewer url="${testCase.url}"></limel-file-viewer>`,
+            });
+
+            expect(page.root).toBeDefined();
+        });
+    });
+});
+
+describe('limel-file-viewer officeViewer', () => {
+    const testCases = [
+        { url: 'example.docx', officeViewer: 'microsoft-office' },
+        { url: 'example.docx', officeViewer: 'google-drive' },
+        { url: 'example.odp', officeViewer: 'microsoft-office' },
+    ];
+
+    testCases.forEach((testCase) => {
+        it(`renders using ${testCase.officeViewer} officeViewer`, async () => {
+            const page = await newSpecPage({
+                components: [FileViewer],
+                html: `<limel-file-viewer url="${testCase.url}" officeViewer="${testCase.officeViewer}"></limel-file-viewer>`,
+            });
+
+            expect(page.root).toBeDefined();
+        });
+    });
+});

--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -1,0 +1,391 @@
+import {
+    Component,
+    Element,
+    h,
+    Prop,
+    State,
+    Event,
+    EventEmitter,
+    Watch,
+} from '@stencil/core';
+import { Languages, ListItem } from '@limetech/lime-elements';
+import translate from '../../global/translations';
+import { detectExtension } from './extension-mapping';
+import { Fullscreen } from './fullscreen';
+import { FileType, OfficeViewer } from './file-viewer.types';
+
+/**
+ * This is a smart component that automatically detects
+ * the most common file types such as image, audio, video, and text,
+ * and properly displays them in the browser.
+ * The component is also capable to render the most common office files.
+ *
+ * :::note
+ * Image files will always be contained in their containers, which means
+ * they automatically increase or decrease in size to fill their containing box
+ * whilst preserving their aspect-ratio.
+ *
+ * Text and PDF files will also always respect the width and height of the
+ * container in which the `limel-file-viewer` is loaded.
+ * :::
+ *
+ * For some file types such as text and images, the component will display a
+ * download button and a button to open the file in a new browser tab.
+ * This will allow users to preview the file in a fullscreen mode with the
+ * browser and take advantage of for example native zooming and panning
+ * functionalities.
+ * @exampleComponent limel-example-file-viewer
+ * @exampleComponent limel-example-file-viewer-office
+ * @exampleComponent limel-example-file-viewer-filename
+ * @exampleComponent limel-example-file-viewer-inbuilt-actions
+ * @exampleComponent limel-example-file-viewer-custom-actions
+ * @exampleComponent limel-example-file-viewer-with-picker
+ * @private
+ */
+
+@Component({
+    tag: 'limel-file-viewer',
+    shadow: true,
+    styleUrl: 'file-viewer.scss',
+})
+export class FileViewer {
+    /**
+     * Link to the file
+     */
+    @Prop({ reflect: true })
+    public url: string;
+
+    /**
+     * The name of the file that must also contains its extension.
+     * This overrides the filename that the `url` ends with.
+     * Useful when the `url` does not contain the filename.
+     * When specified, the `filename` will be used as filename of
+     * the downloaded file.
+     */
+    @Prop({ reflect: true })
+    public filename?: string;
+
+    /**
+     * An optional alternative text, mainly for assistive technologies and screen readers.
+     * It is used for only image files, as an `alt` attribute.
+     * Should optimally hold a description of the image,
+     * which is also displayed on the page if the image can't be loaded for some reason.
+     */
+    @Prop({ reflect: true })
+    public alt?: string;
+
+    /**
+     * Displays a button that allows the user to view the file
+     * in fullscreen mode.
+     * Not displayed for office files!
+     */
+    @Prop({ reflect: true })
+    public allowFullscreen?: boolean = false;
+
+    /**
+     * Displays a button that allows the user to open the file
+     * in a new browser tab.
+     * Not displayed for office files!
+     */
+    @Prop({ reflect: true })
+    public allowOpenInNewTab?: boolean = false;
+
+    /**
+     * Displays a button that allows the user to download the file.
+     * Note that due to the browser's security policies,
+     * the file should be hosted on the same domain
+     * for the download button to work properly.
+     * Not displayed for office files!
+     */
+    @Prop({ reflect: true })
+    public allowDownload?: boolean = false;
+
+    /**
+     * Defines the localization for translations.
+     */
+    @Prop()
+    public language: Languages = 'en';
+
+    /**
+     * Defines the third-party viewer that should be used to render
+     * the content of office files, such as word processing documents,
+     * presentations, or spreadsheets.
+     */
+    @Prop({ reflect: true })
+    public officeViewer: OfficeViewer = 'microsoft-office';
+
+    /**
+     * An array of custom actions that can be displayed
+     * as an action menu on the file which is being displayed.
+     */
+    @Prop()
+    public actions: ListItem[];
+
+    /**
+     * Emitted when a custom action is selected from the action menu.
+     */
+    @Event()
+    public action: EventEmitter<ListItem>;
+
+    @Element()
+    public HostElement: HTMLLimelFileViewerElement;
+
+    private fullscreen: Fullscreen;
+
+    @State()
+    private isFullscreen: boolean = false;
+
+    @State()
+    public fileType: FileType;
+
+    constructor() {
+        this.fullscreen = new Fullscreen(this.HostElement);
+        this.fileType = detectExtension(this.filename, this.url);
+    }
+
+    public render() {
+        if (!this.isOfficeFileAccessibleViaURL) {
+            return this.renderNoFileSupportMessage();
+        }
+
+        return this.renderFileViewer();
+    }
+
+    @Watch('url')
+    protected watchUrl(newUrl: string, oldUrl: string) {
+        if (newUrl === oldUrl) {
+            return;
+        }
+
+        this.fileType = detectExtension(this.filename, this.url);
+    }
+
+    private renderFileViewer() {
+        const fileViewerFunctions = {
+            pdf: this.renderPdf,
+            image: this.renderImage,
+            video: this.renderVideo,
+            audio: this.renderAudio,
+            text: this.renderText,
+            office: this.renderOffice,
+        };
+        const fileViewerFunction =
+            fileViewerFunctions[this.fileType] ||
+            this.renderNoFileSupportMessage;
+
+        return fileViewerFunction();
+    }
+
+    private renderPdf = () => {
+        return [
+            <div class="action-menu-for-pdf-files">
+                {this.renderActionMenu()}
+            </div>,
+            <object data={this.url} type="application/pdf" />,
+        ];
+    };
+
+    private renderImage = () => {
+        return [this.renderButtons(), <img src={this.url} alt={this.alt} />];
+    };
+
+    private renderVideo = () => {
+        return (
+            <video controls>
+                <source src={this.url} />
+            </video>
+        );
+    };
+
+    private renderAudio = () => {
+        return (
+            <audio controls>
+                <source src={this.url} />
+            </audio>
+        );
+    };
+
+    private renderText = () => {
+        return [
+            this.renderButtons(),
+            <object data={this.url} type="text/plain" />,
+        ];
+    };
+
+    private renderOffice = () => {
+        return [
+            <div class="action-menu-for-office-files">
+                {this.renderActionMenu()}
+            </div>,
+            <iframe
+                src={this.getOfficeViewerUrl() + this.url + '&embedded=true'}
+                frameborder="0"
+            />,
+        ];
+    };
+
+    private isOfficeFileAccessibleViaURL = () => {
+        return (
+            this.fileType === 'office' &&
+            !(this.url.startsWith('http://') || this.url.startsWith('https://'))
+        );
+    };
+
+    private getOfficeViewerUrl = () => {
+        const officeViewers = {
+            'microsoft-office':
+                'https://view.officeapps.live.com/op/embed.aspx?src=',
+            'google-drive': 'https://docs.google.com/gview?url=',
+        };
+
+        return officeViewers[this.officeViewer];
+    };
+
+    private renderNoFileSupportMessage = () => {
+        return (
+            <div class="no-support">
+                <limel-icon
+                    class="icon--warning"
+                    name="brake_warning"
+                    size="large"
+                    role="presentation"
+                />
+                <p>{this.getTranslation('message.unsupported-filetype')}</p>
+                {this.renderDownloadButton()}
+            </div>
+        );
+    };
+
+    private renderButtons = () => {
+        return (
+            <div class="buttons">
+                {this.renderActionMenu()}
+                {this.renderToggleFullscreenButton()}
+                {this.renderDownloadButton()}
+                {this.renderOpenInNewTabButton()}
+            </div>
+        );
+    };
+
+    private renderToggleFullscreenButton = () => {
+        if (!this.allowFullscreen || !this.fullscreen.isSupported()) {
+            return;
+        }
+
+        const icon = this.isFullscreen ? 'multiply' : 'fit_to_width';
+        // eslint-disable-next-line multiline-ternary
+        const label = this.isFullscreen
+            ? // eslint-disable-next-line multiline-ternary
+              this.getTranslation('exit-fullscreen')
+            : this.getTranslation('open-in-fullscreen');
+
+        return [
+            <button
+                class="button--toggle-fullscreen"
+                id="tooltip-toggle-fullscreen"
+                role="button"
+                onClick={this.handleToggleFullscreen}
+            >
+                <limel-icon name={icon} />
+                <limel-tooltip
+                    label={label}
+                    elementId="tooltip-toggle-fullscreen"
+                    openDirection="left"
+                />
+            </button>,
+        ];
+    };
+
+    private renderDownloadButton = () => {
+        if (!this.allowDownload || this.isFullscreen) {
+            return;
+        }
+
+        return (
+            <a
+                class="button--download"
+                id="tooltip-download"
+                role="button"
+                download={this.filename ? this.filename : ''}
+                href={this.url}
+                target="_blank"
+            >
+                <limel-icon name="download_2" />
+                <limel-tooltip
+                    label={this.getTranslation('download')}
+                    elementId="tooltip-download"
+                    openDirection="left"
+                />
+            </a>
+        );
+    };
+
+    private renderOpenInNewTabButton = () => {
+        if (!this.allowOpenInNewTab || this.isFullscreen) {
+            return;
+        }
+
+        return (
+            <a
+                class="button--new-tab"
+                id="tooltip-new-tab"
+                role="button"
+                href={this.url}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <limel-icon name="external_link" />
+                <limel-tooltip
+                    label={this.getTranslation('open-in-new-tab')}
+                    elementId="tooltip-new-tab"
+                    openDirection="left"
+                />
+            </a>
+        );
+    };
+
+    private renderActionMenu = () => {
+        if (!this.actions || this.isFullscreen) {
+            return;
+        }
+
+        return (
+            <limel-menu
+                class="action-menu"
+                items={this.actions}
+                onSelect={this.emitOnAction}
+                open-direction="left"
+            >
+                <button
+                    class="button--action"
+                    id="tooltip-more"
+                    role="button"
+                    slot="trigger"
+                >
+                    <limel-icon name="menu_2" />
+                    <limel-tooltip
+                        label={this.getTranslation('more-actions')}
+                        elementId="tooltip-more"
+                        openDirection="left"
+                    />
+                </button>
+            </limel-menu>
+        );
+    };
+
+    private handleToggleFullscreen = () => {
+        if (this.fullscreen.isSupported()) {
+            this.fullscreen.toggle();
+            this.isFullscreen = !this.isFullscreen;
+        }
+    };
+
+    private emitOnAction = (event: CustomEvent<ListItem>) => {
+        event.stopPropagation();
+        this.action.emit(event.detail);
+    };
+
+    private getTranslation(key: string) {
+        return translate.get(`file-viewer.${key}`, this.language);
+    }
+}

--- a/src/components/file-viewer/file-viewer.types.ts
+++ b/src/components/file-viewer/file-viewer.types.ts
@@ -1,0 +1,10 @@
+export type FileType =
+    | 'pdf'
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'text'
+    | 'office'
+    | 'unknown';
+
+export type OfficeViewer = 'microsoft-office' | 'google-drive';

--- a/src/components/file-viewer/fullscreen.ts
+++ b/src/components/file-viewer/fullscreen.ts
@@ -1,0 +1,50 @@
+export class Fullscreen {
+    private enter: () => void;
+    private exit: () => void;
+
+    constructor(element: any) {
+        this.enter =
+            element.requestFullscreen ||
+            element.msRequestFullscreen ||
+            element.mozRequestFullScreen ||
+            element.webkitRequestFullscreen;
+        this.enter = this.enter.bind(element);
+        const doc: any = window.document;
+        this.exit =
+            doc.exitFullscreen ||
+            doc.msExitFullscreen ||
+            doc.mozCancelFullScreen ||
+            doc.webkitExitFullscreen;
+    }
+
+    public requestFullscreen = () => {
+        if (this.enter) {
+            this.enter();
+        }
+    };
+
+    public exitFullscreen = () => {
+        if (this.exit) {
+            this.exit.bind(window.document)();
+        }
+    };
+
+    public toggle = () => {
+        const doc: any = window.document;
+        const isFullscreen =
+            doc.fullscreenElement ||
+            doc.mozFullScreenElement ||
+            doc.webkitFullscreenElement ||
+            doc.msFullscreenElement;
+
+        if (isFullscreen) {
+            this.exitFullscreen();
+        } else {
+            this.requestFullscreen();
+        }
+    };
+
+    public isSupported(): boolean {
+        return !!this.requestFullscreen;
+    }
+}

--- a/src/components/file-viewer/partial-styles/ui-controls.scss
+++ b/src/components/file-viewer/partial-styles/ui-controls.scss
@@ -1,0 +1,73 @@
+.buttons {
+    position: absolute;
+    z-index: 1;
+    top: 0.25rem;
+    right: 0.25rem;
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    @media (pointer: coarse) {
+        // touchscreen devices
+        gap: 0.5rem;
+    }
+}
+
+.no-support {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    border: 1px dashed rgb(var(--contrast-600));
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+
+    .icon--warning {
+        color: rgb(var(--color-orange-default));
+    }
+}
+
+[class^='button--'] {
+    all: unset;
+    @include mixins.is-elevated-clickable;
+    @include mixins.visualize-keyboard-focus;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border-radius: 50%;
+    width: $size-of-buttons;
+    height: $size-of-buttons;
+
+    background-color: rgba(var(--contrast-100), 0.8);
+    backdrop-filter: blur(0.25rem);
+    -webkit-backdrop-filter: blur(0.25rem);
+
+    limel-icon {
+        transition: color 0.2s ease;
+        width: 1.25rem;
+        color: rgb(var(--contrast-1200));
+    }
+
+    &:hover {
+        limel-icon {
+            color: rgb(var(--contrast-1400));
+        }
+    }
+}
+
+.action-menu-for-pdf-files,
+.action-menu-for-office-files {
+    position: absolute;
+    right: 0.75rem;
+}
+.action-menu-for-pdf-files {
+    // Firefox and Chrome render a top bar
+    // for PDF files, but Safari doesn't.
+    bottom: 0.75rem;
+}
+.action-menu-for-office-files {
+    top: 0.75rem;
+}

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -11,4 +11,10 @@ export default {
     'chip-set.clear-all': 'Ryd alle',
     'file.drag-and-drop-tips':
         'Træk og slip filen her, eller klik for at gennemse.',
+    'file-viewer.message.unsupported-filetype': 'Denne fil kan ikke vises!',
+    'file-viewer.download': 'Hent',
+    'file-viewer.exit-fullscreen': 'Afslut fuldskærm',
+    'file-viewer.open-in-fullscreen': 'Åbn i fuld skærm',
+    'file-viewer.open-in-new-tab': 'Åbn i en ny fane',
+    'file-viewer.more-actions': 'Mere…',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -13,4 +13,10 @@ export default {
     'snackbar.dismiss': 'Dismiss',
     'file.drag-and-drop-tips':
         'Drag and drop your file here, or click to browse.',
+    'file-viewer.message.unsupported-filetype': 'Cannot display this file!',
+    'file-viewer.download': 'Download',
+    'file-viewer.exit-fullscreen': 'Exit fullscreen',
+    'file-viewer.open-in-fullscreen': 'Open in fullscreen',
+    'file-viewer.open-in-new-tab': 'Open in a new tab',
+    'file-viewer.more-actions': 'More…',
 };

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -11,4 +11,11 @@ export default {
     'chip-set.clear-all': 'Tyhjennä kaikki',
     'file.drag-and-drop-tips':
         'Vedä ja pudota tiedostosi tähän, tai napsauta selataksesi.',
+    'file-viewer.message.unsupported-filetype':
+        'Tätä tiedostoa ei voi näyttää!',
+    'file-viewer.download': 'Ladata',
+    'file-viewer.exit-fullscreen': 'Poistu koko näytöstä',
+    'file-viewer.open-in-fullscreen': 'Avaa koko näytössä',
+    'file-viewer.open-in-new-tab': 'Avaa uudella välilehdellä',
+    'file-viewer.more-actions': 'Lisää…',
 };

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -11,4 +11,11 @@ export default {
     'chip-set.clear-all': 'Alles wissen',
     'file.drag-and-drop-tips':
         'Sleep uw bestand en zet het hier neer of klik om te bladeren.',
+    'file-viewer.message.unsupported-filetype':
+        'Kan dit bestand niet weergeven!',
+    'file-viewer.download': 'Downloaden',
+    'file-viewer.exit-fullscreen': 'Verlaat volledig scherm',
+    'file-viewer.open-in-fullscreen': 'Open in volledig scherm',
+    'file-viewer.open-in-new-tab': 'Openen op een nieuw tabblad',
+    'file-viewer.more-actions': 'Meer…',
 };

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -11,4 +11,10 @@ export default {
     'chip-set.clear-all': 'Fjern alle',
     'file.drag-and-drop-tips':
         'Dra og slipp filen her, eller klikk for å bla gjennom.',
+    'file-viewer.message.unsupported-filetype': 'Kan ikke vise denne filen!',
+    'file-viewer.download': 'Nedlasting',
+    'file-viewer.exit-fullscreen': 'Gå ut av fullskjerm',
+    'file-viewer.open-in-fullscreen': 'Åpne i fullskjerm',
+    'file-viewer.open-in-new-tab': 'Åpne i en ny fane',
+    'file-viewer.more-actions': 'Mer…',
 };

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -13,4 +13,10 @@ export default {
     'snackbar.dismiss': 'Stäng',
     'file.drag-and-drop-tips':
         'Dra och släpp filen här eller klicka om du vill bläddra.',
+    'file-viewer.message.unsupported-filetype': 'Kan inte visa den här filen!',
+    'file-viewer.download': 'Ladda ner',
+    'file-viewer.exit-fullscreen': 'Avsluta fullskärmsläge',
+    'file-viewer.open-in-fullscreen': 'Öppna i fullskärmsläge',
+    'file-viewer.open-in-new-tab': 'Öppna i ny flik',
+    'file-viewer.more-actions': 'Mer…',
 };


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/3622


- [x] Rebase on the latest Elements
- [x] Add a filename prop that replaces the type prop
- [x] Detect renderer by using the filename extension
- [x] If filename prop isn't given, try grab the file extension by using the URL
- [x] Make sure the Office viewer is used for the file types it supports
- [x] Make it possible to add custom actions
- [x] create a mapping file and move the file extension detectors to that, instead of the main file. 
- [x] check/fix safari fullscreen bug
- [x] Show the "unsupported" message when the render type is "office" and the URL is not starting with https:// (office viewer only works with publicly accessible files, ie not office files selected in the file picker example using the local drive)
- [x] pdf doesn't show the action menu, as we don't know where to put it
- [x] test with all filetype we think the online office viewer will support, and if it doesn't, remove them from the logic

Steps below can be done in follow-up PRs. The component is `@private` at the moment.

- [ ] fix download from external links which aren't on the same domain (Not sure if we even need to fix this issue. See the discussion here: https://github.com/Lundalogik/lime-elements/pull/1430#discussion_r1345389561)
- [ ] upload example files into github using `gh-pages` branch, and when that is merged, use their links in the documentations. Discussion here: https://github.com/Lundalogik/lime-elements/pull/1430#discussion_r1345796492
- [ ] fix skipped e2e tests

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
