### PR TITLE
fix(menu-surface): avoid extra margin

### DIFF
--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -12,7 +12,6 @@
 .mdc-menu-surface {
     max-height: 100%;
     position: relative;
-    margin: 0 0.25rem;
     --mdc-menu-max-width: var(
         --menu-surface-width,
         min(calc(100vw - 2rem), 20rem)


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2668 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
