### PR TITLE
Make the index page for docs versions get published from the latest `next`, also update some stuff on that page

### DIFF
--- a/docs-index.html
+++ b/docs-index.html
@@ -35,8 +35,8 @@
                 return b[2].substring(0, 1) > a[2].substring(0, 1) ? 1 : -1;
             }
         });
-        createLink(`versions/latest/`, 'Latest');
-        createLink(`versions/next/`, 'Next');
+        createLink(`versions/latest/`, 'Latest Official Release');
+        createLink(`versions/next/`, 'Latest nightly (Used by the Lime CRM Web Client)');
         window.versions.forEach(function(version, index) {
             createLink(`versions/${version}/`, version);
         });

--- a/docs-index.html
+++ b/docs-index.html
@@ -12,7 +12,7 @@
     <h1>Lime Elements Documentation</h1>
 
     <p>
-        <a href="https://github.com/Lundalogik/lime-elements/blob/master/CHANGELOG.md">CHANGELOG</a>
+        <a href="https://github.com/Lundalogik/lime-elements/blob/main/CHANGELOG.md">CHANGELOG</a>
     </p>
 
     <section id="versions"></section>

--- a/docs-index.html
+++ b/docs-index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Lime Elements Documentation</title>
+    <script src="versions.js"></script>
+</head>
+<body>
+
+    <h1>Lime Elements Documentation</h1>
+
+    <p>
+        <a href="https://github.com/Lundalogik/lime-elements/blob/master/CHANGELOG.md">CHANGELOG</a>
+    </p>
+
+    <section id="versions"></section>
+
+    <script>
+        var body = document.getElementById('versions');
+        window.versions.sort(function(a, b) {
+            a = a.split('.');
+            b = b.split('.');
+            if (a[0] !== b[0]) {
+                return +b[0] - +a[0];
+            }
+            if (a[1] !== b[1]) {
+                return +b[1] - +a[1];
+            }
+            if (a[2] !== b[2]) {
+                if (a[2].substring(0, 1) !== b[2].substring(0,1)) {
+                    return +b[2].substring(0, 1) - +a[2].substring(0, 1);
+                }
+                return b[2].substring(0, 1) > a[2].substring(0, 1) ? 1 : -1;
+            }
+        });
+        createLink(`versions/latest/`, 'Latest');
+        createLink(`versions/next/`, 'Next');
+        window.versions.forEach(function(version, index) {
+            createLink(`versions/${version}/`, version);
+        });
+
+        function createLink(href, text) {
+            var link = document.createElement('a');
+            link.href = href;
+            link.appendChild(document.createTextNode(text));
+            body.appendChild(link);
+            body.appendChild(document.createElement('br'));
+        }
+    </script>
+</body>
+</html>

--- a/publish-docs.js
+++ b/publish-docs.js
@@ -14,6 +14,7 @@ const runBuild = argv.noBuild === undefined;
 const runCommit = argv.noCommit === undefined;
 const runPush = argv.noPush === undefined;
 const forcePush = !!argv.forcePush;
+const pruneOutdated = argv.noPruneOutdated === undefined;
 const runTeardown = argv.noTeardown === undefined;
 
 const cleanOnFail = runTeardown && argv.noCleanOnFail === undefined;
