### PR TITLE
HACKDAY - add localstorage memory of open state

### DIFF
--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -54,7 +54,8 @@ export class CollapsibleSection {
     /**
      * Set to `false` to disable state memory even when `stateKey` is set.
      * Normally, `stateKey` can just be left without a value to achieve the
-     * same thing.
+     * same thing, but when limel-collapsible-section is used in limel-form,
+     * `stateKey` will always be set. Use this property to override.
      */
     @Prop({ reflect: true })
     public rememberState: boolean = true;

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -148,6 +148,21 @@ export interface LimeSchemaOptions {
      * Mark the field as disabled
      */
     disabled?: boolean;
+
+    /**
+     * Collapsible sections will remember their open/closed state when used
+     * in a form. If different sections are not able to uniquely identify
+     * themselves, they will "share" the same state. To prevent this, a unique
+     * key can be assigned to each section here.
+     */
+    stateKey?: string;
+
+    /**
+     * To disable a collapsible section's "state memory", and always use the
+     * default state as set via the `collapsed` property, set this value to
+     * `false`.
+     */
+    rememberState?: boolean;
 }
 
 /**

--- a/src/components/form/templates/array-field-collapsible-item.ts
+++ b/src/components/form/templates/array-field-collapsible-item.ts
@@ -70,6 +70,12 @@ export class CollapsibleItemTemplate extends React.Component {
                 className: 'limel-form-array-item--object',
                 ref: 'section',
                 'is-open': this.isOpen,
+                'state-key': encodeURIComponent(
+                    schema?.lime?.stateKey ||
+                        `${schema.items?.$ref}-${this.props.index}-${
+                            data.title || data.property
+                        }`
+                ),
             },
             this.props.item.children
         );

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -36,6 +36,10 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
         {
             header: props.title,
             'is-open': defaultOpen,
+            'state-key': encodeURIComponent(
+                props.schema?.lime?.stateKey ||
+                    `${props.formContext?.schema?.$ref}-${props.idSchema?.$id}-${props?.title}`
+            ),
         },
         renderDescription(props.description),
         renderProperties(props.properties, props.schema)

--- a/src/util/state-service.ts
+++ b/src/util/state-service.ts
@@ -1,0 +1,7 @@
+export function getState(key: string) {
+    return JSON.parse(localStorage.getItem(key));
+}
+
+export function setState(key: string, value: any) {
+    localStorage.setItem(key, JSON.stringify(value));
+}


### PR DESCRIPTION
### Replaced by #1452 and #1457


When given a value for the new property `stateKey`, or automatically when used through limel-form,
the collapsible section will remember its state across page loads.

fix: Lundalogik/hack-tuesday#197
fix: Lundalogik/crm-feature#1885

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
