### PR TITLE
feat(checkbox): add support for displaying `helperText`

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -11,6 +11,7 @@
 
 .mdc-form-field {
     display: flex;
+    flex-wrap: wrap;
 
     .mdc-checkbox {
         &.mdc-checkbox--invalid {
@@ -80,3 +81,5 @@
         opacity: 0; // What we like it to become, a moment after it gets focused
     }
 }
+
+@import './partial-styles/_helper-text.scss';

--- a/src/components/checkbox/checkbox.template.tsx
+++ b/src/components/checkbox/checkbox.template.tsx
@@ -8,6 +8,7 @@ interface CheckboxTemplateProps {
     invalid?: boolean;
     onChange?: (event: Event) => void;
     label?: string;
+    helperText?: string;
 }
 
 export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = (
@@ -54,6 +55,21 @@ export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = (
             >
                 {props.label}
             </label>
+            <HelperText text={props.helperText} />
+        </div>
+    );
+};
+
+const HelperText: FunctionalComponent<{ text: string }> = (props) => {
+    if (typeof props.text !== 'string') {
+        return;
+    }
+
+    return (
+        <div class="limel-checkbox-helper-line">
+            <p class="limel-checkbox-helper-text" aria-hidden="true">
+                {props.text.trim()}
+            </p>
         </div>
     );
 };

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -14,6 +14,7 @@ import { CheckboxTemplate } from './checkbox.template';
 
 /**
  * @exampleComponent limel-example-checkbox
+ * @exampleComponent limel-example-checkbox-helper-text
  */
 @Component({
     tag: 'limel-checkbox',
@@ -40,6 +41,12 @@ export class Checkbox {
      */
     @Prop({ reflect: true })
     public label: string;
+
+    /**
+     * Optional helper text to display below the checkbox
+     */
+    @Prop({ reflect: true })
+    public helperText: string;
 
     /**
      * The value of the checkbox. Set to `true` to make the checkbox checked.
@@ -105,6 +112,7 @@ export class Checkbox {
             <CheckboxTemplate
                 disabled={this.disabled || this.readonly}
                 label={this.label}
+                helperText={this.helperText}
                 checked={this.checked}
                 required={this.required}
                 invalid={this.required && this.modified && !this.checked}

--- a/src/components/checkbox/examples/checkbox-helper-text.tsx
+++ b/src/components/checkbox/examples/checkbox-helper-text.tsx
@@ -1,0 +1,31 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * With `helperText`
+ *
+ * Checkboxes can have a helper text, which is useful when providing additional information
+ * can clarify functionality of the checkbox for the user.
+ *
+ * The helper text is displayed when user hovers the checkbox, or focuses on it using keyboard
+ * navigation. However, on touchscreen devices, the helper text is always displayed.
+ */
+
+@Component({
+    tag: 'limel-example-checkbox-helper-text',
+    shadow: true,
+})
+export class CheckboxHelperTextExample {
+    public render() {
+        return (
+            <section>
+                <div>
+                    <limel-checkbox
+                        label="I accept terms of use"
+                        helperText="You need to accept to be able to continue…"
+                        id="terms"
+                    />
+                </div>
+            </section>
+        );
+    }
+}

--- a/src/components/checkbox/partial-styles/_helper-text.scss
+++ b/src/components/checkbox/partial-styles/_helper-text.scss
@@ -1,0 +1,29 @@
+@use '../../../style/internal/shared_input-select-picker';
+
+.limel-checkbox-helper-line {
+    flex-basis: 100%;
+    @include shared_input-select-picker.looks-like-helper-line;
+}
+
+.limel-checkbox-helper-text {
+    @include shared_input-select-picker.looks-like-helper-text;
+    color: shared_input-select-picker.$helper-text-color;
+}
+
+.mdc-form-field {
+    &:hover,
+    &:focus,
+    &:focus-visible,
+    &:focus-within {
+        .limel-checkbox-helper-text {
+            opacity: 1;
+        }
+    }
+}
+
+@media (pointer: coarse) {
+    // touchscreen devices
+    .limel-checkbox-helper-text {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2516

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