@@ -23,8 +24,9 @@ const BASE_URL = '/lime-elements/';
 
 if (argv.h !== undefined) {
     shell.echo(`
-usage: npm run docs:publish [-- [--v=<version>] [--remove=<pattern>] [--pruneDev]
-                                [--noSetup] [--noBuild] [--noCommit] [--noPush]
+usage: npm run docs:publish [-- [--v=<version>] [--remove=<pattern>]
+                                [--pruneDev] [--noSetup] [--noBuild]
+                                [--noCommit] [--noPush] [--noPruneOutdated]
                                 [--noTeardown] [--dryRun] [--noCleanOnFail]
                                 [--gitUser=<commit author name>]
                                 [--gitEmail=<commit author email>]]
@@ -34,8 +36,8 @@ usage: npm run docs:publish [-- [--v=<version>] [--remove=<pattern>] [--pruneDev
     --dryRun        Use dry-run mode. Do not push any changes.
     --remove        Removes all versions matching the given filename-pattern.
     --pruneDev      Alias for --remove=0.0.0-dev*
-    --noSetup       Run no setup. Only use this if you have previously run the setup step
-                    without running the teardown step afterward.
+    --noSetup       Run no setup. Only use this if you have previously run the
+                    setup step without running the teardown step afterward.
     --noBuild       Do not build the documentation.
     --noCommit      Do not commit any changes.
     --noPush        Do not push any commits.
@@ -43,9 +45,11 @@ usage: npm run docs:publish [-- [--v=<version>] [--remove=<pattern>] [--pruneDev
                     when a new version has been released. Any less important
                     runs, like those publishing the docs for a pull request,
                     should NOT use this flag.
+    --noPruneOutdated
+                    Do not remove docs for outdated patch- and next-versions.
     --noTeardown    Run no cleanup at end of script. Implies --noCleanOnFail.
-    --noCleanOnFail Do not run cleanup if script fails. Unless --noTeardown is set,
-                    cleanup will still be run if script is successful.
+    --noCleanOnFail Do not run cleanup if script fails. Unless --noTeardown
+                    is set, cleanup will still be run if script is successful.
 
     --authorName    Commit author name. Will update the local git config if set.
                     Will use existing git config if omitted.
@@ -98,6 +102,10 @@ usage: npm run docs:publish [-- [--v=<version>] [--remove=<pattern>] [--pruneDev
 
     if (runCommit) {
         commit();
+    }
+
+    if (pruneOutdated) {
+        pruneOldPatchAndNextVersions();
     }
 
     if (runPush) {
@@ -287,6 +295,66 @@ function updateVersionList() {
     // Keep only versions that begin with `NEXT-`.
     const nextVersions = files.filter((file) => file.match(/^NEXT-.*/));
     createSymlinkForRelease(nextVersions, 'next');
+}
+
+function pruneOldPatchAndNextVersions() {
+    shell.cd('docsDist');
+    const files = fs
+        .readdirSync('versions')
+        .filter((file) => file !== 'latest' && file !== 'next');
+    shell.cd('..');
+
+    const fullVersionRegex = /^(\d*)\.(\d*)\.(\d*)$/;
+    const fullVersions = files.filter((file) => file.match(fullVersionRegex));
+
+    const nextVersionRegex = /^NEXT-(\d*)\.(\d*)\.(\d*)(.*)/;
+    const nextVersions = files.filter((file) => file.match(nextVersionRegex));
+
+    const collator = new Intl.Collator(undefined, {
+        numeric: true,
+        sensitivity: 'base',
+    });
+
+    fullVersions.sort(collator.compare);
+    fullVersions.reverse();
+
+    let lastCheckedVersion = fullVersions.shift();
+    const versionsToDelete = [];
+    fullVersions.forEach((item) => {
+        const lastChecked = lastCheckedVersion.match(fullVersionRegex);
+        const current = item.match(fullVersionRegex);
+
+        if (lastChecked[1] === current[1] && lastChecked[2] === current[2]) {
+            versionsToDelete.push(item);
+        }
+
+        lastCheckedVersion = item;
+    });
+
+    if (version && version.match(fullVersionRegex)) {
+        // We are publishing a new full version, so let's remove the docs for
+        // all the old next-versions this full version replaces.
+        const newVersion = version.match(fullVersionRegex);
+        nextVersions.forEach((item) => {
+            const current = item.match(nextVersionRegex);
+
+            if (
+                newVersion[1] === current[1] &&
+                newVersion[2] === current[2] &&
+                newVersion[3] === current[3]
+            ) {
+                versionsToDelete.push(item);
+            }
+        });
+    }
+
+    versionsToDelete.forEach((item) => {
+        remove(item);
+
+        if (runCommit) {
+            commit(`chore(docs): remove ${argv.remove}`);
+        }
+    });
 }
 
 function createSymlinkForRelease(versions, alias) {

--- a/publish-docs.js
+++ b/publish-docs.js
@@ -282,14 +282,14 @@ function updateVersionList() {
     // a letter are pull requests, pre-releases, or other special cases, not
     // eligible as "Latest".
     const fullVersions = files.filter((file) => file.match(/^[0-9].*/));
-    findLatestRelease(fullVersions, 'latest');
+    createSymlinkForRelease(fullVersions, 'latest');
 
     // Keep only versions that begin with `NEXT-`.
     const nextVersions = files.filter((file) => file.match(/^NEXT-.*/));
-    findLatestRelease(nextVersions, 'next');
+    createSymlinkForRelease(nextVersions, 'next');
 }
 
-function findLatestRelease(versions, alias) {
+function createSymlinkForRelease(versions, alias) {
     // We need to sort the strings alphanumerically, which javascript doesn't
     // do by default. So I found this neat solution at
     // https://blog.praveen.science/natural-sorting-in-javascript/#solution

--- a/publish-docs.js
+++ b/publish-docs.js
@@ -233,7 +233,29 @@ function copyBuildOutput() {
         shell.exit(1);
     }
 
+    shell.echo(`Copying docs-index.html to 'docsDist/versions/${version}/'`);
+    if (
+        shell.cp('docs-index.html', `docsDist/versions/${version}/`).code !== 0
+    ) {
+        shell.echo(
+            '[WARNING] Copying docs-index.html failed. Not critical, continuing.'
+        );
+    }
+
     updateVersionList();
+
+    shell.echo('Copying docs-index.html from most recent `next` version');
+    if (
+        shell.cp(
+            '-f',
+            'docsDist/versions/next/docs-index.html',
+            'docsDist/index.html'
+        ).code !== 0
+    ) {
+        shell.echo(
+            '[WARNING] Copying docs-index.html from most recent `next` failed. Not critical, continuing.'
+        );
+    }
 }
 
 function remove(pattern) {


### PR DESCRIPTION
It's a pita to update the index page, since you have to check out the gh-pages branch to make changes to it. This PR adds the file to the normal branches. When publishing, we always grab the file from the latest published `next`-version.

See the respective commit messages for the small changes I made to the index file.

Update: I added functionality for removing outdated patch versions (we only keep the latest patch version for each minor version—so if we have 1.2.3 and 1.2.4, we remove the 1.2.3 version), and outdated NEXT versions (when we release v35.0.0, all `NEXT-35.0.0-next.*` are removed).

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
