### PR TITLE
feat: add `limel-color-picker` component

### DIFF
--- a/src/components/color-picker/color-picker-palette.scss
+++ b/src/components/color-picker/color-picker-palette.scss
@@ -1,0 +1,45 @@
+@use '../../design-guidelines/color-system/examples/extended-color-palette';
+@use '../../style/mixins';
+@import './color-picker';
+
+:host {
+    border-radius: 0.75rem; // is like popover's default `--popover-border-radius`
+    background-color: rgb(var(--kompendium-contrast-300));
+}
+
+.color-picker-palette {
+    display: grid;
+    gap: 0.25rem;
+    grid-auto-flow: column;
+    grid-template-columns: repeat(20, 1fr);
+    grid-template-rows: repeat(4, 1fr) auto;
+    margin: 1rem;
+}
+
+.chosen-color-name {
+    box-sizing: border-box;
+    padding: 1rem;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.5rem;
+}
+
+.chosen-color-preview {
+    border: 1px solid rgba(var(--contrast-700), 0.65); // color is the same as
+    // colors in shared_input-select-picker.scss
+    border-radius: 50%;
+}
+
+.swatch:not(.hue) {
+    @include mixins.is-flat-clickable();
+    cursor: pointer;
+
+    &:focus-visible {
+        box-shadow: var(--shadow-depth-8-focused),
+            0 0 0 0.25rem rgb(var(--contrast-100)) inset;
+    }
+}
+
+.swatch--selected {
+    border-radius: 50%;
+}

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -1,0 +1,96 @@
+import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
+import { FormComponent } from '../form/form.types';
+import { brightnesses, colors, getColorName, getCssColor } from './swatches';
+
+/**
+ * @private
+ */
+@Component({
+    tag: 'limel-color-picker-palette',
+    shadow: true,
+    styleUrl: 'color-picker-palette.scss',
+})
+export class Palette implements FormComponent {
+    /**
+     * Color value that is manually typed by the user
+     */
+    @Prop({ reflect: true })
+    public value: string;
+
+    /**
+     * Label of the input field
+     */
+    @Prop({ reflect: true })
+    public label: string;
+
+    /**
+     * Helper text of the input field
+     */
+    @Prop({ reflect: true })
+    public helperText: string;
+
+    /**
+     * Set to `true` if a value is required
+     */
+    @Prop({ reflect: true })
+    public required: boolean;
+
+    /**
+     * Emits chosen value to the parent component
+     */
+    @Event()
+    public change: EventEmitter<string>;
+
+    public render() {
+        const background = this.value ? { '--background': this.value } : {};
+
+        return [
+            <div class="color-picker-palette">{this.renderSwatches()}</div>,
+            <div class="chosen-color-name">
+                <limel-input-field
+                    label={this.label}
+                    helperText={this.helperText}
+                    value={this.value}
+                    onChange={this.handleChange}
+                    required={this.required}
+                />
+                <div class="chosen-color-preview" style={background} />
+            </div>,
+        ];
+    }
+
+    private renderSwatches = () => {
+        return colors.map((color) => {
+            return brightnesses.map(this.renderSwatch(color));
+        });
+    };
+
+    private renderSwatch = (color: string) => (brightness: string) => {
+        const colorName = getColorName(color, brightness);
+        const classList = {
+            swatch: true,
+            [colorName]: true,
+            'swatch--selected': this.value === getCssColor(color, brightness),
+        };
+
+        return (
+            <div
+                class={classList}
+                onClick={this.handleClick(color, brightness)}
+                tabindex="0"
+            ></div>
+        );
+    };
+
+    private handleChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.change.emit(event.detail);
+    };
+
+    private handleClick =
+        (color: string, brightness: string) => (event: MouseEvent) => {
+            const value = getCssColor(color, brightness);
+            event.stopPropagation();
+            this.change.emit(value);
+        };
+}

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -1,0 +1,65 @@
+@use '../../style/mixins';
+
+:host {
+    --popover-surface-width: 50rem;
+    --color-picker-default-background: url("data:image/svg+xml;charset=utf-8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8' style='fill-rule:evenodd;'><path fill-opacity='0.1' d='M0 0h4v4H0zM4 4h4v4H4z'/></svg>");
+}
+
+.color-picker {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: auto 1fr;
+}
+
+.chosen-color-preview,
+.picker-trigger {
+    box-sizing: border-box;
+    position: relative;
+    isolation: isolate;
+    width: 3.5rem;
+    height: 3.5rem;
+
+    &:before,
+    &:after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+    }
+
+    &:before {
+        background: var(--color-picker-default-background);
+        background-size: 0.5rem;
+        z-index: 0;
+    }
+
+    &:after {
+        background: var(--background);
+        z-index: 1;
+    }
+}
+
+.picker-trigger {
+    border-radius: 0.5rem;
+    cursor: pointer;
+    @include mixins.is-elevated-clickable();
+
+    &:after {
+        box-shadow: 0 0 0 0.25rem rgb(var(--contrast-100)) inset;
+    }
+}
+
+:host([readonly]) {
+    .picker-trigger {
+        &:hover,
+        &:active {
+            cursor: default;
+            box-shadow: var(--button-shadow-normal);
+            transform: none;
+        }
+    }
+}
+
+.chosen-color-input[readonly] {
+    transform: translateY(1rem);
+}

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -1,0 +1,95 @@
+import { h } from '@stencil/core';
+import { SpecPage, newSpecPage } from '@stencil/core/testing';
+import { ColorPicker } from './color-picker';
+import { Palette } from './color-picker-palette';
+import { brightnesses, colors } from './swatches';
+
+let page: SpecPage;
+let handleChange: jest.Mock;
+
+beforeEach(async () => {
+    handleChange = jest.fn();
+    page = await newSpecPage({
+        components: [ColorPicker, Palette],
+        template: () => (
+            <limel-color-picker label="Hair color" onChange={handleChange} />
+        ),
+    });
+
+    await page.waitForChanges();
+});
+
+test('the component renders', () => {
+    const palette = getPaletteElement();
+    palette.shadowRoot.innerHTML = '';
+
+    expect(page.body).toEqualHtml(`
+        <limel-color-picker label="Hair color">
+            <mock:shadow-root>
+                <limel-tooltip elementid="tooltip-button"></limel-tooltip>
+                    <div class="color-picker">
+                        <limel-popover>
+                            <div class="picker-trigger" id="tooltip-button" role="button" slot="trigger" tabindex="0"></div>
+                            <limel-color-picker-palette label="Hair color">
+                                <mock:shadow-root></mock:shadow-root>
+                            </limel-color-picker-palette>
+                        </limel-popover>
+                        <limel-input-field class="chosen-color-input" label="Hair color"></limel-input-field>
+                    </div>
+            </mock:shadow-root>
+        </limel-color-picker>`);
+});
+
+test('the component renders all colors in the palette', () => {
+    colors.forEach((color) => {
+        brightnesses.forEach((brightness) => {
+            const swatchElement = getSwatchElement(color, brightness);
+            expect(swatchElement).toEqualHtml(`
+                <div class="--color-${color}-${brightness} swatch" tabindex="0"></div>
+            `);
+        });
+    });
+});
+
+test('a new value is emitted when a swatch is clicked', async () => {
+    const swatchElement = getSwatchElement('pink', 'light');
+    swatchElement.click();
+
+    await page.waitForChanges();
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+            detail: 'rgb(var(--color-pink-light))',
+        })
+    );
+});
+
+test('swatch is set to selected when a value is set', async () => {
+    const picker = getPickerElement();
+    picker.value = 'rgb(var(--color-pink-light))';
+
+    await page.waitForChanges();
+
+    let swatchElement = getSwatchElement('pink', 'light');
+    expect(swatchElement).toHaveClass('swatch--selected');
+
+    swatchElement = getSwatchElement('teal', 'dark');
+    expect(swatchElement).not.toHaveClass('swatch--selected');
+});
+
+function getPickerElement(): HTMLLimelColorPickerElement {
+    return page.body.querySelector('limel-color-picker');
+}
+
+function getPaletteElement(): HTMLLimelColorPickerPaletteElement {
+    return getPickerElement().shadowRoot.querySelector(
+        'limel-color-picker-palette'
+    );
+}
+
+function getSwatchElement(color: string, brightness: string): HTMLDivElement {
+    return getPaletteElement().shadowRoot.querySelector(
+        `.--color-${color}-${brightness}`
+    );
+}

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -1,0 +1,148 @@
+/* eslint-disable multiline-ternary */
+import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import { FormComponent } from '../form/form.types';
+
+/**
+ * This component enables you to select a swatch from out color palette, simply
+ * by clicking on it. You can then copy the css variable name of the chosen color
+ * and use it where desired.
+ *
+ * The color picker can also show you a preview of any valid color name or color value.
+ *
+ * :::note
+ * Make sure to read our [guidelines about usage of colors](/#/DesignGuidelines/color-system.md/) from our palette.
+ * :::
+ *
+ * @exampleComponent limel-example-color-picker
+ * @exampleComponent limel-example-color-picker-readonly
+ */
+@Component({
+    tag: 'limel-color-picker',
+    shadow: true,
+    styleUrl: 'color-picker.scss',
+})
+export class ColorPicker implements FormComponent {
+    /**
+     * Name or code of the chosen color
+     */
+    @Prop({ reflect: true })
+    public value: string;
+
+    /**
+     * The label of the input field
+     */
+    @Prop({ reflect: true })
+    public label: string;
+
+    /**
+     * Helper text of the input field
+     */
+    @Prop({ reflect: true })
+    public helperText: string;
+
+    /**
+     * Displayed as tooltips when picker is hovered.
+     */
+    @Prop({ reflect: true })
+    public tooltipLabel: string;
+
+    /**
+     * Set to `true` if a value is required
+     */
+    @Prop({ reflect: true })
+    public required: boolean;
+
+    /**
+     * Set to `true` if a value is readonly. This makes the component un-interactive.
+     */
+    @Prop({ reflect: true })
+    public readonly: boolean;
+
+    /**
+     * Emits chosen value to the parent component
+     */
+    @Event()
+    public change: EventEmitter<string>;
+
+    @State()
+    private isOpen = false;
+
+    public render() {
+        return [
+            this.renderTooltip(),
+            <div class="color-picker">
+                {this.renderPickerPalette()}
+
+                <limel-input-field
+                    label={this.label}
+                    helperText={this.helperText}
+                    value={this.value}
+                    onChange={this.handleChange}
+                    required={this.required}
+                    readonly={this.readonly}
+                    class="chosen-color-input"
+                />
+            </div>,
+        ];
+    }
+    private renderTooltip = () => {
+        if (!this.readonly) {
+            return (
+                <limel-tooltip
+                    label={this.tooltipLabel}
+                    elementId="tooltip-button"
+                />
+            );
+        }
+    };
+
+    private renderPickerPalette = () => {
+        if (this.readonly) {
+            return this.renderPickerTrigger();
+        }
+
+        return (
+            <limel-popover open={this.isOpen} onClose={this.onPopoverClose}>
+                {this.renderPickerTrigger()}
+                <limel-color-picker-palette
+                    value={this.value}
+                    label={this.label}
+                    helperText={this.helperText}
+                    onChange={this.handleChange}
+                    required={this.required}
+                />
+            </limel-popover>
+        );
+    };
+
+    private renderPickerTrigger = () => {
+        const background = this.value ? { '--background': this.value } : {};
+
+        return (
+            <div
+                class="picker-trigger"
+                slot="trigger"
+                style={background}
+                role="button"
+                tabindex="0"
+                onClick={this.openPopover}
+                id="tooltip-button"
+            />
+        );
+    };
+
+    private openPopover = (event: MouseEvent) => {
+        event.stopPropagation();
+        this.isOpen = true;
+    };
+
+    private onPopoverClose = (event: CustomEvent) => {
+        event.stopPropagation();
+        this.isOpen = false;
+    };
+
+    private handleChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.change.emit(event.detail);
+    };
+}

