### PR TITLE
Revert major update of @rjsf/core and configure dependabot to ignore future major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@rjsf/core"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lundalogik/cz-conventional-changelog": "^3.1.0",
         "@lundalogik/lime-icons8": "^2.7.0",
         "@popperjs/core": "^2.9.3",
-        "@rjsf/core": "^2.5.1",
+        "@rjsf/core": "^2.4.2",
         "@stencil/core": "^2.13.0",
         "@stencil/eslint-plugin": "^0.4.0",
         "@stencil/sass": "^1.5.2",
@@ -2364,9 +2364,9 @@
       }
     },
     "node_modules/@rjsf/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.4.2.tgz",
+      "integrity": "sha512-3EHpGiWryCx8kNv5TcKwnVtKlq08s2QvQTlwCF3pELqK9YQoa7SEsFQtZzU03wWk7o0Wvuig4BhJJKU8Dc2c5A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs2": "^7.8.7",
@@ -16763,9 +16763,9 @@
       "dev": true
     },
     "@rjsf/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.4.2.tgz",
+      "integrity": "sha512-3EHpGiWryCx8kNv5TcKwnVtKlq08s2QvQTlwCF3pELqK9YQoa7SEsFQtZzU03wWk7o0Wvuig4BhJJKU8Dc2c5A==",
       "dev": true,
       "requires": {
         "@babel/runtime-corejs2": "^7.8.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lundalogik/cz-conventional-changelog": "^3.1.0",
         "@lundalogik/lime-icons8": "^2.7.0",
         "@popperjs/core": "^2.9.3",
-        "@rjsf/core": "^4.0.0",
+        "@rjsf/core": "^3.2.1",
         "@stencil/core": "^2.13.0",
         "@stencil/eslint-plugin": "^0.4.0",
         "@stencil/sass": "^1.5.2",
@@ -2354,9 +2354,9 @@
       }
     },
     "node_modules/@rjsf/core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-4.0.0.tgz",
-      "integrity": "sha512-UPfpa0QaI4/nhapFOIvMAiQ44fXdHlqULQt/p8Jky53669TJo6IOMsXmTd7w3FWJTKHp2NSCcDAsyATxZOtRtg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
@@ -2373,7 +2373,7 @@
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": ">=16 || >=17"
+        "react": ">=16"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -16672,9 +16672,9 @@
       "dev": true
     },
     "@rjsf/core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-4.0.0.tgz",
-      "integrity": "sha512-UPfpa0QaI4/nhapFOIvMAiQ44fXdHlqULQt/p8Jky53669TJo6IOMsXmTd7w3FWJTKHp2NSCcDAsyATxZOtRtg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lundalogik/cz-conventional-changelog": "^3.1.0",
         "@lundalogik/lime-icons8": "^2.7.0",
         "@popperjs/core": "^2.9.3",
-        "@rjsf/core": "^3.2.1",
+        "@rjsf/core": "^2.5.1",
         "@stencil/core": "^2.13.0",
         "@stencil/eslint-plugin": "^0.4.0",
         "@stencil/sass": "^1.5.2",
@@ -462,6 +462,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs2": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
+      "integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/@babel/template": {
@@ -2354,23 +2364,26 @@
       }
     },
     "node_modules/@rjsf/core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.2.1.tgz",
-      "integrity": "sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
+        "@babel/runtime-corejs2": "^7.8.7",
+        "@types/json-schema": "^7.0.4",
         "ajv": "^6.7.0",
-        "core-js-pure": "^3.6.5",
+        "core-js": "^2.5.7",
         "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^5.0.0",
+        "jsonpointer": "^4.0.1",
         "lodash": "^4.17.15",
-        "nanoid": "^3.1.23",
         "prop-types": "^15.7.2",
-        "react-is": "^16.9.0"
+        "react-app-polyfill": "^1.0.4",
+        "react-is": "^16.9.0",
+        "shortid": "^2.2.14"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=6",
+        "npm": ">=2.14.7"
       },
       "peerDependencies": {
         "react": ">=16"
@@ -3340,6 +3353,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -4257,16 +4276,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.0.tgz",
-      "integrity": "sha512-VaJUunCZLnxuDbo1rNOzwbet9E1K9joiXS5+DQMPtgxd24wfsZbJZMMfQLGYMlCUvSxLfsRUUhoOR2x28mFfeg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
+    "node_modules/core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.0",
@@ -10233,9 +10247,9 @@
       }
     },
     "node_modules/jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10834,16 +10848,10 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
