### PR TITLE
fix(table): make sure horizontal scrollbar is shown on windows browsers

### DIFF
--- a/src/components/table/partial-styles/tabulator-custom-styles.scss
+++ b/src/components/table/partial-styles/tabulator-custom-styles.scss
@@ -99,9 +99,9 @@
 
     .has-aggregation {
         .tabulator-tableHolder {
-            padding-bottom: functions.pxToRem(
-                28
-            ); // makes sure aggregations row doesn't cover the last table row
+            margin-bottom: functions.pxToRem(
+                24
+            ); // makes sure aggregations row doesn't cover the last table row, and horizontal scroll bar is shown on windows
         }
     }
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2744

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
