### PR TITLE
fix(checkbox): avoid rendering long labels on the next row below the checkbox

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -9,9 +9,12 @@
 @include checkbox.core-styles;
 @include form-field.core-styles;
 
+$constructed-size-of-checkbox: 2.5rem; // MDC has some variables that control the size of the
+// checkbox component,but they will be constructed to `40px` (`2.5rem`) in `height` and` width`
+
 .mdc-form-field {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: $constructed-size-of-checkbox 1fr;
 
     .mdc-checkbox {
         .mdc-checkbox__native-control {

--- a/src/components/checkbox/partial-styles/_helper-text.scss
+++ b/src/components/checkbox/partial-styles/_helper-text.scss
@@ -2,6 +2,8 @@
 
 .limel-checkbox-helper-line {
     @include shared_input-select-picker.looks-like-helper-line;
+    grid-column-start: 1;
+    grid-column-end: -1;
 }
 
 .limel-checkbox-helper-text {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2635

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
