### PR TITLE
224 hack tuesday flexible tab bar

### DIFF
--- a/src/components/tab-bar/examples/tab-bar-shrinkable.tsx
+++ b/src/components/tab-bar/examples/tab-bar-shrinkable.tsx
@@ -1,0 +1,88 @@
+import { Component, h, State } from '@stencil/core';
+import { Tab } from '@limetech/lime-elements';
+/**
+ * With shrinkable tabs
+ * Bla bla…
+ */
+@Component({
+    tag: 'limel-example-tab-bar-shrinkable',
+    shadow: true,
+})
+export class TabBarExample {
+    @State()
+    private text: string = 'Joker';
+
+    @State()
+    private tabs: Tab[] = [
+        {
+            id: 1,
+            text: 'Joker',
+            icon: 'joker',
+            active: true,
+            iconColor: 'var(--lime-green)',
+        },
+        {
+            id: 2,
+            text: 'Parasite',
+            icon: 'insect',
+            iconColor: 'var(--lime-magenta)',
+            badge: 999,
+        },
+        {
+            id: 3,
+            text: 'Harriet',
+            icon: 'administrator_female',
+            iconColor: 'var(--lime-orange)',
+            badge: 99940,
+        },
+        {
+            id: 4,
+            text: 'Bombshell',
+            icon: 'surprised',
+            iconColor: 'var(--lime-blue)',
+        },
+        {
+            id: 5,
+            text: 'Judy',
+            icon: 'female',
+            iconColor: 'var(--lime-deep-red)',
+            badge: 1,
+        },
+        {
+            id: 6,
+            text: 'Friends',
+            icon: 'friends',
+            iconColor: 'var(--lime-yellow)',
+            badge: 1290000,
+        },
+        {
+            id: 7,
+            text: 'Little Women',
+            icon: 'female',
+            iconColor: 'var(--lime-deep-red)',
+            badge: 4,
+        },
+    ];
+
+    public render() {
+        return [
+            <limel-tab-bar
+                tabs={this.tabs}
+                onChangeTab={this.handleChange}
+                class="has-shrinkable-tabs"
+            />,
+            <limel-example-value label="Tab" value={this.text} />,
+        ];
+    }
+
+    private handleChange = (event: CustomEvent<Tab>) => {
+        this.text = event.detail.text;
+        this.tabs = this.tabs.map((tab) => {
+            if (tab.id === event.detail.id) {
+                return event.detail;
+            }
+
+            return tab;
+        });
+    };
+}

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -118,13 +118,9 @@ $tab-scroller-fade-width: 65;
     }
 }
 
-.mdc-tab__content {
-    gap: functions.pxToRem(6);
-}
-
 .mdc-tab__text-label {
     // MDC adds a padding left of 8px using `.mdc-tab:not(.mdc-tab--stacked) .mdc-tab__icon+.mdc-tab__text-label`.
     // The `mdc-tab--stacked` is nothing we use. So,
     // for simplicity, we make it `!important` to override that.
-    padding-left: 0 !important;
+    padding: 0 functions.pxToRem(6) !important;
 }

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -1,5 +1,6 @@
 @use '../../style/internal/z-index';
 @use '../../style/functions';
+@use '../../style/mixins';
 @use '../../style/internal/lime-theme';
 @use '@material/tab-bar/mdc-tab-bar';
 @use '@material/tab-scroller/mdc-tab-scroller';
@@ -123,4 +124,41 @@ $tab-scroller-fade-width: 65;
     // The `mdc-tab--stacked` is nothing we use. So,
     // for simplicity, we make it `!important` to override that.
     padding: 0 functions.pxToRem(6) !important;
+}
+
+:host(.has-shrinkable-tabs) {
+    .mdc-tab-scroller__scroll-area {
+        .mdc-tab-scroller__scroll-content {
+            flex-shrink: 1;
+        }
+
+        .mdc-tab {
+            transition: flex-shrink 0.25s ease, flex-grow 0.25s ease,
+                padding 0.2s ease;
+            flex-shrink: 1;
+            min-width: 0;
+            // min-width: functions.pxToRem(48);
+            padding-right: min(2%, #{functions.pxToRem(12)});
+            padding-left: min(2%, #{functions.pxToRem(20)});
+
+            &.mdc-tab--active {
+                flex-shrink: 0.00001; // otherwise it will not animate in Chrome, if it's zero
+            }
+        }
+
+        .mdc-tab__content {
+            min-width: 0;
+        }
+
+        .mdc-tab__icon {
+            flex-shrink: 0;
+            margin-right: 0;
+        }
+
+        .mdc-tab__text-label {
+            @include mixins.truncate-text();
+            min-width: 0;
+            flex-shrink: 1;
+        }
+    }
 }

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -38,6 +38,7 @@ const HIDE_SCROLL_BUTTONS_WHEN_SCROLLED_LESS_THAN_PX = 40;
  * @exampleComponent limel-example-tab-bar
  * @exampleComponent limel-example-tab-bar-with-dynamic-tab-width
  * @exampleComponent limel-example-tab-bar-with-equal-tab-width
+ * @exampleComponent limel-example-tab-bar-shrinkable
  */
 @Component({
     tag: 'limel-tab-bar',


### PR DESCRIPTION
fix https://github.com/Lundalogik/hack-tuesday/issues/224


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
