### PR TITLE
Add tests and minor fixes for collapsible-section

### DIFF
--- a/src/components/collapsible-section/collapsible-section.e2e.ts
+++ b/src/components/collapsible-section/collapsible-section.e2e.ts
@@ -1,0 +1,317 @@
+import {
+    E2EElement,
+    E2EPage,
+    EventSpy,
+    newE2EPage,
+} from '@stencil/core/testing';
+import { Action } from './action';
+
+describe('limel-collapsible-section', () => {
+    let page: E2EPage;
+    let limelCollapsible: E2EElement;
+    let collapsibleHeader: E2EElement;
+    let collapsibleBody: E2EElement;
+
+    describe('with a header and body', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-collapsible-section header="Header text">
+                    Body text <button>Test</button>
+                </limel-collapsible-section>
+            `);
+            limelCollapsible = await page.find('limel-collapsible-section');
+            collapsibleHeader = await page.find(
+                'limel-collapsible-section >>> .section__header'
+            );
+            collapsibleBody = await page.find(
+                'limel-collapsible-section >>> .section__body'
+            );
+        });
+        it('displays the correct header', () => {
+            expect(collapsibleHeader).toEqualText('Header text');
+        });
+        it('has a slot for the body', () => {
+            expect(collapsibleBody).toEqualHtml(
+                '<div class="section__body"><slot></slot></div>'
+            );
+        });
+        it('is collapsed', async () => {
+            expect(await limelCollapsible.getProperty('isOpen')).toEqual(false);
+            expect(await collapsibleBody.isVisible()).toBeFalsy();
+        });
+
+        describe('header', () => {
+            it('has `tabindex=0`', async () => {
+                expect(collapsibleHeader).toEqualAttribute('tabindex', '0');
+            });
+        });
+
+        describe('when changing the header', () => {
+            beforeEach(async () => {
+                limelCollapsible.setProperty('header', 'new header');
+                await page.waitForChanges();
+            });
+            it('displays the new header', () => {
+                expect(collapsibleHeader).toEqualText('new header');
+            });
+        });
+
+        describe('when clicking the header', () => {
+            let openEventSpy: EventSpy;
+            let closeEventSpy: EventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await limelCollapsible.click();
+                await page.waitForChanges();
+            });
+
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+                expect(await collapsibleBody.isVisible()).toBeTruthy();
+            });
+
+            it('emits `open` event', async () => {
+                expect(openEventSpy).toHaveReceivedEvent();
+            });
+
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then clicking it again', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await limelCollapsible.click();
+                    await page.waitForChanges();
+                });
+
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                    expect(await collapsibleBody.isVisible()).toBeFalsy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('emits `close` event', async () => {
+                    expect(closeEventSpy).toHaveReceivedEvent();
+                });
+            });
+
+            describe('then clicking the body', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await collapsibleBody.click();
+                    await page.waitForChanges();
+                });
+
+                it('does NOT close', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(true);
+                    expect(await collapsibleBody.isVisible()).toBeTruthy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('when focusing the header and pressing ENTER', () => {
+            let openEventSpy: EventSpy;
+            let closeEventSpy: EventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await collapsibleHeader.focus();
+                await page.keyboard.press('Enter');
+                await page.waitForChanges();
+            });
+
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+                expect(await collapsibleBody.isVisible()).toBeTruthy();
+            });
+
+            it('emits `open` event', async () => {
+                expect(openEventSpy).toHaveReceivedEvent();
+            });
+
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then pressing ENTER again', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await page.keyboard.press('Enter');
+                    await page.waitForChanges();
+                });
+
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                    expect(await collapsibleBody.isVisible()).toBeFalsy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('emits `close` event', async () => {
+                    expect(closeEventSpy).toHaveReceivedEvent();
+                });
+            });
+
+            describe('then focusing a button in the body and pressing ENTER', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    const buttonInBody = await page.find('button');
+                    await buttonInBody.focus();
+                    await page.keyboard.press('Enter');
+                    await page.waitForChanges();
+                });
+
+                it('does NOT close', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(true);
+                    expect(await collapsibleBody.isVisible()).toBeTruthy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('when setting `isOpen` to `true`', () => {
+            let openEventSpy: EventSpy;
+            let closeEventSpy: EventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await page.$eval(
+                    'limel-collapsible-section',
+                    (element: HTMLLimelCollapsibleSectionElement) => {
+                        element.isOpen = true;
+                    }
+                );
+                await page.waitForChanges();
+            });
+
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+                expect(await collapsibleBody.isVisible()).toBeTruthy();
+            });
+
+            it('does NOT emit `open` event', async () => {
+                expect(openEventSpy).not.toHaveReceivedEvent();
+            });
+
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then setting `isOpen` to `false`', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await page.$eval(
+                        'limel-collapsible-section',
+                        (element: HTMLLimelCollapsibleSectionElement) => {
+                            element.isOpen = false;
+                        }
+                    );
+                    await page.waitForChanges();
+                });
+
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                    expect(await collapsibleBody.isVisible()).toBeFalsy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('with an action', () => {
+            let actions: Action[];
+            let actionButton: E2EElement;
+            let actionEventSpy;
+            beforeEach(async () => {
+                actions = [
+                    {
+                        id: 'abc',
+                        icon: 'dog',
+                    },
+                ];
+                await page.$eval(
+                    'limel-collapsible-section',
+                    (element: any, value) => {
+                        element.actions = value;
+                    },
+                    actions as any[]
+                );
+                await page.waitForChanges();
+                actionButton = await page.find(
+                    'limel-collapsible-section >>> limel-icon-button'
+                );
+                actionEventSpy = await page.spyOnEvent('action');
+            });
+
+            it('has an action button', () => {
+                expect(actionButton).toBeTruthy();
+            });
+
+            describe('when action button is clicked', () => {
+                beforeEach(async () => {
+                    await actionButton.click();
+                });
+
+                it('emits `action` event', async () => {
+                    expect(actionEventSpy).toHaveReceivedEvent();
+                    expect(actionEventSpy).toHaveReceivedEventDetail(
+                        actions[0]
+                    );
+                });
+            });
+        });
+    });
+});
+
+async function createPage(content) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -33,7 +33,7 @@ export class CollapsibleSection {
     /**
      * Text to display in the header of the section
      */
-    @Prop()
+    @Prop({ reflect: true })
     public header: string;
 
     /**

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -63,11 +63,6 @@ export class CollapsibleSection {
     @Element()
     private host: HTMLLimelCollapsibleSectionElement;
 
-    constructor() {
-        this.onClick = this.onClick.bind(this);
-        this.renderActionButton = this.renderActionButton.bind(this);
-    }
-
     public render() {
         return (
             <section class={`${this.isOpen ? 'open' : ''}`}>
@@ -96,7 +91,7 @@ export class CollapsibleSection {
         );
     }
 
-    private onClick() {
+    private onClick = () => {
         this.isOpen = !this.isOpen;
 
         if (this.isOpen) {
@@ -106,7 +101,7 @@ export class CollapsibleSection {
         } else {
             this.close.emit();
         }
-    }
+    };
 
     private handleKeyDown = (event: KeyboardEvent) => {
         const isEnter = event.key === ENTER || event.keyCode === ENTER_KEY_CODE;
@@ -120,7 +115,7 @@ export class CollapsibleSection {
         }
     };
 
-    private renderActions() {
+    private renderActions = () => {
         if (!this.actions) {
             return;
         }
@@ -130,9 +125,9 @@ export class CollapsibleSection {
                 {this.actions.map(this.renderActionButton)}
             </div>
         );
-    }
+    };
 
-    private renderActionButton(action: Action) {
+    private renderActionButton = (action: Action) => {
         return (
             <limel-icon-button
                 icon={action.icon}
@@ -141,7 +136,7 @@ export class CollapsibleSection {
                 onClick={this.handleActionClick(action)}
             />
         );
-    }
+    };
 
     private handleActionClick = (action: Action) => (event: MouseEvent) => {
         event.stopPropagation();

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -1,11 +1,4 @@
-import {
-    Component,
-    Event,
-    EventEmitter,
-    h,
-    Prop,
-    Element,
-} from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
 import { dispatchResizeEvent } from '../../util/dispatch-resize-event';
 import { Action } from './action';
 import { ENTER, ENTER_KEY_CODE } from '../../util/keycodes';
@@ -60,9 +53,6 @@ export class CollapsibleSection {
     @Event()
     private action: EventEmitter<Action>;
 
-    @Element()
-    private host: HTMLLimelCollapsibleSectionElement;
-
     public render() {
         return (
             <section class={`${this.isOpen ? 'open' : ''}`}>
@@ -92,15 +82,7 @@ export class CollapsibleSection {
     }
 
     private onClick = () => {
-        this.isOpen = !this.isOpen;
-
-        if (this.isOpen) {
-            this.open.emit();
-            const waitForUiToRender = 100;
-            setTimeout(dispatchResizeEvent, waitForUiToRender);
-        } else {
-            this.close.emit();
-        }
+        this.handleInteraction();
     };
 
     private handleKeyDown = (event: KeyboardEvent) => {
@@ -109,9 +91,19 @@ export class CollapsibleSection {
         if (isEnter) {
             event.stopPropagation();
             event.preventDefault();
-            const element = (this.host.shadowRoot.activeElement ||
-                document.activeElement) as HTMLElement;
-            element.click();
+            this.handleInteraction();
+        }
+    };
+
+    private handleInteraction = () => {
+        this.isOpen = !this.isOpen;
+
+        if (this.isOpen) {
+            this.open.emit();
+            const waitForUiToRender = 100;
+            setTimeout(dispatchResizeEvent, waitForUiToRender);
+        } else {
+            this.close.emit();
         }
     };
 


### PR DESCRIPTION
To test the new tests, I would recommend looking at the test description, then breaking the code, so that it no longer does what the test description says, then check that the test fails.

So, for something like `limel-collapsible-section > with a header and body > when clicking the header > opens`, you might want to comment out the code inside the `onClick` function. Then check that that specific test fails in the expected way. If other tests fail (which some probably will), check that it makes sense that they fail because of the change you made. Then undo the change, and repeat for the next test 🙂

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
