### PR TITLE
fix(table): make 'selectAll' is disabled if the table is empty

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -747,6 +747,7 @@ export class Table {
             >
                 <limel-checkbox
                     onChange={this.selectAllOnChange}
+                    disabled={!this.totalRows}
                     checked={this.tableSelection?.hasSelection}
                     indeterminate={
                         this.tableSelection?.hasSelection &&


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2673

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
