### PR TITLE
Uppercase filenames does not resolve to the correct file icon

### DIFF
--- a/src/components/file/file-metadata.spec.ts
+++ b/src/components/file/file-metadata.spec.ts
@@ -1,0 +1,80 @@
+import {
+    getFileIcon,
+    getFileColor,
+    getFileBackgroundColor,
+} from './file-metadata';
+
+describe('file metadata', () => {
+    [
+        {
+            description: 'with a known file extension',
+            input: {
+                id: '',
+                filename: 'file.docx',
+            },
+            expectedOutput: {
+                iconName: 'ms_word_copyrighted',
+                iconColor: 'rgb(var(--color-sky-dark))',
+                iconBackgroundColor: 'rgba(var(--color-sky-lighter), 0.4)',
+            },
+        },
+        {
+            description: 'with an unknown file extension',
+            input: {
+                id: '',
+                filename: 'file.justsomethingrandom',
+            },
+            expectedOutput: {
+                iconName: 'file',
+                iconColor: 'rgb(var(--color-gray-dark))',
+                iconBackgroundColor: 'rgba(var(--color-gray-lighter), 0.4)',
+            },
+        },
+        {
+            description: 'with no file extension',
+            input: {
+                id: '',
+                filename: 'README',
+            },
+            expectedOutput: {
+                iconName: 'file',
+                iconColor: 'rgb(var(--color-gray-dark))',
+                iconBackgroundColor: 'rgba(var(--color-gray-lighter), 0.4)',
+            },
+        },
+        {
+            description: 'file extension matching should be case insensitive',
+            input: {
+                id: '',
+                filename: 'file.DOCX',
+            },
+            expectedOutput: {
+                iconName: 'ms_word_copyrighted',
+                iconColor: 'rgb(var(--color-sky-dark))',
+                iconBackgroundColor: 'rgba(var(--color-sky-lighter), 0.4)',
+            },
+        },
+    ].forEach(({ description, input, expectedOutput }) => {
+        describe(description, () => {
+            describe('getFileIcon', () => {
+                it('returns the expected icon name', () => {
+                    expect(getFileIcon(input)).toEqual(expectedOutput.iconName);
+                });
+            });
+            describe('getFileColor', () => {
+                it('returns the expected color', () => {
+                    expect(getFileColor(input)).toEqual(
+                        expectedOutput.iconColor
+                    );
+                });
+            });
+            describe('getFileBackgroundColor', () => {
+                it('returns the expected color', () => {
+                    expect(getFileBackgroundColor(input)).toEqual(
+                        expectedOutput.iconBackgroundColor
+                    );
+                });
+            });
+        });
+    });
+});

--- a/src/components/file/icon-background-colors.ts
+++ b/src/components/file/icon-background-colors.ts
@@ -129,6 +129,7 @@ const filetypeBackgroundColorTable: Record<string, string> = {
 
 export function getIconBackgroundColorForFile(extension: string): string {
     return (
-        filetypeBackgroundColorTable[extension] || DEFAULT_ICON_BACKGROUND_COLOR
+        filetypeBackgroundColorTable[extension.toLowerCase()] ||
+        DEFAULT_ICON_BACKGROUND_COLOR
     );
 }

--- a/src/components/file/icon-fill-colors.ts
+++ b/src/components/file/icon-fill-colors.ts
@@ -124,5 +124,8 @@ const filetypeFillColorTable: Record<string, string> = {
 };
 
 export function getIconFillColorForFile(extension: string): string {
-    return filetypeFillColorTable[extension] || DEFAULT_ICON_FILL_COLOR;
+    return (
+        filetypeFillColorTable[extension.toLowerCase()] ||
+        DEFAULT_ICON_FILL_COLOR
+    );
 }

--- a/src/components/file/icons.ts
+++ b/src/components/file/icons.ts
@@ -125,5 +125,5 @@ const filetypeIconTable: Record<string, string> = {
 };
 
 export function getIconForFile(extension: string): string {
-    return filetypeIconTable[extension] || DEFAULT_ICON;
+    return filetypeIconTable[extension.toLowerCase()] || DEFAULT_ICON;
 }


### PR DESCRIPTION
Issue: Files with names such as DOC1.DOCX aren't showing the word icon in the web client.

fix: #1668

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
