### PR TITLE
perf(menu): remove deprecated support for default trigger

### DIFF
--- a/src/components/menu/examples/menu-open-left.tsx
+++ b/src/components/menu/examples/menu-open-left.tsx
@@ -18,7 +18,7 @@ export class MenuOpenLeftExample {
 
     public render() {
         return (
-            <limel-menu label="Menu" items={this.items} openDirection="left">
+            <limel-menu items={this.items} openDirection="left">
                 <limel-button label="Menu" slot="trigger" />
             </limel-menu>
         );

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -33,15 +33,6 @@ import {
 })
 export class Menu {
     /**
-     * Is displayed on the default trigger button.
-     *
-     * @deprecated Use with default trigger has been deprecated.
-     * Please supply your own trigger element.
-     */
-    @Prop({ reflect: true })
-    public label = '';
-
-    /**
      * A list of items and separators to show in the menu.
      */
     @Prop()
@@ -144,7 +135,7 @@ export class Menu {
 
         return (
             <div class="mdc-menu-surface--anchor" onClick={this.onTriggerClick}>
-                <slot name="trigger">{this.renderTrigger()}</slot>
+                <slot name="trigger" />
                 <limel-portal
                     class={portalClasses}
                     style={portalPosition}
@@ -179,20 +170,6 @@ export class Menu {
     public componentDidRender() {
         const slotElement = this.host.shadowRoot.querySelector('slot');
         slotElement.assignedElements().forEach(this.setTriggerAttributes);
-    }
-
-    private renderTrigger() {
-        return (
-            <button
-                class={`
-                    menu__trigger
-                    ${this.disabled ? '' : 'menu__trigger-enabled'}
-                `}
-                disabled={this.disabled}
-            >
-                <span>{this.label}</span>
-            </button>
-        );
     }
 
     private setTriggerAttributes = (element: HTMLElement) => {


### PR DESCRIPTION
Support for using `limel-menu` without supplying your own trigger element has been
deprecated for a long while. Remove that support.

BREAKING CHANGE: Support for using `limel-menu` without supplying you own trigger
element has been removed. The deprecated property `label`, which was only used when
the default trigger element was used, has thus also been removed.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