--- a/src/components/color-picker/examples/color-picker-readonly.tsx
+++ b/src/components/color-picker/examples/color-picker-readonly.tsx
@@ -1,0 +1,22 @@
+import { Component, h } from '@stencil/core';
+/**
+ * Using the component in `readonly` mode
+ * It is possible to use the component to visualize a color of your choice.
+ * In this case, users cannot pick any colors, but they can view what you have picked.
+ */
+
+@Component({
+    tag: 'limel-example-color-picker-readonly',
+    shadow: true,
+})
+export class ColorPickerReadonlyExample {
+    public render() {
+        return (
+            <limel-color-picker
+                label="Look at this beautiful color!"
+                readonly={true}
+                value="rgba(var(--color-red-default), 0.4)"
+            />
+        );
+    }
+}

--- a/src/components/color-picker/examples/color-picker.tsx
+++ b/src/components/color-picker/examples/color-picker.tsx
@@ -1,0 +1,25 @@
+import { Component, h, State } from '@stencil/core';
+@Component({
+    tag: 'limel-example-color-picker',
+    shadow: true,
+})
+export class ColorPickerExample {
+    @State()
+    private value: string;
+
+    public render() {
+        return (
+            <limel-color-picker
+                value={this.value}
+                tooltipLabel="Click to pick a color"
+                helperText="You can also type a color name or value to preview it here"
+                label="Chosen color"
+                onChange={this.onChange}
+            />
+        );
+    }
+
+    private onChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/color-picker/swatches.ts
+++ b/src/components/color-picker/swatches.ts
@@ -1,0 +1,32 @@
+export const colors = [
+    'red',
+    'pink',
+    'magenta',
+    'purple',
+    'violet',
+    'indigo',
+    'blue',
+    'sky',
+    'cyan',
+    'teal',
+    'green',
+    'lime',
+    'grass',
+    'yellow',
+    'amber',
+    'orange',
+    'coral',
+    'brown',
+    'gray',
+    'glaucous',
+];
+
+export const brightnesses = ['lighter', 'light', 'default', 'dark', 'darker'];
+
+export function getColorName(color: string, brightness: string): string {
+    return `--color-${color}-${brightness}`;
+}
+
+export function getCssColor(color: string, brightness: string): string {
+    return `rgb(var(${getColorName(color, brightness)}))`;
+}

--- a/src/design-guidelines/color-system/examples/shared-styles.scss
+++ b/src/design-guidelines/color-system/examples/shared-styles.scss
@@ -23,6 +23,7 @@
     justify-content: center;
     color: rgba(var(--kompendium-color-white), 0.4);
     font-size: functions.pxToRem(20);
+    line-height: 99%;
 
     &:after {
         // this makes the aspect ratio 1:1


### PR DESCRIPTION
Things left to fix:

- [x] make the swatches are navigatabel with keyboard tab
- [x] ~use translation keys~
- [x] make some things props
- [x] make sure selected color in the picker is highlighted
- [x] implement `FormComponent`
- [x] add `componentWillLoad` 
- [x] link to color guidelines.
- [x] implement required (maybe disabled) prop

fix https://github.com/Lundalogik/crm-feature/issues/2503

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
