### PR TITLE
fix(icon-button): apply the default background color if it's not specified

### DIFF
--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -9,10 +9,12 @@
 }
 
 /**
- * @prop --icon-background-color: Background color when attribute `elevated` is set to `true`.
+ * @prop --icon-button-background-color: Background color when attribute `elevated` is set to `true`.
  */
 
 :host {
+    --specified-background-color: var(--icon-button-background-color),
+        (var(--icon-background-color));
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -33,6 +35,10 @@
 
     limel-icon {
         @include mixins.is-elevated-clickable;
+        background-color: var(
+            --specified-background-color,
+            rgb(var(--contrast-100), 0.8)
+        );
     }
 }
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2630


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
