### PR TITLE
honor `lime.component.props.disabled` for form components

### DIFF
--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -138,7 +138,11 @@ export class LimeElementsWidgetAdapter extends React.Component {
         const widgetProps = this.props.widgetProps;
         const options: LimeSchemaOptions = widgetProps.schema.lime;
 
-        return widgetProps.disabled || options?.disabled;
+        return (
+            widgetProps.disabled ||
+            options?.disabled ||
+            options?.component?.props?.disabled
+        );
     }
 
     private isReadOnly() {

--- a/src/components/form/widgets/select.ts
+++ b/src/components/form/widgets/select.ts
@@ -26,6 +26,8 @@ export class Select extends React.Component {
             value = findValue(props.value, options);
         }
 
+        const additionalProps = props.schema.lime?.component?.props || {};
+
         return React.createElement(LimeElementsWidgetAdapter, {
             name: 'limel-select',
             value: value,
@@ -36,6 +38,7 @@ export class Select extends React.Component {
             extraProps: {
                 multiple: props.multiple,
                 options: options,
+                ...additionalProps,
             },
         });
     }


### PR DESCRIPTION
fix: #1477

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
