### PR TITLE
fix(input-field): avoid unnecessary code error messages at webclient

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -276,6 +276,7 @@ export class Form {
         const errors: FormError[] = originalErrors.map((error: AjvError) => {
             return {
                 name: error.name,
+                params: error.params,
                 property: error.property,
                 message: error.message,
                 // For some reason 'schemaPath' is missing from the AjvError type definition:

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -21,6 +21,11 @@ export interface FormError {
     name: string;
 
     /**
+     * Params of the error
+     */
+    params?: unknown;
+
+    /**
      * Name of the invalid property
      */
     property: string;


### PR DESCRIPTION
## Review:
fix: https://github.com/Lundalogik/crm-feature/issues/2657
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
