### PR TITLE
fix(form): properly support displaying `helperText` for custom compon…

### DIFF
--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -8,31 +8,31 @@ import { ListItem } from '../../list/list-item.types';
 })
 export class CustomPickerExample implements FormComponent<number> {
     /**
-     * The value of the property
+     * @inheritdoc
      */
     @Prop()
     public value: number;
 
     /**
-     * Label to display next to the input field
+     * @inheritdoc
      */
     @Prop()
     public label: string;
 
     /**
-     * Set to `true` if a value is required
+     * @inheritdoc
      */
     @Prop()
     public required: boolean;
 
     /**
-     * Set to `true` if the value is readonly
+     * @inheritdoc
      */
     @Prop()
     public readonly: boolean;
 
     /**
-     * Set to `true` if input should be disabled
+     * @inheritdoc
      */
     @Prop()
     public disabled: boolean;

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -10,31 +10,31 @@ export class CustomPickerExample implements FormComponent<number> {
     /**
      * @inheritdoc
      */
-    @Prop()
+    @Prop({ reflect: true })
     public value: number;
 
     /**
      * @inheritdoc
      */
-    @Prop()
+    @Prop({ reflect: true })
     public label: string;
 
     /**
      * @inheritdoc
      */
-    @Prop()
+    @Prop({ reflect: true })
     public required: boolean;
 
     /**
      * @inheritdoc
      */
-    @Prop()
+    @Prop({ reflect: true })
     public readonly: boolean;
 
     /**
      * @inheritdoc
      */
-    @Prop()
+    @Prop({ reflect: true })
     public disabled: boolean;
 
     /**

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -38,6 +38,12 @@ export class CustomPickerExample implements FormComponent<number> {
     public disabled: boolean;
 
     /**
+     * @inheritdoc
+     */
+    @Prop({ reflect: true })
+    public helperText?: string;
+
+    /**
      * Emitted when the value is changed
      */
     @Event()
@@ -93,6 +99,7 @@ export class CustomPickerExample implements FormComponent<number> {
                 required={this.required}
                 onChange={this.handleChange}
                 searcher={this.search}
+                helperText={this.helperText}
             />
         );
     }

--- a/src/components/form/examples/custom-component-schema.ts
+++ b/src/components/form/examples/custom-component-schema.ts
@@ -17,6 +17,9 @@ export const schema = {
             lime: {
                 component: {
                     name: 'limel-example-custom-picker',
+                    props: {
+                        helperText: 'Pick your superhero!',
+                    },
                 },
             },
         },

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -150,7 +150,9 @@ export class SchemaField extends React.Component<FieldProps> {
         const { errorSchema, schema } = this.props;
 
         if (!this.isInvalid()) {
-            return schema.description;
+            const helperText = schema.lime?.component?.props?.helperText;
+
+            return helperText || schema.description;
         }
 
         if (!isEmpty(errorSchema) && '__errors' in errorSchema) {


### PR DESCRIPTION
…ents

fix https://github.com/Lundalogik/crm-feature/issues/2582

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
