### PR TITLE
fix(input-field): make icons disabled if input-field is empty

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -65,6 +65,13 @@
     }
 }
 
+.lime-text-field--empty {
+    .mdc-text-field__icon--trailing {
+        @include shared_input-select-picker.looks-disabled;
+        box-shadow: none !important;
+    }
+}
+
 .mdc-text-field {
     width: 100%;
 }

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -342,6 +342,7 @@ export class InputField {
             'lime-text-field--readonly': this.readonly,
             'mdc-text-field--required': this.required,
             'mdc-text-field--with-trailing-icon': !!this.getTrailingIcon(),
+            'lime-text-field--empty': !this.value,
         };
 
         if (this.type === 'textarea') {
@@ -583,7 +584,7 @@ export class InputField {
             <a
                 {...linkProps}
                 class="material-icons mdc-text-field__icon lime-trailing-icon-for-link"
-                tabindex={this.disabled ? '-1' : '0'}
+                tabindex={this.disabled || !this.value ? '-1' : '0'}
                 role="button"
             >
                 <limel-icon name={icon} />


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1624

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
