### PR TITLE
fix(badge): don't let it shrink in width, when container is too small

### DIFF
--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -17,6 +17,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-shrink: 0;
 
     font-size: functions.pxToRem(11);
 


### PR DESCRIPTION
We [refactored limel badge recently](https://github.com/Lundalogik/lime-elements/pull/1577) and made the host a flex. I a badge is placed inside a container that doesn't have enough space for it, it will shrink. This PR fixes that:

### Before:
![image](https://user-images.githubusercontent.com/35954987/153367580-a87ac0f4-b66b-4898-9a9d-e030ba430913.png)

### After
![image](https://user-images.githubusercontent.com/35954987/153367662-c5005487-5b65-425e-9bc7-c5e2e9bb3e90.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
