### PR TITLE
Fixes for limel-menu with secondaryText

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -91,9 +91,9 @@ $list-border-radius: 0.375rem; // 6px
             bottom: 0;
 
             &.mdc-deprecated-list-divider--inset {
-                --icon-width: #{functions.pxToRem(41)};
-                --icon-right-padding: #{functions.pxToRem(16)};
-                --list-right-padding: #{functions.pxToRem(16)};
+                --icon-width: #{functions.pxToRem(40)};
+                --icon-right-padding: #{functions.pxToRem(12)};
+                --list-right-padding: #{functions.pxToRem(12)};
                 right: 0;
                 width: calc(
                     100% - var(--icon-width) - var(--icon-right-padding) -
@@ -101,11 +101,11 @@ $list-border-radius: 0.375rem; // 6px
                 );
 
                 &.x-small {
-                    --icon-width: #{functions.pxToRem(23)};
+                    --icon-width: #{functions.pxToRem(24)};
                 }
 
                 &.small {
-                    --icon-width: #{functions.pxToRem(30)};
+                    --icon-width: #{functions.pxToRem(32)};
                 }
 
                 &.medium {
@@ -113,7 +113,7 @@ $list-border-radius: 0.375rem; // 6px
                 }
 
                 &.large {
-                    --icon-width: #{functions.pxToRem(46)};
+                    --icon-width: #{functions.pxToRem(48)};
                 }
             }
         }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -94,9 +94,7 @@ $list-border-radius: 0.375rem; // 6px
                 --icon-width: #{functions.pxToRem(41)};
                 --icon-right-padding: #{functions.pxToRem(16)};
                 --list-right-padding: #{functions.pxToRem(16)};
-                margin-left: calc(
-                    var(--icon-width) + var(--icon-right-padding)
-                );
+                right: 0;
                 width: calc(
                     100% - var(--icon-width) - var(--icon-right-padding) -
                         var(--list-right-padding)

--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -58,6 +58,7 @@ export class MenuListRenderer {
                 aria-hidden={true}
                 role="menu"
                 aria-orientation="vertical"
+                style={{ '--maxLinesSecondaryText': '2' }}
             >
                 {items.map(this.renderMenuItem)}
             </ul>

--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -20,4 +20,10 @@
             margin-right: functions.pxToRem(14);
         }
     }
+
+    hr.mdc-deprecated-list-divider {
+        &.mdc-deprecated-list-divider--inset {
+            display: none;
+        }
+    }
 }

--- a/src/components/menu/examples/menu-basic-secondary-text.scss
+++ b/src/components/menu/examples/menu-basic-secondary-text.scss
@@ -1,0 +1,6 @@
+:host {
+    --menu-surface-width: min(
+        calc(100vw - 4rem),
+        20rem
+    ); // The `min()` function selects the smallest value from a list of comma-separated expressions.
+}

--- a/src/components/menu/examples/menu-basic-secondary-text.tsx
+++ b/src/components/menu/examples/menu-basic-secondary-text.tsx
@@ -1,0 +1,66 @@
+import { MenuItem, ListSeparator } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * With `secondaryText`
+ *
+ * Menu items can display secondary text as well. By default, the secondary text
+ * will be displayed in two lines, and then get truncated.
+ *
+ * :::important
+ * Keep in mind that a menu's drop-down will stretch as much as it can to display
+ * its content. You must therefore specify a maximum width for menus with
+ * long secondary text, otherwise they will fill out the entire screen width.
+ *
+ * But do not forget that menus should behave responsively, thus using a fixed `width`
+ * should be avoided. To make the width responsive, try using the `min()` function.
+ * This function selects the smallest value from a list of comma-separated expressions
+ * which are placed within the parentheses.
+ *
+ * For example, `--menu-surface-width: min(90vw, 40rem);` will output
+ * `width: min(90wv, 40rem);` which will tell the browser to render the menu
+ * content in a grid that's allowed to take up 90% of the viewport's width (`90vw`)
+ * up to a maximum of `40rem`.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-menu-secondary-text',
+    shadow: true,
+    styleUrl: 'menu-basic-secondary-text.scss',
+})
+export class MenuBasicExample {
+    @State()
+    private lastSelectedItem: string;
+
+    private items: Array<MenuItem | ListSeparator> = [
+        {
+            text: 'This item only has one line of primary text',
+        },
+        { separator: true },
+        {
+            text: 'Very long primary texts like this one can truncate based on what you specify for `--menu-surface-width`.',
+            secondaryText: 'This is a short secondary text.',
+        },
+        {
+            text: 'This item only has one line of primary text',
+            secondaryText:
+                'The length of secondary text exceeds maximum allowed number of lines, which is two. This happens because `--menu-surface-width` specified here is not so large. Thus the lines will truncate.',
+        },
+    ];
+
+    public render() {
+        return [
+            <limel-menu items={this.items} onSelect={this.handleSelect}>
+                <limel-button label="Menu" slot="trigger" />
+            </limel-menu>,
+            <limel-example-value
+                label="Last selected item"
+                value={this.lastSelectedItem}
+            />,
+        ];
+    }
+
+    private handleSelect = (event: CustomEvent<MenuItem>) => {
+        this.lastSelectedItem = event.detail.text;
+    };
+}

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -25,6 +25,7 @@ import {
  * @exampleComponent limel-example-menu-grid
  * @exampleComponent limel-example-menu-composite
  * @exampleComponent limel-example-menu-hotkeys
+ * @exampleComponent limel-example-menu-secondary-text
  */
 @Component({
     tag: 'limel-menu',

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -23,9 +23,9 @@ import {
  * @exampleComponent limel-example-menu-icons
  * @exampleComponent limel-example-menu-badge-icons
  * @exampleComponent limel-example-menu-grid
- * @exampleComponent limel-example-menu-composite
  * @exampleComponent limel-example-menu-hotkeys
  * @exampleComponent limel-example-menu-secondary-text
+ * @exampleComponent limel-example-menu-composite
  */
 @Component({
     tag: 'limel-menu',


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2609

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
