### PR TITLE
chore: bump tabulator to 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/jest": "^27.4.0",
         "@types/lodash-es": "^4.17.8",
         "@types/react": "^18.2.20",
-        "@types/tabulator-tables": "^5.1.1",
+        "@types/tabulator-tables": "^5.4.10",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.62.0",
         "ajv": "^6.12.6",
@@ -55,7 +55,7 @@
         "shelljs": "0.8.5",
         "showdown": "2.1.0",
         "shx": "^0.3.3",
-        "tabulator-tables": "^5.1.8",
+        "tabulator-tables": "^5.5.1",
         "typescript": "^4.9.5"
       }
     },
@@ -2453,9 +2453,9 @@
       "dev": true
     },
     "node_modules/@types/tabulator-tables": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-5.1.1.tgz",
-      "integrity": "sha512-/zxeR0zRq3YnyYH7ECtGOpMd7G3NgjxPY0+1JNAx+0FaSQbYQGvKAPNmKggu8JjrDhl7V/5IDLoydpyyYFtW9A==",
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-5.4.10.tgz",
+      "integrity": "sha512-ale/wbhA7zsmSSz6lTnxferRCCbKq3oZtxaNY8osb7YND2k27ZlEhfZzlVfRq8b5t7shhP8M53HyAgm1M0O+FA==",
       "dev": true
     },
     "node_modules/@types/tern": {
@@ -9517,9 +9517,9 @@
       "dev": true
     },
     "node_modules/tabulator-tables": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.1.8.tgz",
-      "integrity": "sha512-5ah2ftxNEKiSF5QaAETA4gX49OHiv+kFZLaD+s++LOx2oSvH0J0CujxH570Ou4Bo4Zq6MmI4T7idRS0jhq/VfA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.5.1.tgz",
+      "integrity": "sha512-YxWVXbWVgUOMhU/g2xnf7y4Vrk1grYpDftQigbY/yAOKMEfgCRYzNaNEpMZbaimWdCt7KdpIp+lpp+HM5DY5sQ==",
       "dev": true
     },
     "node_modules/tar-fs": {
@@ -12719,9 +12719,9 @@
       "dev": true
     },
     "@types/tabulator-tables": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-5.1.1.tgz",
-      "integrity": "sha512-/zxeR0zRq3YnyYH7ECtGOpMd7G3NgjxPY0+1JNAx+0FaSQbYQGvKAPNmKggu8JjrDhl7V/5IDLoydpyyYFtW9A==",
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-5.4.10.tgz",
+      "integrity": "sha512-ale/wbhA7zsmSSz6lTnxferRCCbKq3oZtxaNY8osb7YND2k27ZlEhfZzlVfRq8b5t7shhP8M53HyAgm1M0O+FA==",
       "dev": true
     },
     "@types/tern": {
@@ -18115,9 +18115,9 @@
       "dev": true
     },
     "tabulator-tables": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.1.8.tgz",
-      "integrity": "sha512-5ah2ftxNEKiSF5QaAETA4gX49OHiv+kFZLaD+s++LOx2oSvH0J0CujxH570Ou4Bo4Zq6MmI4T7idRS0jhq/VfA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.5.1.tgz",
+      "integrity": "sha512-YxWVXbWVgUOMhU/g2xnf7y4Vrk1grYpDftQigbY/yAOKMEfgCRYzNaNEpMZbaimWdCt7KdpIp+lpp+HM5DY5sQ==",
       "dev": true
     },
     "tar-fs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/jest": "^27.4.0",
         "@types/lodash-es": "^4.17.8",
         "@types/react": "^18.2.20",
-        "@types/tabulator-tables": "^4.9.4",
+        "@types/tabulator-tables": "^5.1.1",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.62.0",
         "ajv": "^6.12.6",
@@ -55,7 +55,7 @@
         "shelljs": "0.8.5",
         "showdown": "2.1.0",
         "shx": "^0.3.3",
-        "tabulator-tables": "^4.9.3",
+        "tabulator-tables": "^5.1.8",
         "typescript": "^4.9.5"
       }
     },
