### PR TITLE
chore(form): remove the deprecated property `span` from `FormLayoutOptions`

### DIFF
--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -171,11 +171,6 @@ export interface FormLayoutOptions<T = FormLayoutType.Default> {
      * The type of layout to use
      */
     type: T;
-
-    /**
-     * @deprecated use `GridLayoutOptions.colSpan` instead
-     */
-    span?: 'all';
 }
 
 export interface GridLayoutOptions

--- a/src/components/form/templates/field.ts
+++ b/src/components/form/templates/field.ts
@@ -31,7 +31,7 @@ export const FieldTemplate = (props) => {
 
 function getColSpan(schema: any) {
     const layout: GridLayoutOptions = schema.lime?.layout;
-    const colSpan = layout?.colSpan || layout?.span;
+    const colSpan = layout?.colSpan;
 
     if (!colSpan && isObjectType(schema)) {
         return 'all';


### PR DESCRIPTION
The property is deprecated, so remove it.

BREAKING CHANGE: The deprecated property `span` has been removed from the interface
`FormLayoutOptions`. To achieve the same functionality, switch the interface used from
`FormLayoutOptions` to `GridLayoutOptions` and set the property `colSpan` instead.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
