### PR TITLE
fix(input-field): make sure label has our default label color

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -57,6 +57,7 @@
 @include shared_input-select-picker.disabled-overrides;
 @include shared_input-select-picker.leading-icon;
 @include shared_input-select-picker.trailing-icon;
+@include shared_input-select-picker.floating-label-overrides;
 
 .mdc-text-field--with-trailing-icon {
     .mdc-text-field__icon--trailing {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -42,7 +42,9 @@
 }
 
 .limel-select__selected-option__text {
-    @include shared_input-select-picker.looks-like-input-label;
+    .mdc-select:not(.mdc-select--disabled) & {
+        @include shared_input-select-picker.looks-like-input-label;
+    }
     @include mixins.truncate-text;
 }
 
@@ -72,6 +74,7 @@
         }
 
         .mdc-floating-label {
+            color: shared_input-select-picker.$label-color;
             width: calc(
                 100% - #{functions.pxToRem(16)}
             ); //This forces the label to truncate when container is too little.

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -7,11 +7,18 @@
 @use '@material/slider/styles';
 @use '@material/floating-label/mdc-floating-label';
 
+:host([disabled]:not([readonly])) {
+    .slider__label {
+        color: shared_input-select-picker.$label-color-disabled;
+    }
+}
+
 .slider {
     position: relative;
 }
 
 .slider__label {
+    color: shared_input-select-picker.$label-color;
     padding-left: functions.pxToRem(20);
     top: functions.pxToRem(
         9

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -54,6 +54,7 @@ $cropped-label-hack--font-size: 0.875rem; //14px
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
 
+    color: $input-text-color;
     font-size: functions.pxToRem(14);
     font-weight: 400;
     letter-spacing: 0.009375em;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2624

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
