### PR TITLE
fix(checkbox): clean up animation classes before reconnected

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -102,20 +102,6 @@ export class Checkbox {
         this.initialize();
     }
 
-    private initialize() {
-        const element =
-            this.limelCheckbox.shadowRoot.querySelector('.mdc-form-field');
-        if (!element) {
-            return;
-        }
-
-        this.formField = new MDCFormField(element);
-        this.mdcCheckbox = new MDCCheckbox(
-            this.limelCheckbox.shadowRoot.querySelector('.mdc-checkbox')
-        );
-        this.formField.input = this.mdcCheckbox;
-    }
-
     public disconnectedCallback() {
         this.mdcCheckbox?.destroy();
         this.formField?.destroy();
@@ -135,6 +121,20 @@ export class Checkbox {
                 id={this.id}
             />
         );
+    }
+
+    private initialize() {
+        const element =
+            this.limelCheckbox.shadowRoot.querySelector('.mdc-form-field');
+        if (!element) {
+            return;
+        }
+
+        this.formField = new MDCFormField(element);
+        this.mdcCheckbox = new MDCCheckbox(
+            this.limelCheckbox.shadowRoot.querySelector('.mdc-checkbox')
+        );
+        this.formField.input = this.mdcCheckbox;
     }
 
     private onChange = (event: Event) => {

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,4 +1,4 @@
-import { MDCCheckbox } from '@material/checkbox';
+import { MDCCheckbox, cssClasses } from '@material/checkbox';
 import { MDCFormField } from '@material/form-field';
 import {
     Component,
@@ -105,6 +105,18 @@ export class Checkbox {
     public disconnectedCallback() {
         this.mdcCheckbox?.destroy();
         this.formField?.destroy();
+
+        const checkboxElement = this.getCheckboxElement();
+        if (checkboxElement) {
+            checkboxElement.classList.remove(
+                cssClasses.ANIM_CHECKED_INDETERMINATE,
+                cssClasses.ANIM_CHECKED_UNCHECKED,
+                cssClasses.ANIM_INDETERMINATE_CHECKED,
+                cssClasses.ANIM_INDETERMINATE_UNCHECKED,
+                cssClasses.ANIM_UNCHECKED_CHECKED,
+                cssClasses.ANIM_UNCHECKED_INDETERMINATE
+            );
+        }
     }
 
     public render() {
@@ -131,10 +143,12 @@ export class Checkbox {
         }
 
         this.formField = new MDCFormField(element);
-        this.mdcCheckbox = new MDCCheckbox(
-            this.limelCheckbox.shadowRoot.querySelector('.mdc-checkbox')
-        );
+        this.mdcCheckbox = new MDCCheckbox(this.getCheckboxElement());
         this.formField.input = this.mdcCheckbox;
+    };
+
+    private getCheckboxElement = () => {
+        return this.limelCheckbox.shadowRoot.querySelector('.mdc-checkbox');
     };
 
     private onChange = (event: Event) => {

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -123,7 +123,7 @@ export class Checkbox {
         );
     }
 
-    private initialize() {
+    private initialize = () => {
         const element =
             this.limelCheckbox.shadowRoot.querySelector('.mdc-form-field');
         if (!element) {
@@ -135,7 +135,7 @@ export class Checkbox {
             this.limelCheckbox.shadowRoot.querySelector('.mdc-checkbox')
         );
         this.formField.input = this.mdcCheckbox;
-    }
+    };
 
     private onChange = (event: Event) => {
         event.stopPropagation();


### PR DESCRIPTION
fix #1527  (that PR contains a visual repro that should not be added to the examples, hence this separate PR with the fix)

when the checkbox is disconnected and the mdc checkbox
instance is destroyed, it will prematurely remove the
animation end handler that removes all the animation
classes mdc adds when interacting with the checkbox.



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
