### PR TITLE
test(snackbar): increase timeout for blinking test

### DIFF
--- a/src/components/snackbar/snackbar.e2e.ts
+++ b/src/components/snackbar/snackbar.e2e.ts
@@ -78,7 +78,7 @@ describe('limel-snackbar', () => {
 
         it('displays the message', async () => {
             // Some extra waiting is required for the content to be populated.
-            await page.waitForTimeout(1000);
+            await page.waitForTimeout(2000);
             snackbarLabel = await mdcSnackbar.find('.mdc-snackbar__label');
             expect(snackbarLabel).toEqualText('This is a message');
         });


### PR DESCRIPTION
This test has been blinking repeatedly for a while now. Just increasing the timout
is a poor fix, but it might help a little.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