@@ -2453,9 +2453,9 @@
       "dev": true
     },
     "node_modules/@types/tabulator-tables": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-4.9.4.tgz",
-      "integrity": "sha512-yx8lZb15X+RP5a0ih6Fw5AaD/1m62+35ULMcm3TxQaheiH76lyBr2Zs20Wf7KNWsIGy1nwMmbjkCt6vjMczJQQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-5.1.1.tgz",
+      "integrity": "sha512-/zxeR0zRq3YnyYH7ECtGOpMd7G3NgjxPY0+1JNAx+0FaSQbYQGvKAPNmKggu8JjrDhl7V/5IDLoydpyyYFtW9A==",
       "dev": true
     },
     "node_modules/@types/tern": {
@@ -9517,9 +9517,9 @@
       "dev": true
     },
     "node_modules/tabulator-tables": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-4.9.3.tgz",
-      "integrity": "sha512-iwwQqAEGGxlgrBpcmJJvMJrfjGLcCXOB3AOb/DGkXqBy1YKoYA36hIl7qXGp6Jo8dSkzFAlDT6pKLZgyhs9OnQ==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.1.8.tgz",
+      "integrity": "sha512-5ah2ftxNEKiSF5QaAETA4gX49OHiv+kFZLaD+s++LOx2oSvH0J0CujxH570Ou4Bo4Zq6MmI4T7idRS0jhq/VfA==",
       "dev": true
     },
     "node_modules/tar-fs": {
@@ -12719,9 +12719,9 @@
       "dev": true
     },
     "@types/tabulator-tables": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-4.9.4.tgz",
-      "integrity": "sha512-yx8lZb15X+RP5a0ih6Fw5AaD/1m62+35ULMcm3TxQaheiH76lyBr2Zs20Wf7KNWsIGy1nwMmbjkCt6vjMczJQQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/tabulator-tables/-/tabulator-tables-5.1.1.tgz",
+      "integrity": "sha512-/zxeR0zRq3YnyYH7ECtGOpMd7G3NgjxPY0+1JNAx+0FaSQbYQGvKAPNmKggu8JjrDhl7V/5IDLoydpyyYFtW9A==",
       "dev": true
     },
     "@types/tern": {
@@ -18115,9 +18115,9 @@
       "dev": true
     },
     "tabulator-tables": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-4.9.3.tgz",
-      "integrity": "sha512-iwwQqAEGGxlgrBpcmJJvMJrfjGLcCXOB3AOb/DGkXqBy1YKoYA36hIl7qXGp6Jo8dSkzFAlDT6pKLZgyhs9OnQ==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-5.1.8.tgz",
+      "integrity": "sha512-5ah2ftxNEKiSF5QaAETA4gX49OHiv+kFZLaD+s++LOx2oSvH0J0CujxH570Ou4Bo4Zq6MmI4T7idRS0jhq/VfA==",
       "dev": true
     },
     "tar-fs": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "^27.4.0",
     "@types/lodash-es": "^4.17.8",
     "@types/react": "^18.2.20",
-    "@types/tabulator-tables": "^5.1.1",
+    "@types/tabulator-tables": "^5.4.10",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.62.0",
     "ajv": "^6.12.6",
@@ -86,7 +86,7 @@
     "shelljs": "0.8.5",
     "showdown": "2.1.0",
     "shx": "^0.3.3",
-    "tabulator-tables": "^5.1.8",
+    "tabulator-tables": "^5.5.1",
     "typescript": "^4.9.5"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "^27.4.0",
     "@types/lodash-es": "^4.17.8",
     "@types/react": "^18.2.20",
-    "@types/tabulator-tables": "^4.9.4",
+    "@types/tabulator-tables": "^5.1.1",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.62.0",
     "ajv": "^6.12.6",
@@ -86,7 +86,7 @@
     "shelljs": "0.8.5",
     "showdown": "2.1.0",
     "shx": "^0.3.3",