+      "dev": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -11388,6 +11396,12 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -11555,6 +11569,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "dev": true,
+      "dependencies": {
+        "asap": "~2.0.6"
       }
     },
     "node_modules/prompts": {
@@ -11731,6 +11754,15 @@
         }
       ]
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -11742,6 +11774,34 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-app-polyfill": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
+      "integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.5.0",
+        "object-assign": "^4.1.1",
+        "promise": "^8.0.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.3",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-app-polyfill/node_modules/core-js": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/react-dom": {
@@ -11891,6 +11951,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -12688,6 +12754,15 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "dev": true,
+      "dependencies": {
+        "nanoid": "^2.1.0"
+      }
     },
     "node_modules/showdown": {
       "version": "2.0.0",
@@ -14147,6 +14222,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
+      "dev": true
+    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -14856,6 +14937,16 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.16.7"
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
+      "integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -16672,20 +16763,22 @@
       "dev": true
     },
     "@rjsf/core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.2.1.tgz",
-      "integrity": "sha512-dk8ihvxFbcuIwU7G+HiJbFgwyIvaumPt5g5zfnuC26mwTUPlaDGFXKK2yITp8tJ3+hcwS5zEXtAN9wUkfuM4jA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.7",
+        "@babel/runtime-corejs2": "^7.8.7",
+        "@types/json-schema": "^7.0.4",
         "ajv": "^6.7.0",
-        "core-js-pure": "^3.6.5",
+        "core-js": "^2.5.7",
         "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^5.0.0",
+        "jsonpointer": "^4.0.1",
         "lodash": "^4.17.15",
-        "nanoid": "^3.1.23",
         "prop-types": "^15.7.2",
-        "react-is": "^16.9.0"
+        "react-app-polyfill": "^1.0.4",
+        "react-is": "^16.9.0",
+        "shortid": "^2.2.14"
       }
     },
     "@sinonjs/commons": {
@@ -17421,6 +17514,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "assign-symbols": {
@@ -18161,10 +18260,10 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js-pure": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.0.tgz",
-      "integrity": "sha512-VaJUunCZLnxuDbo1rNOzwbet9E1K9joiXS5+DQMPtgxd24wfsZbJZMMfQLGYMlCUvSxLfsRUUhoOR2x28mFfeg==",
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
     "cosmiconfig": {
@@ -22793,9 +22892,9 @@
       }
     },
     "jsonpointer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
-      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
       "dev": true
     },
     "jsx-ast-utils": {
@@ -23304,9 +23403,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
       "dev": true
     },
     "nanomatch": {
@@ -23741,6 +23840,12 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -23862,6 +23967,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.6"
+      }
     },
     "prompts": {
       "version": "2.3.2",
@@ -23986,6 +24100,15 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -23994,6 +24117,28 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-app-polyfill": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
+      "integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.5.0",
+        "object-assign": "^4.1.1",
+        "promise": "^8.0.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.3",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
+          "dev": true
+        }
       }
     },
     "react-dom": {
@@ -24114,6 +24259,12 @@
       "requires": {
         "resolve": "^1.1.6"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -24735,6 +24886,15 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
     },
     "showdown": {
       "version": "2.0.0",
@@ -25948,6 +26108,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lundalogik/cz-conventional-changelog": "^3.1.0",
     "@lundalogik/lime-icons8": "^2.7.0",
     "@popperjs/core": "^2.9.3",
-    "@rjsf/core": "^2.5.1",
+    "@rjsf/core": "^2.4.2",
     "@stencil/core": "^2.13.0",
     "@stencil/eslint-plugin": "^0.4.0",
     "@stencil/sass": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lundalogik/cz-conventional-changelog": "^3.1.0",
     "@lundalogik/lime-icons8": "^2.7.0",
     "@popperjs/core": "^2.9.3",
-    "@rjsf/core": "^4.0.0",
+    "@rjsf/core": "^3.2.1",
     "@stencil/core": "^2.13.0",
     "@stencil/eslint-plugin": "^0.4.0",
     "@stencil/sass": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lundalogik/cz-conventional-changelog": "^3.1.0",
     "@lundalogik/lime-icons8": "^2.7.0",
     "@popperjs/core": "^2.9.3",
-    "@rjsf/core": "^3.2.1",
+    "@rjsf/core": "^2.5.1",
     "@stencil/core": "^2.13.0",
     "@stencil/eslint-plugin": "^0.4.0",
     "@stencil/sass": "^1.5.2",


### PR DESCRIPTION
@rjsf/core 4.x makes Lime Admin unusable with certain schemas + data and until further investigation is done, this bump  must be reverted to provide a functional product.

The rjsf playground shows the same error using the problematic schema + data and is caused by the large nested structure and live validation performed.


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
