### PR TITLE
add some table tests

### DIFF
--- a/src/components/table/table.e2e.ts
+++ b/src/components/table/table.e2e.ts
@@ -1,0 +1,138 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+import { Table } from './table';
+
+/*
+ * Tabulator performs an instance type check of the element
+ * passed to its constructor, where using newSpecPage wouldn't work,
+ * since it returns a MockHTMLElement (prevents Tabulator from initializing),
+ * hence the use of an E2E test to test the table.
+ */
+describe('limel-table', () => {
+    let page: E2EPage;
+    let table: E2EElement;
+    let tableContainer: E2EElement;
+
+    async function render(props: Partial<Table>): Promise<E2EPage> {
+        page = await newE2EPage({ html: '<limel-table></limel-table>' });
+        table = await page.find('limel-table');
+        tableContainer = await page.find('limel-table>>>#tabulator-container');
+
+        for (const [key, value] of Object.entries(props)) {
+            table.setProperty(key, value);
+        }
+
+        await page.waitForChanges();
+
+        return page;
+    }
+
+    async function getFirstRowCells() {
+        await page.waitForChanges();
+        const row = await tableContainer.find(
+            '.tabulator-table .tabulator-row'
+        );
+        if (!row) {
+            throw new Error('no row found');
+        }
+
+        return row.findAll('[role="gridcell"]');
+    }
+
+    async function getFirstRowContent() {
+        const cells = await getFirstRowCells();
+
+        return cells.map((c) => c.textContent);
+    }
+
+    describe('column headers', () => {
+        let columns;
+        beforeEach(() => {
+            columns = [
+                { field: 'colA', title: 'A' },
+                { field: 'colB', title: 'B' },
+            ];
+        });
+        it('renders', async () => {
+            await render({ columns: columns });
+            const headers = await tableContainer.findAll(
+                '[role="columnheader"]'
+            );
+
+            expect(headers.length).toEqual(2);
+            const [headerA, headerB] = headers;
+            expect(headerA.textContent).toEqual('A');
+            expect(headerB.textContent).toEqual('B');
+        });
+
+        it('click sorts the data rows', async () => {
+            let rowData;
+            const data = [
+                { id: 1, colA: 1, colB: 'ascending' },
+                { id: 2, colA: 2, colB: 'descending' },
+            ];
+
+            // apparently data MUST come before columns
+            await render({ data: data, columns: columns });
+            const headers = await tableContainer.findAll(
+                '[role="columnheader"]'
+            );
+            const [headerA, headerB] = headers;
+
+            headerA.click();
+            rowData = await getFirstRowContent();
+            expect(rowData[0]).toEqual('1');
+            headerA.click();
+            rowData = await getFirstRowContent();
+            expect(rowData[0]).toEqual('2');
+
+            headerB.click();
+            rowData = await getFirstRowContent();
+            expect(rowData[1]).toEqual('ascending');
+            headerB.click();
+            rowData = await getFirstRowContent();
+            expect(rowData[1]).toEqual('descending');
+        });
+    });
+
+    describe('row selection', () => {
+        it('adds a checkbox column', async () => {
+            const columns = [{ field: 'name', title: 'Name' }];
+            const data = [{ name: 'Alpha' }, { name: 'Beta' }];
+
+            await render({
+                data: data,
+                selectable: true,
+                columns: columns,
+            });
+            const headers = await tableContainer.findAll(
+                '[role="columnheader"]'
+            );
+            const rowSelectors = await tableContainer.findAll(
+                '.tabulator-table .tabulator-row .tabulator-cell:first-child limel-checkbox'
+            );
+
+            expect(rowSelectors.length).toEqual(2);
+            expect(headers.length).toEqual(2);
+            const [headerA, headerB] = headers;
+            expect(headerA.textContent.trim()).toEqual('');
+            expect(headerB.textContent).toEqual('Name');
+        });
+        it('adds a select all checkbox', async () => {
+            const columns = [{ field: 'name', title: 'Name' }];
+            const data = [{ name: 'Alpha' }, { name: 'Beta' }];
+            await render({
+                data: data,
+                selectable: true,
+                columns: columns,
+            });
+            const selectAllCheckbox = await tableContainer.find(
+                '.select-all limel-checkbox'
+            );
+
+            expect(
+                await selectAllCheckbox.getProperty('indeterminate')
+            ).toBeFalsy();
+            expect(await selectAllCheckbox.getProperty('checked')).toBeFalsy();
+        });
+    });
+});

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -200,14 +200,7 @@ export class Table {
 
     public componentWillLoad() {
         this.firstRequest = this.mode === 'remote';
-        if (this.selectable) {
-            this.tableSelection = new TableSelection(
-                () => this.tabulator,
-                this.pool,
-                this.select
-            );
-            this.tableSelection.setSelection(this.selection);
-        }
+        this.initTableSelection();
     }
 
     public componentDidLoad() {
@@ -327,6 +320,16 @@ export class Table {
         this.tableSelection.setSelection(newSelection);
     }
 
+    @Watch('selectable')
+    protected updateSelectable() {
+        if (this.tableSelection && !this.selectable) {
+            this.tableSelection = null;
+        }
+
+        this.initTableSelection();
+        this.init();
+    }
+
     private areSameColumns(newColumns: Column[], oldColumns: Column[]) {
         return (
             newColumns.length === oldColumns.length &&
@@ -355,7 +358,6 @@ export class Table {
         const options = this.getOptions();
         const table: HTMLElement =
             this.host.shadowRoot.querySelector('#tabulator-table');
-
         this.initTabulatorComponent(table, options);
     }
 
@@ -390,6 +392,17 @@ export class Table {
             observer.unobserve(table);
         });
         observer.observe(table);
+    }
+
+    private initTableSelection() {
+        if (this.selectable) {
+            this.tableSelection = new TableSelection(
+                () => this.tabulator,
+                this.pool,
+                this.select
+            );
+            this.tableSelection.setSelection(this.selection);
+        }
     }
 
     private setSelection() {


### PR DESCRIPTION
- Tabulator has an instance type check on the given element, requiring full e2e tests to be used over `newSpecPage`
- Using e2e tests requires mutation of properties (from the outside, not from the inside ie using `@Prop({ mutable: true  })` after adding the element, thus adding mutability of the selectable prop
- Row selection + select all interaction is not testable (even after waiting for page changes + select event) and is intentionally left out
- This PR does not intend to add a complete set of tests covering all limel-table features, but hopefully we can add more in the future (preferably without e2e tests)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
