### PR TITLE
perf(menu): remove deprecated property `fixed`

### DIFF
--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -18,7 +18,6 @@ export class MenuCompositeExample {
     private props = {
         badgeIcons: true,
         disabled: false,
-        fixed: false,
         items: [
             {
                 text: 'Copy',
@@ -67,7 +66,6 @@ export class MenuCompositeExample {
                 disabled={this.props.disabled}
                 openDirection={this.props.openDirection as any}
                 badgeIcons={this.props.badgeIcons}
-                fixed={this.props.fixed}
                 open={this.props.open}
                 gridLayout={this.props.gridLayout}
                 onSelect={this.handleSelect}

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -78,16 +78,6 @@ export class Menu {
     public gridLayout = false;
 
     /**
-     * Defines whether the menu should have a fixed position on the screen.
-     *
-     * @deprecated Fixed position was used to get around a bug in the placement
-     * of the menu. This bug has since been fixed, which makes this attribute
-     * obsolete.
-     */
-    @Prop()
-    public fixed = false;
-
-    /**
      * Is emitted when the menu is cancelled.
      */
     @Event()
@@ -137,21 +127,15 @@ export class Menu {
         const dropdownZIndex = getComputedStyle(this.host).getPropertyValue(
             '--dropdown-z-index'
         );
-        const portalClasses = {
-            'limel-portal--fixed': this.fixed,
-        };
-        const portalPosition = this.getPortalPosition();
 
         return (
             <div class="mdc-menu-surface--anchor" onClick={this.onTriggerClick}>
                 <slot name="trigger">{this.renderTrigger()}</slot>
                 <limel-portal
-                    class={portalClasses}
-                    style={portalPosition}
                     visible={this.open}
                     containerId={this.portalId}
                     openDirection={this.openDirection}
-                    position={this.fixed ? 'fixed' : 'absolute'}
+                    position="absolute"
                     containerStyle={{ 'z-index': dropdownZIndex }}
                 >
                     <limel-menu-surface
@@ -237,24 +221,6 @@ export class Menu {
         this.select.emit(event.detail);
         this.open = false;
     };
-
-    private getPortalPosition() {
-        if (!this.fixed) {
-            return {};
-        }
-
-        const rect = this.host.getBoundingClientRect();
-        const portalPosition = {
-            top: `${rect.y + rect.height}px`,
-            left: `${rect.x}px`,
-        };
-
-        if (this.openDirection === 'left') {
-            portalPosition.left = `${rect.x + rect.width}px`;
-        }
-
-        return portalPosition;
-    }
 
     private getCssProperties() {
         const propertyNames = [


### PR DESCRIPTION
The property `fixed` was deprecated long ago. Removing it reduces complexity of the code slightly,
and also slightly improves performance, since there are some checks we no longer need to perform.

BREAKING CHANGE: The deprecated property `fixed` on `limel-menu` has been removed.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
