### PR TITLE
fix(date-picker): prevent month picker from sometimes skipping a year when navigating

### DIFF
--- a/src/components/date-picker/pickers/MonthPicker.tsx
+++ b/src/components/date-picker/pickers/MonthPicker.tsx
@@ -161,17 +161,25 @@ export class MonthPicker extends Picker {
         }
     }
 
-    private prevYear(event) {
+    private prevYear() {
         if (!this.nativePicker) {
-            event.stopImmediatePropagation();
-            this.flatpickr.changeMonth(-NBROFMONTHS);
+            // Preventing default or stopping the event from propagating doesn't
+            // stop flatpickr from moving one month on its own, so we let it do
+            // that, and then move the other 11 months to make it a full year.
+            // /Ads
+            const monthsToMove = 11;
+            this.flatpickr.changeMonth(-monthsToMove);
         }
     }
 
-    private nextYear(event) {
+    private nextYear() {
         if (!this.nativePicker) {
-            event.stopImmediatePropagation();
-            this.flatpickr.changeMonth(NBROFMONTHS);
+            // Preventing default or stopping the event from propagating doesn't
+            // stop flatpickr from moving one month on its own, so we let it do
+            // that, and then move the other 11 months to make it a full year.
+            // /Ads
+            const monthsToMove = 11;
+            this.flatpickr.changeMonth(monthsToMove);
         }
     }
 }


### PR DESCRIPTION
fix: #1455



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
