### PR TITLE
fix(list): make list items to be as wide as the list

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -18,7 +18,7 @@ $list-border-radius: 0.375rem; // 6px
  * @prop --list-grid-gap: Distance between items in a list that has `has-grid-layout` class. Defaults to `0.75rem`.
  */
 
-:host {
+:host(limel-list) {
     display: block;
 }
 
@@ -37,6 +37,7 @@ $list-border-radius: 0.375rem; // 6px
     border-radius: $list-border-radius;
 
     .mdc-deprecated-list-item {
+        box-sizing: border-box;
         z-index: z-index.$list-mdc-list-item; // in Chrome on Windows, menus flicker when they have a scroll bar and user hovers on them. We may be able to remove this in future versions of Chrome. Kia 2021-May-12
 
         &.mdc-deprecated-list-item--disabled {


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1467

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
