### PR TITLE
chore(dialog): remove deprecated property `badgeIcon` from `DialogHeading`

### DIFF
--- a/src/components/dialog/dialog.types.ts
+++ b/src/components/dialog/dialog.types.ts
@@ -3,8 +3,4 @@ export interface DialogHeading {
     subtitle?: string;
     supportingText?: string;
     icon: string;
-    /**
-     * @deprecated
-     */
-    badgeIcon?: boolean;
 }


### PR DESCRIPTION
The property has been deprecated for a long time, and setting it no longer has any
effect.

BREAKING CHANGE: The deprecated property `badgeIcon` on the interface `DialogHeading`
has been removed. Setting the property already had no effect, but since the property
has now been removed, any consumers that are importing types from
**@limetech/lime-elements** and are setting this property, will get an error when
building. The solution is to simply not set the property.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
