### PR TITLE
fix(menu-list): display: block, to avoid a vertical scroll bar

### DIFF
--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -2,6 +2,10 @@
 
 @import '../list/list';
 
+:host(limel-menu-list) {
+    display: block;
+}
+
 .mdc-menu {
     max-height: 70vh; // force tall menus render inside the viewport when menu is at the bottom of the screen
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2542

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
