### PR TITLE
fix(table): correct checkbox target area size in row selectors

### DIFF
--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -5,14 +5,14 @@
 
 .select-all,
 .limel-table--row-selector {
-    --mdc-checkbox-ripple-size: 1rem; // prevent the checkbox affecting the row height
+    --mdc-checkbox-touch-target-size: 1rem; // prevent the checkbox affecting the row height
 }
 
 .select-all {
     position: absolute;
     z-index: z-index.$table--limel-table--row-selector;
     left: 0;
-    top: functions.pxToRem(7);
+    top: functions.pxToRem(6);
     width: functions.pxToRem(41); // width of the selector column
 
     display: flex !important;


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1609

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
