### PR TITLE
fix(limel-form): suppress ajv $ref: keywords warning

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -161,6 +161,7 @@ export class Form {
             React.createElement(
                 JSONSchemaForm,
                 {
+                    noValidate: true,
                     schema: this.modifiedSchema,
                     formData: this.value,
                     onChange: this.handleChange,

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -233,6 +233,7 @@ export class Form {
             unknownFormats: 'ignore',
             allErrors: true,
             multipleOfPrecision: 2,
+            extendRefs: true,
         }).addFormat('integer', isInteger);
         this.validator = validator.compile(this.schema);
     }


### PR DESCRIPTION
Fixes #1709

The main reason for these warnings (described in issue above) seems to be a discrepancy between the json-schema specification of the schema generated by the backend (lime-serializer), and the specification of the schema library (ajv) used on the frontend, notably by limel-form. 

Limel-form currently uses an older version of [ajv](https://github.com/Lundalogik/lime-elements/blob/633eba877525a73e2cfbfb79e79d1ebc5a92d675/package.json#L61) which only supports draft version 6 of JSON-Schema. This version of the specification treats nested schemas differently and [doesn't allow any extra keywords to be specified](https://json-schema.org/understanding-json-schema/structuring.html#ref) with the `$ref` keyword. However, lime-serializer ignore this fact and seems to adhere to a later draft of the specification which does indeed allow keywords together with $ref. The default for this version of ajv is to [log a warning](https://github.com/ajv-validator/ajv/tree/v6.7.0#referenced-schema-options) about this:

> when $ref is used other keywords are ignored (as per [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-3) standard). A warning will be logged during the schema compilation.

One way of fixing this problem would obviously be to make the backend adhere to the older draft json-schema specification, but that would just be counterproductive looking forward.

Luckily there's an option to force ajv to validate _all_ keywords, including the 'extra keywords' (default behaviour in [newer versions of the draft](https://ajv.js.org/v6-to-v8-migration.html#removed-options)) instead of logging a warning. This would effectively quench the warning logs. However, ajv is used in two places in the limel-form component. It's used as a stand-alone validator but also integrated in the react-json-schema-form component which limel-form is essentially a wrapper to. 

At one point validation was moved out from react-json-schema-form to using the 'stand-alone' ajv library instead, but some validation is still being done by rsjf; about 1/3 of the warnings are produced by rjsf.

This PR does two things:

- completely disables validation by react-json-schema-form; this should be safe since [validation is already done outside rsjf](https://github.com/Lundalogik/lime-elements/pull/855).
- treat and validate $ref siblings ('keywords') as normal keywords [as is consistent with later specs](https://ajv.js.org/v6-to-v8-migration.html#removed-options).


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
