### PR TITLE
chore: remove deprecated config option `namedExports`

### DIFF
--- a/stencil.config.dist.ts
+++ b/stencil.config.dist.ts
@@ -9,15 +9,6 @@ export const config: Config = {
             copy: [{ src: 'style/' }],
         },
     ],
-    commonjs: {
-        namedExports: {
-            'node_modules/react-dom/index.js': [
-                'render',
-                'unmountComponentAtNode',
-            ],
-            'node_modules/react/index.js': ['Component', 'forwardRef'],
-        },
-    },
     plugins: [sass()],
     tsconfig: './tsconfig.dist.json',
     globalStyle: 'src/global/core-styles.scss',

--- a/stencil.config.docs.ts
+++ b/stencil.config.docs.ts
@@ -34,15 +34,6 @@ export const config: Config = {
             ],
         },
     ],
-    commonjs: {
-        namedExports: {
-            'node_modules/react-dom/index.js': [
-                'render',
-                'unmountComponentAtNode',
-            ],
-            'node_modules/react/index.js': ['Component', 'forwardRef'],
-        },
-    },
     plugins: [sass()],
     tsconfig: './tsconfig.docs.json',
     globalStyle: 'src/global/core-styles.scss',

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -41,15 +41,6 @@ export const config: Config = {
             ],
         },
     ],
-    commonjs: {
-        namedExports: {
-            'node_modules/react-dom/index.js': [
-                'render',
-                'unmountComponentAtNode',
-            ],
-            'node_modules/react/index.js': ['Component', 'forwardRef'],
-        },
-    },
     plugins: [sass()],
     tsconfig: './tsconfig.dev.json',
     globalStyle: 'src/global/core-styles.scss',


### PR DESCRIPTION
Once build warning less…

Builds just fine, tests pass. I haven't tested the docs or in lime-webclient yet, so please do! No hurry though 😊

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
