### PR TITLE
fix(dialog): add padding to the footer in mobile view

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -120,4 +120,7 @@ slot[name='button'] {
     slot[name='button'] {
         flex-direction: column-reverse;
     }
+    .mdc-dialog__actions {
+        padding: 1rem 1.5rem 1.5rem 1.5rem;
+    }
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1525

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
