### PR TITLE
feat(collapsible-section-stateful): add collapsible section with state memory

### DIFF
--- a/src/components/collapsible-section-stateful/collapsible-section-stateful.e2e.ts
+++ b/src/components/collapsible-section-stateful/collapsible-section-stateful.e2e.ts
@@ -1,0 +1,382 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+import { clickElement } from '../../util/e2eClickElement';
+
+describe('limel-collapsible-section.stateful', () => {
+    let page: E2EPage;
+    let statefulCollapsible: E2EElement;
+    let limelCollapsible: E2EElement;
+
+    afterEach(async () => {
+        await page.$eval('body', () => {
+            window.localStorage.clear();
+        });
+    });
+
+    describe('with a header and body', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-collapsible-section-stateful header="Header text">
+                    Body text <button>Test</button>
+                </limel-collapsible-section>
+            `);
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders a limel-collapsible-section', () => {
+            expect(limelCollapsible).toBeTruthy();
+        });
+        it('passes on `header`', () => {
+            expect(limelCollapsible).toEqualAttribute('header', 'Header text');
+        });
+        it('is collapsed', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                false
+            );
+            expect(await limelCollapsible.getProperty('isOpen')).toEqual(false);
+        });
+
+        describe('when changing the header', () => {
+            beforeEach(async () => {
+                statefulCollapsible.setProperty('header', 'new header');
+                await page.waitForChanges();
+            });
+            it('sets the new header', () => {
+                expect(limelCollapsible).toEqualAttribute(
+                    'header',
+                    'new header'
+                );
+            });
+        });
+
+        describe('when setting `isOpen` to `true`', () => {
+            let openEventSpy;
+            let closeEventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await page.$eval(
+                    'limel-collapsible-section-stateful',
+                    (element: HTMLLimelCollapsibleSectionStatefulElement) => {
+                        element.isOpen = true;
+                    }
+                );
+                await page.waitForChanges();
+            });
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+            });
+            it('does NOT emit `open` event', async () => {
+                expect(openEventSpy).not.toHaveReceivedEvent();
+            });
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then setting `isOpen` to `false`', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await page.$eval(
+                        'limel-collapsible-section-stateful',
+                        (
+                            element: HTMLLimelCollapsibleSectionStatefulElement
+                        ) => {
+                            element.isOpen = false;
+                        }
+                    );
+                    await page.waitForChanges();
+                });
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                });
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('when clicking the header', () => {
+            let openEventSpy;
+            let closeEventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await clickElement(page, [
+                    limelCollapsible,
+                    statefulCollapsible,
+                ]);
+                await page.waitForChanges();
+            });
+            it('opens', async () => {
+                expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+            });
+            it('emits `open` event', async () => {
+                expect(openEventSpy).toHaveReceivedEvent();
+            });
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then clicking it again', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await clickElement(page, [
+                        limelCollapsible,
+                        statefulCollapsible,
+                    ]);
+                    await page.waitForChanges();
+                });
+                it('closes', async () => {
+                    expect(
+                        await statefulCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                });
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+                it('emits `close` event', async () => {
+                    expect(closeEventSpy).toHaveReceivedEvent();
+                });
+            });
+        });
+    });
+
+    describe('with stored state `isOpen=true` and no value set by consumer', () => {
+        let openEventSpy;
+        beforeEach(async () => {
+            page = await createPage('<div></div>');
+            openEventSpy = await page.spyOnEvent('open');
+            await page.$eval('div', (element: HTMLElement) => {
+                window.localStorage.setItem(
+                    'limel-collapsible-section-stateful.myStateKey.isOpen',
+                    JSON.stringify(true)
+                );
+                const collapsible = document.createElement(
+                    'limel-collapsible-section-stateful'
+                );
+                (collapsible as any).header = 'Header text';
+                (collapsible as any).stateKey = 'myStateKey';
+                element.appendChild(collapsible);
+            });
+            await page.waitForChanges();
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders open', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                true
+            );
+        });
+        it('emits `open` event', async () => {
+            expect(openEventSpy).toHaveReceivedEvent();
+        });
+    });
+
+    describe('with stored state `isOpen=true` and `isOpen=false` set by consumer', () => {
+        let openEventSpy;
+        beforeEach(async () => {
+            page = await createPage('<div></div>');
+            openEventSpy = await page.spyOnEvent('open');
+            await page.$eval('div', (element: HTMLElement) => {
+                window.localStorage.setItem(
+                    'limel-collapsible-section-stateful.myStateKey.isOpen',
+                    JSON.stringify(true)
+                );
+                const collapsible = document.createElement(
+                    'limel-collapsible-section-stateful'
+                );
+                (collapsible as any).header = 'Header text';
+                (collapsible as any).stateKey = 'myStateKey';
+                (collapsible as any).isOpen = false;
+                element.appendChild(collapsible);
+            });
+            await page.waitForChanges();
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders open', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                true
+            );
+        });
+        it('emits `open` event', async () => {
+            expect(openEventSpy).toHaveReceivedEvent();
+        });
+    });
+
+    describe('with stored state `isOpen=true` and `isOpen=true` set by consumer', () => {
+        let openEventSpy;
+        beforeEach(async () => {
+            page = await createPage('<div></div>');
+            openEventSpy = await page.spyOnEvent('open');
+            await page.$eval('div', (element: HTMLElement) => {
+                window.localStorage.setItem(
+                    'limel-collapsible-section-stateful.myStateKey.isOpen',
+                    JSON.stringify(true)
+                );
+                const collapsible = document.createElement(
+                    'limel-collapsible-section-stateful'
+                );
+                (collapsible as any).header = 'Header text';
+                (collapsible as any).stateKey = 'myStateKey';
+                (collapsible as any).isOpen = true;
+                element.appendChild(collapsible);
+            });
+            await page.waitForChanges();
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders open', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                true
+            );
+        });
+        it('does NOT emit `open` event', async () => {
+            expect(openEventSpy).not.toHaveReceivedEvent();
+        });
+    });
+
+    describe('with stored state `isOpen=false` and no value set by consumer', () => {
+        let closeEventSpy;
+        beforeEach(async () => {
+            page = await createPage('<div></div>');
+            closeEventSpy = await page.spyOnEvent('close');
+            await page.$eval('div', (element: HTMLElement) => {
+                window.localStorage.setItem(
+                    'limel-collapsible-section-stateful.myStateKey.isOpen',
+                    JSON.stringify(false)
+                );
+                const collapsible = document.createElement(
+                    'limel-collapsible-section-stateful'
+                );
+                (collapsible as any).header = 'Header text';
+                (collapsible as any).stateKey = 'myStateKey';
+                element.appendChild(collapsible);
+            });
+            await page.waitForChanges();
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders closed', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                false
+            );
+        });
+        it('does NOT emit `close` event', async () => {
+            expect(closeEventSpy).not.toHaveReceivedEvent();
+        });
+    });
+
+    describe('with stored state `isOpen=false` and `isOpen=false` set by consumer', () => {
+        let closeEventSpy;
+        beforeEach(async () => {
+            page = await createPage('<div></div>');
+            closeEventSpy = await page.spyOnEvent('close');
+            await page.$eval('div', (element: HTMLElement) => {
+                window.localStorage.setItem(
+                    'limel-collapsible-section-stateful.myStateKey.isOpen',
+                    JSON.stringify(false)
+                );
+                const collapsible = document.createElement(
+                    'limel-collapsible-section-stateful'
+                );
+                (collapsible as any).header = 'Header text';
+                (collapsible as any).stateKey = 'myStateKey';
+                (collapsible as any).isOpen = false;
+                element.appendChild(collapsible);
+            });
+            await page.waitForChanges();
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders closed', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                false
+            );
+        });
+        it('does NOT emit `close` event', async () => {
+            expect(closeEventSpy).not.toHaveReceivedEvent();
+        });
+    });
+
+    describe('with stored state `isOpen=false` and `isOpen=true` set by consumer', () => {
+        let closeEventSpy;
+        beforeEach(async () => {
+            page = await createPage('<div></div>');
+            closeEventSpy = await page.spyOnEvent('close');
+            await page.$eval('div', (element: HTMLElement) => {
+                window.localStorage.setItem(
+                    'limel-collapsible-section-stateful.myStateKey.isOpen',
+                    JSON.stringify(false)
+                );
+                const collapsible = document.createElement(
+                    'limel-collapsible-section-stateful'
+                );
+                (collapsible as any).header = 'Header text';
+                (collapsible as any).stateKey = 'myStateKey';
+                (collapsible as any).isOpen = true;
+                element.appendChild(collapsible);
+            });
+            await page.waitForChanges();
+            statefulCollapsible = await page.find(
+                'limel-collapsible-section-stateful'
+            );
+            await page.waitForChanges();
+            limelCollapsible = await page.find(
+                'limel-collapsible-section-stateful >>> limel-collapsible-section'
+            );
+        });
+        it('renders closed', async () => {
+            expect(await statefulCollapsible.getProperty('isOpen')).toEqual(
+                false
+            );
+        });
+        it('emits `close` event', async () => {
+            expect(closeEventSpy).toHaveReceivedEvent();
+        });
+    });
+});
+
+async function createPage(content: string) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/collapsible-section-stateful/collapsible-section-stateful.tsx
+++ b/src/components/collapsible-section-stateful/collapsible-section-stateful.tsx
@@ -52,7 +52,7 @@ export class CollapsibleSectionStateful {
      * Emitted when an action is clicked inside the header
      */
     @Event()
-    private action: EventEmitter<Action>;
+    protected action: EventEmitter<Action>;
 
     private stateId: string;
 
@@ -80,7 +80,6 @@ export class CollapsibleSectionStateful {
                 actions={this.actions}
                 onOpen={this.handleOpenEvent}
                 onClose={this.handleCloseEvent}
-                onAction={this.handleActionEvent}
             >
                 <slot />
             </limel-collapsible-section>
@@ -112,10 +111,5 @@ export class CollapsibleSectionStateful {
         if (this.isOpen) {
             this.isOpen = false;
         }
-    };
-
-    private handleActionEvent = (event: CustomEvent) => {
-        event.stopPropagation();
-        this.action.emit(event.detail);
     };
 }

--- a/src/components/collapsible-section-stateful/collapsible-section-stateful.tsx
+++ b/src/components/collapsible-section-stateful/collapsible-section-stateful.tsx
@@ -1,0 +1,121 @@
+import { Component, Event, EventEmitter, h, Prop, Watch } from '@stencil/core';
+import { Action } from '../collapsible-section/action';
+import { getState, setState } from '../../util/state-service';
+
+/**
+ * @slot - Content to put inside the collapsible section
+ * @exampleComponent limel-example-collapsible-section-stateful
+ */
+@Component({
+    tag: 'limel-collapsible-section-stateful',
+    shadow: true,
+})
+export class CollapsibleSectionStateful {
+    /**
+     * `true` if the section is expanded, `false` if collapsed.
+     */
+    @Prop({ mutable: true, reflect: true })
+    public isOpen: boolean = false;
+
+    /**
+     * Text to display in the header of the section
+     */
+    @Prop({ reflect: true })
+    public header: string;
+
+    /**
+     * Actions to place to the far right inside the header
+     */
+    @Prop()
+    public actions: Action[];
+
+    /**
+     * Used to identify the section for the purpose of remembering the
+     * open/closed state.
+     */
+    @Prop({ reflect: true })
+    public stateKey: string;
+
+    /**
+     * Emitted when the section is expanded
+     */
+    @Event()
+    private open: EventEmitter<void>;
+
+    /**
+     * Emitted when the section is collapsed
+     */
+    @Event()
+    private close: EventEmitter<void>;
+
+    /**
+     * Emitted when an action is clicked inside the header
+     */
+    @Event()
+    private action: EventEmitter<Action>;
+
+    private stateId: string;
+
+    public connectedCallback() {
+        if (this.stateKey) {
+            this.stateId = `limel-collapsible-section-stateful.${this.stateKey}.isOpen`;
+
+            const isOpen = getState(this.stateId);
+
+            if (
+                (isOpen === true || isOpen === false) &&
+                this.isOpen !== isOpen
+            ) {
+                this.isOpen = isOpen;
+                this.emitOpenState();
+            }
+        }
+    }
+
+    public render() {
+        return (
+            <limel-collapsible-section
+                isOpen={this.isOpen}
+                header={this.header}
+                actions={this.actions}
+                onOpen={this.handleOpenEvent}
+                onClose={this.handleCloseEvent}
+                onAction={this.handleActionEvent}
+            >
+                <slot />
+            </limel-collapsible-section>
+        );
+    }
+
+    @Watch('isOpen')
+    protected openCloseHandler(value: boolean) {
+        if (this.stateId) {
+            setState(this.stateId, value);
+        }
+    }
+
+    private emitOpenState = () => {
+        if (this.isOpen) {
+            this.open.emit();
+        } else {
+            this.close.emit();
+        }
+    };
+
+    private handleOpenEvent = () => {
+        if (!this.isOpen) {
+            this.isOpen = true;
+        }
+    };
+
+    private handleCloseEvent = () => {
+        if (this.isOpen) {
+            this.isOpen = false;
+        }
+    };
+
+    private handleActionEvent = (event: CustomEvent) => {
+        event.stopPropagation();
+        this.action.emit(event.detail);
+    };
+}

--- a/src/components/collapsible-section-stateful/examples/collapsible-section-stateful.tsx
+++ b/src/components/collapsible-section-stateful/examples/collapsible-section-stateful.tsx
@@ -1,0 +1,22 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+    tag: 'limel-example-collapsible-section-stateful',
+    shadow: true,
+})
+export class CollapsibleSectionStatefulExample {
+    public render() {
+        return (
+            <div>
+                <limel-collapsible-section-stateful
+                    header="Open me!"
+                    stateKey="yourKeyShouldBeUnique"
+                >
+                    <p>
+                        This element remembers its open-state across page-loads.
+                    </p>
+                </limel-collapsible-section-stateful>
+            </div>
+        );
+    }
+}

--- a/src/components/collapsible-section/collapsible-section.e2e.ts
+++ b/src/components/collapsible-section/collapsible-section.e2e.ts
@@ -1,0 +1,313 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+import { clickElement } from '../../util/e2eClickElement';
+import { Action } from './action';
+
+describe('limel-collapsible-section', () => {
+    let page: E2EPage;
+    let limelCollapsible: E2EElement;
+    let collapsibleHeader: E2EElement;
+    let collapsibleBody: E2EElement;
+
+    describe('with a header and body', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-collapsible-section header="Header text">
+                    Body text <button>Test</button>
+                </limel-collapsible-section>
+            `);
+            limelCollapsible = await page.find('limel-collapsible-section');
+            collapsibleHeader = await page.find(
+                'limel-collapsible-section >>> .section__header'
+            );
+            collapsibleBody = await page.find(
+                'limel-collapsible-section >>> .section__body'
+            );
+        });
+        it('displays the correct header', () => {
+            expect(collapsibleHeader).toEqualText('Header text');
+        });
+        it('has a slot for the body', () => {
+            expect(collapsibleBody).toEqualHtml(
+                '<div class="section__body"><slot></slot></div>'
+            );
+        });
+        it('is collapsed', async () => {
+            expect(await limelCollapsible.getProperty('isOpen')).toEqual(false);
+            expect(await collapsibleBody.isVisible()).toBeFalsy();
+        });
+
+        describe('header', () => {
+            it('has `tabindex=0`', async () => {
+                expect(collapsibleHeader).toEqualAttribute('tabindex', '0');
+            });
+        });
+
+        describe('when changing the header', () => {
+            beforeEach(async () => {
+                limelCollapsible.setProperty('header', 'new header');
+                await page.waitForChanges();
+            });
+            it('displays the new header', () => {
+                expect(collapsibleHeader).toEqualText('new header');
+            });
+        });
+
+        describe('when clicking the header', () => {
+            let openEventSpy;
+            let closeEventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await clickElement(page, [limelCollapsible]);
+                await page.waitForChanges();
+            });
+
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+                expect(await collapsibleBody.isVisible()).toBeTruthy();
+            });
+
+            it('emits `open` event', async () => {
+                expect(openEventSpy).toHaveReceivedEvent();
+            });
+
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then clicking it again', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await clickElement(page, [limelCollapsible]);
+                    await page.waitForChanges();
+                });
+
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                    expect(await collapsibleBody.isVisible()).toBeFalsy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('emits `close` event', async () => {
+                    expect(closeEventSpy).toHaveReceivedEvent();
+                });
+            });
+
+            describe('then clicking the body', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    clickElement(page, [collapsibleBody, limelCollapsible]);
+                    await page.waitForChanges();
+                });
+
+                it('does NOT close', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(true);
+                    expect(await collapsibleBody.isVisible()).toBeTruthy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('when focusing the header and pressing ENTER', () => {
+            let openEventSpy;
+            let closeEventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await collapsibleHeader.focus();
+                await page.keyboard.press('Enter');
+                await page.waitForChanges();
+            });
+
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+                expect(await collapsibleBody.isVisible()).toBeTruthy();
+            });
+
+            it('emits `open` event', async () => {
+                expect(openEventSpy).toHaveReceivedEvent();
+            });
+
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then pressing ENTER again', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await page.keyboard.press('Enter');
+                    await page.waitForChanges();
+                });
+
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                    expect(await collapsibleBody.isVisible()).toBeFalsy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('emits `close` event', async () => {
+                    expect(closeEventSpy).toHaveReceivedEvent();
+                });
+            });
+
+            describe('then focusing a button in the body and pressing ENTER', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    const buttonInBody = await page.find('button');
+                    await buttonInBody.focus();
+                    await page.keyboard.press('Enter');
+                    await page.waitForChanges();
+                });
+
+                it('does NOT close', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(true);
+                    expect(await collapsibleBody.isVisible()).toBeTruthy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('when setting `isOpen` to `true`', () => {
+            let openEventSpy;
+            let closeEventSpy;
+            beforeEach(async () => {
+                openEventSpy = await page.spyOnEvent('open');
+                closeEventSpy = await page.spyOnEvent('close');
+                await page.$eval(
+                    'limel-collapsible-section',
+                    (element: HTMLLimelCollapsibleSectionElement) => {
+                        element.isOpen = true;
+                    }
+                );
+                await page.waitForChanges();
+            });
+
+            it('opens', async () => {
+                expect(await limelCollapsible.getProperty('isOpen')).toEqual(
+                    true
+                );
+                expect(await collapsibleBody.isVisible()).toBeTruthy();
+            });
+
+            it('does NOT emit `open` event', async () => {
+                expect(openEventSpy).not.toHaveReceivedEvent();
+            });
+
+            it('does NOT emit `close` event', async () => {
+                expect(closeEventSpy).not.toHaveReceivedEvent();
+            });
+
+            describe('then setting `isOpen` to `false`', () => {
+                beforeEach(async () => {
+                    openEventSpy = await page.spyOnEvent('open');
+                    closeEventSpy = await page.spyOnEvent('close');
+                    await page.$eval(
+                        'limel-collapsible-section',
+                        (element: HTMLLimelCollapsibleSectionElement) => {
+                            element.isOpen = false;
+                        }
+                    );
+                    await page.waitForChanges();
+                });
+
+                it('closes', async () => {
+                    expect(
+                        await limelCollapsible.getProperty('isOpen')
+                    ).toEqual(false);
+                    expect(await collapsibleBody.isVisible()).toBeFalsy();
+                });
+
+                it('does NOT emit `open` event', async () => {
+                    expect(openEventSpy).not.toHaveReceivedEvent();
+                });
+
+                it('does NOT emit `close` event', async () => {
+                    expect(closeEventSpy).not.toHaveReceivedEvent();
+                });
+            });
+        });
+
+        describe('with an action', () => {
+            let actions: Action[];
+            let actionButton: E2EElement;
+            let actionEventSpy;
+            beforeEach(async () => {
+                actions = [
+                    {
+                        id: 'abc',
+                        icon: 'dog',
+                    },
+                ];
+                await page.$eval(
+                    'limel-collapsible-section',
+                    (element: any, value) => {
+                        element.actions = value;
+                    },
+                    actions as any[]
+                );
+                await page.waitForChanges();
+                actionButton = await page.find(
+                    'limel-collapsible-section >>> limel-icon-button'
+                );
+                actionEventSpy = await page.spyOnEvent('action');
+            });
+
+            it('has an action button', () => {
+                expect(actionButton).toBeTruthy();
+            });
+
+            describe('when action button is clicked', () => {
+                beforeEach(async () => {
+                    await clickElement(page, [actionButton, limelCollapsible]);
+                });
+
+                it('emits `action` event', async () => {
+                    expect(actionEventSpy).toHaveReceivedEvent();
+                    expect(actionEventSpy).toHaveReceivedEventDetail(
+                        actions[0]
+                    );
+                });
+            });
+        });
+    });
+});
+
+async function createPage(content) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -33,7 +33,7 @@ export class CollapsibleSection {
     /**
      * Text to display in the header of the section
      */
-    @Prop()
+    @Prop({ reflect: true })
     public header: string;
 
     /**

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -63,11 +63,6 @@ export class CollapsibleSection {
     @Element()
     private host: HTMLLimelCollapsibleSectionElement;
 
-    constructor() {
-        this.onClick = this.onClick.bind(this);
-        this.renderActionButton = this.renderActionButton.bind(this);
-    }
-
     public render() {
         return (
             <section class={`${this.isOpen ? 'open' : ''}`}>
@@ -96,7 +91,7 @@ export class CollapsibleSection {
         );
     }
 
-    private onClick() {
+    private onClick = () => {
         this.isOpen = !this.isOpen;
 
         if (this.isOpen) {
@@ -106,7 +101,7 @@ export class CollapsibleSection {
         } else {
             this.close.emit();
         }
-    }
+    };
 
     private handleKeyDown = (event: KeyboardEvent) => {
         const isEnter = event.key === ENTER || event.keyCode === ENTER_KEY_CODE;
@@ -120,7 +115,7 @@ export class CollapsibleSection {
         }
     };
 
-    private renderActions() {
+    private renderActions = () => {
         if (!this.actions) {
             return;
         }
@@ -130,9 +125,9 @@ export class CollapsibleSection {
                 {this.actions.map(this.renderActionButton)}
             </div>
         );
-    }
+    };
 
-    private renderActionButton(action: Action) {
+    private renderActionButton = (action: Action) => {
         return (
             <limel-icon-button
                 icon={action.icon}
@@ -141,7 +136,7 @@ export class CollapsibleSection {
                 onClick={this.handleActionClick(action)}
             />
         );
-    }
+    };
 
     private handleActionClick = (action: Action) => (event: MouseEvent) => {
         event.stopPropagation();

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -1,11 +1,4 @@
-import {
-    Component,
-    Event,
-    EventEmitter,
-    h,
-    Prop,
-    Element,
-} from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
 import { dispatchResizeEvent } from '../../util/dispatch-resize-event';
 import { Action } from './action';
 import { ENTER, ENTER_KEY_CODE } from '../../util/keycodes';
@@ -60,9 +53,6 @@ export class CollapsibleSection {
     @Event()
     private action: EventEmitter<Action>;
 
-    @Element()
-    private host: HTMLLimelCollapsibleSectionElement;
-
     public render() {
         return (
             <section class={`${this.isOpen ? 'open' : ''}`}>
@@ -92,15 +82,7 @@ export class CollapsibleSection {
     }
 
     private onClick = () => {
-        this.isOpen = !this.isOpen;
-
-        if (this.isOpen) {
-            this.open.emit();
-            const waitForUiToRender = 100;
-            setTimeout(dispatchResizeEvent, waitForUiToRender);
-        } else {
-            this.close.emit();
-        }
+        this.handleInteraction();
     };
 
     private handleKeyDown = (event: KeyboardEvent) => {
@@ -109,9 +91,19 @@ export class CollapsibleSection {
         if (isEnter) {
             event.stopPropagation();
             event.preventDefault();
-            const element = (this.host.shadowRoot.activeElement ||
-                document.activeElement) as HTMLElement;
-            element.click();
+            this.handleInteraction();
+        }
+    };
+
+    private handleInteraction = () => {
+        this.isOpen = !this.isOpen;
+
+        if (this.isOpen) {
+            this.open.emit();
+            const waitForUiToRender = 100;
+            setTimeout(dispatchResizeEvent, waitForUiToRender);
+        } else {
+            this.close.emit();
         }
     };
 

--- a/src/util/e2eClickElement.ts
+++ b/src/util/e2eClickElement.ts
@@ -1,0 +1,33 @@
+import { E2EElement, E2EPage } from '@stencil/core/testing';
+
+/* eslint-disable no-underscore-dangle */
+export async function clickElement(page: E2EPage, elements: E2EElement[]) {
+    const outerElement = elements.pop();
+    const selectors: string[] = elements.map((element) => {
+        return (element as any)._elmHandle._remoteObject.description;
+    });
+
+    const boundingRect = await page.$eval(
+        (outerElement as any)._elmHandle._remoteObject.description,
+        (inPageElement: HTMLElement, inPageSelectors: string[]) => {
+            let childElement = inPageElement;
+            while (inPageSelectors.length) {
+                const nextSelector = inPageSelectors.pop();
+                childElement =
+                    inPageElement.querySelector(nextSelector) ||
+                    inPageElement.shadowRoot?.querySelector(nextSelector);
+            }
+
+            const { x, y } = childElement.getBoundingClientRect();
+
+            return { x: x, y: y };
+        },
+        selectors
+    );
+
+    const offsetFromElementEdge = 5;
+    await page.mouse.click(
+        boundingRect.x + offsetFromElementEdge,
+        boundingRect.y + offsetFromElementEdge
+    );
+}

--- a/src/util/state-service.ts
+++ b/src/util/state-service.ts
@@ -1,0 +1,7 @@
+export function getState(key: string) {
+    return JSON.parse(localStorage.getItem(key));
+}
+
+export function setState(key: string, value: any) {
+    localStorage.setItem(key, JSON.stringify(value));
+}


### PR DESCRIPTION
fix: Lundalogik/hack-tuesday#197
fix: Lundalogik/crm-feature#1885

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
