### PR TITLE
fix(slider): round invalid values to step

### DIFF
--- a/src/components/slider/examples/slider-multiplier.tsx
+++ b/src/components/slider/examples/slider-multiplier.tsx
@@ -1,7 +1,12 @@
 import { Component, h, State } from '@stencil/core';
 
 /**
- * With Multiplier
+ * With multiplier and step
+ *
+ * When step is configured and the initial value is not a multiple of the step
+ * value, the slider will round the value to the nearest step when it is changed
+ * for the first time. After a valid value has been set, only discrete valid
+ * values will be possible to pick.
  */
 @Component({
     tag: 'limel-example-slider-multiplier',
@@ -14,6 +19,7 @@ export class SliderMultiplierExample {
     private factor = 100;
     private minValue = 0;
     private maxValue = 1;
+    private step = 0.1;
 
     public render() {
         return (
@@ -23,6 +29,7 @@ export class SliderMultiplierExample {
                     unit=" %"
                     value={this.value}
                     factor={this.factor}
+                    step={this.step}
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
                     onChange={this.handleChange}

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -118,13 +118,11 @@ export class Slider {
     }
 
     private initialize() {
-        const element =
-            this.rootElement.shadowRoot.querySelector('.mdc-slider');
-        if (!element) {
+        const inputElement = this.getInputElement();
+        if (!inputElement) {
             return;
         }
 
-        const inputElement: HTMLInputElement = element.querySelector('input');
         const value = this.getValue();
 
         /*
@@ -151,7 +149,6 @@ export class Slider {
         */
         const greaterThanOrEqualMin = value >= this.valuemin;
         const lessThanOrEqualMax = value <= this.valuemax;
-        const dividableByStep = value % this.step === 0;
 
         if (!greaterThanOrEqualMin) {
             const newMin = this.multiplyByFactor(value);
@@ -163,13 +160,11 @@ export class Slider {
             inputElement.setAttribute('max', `${newMax}`);
         }
 
-        if (!dividableByStep) {
+        if (!this.isMultipleOfStep(value, this.step)) {
             inputElement.removeAttribute('step');
         }
 
-        this.mdcSlider = new MDCSlider(element);
-        this.mdcSlider.listen('MDCSlider:change', this.changeHandler);
-        this.mdcSlider.listen('MDCSlider:input', this.inputHandler);
+        this.createMDCSlider();
     }
 
     public componentWillLoad() {
@@ -177,9 +172,7 @@ export class Slider {
     }
 
     public disconnectedCallback() {
-        this.mdcSlider.unlisten('MDCSlider:change', this.changeHandler);
-        this.mdcSlider.unlisten('MDCSlider:input', this.inputHandler);
-        this.mdcSlider.destroy();
+        this.destroyMDCSlider();
     }
 
     private getContainerClassList() {
@@ -288,7 +281,19 @@ export class Slider {
             return;
         }
 
-        this.mdcSlider.setValue(this.multiplyByFactor(this.getValue()));
+        const value = this.multiplyByFactor(this.getValue());
+        this.mdcSlider.setValue(value);
+
+        if (this.isStepConfigured()) {
+            return;
+        }
+
+        const step = this.multiplyByFactor(this.step);
+        if (!this.isMultipleOfStep(value, step)) {
+            return;
+        }
+
+        this.reCreateSliderWithStep();
     }
 
     private updateDisabledState() {
@@ -300,7 +305,14 @@ export class Slider {
     }
 
     private changeHandler = (event) => {
-        this.change.emit(event.detail.value / this.factor);
+        let value = event.detail.value;
+        const step = this.multiplyByFactor(this.step);
+
+        if (!this.isMultipleOfStep(value, step)) {
+            value = this.roundToStep(value, step);
+        }
+
+        this.change.emit(value / this.factor);
     };
 
     private multiplyByFactor(value) {
@@ -324,5 +336,68 @@ export class Slider {
         this.percentageClass = getPercentageClass(
             (value - this.valuemin) / (this.valuemax - this.valuemin)
         );
+    }
+
+    private isMultipleOfStep(value: number, step: number): boolean {
+        if (!step) {
+            return true;
+        }
+
+        return value % step === 0;
+    }
+
+    private roundToStep(value: number, step: number): number {
+        return Math.round(value / step) * step;
+    }
+
+    private getRootElement(): HTMLElement | undefined {
+        return this.rootElement.shadowRoot.querySelector('.mdc-slider');
+    }
+
+    private getInputElement(): HTMLInputElement | undefined {
+        const element = this.getRootElement();
+        if (!element) {
+            return;
+        }
+
+        return element.querySelector('input');
+    }
+
+    private isStepConfigured(): boolean {
+        if (!this.step) {
+            return true;
+        }
+
+        const input = this.getInputElement();
+        if (!input) {
+            return true;
+        }
+
+        return input.hasAttribute('step');
+    }
+
+    private reCreateSliderWithStep() {
+        const inputElement = this.getInputElement();
+        const step = `${this.multiplyByFactor(this.step)}`;
+
+        inputElement.setAttribute('step', step);
+
+        this.destroyMDCSlider();
+        this.createMDCSlider();
+    }
+
+    private createMDCSlider() {
+        const element = this.getRootElement();
+
+        this.mdcSlider = new MDCSlider(element);
+        this.mdcSlider.listen('MDCSlider:change', this.changeHandler);
+        this.mdcSlider.listen('MDCSlider:input', this.inputHandler);
+    }
+
+    private destroyMDCSlider() {
+        this.mdcSlider.unlisten('MDCSlider:change', this.changeHandler);
+        this.mdcSlider.unlisten('MDCSlider:input', this.inputHandler);
+        this.mdcSlider.destroy();
+        this.mdcSlider = undefined;
     }
 }


### PR DESCRIPTION
When step is configured and the initial value is not a multiple of the step value, the slider will
round the value to the nearest step when it is changed for the first time. After a valid value has
been set, only discrete valid values will be possible to pick.

re Lundalogik/crm-feature#2301 Lundalogik/crm-feature#2419



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
