### PR TITLE
style(slider): move imported partial styles to the last line

### DIFF
--- a/src/components/slider/partial-styles/_helper-text.scss
+++ b/src/components/slider/partial-styles/_helper-text.scss
@@ -1,9 +1,17 @@
+:host(:focus),
+:host(:focus-visible),
+:host(:focus-within) {
+    .mdc-slider-helper-text {
+        opacity: 1;
+    }
+}
+
 .mdc-slider-helper-line {
     @include shared_input-select-picker.looks-like-helper-line;
 }
 .mdc-slider-helper-text {
     @include shared_input-select-picker.looks-like-helper-text;
-    opacity: 1;
+
     &:before {
         @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
     }

--- a/src/components/slider/partial-styles/_helper-text.scss
+++ b/src/components/slider/partial-styles/_helper-text.scss
@@ -1,0 +1,10 @@
+.mdc-slider-helper-line {
+    @include shared_input-select-picker.looks-like-helper-line;
+}
+.mdc-slider-helper-text {
+    @include shared_input-select-picker.looks-like-helper-text;
+    opacity: 1;
+    &:before {
+        @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
+    }
+}

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -71,17 +71,7 @@
     }
 }
 
-.mdc-slider-helper-line {
-    @include shared_input-select-picker.looks-like-helper-line;
-}
-.mdc-slider-helper-text {
-    @include shared_input-select-picker.looks-like-helper-text;
-    opacity: 1;
-    &:before {
-        @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
-    }
-}
-
 @import './partial-styles/percentage-color';
 @import './partial-styles/_readonly';
 @import './partial-styles/_thumb';
+@import './partial-styles/_helper-text';

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -7,10 +7,6 @@
 @use '@material/slider/styles';
 @use '@material/floating-label/mdc-floating-label';
 
-@import './partial-styles/percentage-color.scss';
-@import './partial-styles/_readonly.scss';
-@import './partial-styles/_thumb.scss';
-
 .slider {
     position: relative;
 }
@@ -85,3 +81,7 @@
         @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
     }
 }
+
+@import './partial-styles/percentage-color';
+@import './partial-styles/_readonly';
+@import './partial-styles/_thumb';


### PR DESCRIPTION
As a convention, it's better to keep imports at the bottom,
in case they are overriding something.
Also this keep it consistent with other components.
Additionally removed the extension `.scss` as it's not needed.

fix https://github.com/Lundalogik/crm-feature/issues/2592

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
