### PR TITLE
fix(color-picker): add support for showing deprecated `lime-light-gre…

### DIFF
--- a/src/components/color-picker/partial-styles/_lime-admin-hack.scss
+++ b/src/components/color-picker/partial-styles/_lime-admin-hack.scss
@@ -42,4 +42,9 @@
             background-color: var(--lime-yellow);
         }
     }
+    &[style='--background:lime-light-grey;'] {
+        &:after {
+            background-color: var(--lime-light-grey);
+        }
+    }
 }


### PR DESCRIPTION
…y` color



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
