### PR TITLE
fix(input-field): prevent value being covered by trailing icon when `…

### DIFF
--- a/src/components/input-field/partial-styles/_readonly.scss
+++ b/src/components/input-field/partial-styles/_readonly.scss
@@ -15,3 +15,17 @@
         }
     }
 }
+
+:host([type='url']),
+:host([type='email']),
+:host([type='urlAsText']),
+:host([type='tel']) {
+    .mdc-text-field {
+        &.lime-text-field--readonly {
+            .mdc-text-field__input {
+                @include mixins.truncate-text();
+                width: calc(100% - 2.75rem);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…showLink=true` & `readonly`

fix https://github.com/Lundalogik/lime-elements/issues/1480

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
