### PR TITLE
fix(progress-flow): fix rendering problem on iOS

### DIFF
--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
@@ -134,8 +134,7 @@
 
     position: absolute;
     z-index: z-index.$limel-progress-flow-divider;
-    right: 0;
-    transform: translateX(50%);
+    right: calc(var(--step-height) / 2 * -1);
     overflow: hidden;
 
     &:after {


### PR DESCRIPTION
in some bizarre way, (probably when the component is embedded
in another web-component) iOS could not render the dividers correctly
due to combination of `overflow` and `transform`.

fix: https://github.com/Lundalogik/crm-feature/issues/2453

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [ ] iOS
