### PR TITLE
fix(list): fix layout of two-lined lists, when only some individual i…

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -123,7 +123,8 @@ $list-border-radius: 0.375rem; // 6px
 
     &.mdc-deprecated-list--two-line {
         .mdc-deprecated-list-item__text {
-            padding: functions.pxToRem(8) 0;
+            padding-top: functions.pxToRem(8);
+            padding-bottom: functions.pxToRem(8);
         }
         .mdc-deprecated-list-item__primary-text {
             margin-bottom: functions.pxToRem(4);


### PR DESCRIPTION
…tems have `secondaryText`

fix https://github.com/Lundalogik/crm-feature/issues/2573

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
