### PR TITLE
feat(table): add aggregates property

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -8,7 +8,12 @@ import {
     Event,
 } from '@stencil/core';
 import TabulatorTable from 'tabulator-tables';
-import { Column, TableParams, ColumnSorter } from './table.types';
+import {
+    Column,
+    TableParams,
+    ColumnSorter,
+    ColumnAggregate,
+} from './table.types';
 import { ColumnDefinitionFactory, createColumnSorter } from './columns';
 import { isEqual, has } from 'lodash-es';
 import { ElementPool } from './element-pool';
@@ -116,6 +121,12 @@ export class Table {
     public emptyMessage: string;
 
     /**
+     * Column aggregates to be displayed in the table
+     */
+    @Prop()
+    public aggregates: ColumnAggregate[];
+
+    /**
      * Enables row selection
      */
     @Prop()
@@ -182,6 +193,7 @@ export class Table {
         this.updateMaxPage = this.updateMaxPage.bind(this);
         this.initTabulatorComponent = this.initTabulatorComponent.bind(this);
         this.setSelection = this.setSelection.bind(this);
+        this.addColumnAggregator = this.addColumnAggregator.bind(this);
         this.pool = new ElementPool(document);
         this.columnFactory = new ColumnDefinitionFactory(this.pool);
     }
@@ -283,6 +295,29 @@ export class Table {
         this.init();
     }
 
+    @Watch('aggregates')
+    protected updateAggregates(
+        newAggregates: ColumnAggregate[],
+        oldAggregates: ColumnAggregate[]
+    ) {
+        if (!this.tabulator) {
+            return;
+        }
+
+        if (isEqual(newAggregates, oldAggregates)) {
+            return;
+        }
+
+        if (!this.haveSameAggregateFields(newAggregates, oldAggregates)) {
+            this.init();
+
+            return;
+        }
+
+        this.tabulator.recalc();
+        this.tabulator.rowManager.redraw();
+    }
+
     @Watch('selection')
     protected updateSelection(newSelection: any[]) {
         if (!this.tableSelection) {
@@ -296,6 +331,18 @@ export class Table {
         return (
             newColumns.length === oldColumns.length &&
             newColumns.every((column) => oldColumns.includes(column))
+        );
+    }
+
+    private haveSameAggregateFields(
+        newAggregates: ColumnAggregate[],
+        oldAggregates: ColumnAggregate[]
+    ) {
+        const oldAggregateFields = oldAggregates?.map((a) => a.field) || [];
+
+        return (
+            newAggregates?.length === oldAggregates?.length &&
+            !!newAggregates?.every((a) => oldAggregateFields.includes(a.field))
         );
     }
 
@@ -390,13 +437,48 @@ export class Table {
     }
 
     private getColumnDefinitions(): Tabulator.ColumnDefinition[] {
-        const columnDefinitions = this.columns.map(this.columnFactory.create);
+        const columnDefinitions = this.columns
+            .map(this.addColumnAggregator)
+            .map(this.columnFactory.create);
 
         if (this.tableSelection) {
             return this.tableSelection.getColumnDefinitions(columnDefinitions);
         }
 
         return columnDefinitions;
+    }
+
+    private addColumnAggregator(column: Column<any>): Column<any> {
+        if (!this.aggregates?.length || column.aggregator) {
+            return column;
+        }
+
+        const aggregate = this.aggregates.find((a) => a.field === column.field);
+        if (aggregate) {
+            column.aggregator = (
+                col?: Column,
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                _values?: any[],
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                _data?: any[]
+            ) => {
+                if (!col) {
+                    return undefined;
+                }
+
+                const value = this.aggregates.find(
+                    (a) => a.field === col.field
+                )?.value;
+
+                if (col.formatter) {
+                    return col.formatter(value);
+                }
+
+                return value;
+            };
+        }
+
+        return column;
     }
 
     private getAjaxOptions(): Tabulator.OptionsData {

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -158,3 +158,17 @@ export type ColumnAggregatorFunction<T = object> = (
     values?: any[],
     data?: T[]
 ) => any;
+
+/**
+ * Defines aggregate values for columns
+ */
+export interface ColumnAggregate {
+    /**
+     * The name of the `Column` field
+     */
+    field: string;
+    /**
+     * The aggregate value
+     */
+    value: any;
+}


### PR DESCRIPTION
## Problem

Updating aggregate values only is not currently possible without changing the columns and re-initialize the table.

## Solution

By adding a new `@Prop` called `aggregates` the user of `<limel-table>` can let the table re-render with new aggregate values. A watcher of the added prop can call Tabulator's `recalc` function to update the values in its calculation row (`bottomCalc`).

Note: The aggregator given by the column definition should have higher priority than the value in the `aggregates` prop. 

## Use case

This feature is added to support updating the aggregate value as the user selects rows using the `selection` prop added in #1514.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
