### PR TITLE
feat(table): adjust row height to custom component

### DIFF
--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -180,7 +180,7 @@ export function createCustomComponent(
     element.style.display = 'inline-block';
     setElementProperties(element, props);
 
-    createResizeObserver(element, cell.getColumn());
+    createResizeObserver(element, cell);
 
     return element;
 }
@@ -235,24 +235,31 @@ function getEventName(eventListener: string): string {
 
 function createResizeObserver(
     element: HTMLElement,
-    column: Tabulator.ColumnComponent
+    cell: Tabulator.CellComponent
 ) {
     if (!('ResizeObserver' in window)) {
         return;
     }
 
     const RESIZE_TIMEOUT = 1000;
-    const COLUMN_PADDING = 16;
+    const TABULATOR_CELL_PADDING = 16;
+    const column = cell.getColumn();
 
     const observer = new ResizeObserver(() => {
-        const width = element.getBoundingClientRect().width;
-        const newWidth = width + COLUMN_PADDING;
+        const rect = element.getBoundingClientRect();
+        const cellRect = cell.getElement().getBoundingClientRect();
+        const width = rect.width;
+        const newWidth = width + TABULATOR_CELL_PADDING;
+        const height = rect.height;
+        const newHeight = height + TABULATOR_CELL_PADDING;
 
-        if (newWidth < column.getWidth()) {
-            return;
+        if (newWidth > cellRect.width) {
+            column.setWidth(true);
         }
 
-        column.setWidth(newWidth);
+        if (newHeight > cellRect.height) {
+            cell.checkHeight();
+        }
     });
     observer.observe(element);
 


### PR DESCRIPTION
#1522

tell tabulator to check the row height when the custom component have rendered.

Note: this is just a draft because it seems to interfere with Tabulator's vertical VDom when scrolling. 
The solution works for the initial rows but as soon as more rows are added on scroll (row virtualization) changing the height of these rows while also the VDom code sets the scrollTop makes the table scroll to top over and over again while trying to scroll down to the bottom of the table. 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
