### PR TITLE
chore(picker): remove deprecated and unused property `displayFullList`

### DIFF
--- a/src/components/picker/examples/picker-icons.tsx
+++ b/src/components/picker/examples/picker-icons.tsx
@@ -4,7 +4,7 @@ import { Component, h, State } from '@stencil/core';
 const NETWORK_DELAY = 500;
 
 /**
- * With icons and displaying full list without cutting content
+ * With icons
  */
 @Component({
     tag: 'limel-example-picker-icons',
@@ -129,7 +129,6 @@ export class PickerIconsExample {
                 value={this.selectedItems}
                 searchLabel={'Search your awesomenaut'}
                 multiple={true}
-                displayFullList={true}
                 searcher={this.search}
                 onChange={this.onChange}
                 onInteract={this.onInteract}

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -90,7 +90,6 @@ export class PickerStaticActionsExample {
                 label="Select your favorite pet"
                 value={this.selectedItem}
                 searchLabel={'Search your awesomenaut'}
-                displayFullList={true}
                 searcher={this.search}
                 onChange={this.onChange}
                 onInteract={this.onInteract}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -113,16 +113,6 @@ export class Picker {
     public delimiter: string = null;
 
     /**
-     * True if the dropdown list should be displayed without cutting the content
-     *
-     * @deprecated This was used for a workaround, and isn't needed any
-     * longer. Setting it has no effect, and the property will be removed
-     * in the next major version.
-     */
-    @Prop()
-    public displayFullList: boolean = false;
-
-    /**
      * Static actions that can be clicked by the user.
      */
     @Prop()


### PR DESCRIPTION
The property `displayFullList` on `limel-picker` is deprecated and setting it has no
effect. Remove it.

BREAKING CHANGE: The deprecated property `displayFullList` on `limel-picker` has been
removed. Setting the property had no effect even before this change, but since the
property has now been removed, any consumers that are importing types from
@limetech/lime-elements and are setting this property, will get an error when
building. The solution is to simply not set the property.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
