### PR TITLE
chore: use official `cz-conventional-changelog` instead of fork

### DIFF
--- a/.czrc
+++ b/.czrc
@@ -1,0 +1,3 @@
+{
+  "path": "cz-conventional-changelog"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/config-conventional": "^16.0.0",
-        "@lundalogik/cz-conventional-changelog": "^3.1.0",
         "@lundalogik/lime-icons8": "^2.7.0",
         "@popperjs/core": "^2.11.5",
         "@rjsf/core": "^2.4.2",
@@ -29,8 +28,8 @@
         "ajv": "^6.12.6",
         "awesome-debounce-promise": "^2.1.0",
         "codemirror": "^5.62.3",
-        "commitizen": "^4.2.4",
         "cross-env": "^7.0.3",
+        "cz-conventional-changelog": "^3.3.0",
         "dayjs": "^1.11.0",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.5.0",
@@ -1231,27 +1230,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@lundalogik/cz-conventional-changelog": {
-      "version": "3.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/cz-conventional-changelog/3.1.0/a6f53f554e3653f7b6918975b9040ad5e236c79a89cd85e82c896398eb1829d3",
-      "integrity": "sha512-41P5BCXPEIT0BlZCxAXR5mLsBmPTWqGs93rnwN2BBVxxAFtGouRk8H8nVx5wE2UTU3dbpXd2GnUGXKAXffn7RA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "commitizen": "^4.0.3",
-        "conventional-commit-types": "^3.0.0",
-        "lodash.map": "^4.5.1",
-        "longest": "^2.0.1",
-        "right-pad": "^1.0.1",
-        "word-wrap": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@commitlint/load": ">6.1.1"
       }
     },
     "node_modules/@lundalogik/lime-icons8": {
@@ -4191,6 +4169,26 @@
         "node": ">= 10"
       }
     },
+    "node_modules/commitizen/node_modules/cz-conventional-changelog": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
+      "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "commitizen": "^4.0.3",
+        "conventional-commit-types": "^3.0.0",
+        "lodash.map": "^4.5.1",
+        "longest": "^2.0.1",
+        "word-wrap": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@commitlint/load": ">6.1.1"
+      }
+    },
     "node_modules/commitizen/node_modules/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -4401,9 +4399,9 @@
       "dev": true
     },
     "node_modules/cz-conventional-changelog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
-      "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+      "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
       "dev": true,
       "dependencies": {
         "chalk": "^2.4.1",
@@ -12397,15 +12395,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/right-pad": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -15478,22 +15467,6 @@
         }
       }
     },
-    "@lundalogik/cz-conventional-changelog": {
-      "version": "3.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/cz-conventional-changelog/3.1.0/a6f53f554e3653f7b6918975b9040ad5e236c79a89cd85e82c896398eb1829d3",
-      "integrity": "sha512-41P5BCXPEIT0BlZCxAXR5mLsBmPTWqGs93rnwN2BBVxxAFtGouRk8H8nVx5wE2UTU3dbpXd2GnUGXKAXffn7RA==",
-      "dev": true,
-      "requires": {
-        "@commitlint/load": ">6.1.1",
-        "chalk": "^2.4.1",
-        "commitizen": "^4.0.3",
-        "conventional-commit-types": "^3.0.0",
-        "lodash.map": "^4.5.1",
-        "longest": "^2.0.1",
-        "right-pad": "^1.0.1",
-        "word-wrap": "^1.0.3"
-      }
-    },
     "@lundalogik/lime-icons8": {
       "version": "2.7.0",
       "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.7.0/a58599fabb94e662abde289323e15c40de2379e9f8640ebcc6b2ed478812cfed",
@@ -18099,6 +18072,21 @@
         "strip-json-comments": "3.0.1"
       },
       "dependencies": {
+        "cz-conventional-changelog": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
+          "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+          "dev": true,
+          "requires": {
+            "@commitlint/load": ">6.1.1",
+            "chalk": "^2.4.1",
+            "commitizen": "^4.0.3",
+            "conventional-commit-types": "^3.0.0",
+            "lodash.map": "^4.5.1",
+            "longest": "^2.0.1",
+            "word-wrap": "^1.0.3"
+          }
+        },
         "glob": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -18282,9 +18270,9 @@
       "dev": true
     },
     "cz-conventional-changelog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
-      "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+      "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
       "dev": true,
       "requires": {
         "@commitlint/load": ">6.1.1",
@@ -24532,12 +24520,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
-    "right-pad": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
       "dev": true
     },
     "rimraf": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   ],
   "scripts": {
     "build": "cross-env-shell NODE_ENV=prod SASS_PATH=node_modules \"stencil build --config stencil.config.dist.ts\"",
-    "cm": "git-cz",
     "dev": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --docs\"",
     "watch": "cross-env-shell SASS_PATH=node_modules \"stencil build --dev --watch --docs --serve\"",
     "watch:prod": "shx rm -rf www/ && cross-env-shell SASS_PATH=node_modules \"stencil build --watch\"",
@@ -42,7 +41,6 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^16.0.0",
-    "@lundalogik/cz-conventional-changelog": "^3.1.0",
     "@lundalogik/lime-icons8": "^2.7.0",
     "@popperjs/core": "^2.11.5",
     "@rjsf/core": "^2.4.2",
@@ -61,8 +59,8 @@
     "ajv": "^6.12.6",
     "awesome-debounce-promise": "^2.1.0",
     "codemirror": "^5.62.3",
-    "commitizen": "^4.2.4",
     "cross-env": "^7.0.3",
+    "cz-conventional-changelog": "^3.3.0",
     "dayjs": "^1.11.0",
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",
@@ -106,16 +104,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/@lundalogik/cz-conventional-changelog",
-      "additionalTypes": {
-        "switched": {
-          "description": "Not-yet-released functionality hidden behind a feature switch",
-          "title": "Not Released (feature switched)"
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Also remove direct dependency on `commitizen`.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
