### PR TITLE
fix(table): prevent moving the checkbox column

### DIFF
--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -99,7 +99,7 @@
     .tabulator-col.limel-table--row-selector {
     border: none;
     cursor: default;
-    pointer-events: unset;
+    pointer-events: none;
     background-color: transparent;
     background-image: linear-gradient(
         to right,


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1541

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
