### PR TITLE
feat(limel-list): enable keyboard typeahead navigation

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -177,6 +177,7 @@ export class List {
         }
 
         this.mdcList = new MDCList(element);
+        this.mdcList.hasTypeahead = true;
         this.mdcList.listElements.forEach((item) => new MDCRipple(item));
     };
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1424

Users can jump to an item in a list by typing the first X letters.

Example:

    ┌──────────────┐
    │    Robin  <----- Active selection
    ├──────────────┤
    │     Alex     │
    ├──────────────┤
    │    Frank     │
    ├──────────────┤
    │   Francis    │
    └──────────────┘

* The user types "Fra" -> Selection in list will jump to "Frank"
* The user types "A" -> Selection in list will jump to "Alex"
* The user types "R" -> Selection in list will jump to "Robin"
* The user types "Franc" -> Selection in list will jump to "Francis"



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
