### PR TITLE
docs(dialog): add note about opening dialogs in Lime CRM

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -22,6 +22,13 @@ import { createRandomString } from '../../util/random-string';
  * See the example _Nested `close` events_.
  * :::
  *
+ * :::important
+ * Are you developing for
+ * [Lime CRM](https://www.lime-technologies.com/en/lime-crm/)? Please note that
+ * you should use the [DialogService](https://lundalogik.github.io/lime-web-components/versions/latest/#/api/dialog-service)
+ * from Lime Web Components to open dialogs in Lime CRM.
+ * :::
+ *
  * @exampleComponent limel-example-dialog
  * @exampleComponent limel-example-dialog-nested-close-events
  * @exampleComponent limel-example-dialog-heading


### PR DESCRIPTION
Prompted by a request from @DavidAkkerman:

> Almost a year ago, you helped me solve a problem with the rendering of a dialog in the web client, by advising me to use the dialogservice for creating the dialog. I am now getting questions from several other appers that are running into the same problem, because the first thing everyone does is going to the lime-elements documentation page and copy-paste some code from the examples, which most of the time works really well. However, if you go to the documentation of the dialog, the example just shows that you can render a button and a dialog in the same web component, and that you only have to set the dialog as open when you click the button. I'm guessing it's not possible to use the dialogservice in the example because it's not available, but would it be possible to add some note/warning at the top of the page that people should 'always' use the dialogservice to create a dialog, so that they don't face rendering issues? I'm hoping that would help people prevent this problem before they run into it 🙂

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
