### PR TITLE
feat(form): add transformErrors prop

### DIFF
--- a/src/components/form/examples/custom-error-message-form.tsx
+++ b/src/components/form/examples/custom-error-message-form.tsx
@@ -1,0 +1,67 @@
+import { ValidationStatus, FormError } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+import { schema } from './custom-error-message-schema';
+
+/**
+ * Form with custom error message
+ *
+ * @link custom-error-message-schema.ts
+ */
+@Component({
+    tag: 'limel-example-custom-error-message',
+    shadow: true,
+})
+export class CustomErrorMessageFormExample {
+    @State()
+    private formData: object = {
+        personalIdentityNumber: '',
+    };
+
+    @State()
+    private valid = true;
+
+    public render() {
+        return [
+            <limel-form
+                onValidate={this.handleFormValidate}
+                onChange={this.handleFormChange}
+                value={this.formData}
+                schema={schema}
+                transformErrors={this.transformErrors}
+            />,
+            <br />,
+            <limel-button
+                label="Submit"
+                primary={true}
+                disabled={!this.valid}
+                onClick={this.handleSubmit}
+            />,
+        ];
+    }
+
+    private handleFormChange = (event) => {
+        this.formData = event.detail;
+    };
+
+    private handleSubmit = () => {
+        const json = JSON.stringify(this.formData, null, '    ');
+        alert(`Sending information to villains...\n\n${json}`);
+    };
+
+    private handleFormValidate = (event: CustomEvent<ValidationStatus>) => {
+        this.valid = event.detail.valid;
+    };
+
+    private transformErrors = (errors: FormError[]): FormError[] => {
+        return errors.map((error) => {
+            if (
+                error.name === 'pattern' &&
+                error.property === '.personalIdentityNumber'
+            ) {
+                error.message = 'Invalid format, use YYYYMMDD-NNNN';
+            }
+
+            return error;
+        });
+    };
+}

--- a/src/components/form/examples/custom-error-message-schema.ts
+++ b/src/components/form/examples/custom-error-message-schema.ts
@@ -1,0 +1,14 @@
+export const schema = {
+    title: 'Personal identity number form',
+    description: 'Please enter your personal identity number',
+    type: 'object',
+    required: ['personalIdentityNumber'],
+    properties: {
+        personalIdentityNumber: {
+            type: 'string',
+            title: 'Personal identity number',
+            description: 'Enter your personal identity number',
+            pattern: '[0-9]{8}[-][0-9]{4}',
+        },
+    },
+};


### PR DESCRIPTION
Make it possible to provide the [transformErrors](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/form-props/#transformerrors) function to customize the error messages.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
