### PR TITLE
test(list): remove unnecessary awaits

### DIFF
--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -23,7 +23,7 @@ describe('limel-list', () => {
         let items: Array<ListItem | ListSeparator>;
         beforeEach(async () => {
             items = [{ text: 'item 1' }];
-            await limelList.setProperty('items', items);
+            limelList.setProperty('items', items);
             await page.waitForChanges();
         });
         it('renders the item', () => {
@@ -86,7 +86,7 @@ describe('limel-list', () => {
                 },
                 { text: 'item 5' },
             ];
-            await limelList.setProperty('items', items);
+            limelList.setProperty('items', items);
             await page.waitForChanges();
         });
         it('renders the items', () => {
@@ -191,7 +191,7 @@ describe('limel-list', () => {
                 limelList = await page.find('limel-list');
                 innerList = await page.find('limel-list>>>ul');
                 items = [{ text: 'item 1' }];
-                await limelList.setProperty('items', items);
+                limelList.setProperty('items', items);
                 await page.waitForChanges();
             });
             it('is selectable', () => {


### PR DESCRIPTION
My editor said these awaits where unnecessary, as the functions they are awaiting aren't async, and the tests pass without them too.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
