### PR TITLE
fix(list): fix broken import of `MenuItem` so docs builds correctly

### DIFF
--- a/src/components/list/list-item.types.ts
+++ b/src/components/list/list-item.types.ts
@@ -1,4 +1,4 @@
-import { MenuItem } from '@limetech/lime-elements';
+import { MenuItem } from '../menu/menu.types';
 
 export interface ListItem<T = any> {
     /**


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
