### PR TITLE
fix(menu-list): add margin to visualize keyboard-focused items

### DIFF
--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -7,6 +7,8 @@
 }
 
 .mdc-deprecated-list {
+    margin: functions.pxToRem(4);
+    // added space to visualize keyboard-focused items
     .mdc-deprecated-list-item[role='menuitem'] {
         font-size: functions.pxToRem(13);
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2491
![image](https://user-images.githubusercontent.com/50618208/145370992-d5155ccd-2629-498d-a8a0-7e143dc2b83a.png)
![image](https://user-images.githubusercontent.com/50618208/145371056-d71b109d-9716-4bde-b582-c4f7aca46515.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