-    "tabulator-tables": "^4.9.3",
+    "tabulator-tables": "^5.1.8",
     "typescript": "^4.9.5"
   },
   "keywords": [

--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -1,5 +1,12 @@
 import { Column, ColumnSorter, ColumnAggregatorFunction } from './table.types';
-import { Tabulator } from 'tabulator-tables';
+import {
+    CellComponent,
+    ColumnCalc,
+    ColumnComponent,
+    ColumnDefinition,
+    Formatter,
+    SorterFromTable,
+} from 'tabulator-tables';
 import { escape } from 'html-escaper';
 import { ElementPool } from './element-pool';
 import { pickBy, negate } from 'lodash-es';
@@ -12,10 +19,10 @@ export class ColumnDefinitionFactory {
     /**
      * Create Tabulator column definitions from a limel-table column configuration
      * @param {Column} column config describing the column
-     * @returns {Tabulator.ColumnDefinition} Tabulator column
+     * @returns {ColumnDefinition} Tabulator column
      */
-    public create(column: Column<object>): Tabulator.ColumnDefinition {
-        const definition: Tabulator.ColumnDefinition = {
+    public create(column: Column<object>): ColumnDefinition {
+        const definition: ColumnDefinition = {
             title: column.title,
             field: column.field,
             hozAlign: column.horizontalAlign,
@@ -76,12 +83,9 @@ export const formatHeader = (column: Column) => (): string | HTMLElement => {
  * Create a formatter to be used to format values in a column
  * @param {Column} column config describing the column
  * @param {ElementPool} pool pool to get custom components from
- * @returns {Tabulator.Formatter} Tabulator formatter
+ * @returns {Formatter} Tabulator formatter
  */
-export function createFormatter(
-    column: Column,
-    pool: ElementPool
-): Tabulator.Formatter {
+export function createFormatter(column: Column, pool: ElementPool): Formatter {
     if (!column.component?.name) {
         return formatCell;
     }
@@ -97,7 +101,7 @@ export function createFormatter(
         return formatCell;
     }
 
-    return (cell: Tabulator.CellComponent) => {
+    return (cell: CellComponent) => {
         const value = formatCell(cell, column);
 
         return createCustomComponent(cell, column, value, pool);
@@ -118,14 +122,11 @@ function columnElementExists(column: Column<any>) {
 
 /**
  * Format the value of a cell in the table
- * @param {Tabulator.CellComponent} cell the cell being rendered in the table
+ * @param {CellComponent} cell the cell being rendered in the table
  * @param {Column} column configuration for the current column
  * @returns {string} the formatted value
  */
-export function formatCell(
-    cell: Tabulator.CellComponent,
-    column: Column
-): string {
+export function formatCell(cell: CellComponent, column: Column): string {
     const data = cell.getData();
     let value = cell.getValue();
 
@@ -142,14 +143,14 @@ export function formatCell(
 
 /**
  * Create a custom component that renders a cell value
- * @param {Tabulator.CellComponent} cell Tabulator cell
+ * @param {CellComponent} cell Tabulator cell
  * @param {Column} column lime-elements column configuration
  * @param {string} value the value of the cell being rendered
  * @param {ElementPool} pool pool to get custom components from
  * @returns {HTMLElement} custom component that renders a value in the table
  */
 export function createCustomComponent(
-    cell: Tabulator.CellComponent,
+    cell: CellComponent,
     column: Column,
     value: string,
     pool: ElementPool
@@ -226,10 +227,7 @@ function getEventName(eventListener: string): string {
     return eventListener.charAt(2).toLowerCase() + eventListener.slice(3);
 }
 
-function createResizeObserver(
-    element: HTMLElement,
-    column: Tabulator.ColumnComponent
-) {
+function createResizeObserver(element: HTMLElement, column: ColumnComponent) {
     if (!('ResizeObserver' in window)) {
         return;
     }
@@ -263,7 +261,7 @@ function createResizeObserver(
  */
 export const createColumnSorter =
     (columns: Column[]) =>
-    (sorter: Tabulator.SorterFromTable): ColumnSorter => {
+    (sorter: SorterFromTable): ColumnSorter => {
         const column = columns.find((col) => col.field === sorter.field);
         const direction = sorter.dir.toUpperCase() as 'ASC' | 'DESC';
 
@@ -273,7 +271,7 @@ export const createColumnSorter =
         };
     };
 
-export function getColumnAggregator(column: Column): Tabulator.ColumnCalc {
+export function getColumnAggregator(column: Column): ColumnCalc {
     const aggregator = column.aggregator;
     if (isAggregatorFunction(aggregator)) {
         return (values: any[], data: object[]) => {

--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -1,5 +1,5 @@
 import { Column, ColumnSorter, ColumnAggregatorFunction } from './table.types';
-import Tabulator from 'tabulator-tables';
+import { Tabulator } from 'tabulator-tables';
 import { escape } from 'html-escaper';
 import { ElementPool } from './element-pool';
 import { pickBy, negate } from 'lodash-es';
@@ -256,12 +256,6 @@ function createResizeObserver(
     }, RESIZE_TIMEOUT);
 }
 
-// Tabulator seems to also have this `field` property, that does not appear on
-// the interface for some reason
-interface TabulatorSorter extends Tabulator.Sorter {
-    field: string;
-}
-
 /**
  * Create a column sorter from a tabulator sorter
  * @param {Column[]} columns all available columns in the table
@@ -269,7 +263,7 @@ interface TabulatorSorter extends Tabulator.Sorter {
  */
 export const createColumnSorter =
     (columns: Column[]) =>
-    (sorter: TabulatorSorter): ColumnSorter => {
+    (sorter: Tabulator.SorterFromTable): ColumnSorter => {
         const column = columns.find((col) => col.field === sorter.field);
         const direction = sorter.dir.toUpperCase() as 'ASC' | 'DESC';
 

--- a/src/components/table/table-selection.spec.ts
+++ b/src/components/table/table-selection.spec.ts
@@ -1,3 +1,4 @@
+import { CellComponent, RowComponent } from 'tabulator-tables';
 import { ElementPool } from './element-pool';
 import { TableSelection } from './table-selection';
 
@@ -37,7 +38,7 @@ describe('table selection', () => {
         ...rowData: any[]
     ) => Map<any, { checked: boolean }> = (...rowData: any[]) => {
         const rowCheckboxMap = new Map<any, { checked: boolean }>();
-        const makeCell: (row: any, data: any) => Tabulator.CellComponent = (
+        const makeCell: (row: any, data: any) => CellComponent = (
             row: any,
             data: any
         ) => {
@@ -53,11 +54,11 @@ describe('table selection', () => {
             return cell as any;
         };
 
-        const makeRow: (
-            data: any,
-            position: number
-        ) => Tabulator.RowComponent = (data, position) => {
-            const row: Partial<Tabulator.RowComponent> = {
+        const makeRow: (data: any, position: number) => RowComponent = (
+            data,
+            position
+        ) => {
+            const row: Partial<RowComponent> = {
                 getData: () => data,
                 getPosition: () => position,
             };

--- a/src/components/table/table-selection.ts
+++ b/src/components/table/table-selection.ts
@@ -1,5 +1,10 @@
 import { EventEmitter } from '@stencil/core';
-import { Tabulator } from 'tabulator-tables';
+import {
+    CellComponent,
+    ColumnDefinition,
+    RowComponent,
+    Tabulator,
+} from 'tabulator-tables';
 import { setElementProperties } from './columns';
 import { ElementPool } from './element-pool';
 import { Selection, SelectionChangeSet } from './selection';
@@ -61,16 +66,16 @@ export class TableSelection {
 
     /**
      * Prepends a checkbox column used for row selection to the given column definitions
-     * @param {Tabulator.ColumnDefinition[]} columnDefinitions The column definition for the table
-     * @returns {Tabulator.ColumnDefinition[]} The column definitions with the checkbox column prepended to it
+     * @param {ColumnDefinition[]} columnDefinitions The column definition for the table
+     * @returns {ColumnDefinition[]} The column definitions with the checkbox column prepended to it
      */
     public getColumnDefinitions(
-        columnDefinitions: Tabulator.ColumnDefinition[]
-    ): Tabulator.ColumnDefinition[] {
+        columnDefinitions: ColumnDefinition[]
+    ): ColumnDefinition[] {
         return [this.getRowSelectorColumnDefinition(), ...columnDefinitions];
     }
 
-    private getRowSelectorColumnDefinition(): Tabulator.ColumnDefinition {
+    private getRowSelectorColumnDefinition(): ColumnDefinition {
         return {
             title: '',
             formatter: this.getRowSelectorFormatter(),
@@ -89,7 +94,7 @@ export class TableSelection {
     }
 
     private getRowSelectorFormatter() {
-        return (cell: Tabulator.CellComponent) => {
+        return (cell: CellComponent) => {
             const element = this.pool.get(LIMEL_CHECKBOX);
             setElementProperties(element, {
                 checked: this.selection.has(cell.getData()),
@@ -105,17 +110,21 @@ export class TableSelection {
      * row and toggles the selection from the last clicked row if the shift key
      * is pressed down.
      * @param {PointerEvent} ev The pointer event
-     * @param {Tabulator.CellComponent} cell The clicked cell component
+     * @param {CellComponent} cell The clicked cell component
      */
     protected rowSelectorCellClick = (
         ev: PointerEvent,
-        cell: Tabulator.CellComponent
+        cell: CellComponent
     ) => {
         ev.stopPropagation();
         ev.preventDefault();
 
         const clickedRow = cell.getRow();
         const rowPosition = clickedRow.getPosition(true);
+
+        if (rowPosition === false) {
+            return;
+        }
 
         if (ev.shiftKey) {
             this.updateRowSelectors(
@@ -136,10 +145,7 @@ export class TableSelection {
             .forEach((row) => this.updateRowSelector(row, changeSet.selected));
     };
 
-    private updateRowSelector = (
-        row: Tabulator.RowComponent,
-        checked: boolean
-    ) => {
+    private updateRowSelector = (row: RowComponent, checked: boolean) => {
         const cell = row.getCells()[0];
         if (cell) {
             const checkBox = cell.getElement().querySelector(LIMEL_CHECKBOX);
@@ -147,7 +153,7 @@ export class TableSelection {
         }
     };
 
-    private getActiveRows: () => Tabulator.RowComponent[] = () => {
+    private getActiveRows: () => RowComponent[] = () => {
         const table = this.getTable();
         if (!table) {
             return [];

--- a/src/components/table/table-selection.ts
+++ b/src/components/table/table-selection.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '@stencil/core';
-import Tabulator from 'tabulator-tables';
+import { Tabulator } from 'tabulator-tables';
 import { setElementProperties } from './columns';
 import { ElementPool } from './element-pool';
 import { Selection, SelectionChangeSet } from './selection';

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -610,7 +610,7 @@ export class Table {
         return this.mode === 'remote';
     }
 
-    private handleDataSorting(sorters: Tabulator.Sorter[]): void {
+    private handleDataSorting(sorters: Tabulator.SorterFromTable[]): void {
         if (this.isRemoteMode()) {
             return;
         }

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -8,7 +8,7 @@ import {
     Event,
     Host,
 } from '@stencil/core';
-import TabulatorTable from 'tabulator-tables';
+import { Tabulator, TabulatorFull } from 'tabulator-tables';
 import {
     Column,
     TableParams,
@@ -192,7 +192,7 @@ export class Table {
 
     private currentLoad: { page: number; sorters: ColumnSorter[] };
 
-    private tabulator: Tabulator;
+    private tabulator: TabulatorFull;
 
     private pool: ElementPool;
     private columnFactory: ColumnDefinitionFactory;

--- a/types/tabulator-tables/index.d.ts
+++ b/types/tabulator-tables/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'tabulator-tables' {
-    export default Tabulator;
-}


### PR DESCRIPTION
Work for upgrading limel-table component to use tabulator 5.x where a lot of things in the API have been changed.

Upgrade guide:
http://tabulator.info/docs/5.0/upgrade

Identified tasks:

- [x] callbacks moved to events
- [x] update sort events to use "output" interface (missing in `@types/tabulator-tables` and added here https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58857)
- [x] rename ajax-related props according to upgrade guide
- [x] make remote load work with the new data loaders
- [ ] turn off invalidOption warnings when being sure all renamed options are migrated/taken care of (http://tabulator.info/docs/5.0/upgrade#debug)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
adjust imports