### PR TITLE
update @stencil/sass from v1.4.1 to v1.5.2 (plus replacing some now deprecated syntax in two scss files)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@rjsf/core": "^2.5.1",
         "@stencil/core": "^2.10.0",
         "@stencil/eslint-plugin": "^0.4.0",
-        "@stencil/sass": "^1.4.1",
+        "@stencil/sass": "^1.5.2",
         "@types/codemirror": "^5.60.2",
         "@types/html-escaper": "^3.0.0",
         "@types/jest": "^27.4.0",
@@ -2410,9 +2410,9 @@
       }
     },
     "node_modules/@stencil/sass": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.1.tgz",
-      "integrity": "sha512-aFKoqtxZ/8BRbvNFiWRycGiqvMI22Ifn5qsKfq0U23j43XD81jT6d7K0WQd55ejNpoSpdxJcbOuFgQy3mXizfA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
+      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ==",
       "dev": true,
       "peerDependencies": {
         "@stencil/core": ">=1.0.2"
@@ -15046,9 +15046,9 @@
       }
     },
     "@stencil/sass": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.1.tgz",
-      "integrity": "sha512-aFKoqtxZ/8BRbvNFiWRycGiqvMI22Ifn5qsKfq0U23j43XD81jT6d7K0WQd55ejNpoSpdxJcbOuFgQy3mXizfA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
+      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@rjsf/core": "^2.5.1",
     "@stencil/core": "^2.10.0",
     "@stencil/eslint-plugin": "^0.4.0",
-    "@stencil/sass": "^1.4.1",
+    "@stencil/sass": "^1.5.2",
     "@types/codemirror": "^5.60.2",
     "@types/html-escaper": "^3.0.0",
     "@types/jest": "^27.4.0",

--- a/src/components/spinner/spinner.scss
+++ b/src/components/spinner/spinner.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @use '../../style/functions';
 @use '../../style/internal/lime-theme';
 
@@ -28,8 +29,8 @@ $colors: var(--spinner-color-1, rgb(var(--lime-brand-color-deep-red))),
     var(--spinner-color-9, rgb(var(--lime-brand-color-light-grey)));
 $dash: 63;
 $duration: length($colors) * 1s;
-$duration-alt: $duration / length($colors);
-$keyframe: 1 / (length($colors) * 2) * 100;
+$duration-alt: math.div($duration, length($colors));
+$keyframe: math.div(1, length($colors) * 2) * 100;
 
 @keyframes spin {
     50% {

--- a/src/style/functions.scss
+++ b/src/style/functions.scss
@@ -5,6 +5,8 @@
  * without being explicitly called by outside code.
  */
 
+@use 'sass:math';
+
 @function pxToRem($px) {
-    @return #{$px/16}rem;
+    @return #{math.div($px, 16)}rem;
 }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
