### PR TITLE
docs(flex-container): deprecate component and make the docs private

### DIFF
--- a/src/components/flex-container/flex-container.tsx
+++ b/src/components/flex-container/flex-container.tsx
@@ -6,6 +6,12 @@ import {
 import { Component, h, Prop } from '@stencil/core';
 
 /**
+ * This component is deprecated and will be removed in a future version of
+ * Lime Elements. Please use CSS for your flexible container needs 🙂
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox
+ *
+ * @deprecated
+ * @private
  * @exampleComponent limel-example-flex-container
  * @slot - Container content
  */
@@ -38,6 +44,13 @@ export class FlexContainer {
      */
     @Prop({ reflect: true })
     public reverse = false;
+
+    public componentWillLoad() {
+        /* eslint-disable-next-line no-console */
+        console.warn(
+            'limel-flex-container is deprecated, please use CSS instead: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox'
+        );
+    }
 
     public render() {
         return <slot />;


### PR DESCRIPTION
fix: Lundalogik/crm-feature#2659

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
