### PR TITLE
fix(color-picker): render the tooltip if there is a tooltip label

### DIFF
--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -26,7 +26,6 @@ test('the component renders', () => {
     expect(page.body).toEqualHtml(`
         <limel-color-picker label="Hair color">
             <mock:shadow-root>
-                <limel-tooltip elementid="tooltip-button"></limel-tooltip>
                     <div class="color-picker">
                         <limel-popover>
                             <div class="picker-trigger" id="tooltip-button" role="button" slot="trigger" tabindex="0"></div>

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -86,7 +86,7 @@ export class ColorPicker implements FormComponent {
         ];
     }
     private renderTooltip = () => {
-        if (!this.readonly) {
+        if (!this.readonly && this.tooltipLabel) {
             return (
                 <limel-tooltip
                     label={this.tooltipLabel}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2522
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
