### PR TITLE
Table color corrections

### DIFF
--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -109,3 +109,13 @@
     position: sticky;
     left: 0;
 }
+
+.tabulator-calcs {
+    .tabulator-cell {
+        .has-selection & {
+            color: var(
+                --table-arrow-color--active
+            ); // to indicate that aggregated numbers are coming from the selcted rows not all rows
+        }
+    }
+}

--- a/src/components/table/partial-styles/tabulator-arrow.scss
+++ b/src/components/table/partial-styles/tabulator-arrow.scss
@@ -34,6 +34,10 @@
         transform: rotate(45deg);
         left: functions.pxToRem(-4);
         top: functions.pxToRem(4);
+
+        .tabulator-col.tabulator-sortable:hover & {
+            background-color: rgb(var(--table-header-background-color--hover));
+        }
     }
     &:after {
         width: functions.pxToRem(2);

--- a/src/components/table/partial-styles/tabulator-arrow.scss
+++ b/src/components/table/partial-styles/tabulator-arrow.scss
@@ -13,10 +13,16 @@
         border-bottom-color: rgb(var(--table-arrow-color)) !important;
     }
     [aria-sort='desc'] & {
-        border-top-color: rgb(var(--table-arrow-color--active)) !important;
+        border-top-color: var(--table-arrow-color--active) !important;
     }
     [aria-sort='asc'] & {
-        border-bottom-color: rgb(var(--table-arrow-color--active)) !important;
+        border-bottom-color: var(--table-arrow-color--active) !important;
+    }
+    [aria-sort='desc'] &,
+    [aria-sort='asc'] & {
+        &:after {
+            background-color: var(--table-arrow-color--active);
+        }
     }
 
     &:before,
@@ -56,13 +62,6 @@
 
         &:after {
             top: functions.pxToRem(-11);
-        }
-    }
-
-    [aria-sort='desc'] &,
-    [aria-sort='asc'] & {
-        &:after {
-            background-color: rgb(var(--table-arrow-color--active));
         }
     }
 }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -23,7 +23,7 @@
     --table-row-background-color--active: var(--color-teal-lighter);
 
     --table-arrow-color: var(--contrast-800);
-    --table-arrow-color--active: var(--color-teal-default);
+    --table-arrow-color--active: var(--mdc-theme-primary);
 }
 
 #tabulator-container {

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -42,17 +42,17 @@
 .tabulator {
     .tabulator-header {
         border-bottom: 0;
-        background-color: rgb(var(--table-header-background-color--hover));
+        background-color: rgb(var(--table-header-background-color));
 
         .tabulator-col {
             transition: background-color 0.2s ease;
-            background-color: rgb(var(--table-header-background-color--hover));
+            background-color: rgb(var(--table-header-background-color));
             border-right-color: rgb(var(--contrast-200));
 
             &.tabulator-sortable {
                 &:hover {
-                    background-color: var(
-                        --table-header-background-color--hover
+                    background-color: rgb(
+                        var(--table-header-background-color--hover)
                     );
                 }
             }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
