### PR TITLE
Specify a default max-width for limel-menu

### DIFF
--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -13,4 +13,9 @@
     width: var(--menu-surface-width, auto);
     max-height: 100%;
     position: relative;
+:host(limel-menu-surface.has-grid-layout) {
+    .mdc-menu-surface {
+        width: var(--menu-surface-width, min(calc(100vw - 2rem), 40rem));
+        max-width: unset;
+    }
 }

--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -10,9 +10,14 @@
 @include menu.core-styles;
 
 .mdc-menu-surface {
-    width: var(--menu-surface-width, auto);
     max-height: 100%;
     position: relative;
+    --mdc-menu-max-width: var(
+        --menu-surface-width,
+        min(calc(100vw - 2rem), 20rem)
+    );
+}
+
 :host(limel-menu-surface.has-grid-layout) {
     .mdc-menu-surface {
         width: var(--menu-surface-width, min(calc(100vw - 2rem), 40rem));

--- a/src/components/menu/examples/menu-basic-secondary-text.tsx
+++ b/src/components/menu/examples/menu-basic-secondary-text.tsx
@@ -8,11 +8,11 @@ import { Component, h, State } from '@stencil/core';
  * will be displayed in two lines, and then get truncated.
  *
  * :::important
- * Keep in mind that a menu's drop-down will stretch as much as it can to display
- * its content. You must therefore specify a maximum width for menus with
- * long secondary text, otherwise they will fill out the entire screen width.
+ * Keep in mind that a menu's drop-down surface will stretch as much as its default
+ * maximum width values allow. However, if this default maximum width does not suit
+ * your use case, you can override it using the `--menu-surface-width` variable.
  *
- * But do not forget that menus should behave responsively, thus using a fixed `width`
+ * But do not forget that menus should still behave responsively, thus assigning a fixed value
  * should be avoided. To make the width responsive, try using the `min()` function.
  * This function selects the smallest value from a list of comma-separated expressions
  * which are placed within the parentheses.

--- a/src/components/menu/examples/menu-grid.tsx
+++ b/src/components/menu/examples/menu-grid.tsx
@@ -3,15 +3,16 @@ import { Component, h } from '@stencil/core';
 
 /**
  * With grid layout
- * To render items of a menu in a gird layout instead of a vertical list,
- * two things are required:
- * 1. Simply setting the `gridLayout` property to `true`, and
- * 1. Specifying a proper width for the menu surface, using the
- * `--menu-surface-width` variable.
+ * To render items of a menu in a grid layout instead of a vertical list,
+ * simply setting the `gridLayout` property to `true`.
  *
  * :::note
- * Do not forget that menus should behave responsively, thus using a fixed `width`
- * should be avoided. To make the width responsive, try using the `min()` function.
+ * Menus with the grid layout has a responsive width by default,
+ * which will not grow wider than a certain size. However, if the default size is not
+ * wide enough for your use case, you can try setting another responsive width, using
+ * the `--menu-surface-width` variable.
+ *
+ * To achieve a responsive width, try using the `min()` function.
  * This function selects the smallest value from a list of comma-separated expressions
  * which are placed within the parentheses.
  *

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -4,7 +4,7 @@
 
 /**
  * @prop --dropdown-z-index: `z-index` of the dropdown menu.
- * @prop --menu-surface-width: Width of the menu surface. Defaults to `auto`.
+ * @prop --menu-surface-width: Width of the menu surface.
  * @prop --list-grid-item-max-width: Maximum width of items in the menu list when `gridLayout={true}`. Defaults to `10rem`.
  * @prop --list-grid-item-min-width: Minimum width of items in the menu list when `gridLayout={true}`. Defaults to `7.5rem`.
  * @prop --list-grid-gap: Distance between the items in the menu list when `gridLayout={true}`. Defaults to `0.75rem`.

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -134,6 +134,9 @@ export class Menu {
                         open={this.open}
                         onDismiss={this.onClose}
                         style={cssProperties}
+                        class={{
+                            'has-grid-layout': this.gridLayout,
+                        }}
                     >
                         <limel-menu-list
                             class={{


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2623

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
