### PR TITLE
fix(list): don't set selected index on mdc-list if selected item not found

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -155,9 +155,15 @@ export class List {
                 .filter((item: ListItem) => item.selected)
                 .map((item: ListItem) => listItems.indexOf(item));
         } else {
-            this.mdcList.selectedIndex = listItems.findIndex(
+            const selectedIndex = listItems.findIndex(
                 (item: ListItem) => item.selected
             );
+
+            if (selectedIndex === -1) {
+                this.mdcList.initializeListType();
+            } else {
+                this.mdcList.selectedIndex = selectedIndex;
+            }
         }
     }
 

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -150,17 +150,15 @@ export class List {
 
         const listItems = this.items.filter(this.isListItem);
 
-        if (!this.multiple) {
+        if (this.multiple) {
+            this.mdcList.selectedIndex = listItems
+                .filter((item: ListItem) => item.selected)
+                .map((item: ListItem) => listItems.indexOf(item));
+        } else {
             this.mdcList.selectedIndex = listItems.findIndex(
                 (item: ListItem) => item.selected
             );
-
-            return;
         }
-
-        this.mdcList.selectedIndex = listItems
-            .filter((item: ListItem) => item.selected)
-            .map((item: ListItem) => listItems.indexOf(item));
     }
 
     private setup = () => {


### PR DESCRIPTION
Note to the reviewer: There are two commits, one pure refactor and one that changes the functionality. Reviewing them one by one is recommended. I tried adding a regression test for the bug, but couldn't get it to work, and I don't think we should delay getting the bug fix because I'm currently having trouble understanding how to properly test for errors in async functionality involving user input 😅 (My failures at adding a test can be witnessed in #1602)
/ @adrianschmidt

Setting selectedIndex -1 on mdc-list will cause consequential errors.
This happens when none of the items are selected or if the selected prop is missing on the items.

Bug introduced in this commit: https://github.com/Lundalogik/lime-elements/commit/0a2fad6ed61d6c071ce364fb2fb255adbf9c357c

Not sure if this will cause other problems, please shout in that case.

**How to reproduce:**
Update the items in a list with items that doesn't have the `selected` property will result in this error:

![Skärmavbild 2022-01-03 kl  16 27 34](https://user-images.githubusercontent.com/21986391/147948704-7ae8ef0d-311a-48cf-ae4d-8b6af6e12e4b.png)

fix: #1593 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
