### PR TITLE
eslint: fix false positives from rule `no-shadow`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,7 +86,8 @@ module.exports = {
         'no-new-wrappers': 'error',
         'no-return-await': 'error',
         'no-sequences': 'error',
-        'no-shadow': [
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': [
             'error',
             {
                 hoist: 'all',

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -72,7 +72,6 @@ export function getFactoryProps(
     formContext: any,
     schema: any
 ): Record<string, any> {
-    // eslint-disable-next-line no-shadow
     const factory: (schema: any) => Record<string, any> =
         formContext.propsFactory;
     if (typeof factory !== 'function') {

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -209,7 +209,6 @@ export interface GridLayoutOptions
     dense?: boolean;
 }
 
-// eslint-disable-next-line no-shadow
 export enum FormLayoutType {
     /**
      * The default layout

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -117,7 +117,6 @@ export interface TableParams {
     sorters?: ColumnSorter[];
 }
 
-// eslint-disable-next-line no-shadow
 export enum ColumnAggregatorType {
     /**
      * Calculates the average value of all numerical cells in the column


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
