### PR TITLE
fix(table): never emit internal row selector column

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -266,11 +266,15 @@ export class Table {
             return;
         }
 
-        const existingColumns = this.tabulator
+        const columnsInTable = this.tabulator
             .getColumns()
-            .map(this.findColumn);
+            .filter((c) => c.getField());
 
-        if (this.areSameColumns(newColumns, existingColumns)) {
+        const oldColumnsInTable = columnsInTable.map((c) =>
+            oldColumns.find((old) => old.field === c.getField())
+        );
+
+        if (this.areSameColumns(newColumns, oldColumnsInTable)) {
             return;
         }
 
@@ -593,7 +597,7 @@ export class Table {
     };
 
     private handleMoveColumn = (_, components: Tabulator.ColumnComponent[]) => {
-        const columns = components.map(this.findColumn);
+        const columns = components.map(this.findColumn).filter((c) => c);
         this.changeColumns.emit(columns);
     };
 


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
