### PR TITLE
fix(color-picker-pallet): add support for deprecated lime colors

### DIFF
--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -1,4 +1,5 @@
 @use '../../style/mixins';
+@import './partial-styles/lime-admin-hack';
 
 :host {
     --popover-surface-width: 50rem;

--- a/src/components/color-picker/partial-styles/_lime-admin-hack.scss
+++ b/src/components/color-picker/partial-styles/_lime-admin-hack.scss
@@ -1,0 +1,45 @@
+// In Lime Admin, old lime colors can be either written like this:
+// `lime-colorName` or like this `var(--lime-color-name)` .
+// They would work fine either way in the front-end. But this
+// component cannot visualize the first: (`lime-colorName`) and will
+// display a transparent color. Therefore, this hack is needed to make
+// it work perfectly in Lime Admin.
+
+.picker-trigger,
+.chosen-color-preview {
+    &[style='--background:lime-blue;'] {
+        &:after {
+            background-color: var(--lime-blue);
+        }
+    }
+    &[style='--background:lime-orange;'] {
+        &:after {
+            background-color: var(--lime-orange);
+        }
+    }
+    &[style='--background:lime-green;'] {
+        &:after {
+            background-color: var(--lime-green);
+        }
+    }
+    &[style='--background:lime-red;'] {
+        &:after {
+            background-color: var(--lime-red);
+        }
+    }
+    &[style='--background:lime-dark-blue;'] {
+        &:after {
+            background-color: var(--lime-dark-blue);
+        }
+    }
+    &[style='--background:lime-turquoise;'] {
+        &:after {
+            background-color: var(--lime-turquoise);
+        }
+    }
+    &[style='--background:lime-yellow;'] {
+        &:after {
+            background-color: var(--lime-yellow);
+        }
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2524

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
