### PR TITLE
fix(chip-set): make placement of helper text aligned with other compo…

### DIFF
--- a/src/components/chip-set/partial-styles/_helper-text.scss
+++ b/src/components/chip-set/partial-styles/_helper-text.scss
@@ -2,6 +2,12 @@
     flex-basis: 100%;
 }
 
+.mdc-text-field-helper-text {
+    &:before {
+        @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
+    }
+}
+
 :host(:not([type='input'])) {
     .mdc-chip-set {
         &:hover,


### PR DESCRIPTION
…nents

fix https://github.com/Lundalogik/crm-feature/issues/2585

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
