### PR TITLE
feat(chip-set): make it possible to set `input` type of `search` or `text`

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -220,6 +220,14 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
             position: absolute;
             z-index: z-index.$chip-set--hidden-text-field; // to let users interact with chips, in case they're covered
         }
+        &[type='search'] {
+            -webkit-appearance: textfield; // Removes the default magnifying glass icon on iOS which appears automatically on input fields with type of search
+            background-color: transparent; // overides styles caused by previous line
+
+            &::-webkit-search-cancel-button {
+                display: none; // removes the default X button
+            }
+        }
     }
 }
 

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -29,6 +29,8 @@ const INPUT_FIELD_TABINDEX = 1;
  * @exampleComponent limel-example-chip-set-filter
  * @exampleComponent limel-example-chip-set-filter-badge
  * @exampleComponent limel-example-chip-set-input
+ * @exampleComponent limel-example-chip-set-input-type-text
+ * @exampleComponent limel-example-chip-set-input-type-search
  * @exampleComponent limel-example-chip-icon-color
  * @exampleComponent limel-example-chip-set-composite
  */
@@ -87,6 +89,13 @@ export class ChipSet {
      */
     @Prop({ reflect: true })
     public readonly: boolean = false;
+
+    /**
+     * For chip-sets of type `input`. Value to use for the `type` attribute on the
+     * input field inside the chip-set.
+     */
+    @Prop({ reflect: true })
+    public inputType: 'search' | 'text' = 'text';
 
     /**
      * For chip-sets of type `input`. Limits the maximum number of chips.
@@ -370,7 +379,7 @@ export class ChipSet {
                 {this.value.map(this.renderInputChip)}
                 <input
                     tabIndex={INPUT_FIELD_TABINDEX}
-                    type="text"
+                    type={this.inputType}
                     id="input-element"
                     disabled={this.readonly || this.disabled}
                     class={{

--- a/src/components/chip-set/examples/chip-set-input-type-search.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-search.tsx
@@ -1,0 +1,81 @@
+import { Chip } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+import { ENTER, ENTER_KEY_CODE } from '../../../util/keycodes';
+
+/**
+ * Input chip set with `inputType` of `search`
+ *
+ * When autocorrection is potentially harmful for the user experience and for
+ * your intended result, use `search` as `inputType`. For instance, for a
+ * question like "Please suggest unique names for our newly founded company",
+ * you probably don't want autocorrection, because you would expect many
+ * valid suggestions to not exist in the autocorrection dictionary. Therefore,
+ * you do not want the respondent's input to be regarded as a typo and to be
+ * changed when they press <kbd>Enter</kbd> or <kbd>Space</kbd>.
+ */
+@Component({
+    tag: 'limel-example-chip-set-input-type-search',
+    shadow: true,
+})
+export class ChipSetInputExample {
+    @State()
+    private value: Chip[];
+
+    @State()
+    private textValue = '';
+
+    @State()
+    private maxItems = 3;
+
+    @State()
+    private emptyInputOnBlur: boolean = true;
+
+    constructor() {
+        this.value = [this.createChip('Lundalogik'), this.createChip('Lime')];
+    }
+
+    public render() {
+        return [
+            <limel-chip-set
+                type="input"
+                inputType="search"
+                label="Suggest three unique names for our newly founded company"
+                maxItems={this.maxItems}
+                value={this.value}
+                onChange={this.handleChange}
+                onInput={this.handleInput}
+                onKeyUp={this.onKeyUp}
+                emptyInputOnBlur={this.emptyInputOnBlur}
+            />,
+        ];
+    }
+
+    private handleInput = (event: CustomEvent<string>) => {
+        this.textValue = event.detail;
+    };
+
+    private onKeyUp = (event: KeyboardEvent) => {
+        if (
+            (event.key === ENTER || event.keyCode === ENTER_KEY_CODE) &&
+            this.textValue.trim()
+        ) {
+            this.value = [
+                ...this.value,
+                this.createChip(this.textValue.trim()),
+            ];
+            this.textValue = '';
+        }
+    };
+
+    private handleChange = (event: CustomEvent<Chip[]>) => {
+        this.value = event.detail;
+    };
+
+    private createChip = (name: string): Chip => {
+        return {
+            id: name,
+            text: name,
+            removable: true,
+        };
+    };
+}

--- a/src/components/chip-set/examples/chip-set-input-type-text.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-text.tsx
@@ -1,0 +1,106 @@
+import { Chip } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+import { ENTER, ENTER_KEY_CODE } from '../../../util/keycodes';
+
+/**
+ * Input chip set with `inputType` of `text`
+ *
+ * There is a slight difference in the way browsers treat `input` field
+ * with `type="text"` and `type="search"`. You can read more about this
+ * difference in [Mozilla's documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#using_search_inputs),
+ * but the most important difference in this case is activation of the
+ * autocorrection feature on most smart devices.
+ *
+ * When a user makes a spelling mistake while typing in an input field with
+ * `type="text"`, the mistake will be corrected automatically, right after they
+ * press <kbd>Enter</kbd> or <kbd>Space</kbd>. Input fields with `type="search"`
+ * do not auto correct the user's input.
+ *
+ * If you want to use limel-chip-set in a form context, where autocorrection is
+ * a good thing, use `text` as `inputType`. It is important to know that the
+ * chip-set component creates a chip from the autocorrected value, after the
+ * user has pressed the <kbd>Enter</kbd> key and the auto correction has fixed
+ * existing typos! For example, for a question like "Please type five of your
+ * favorite fruits", you would want to avoid misspellings, to collect higher
+ * quality data.
+ */
+@Component({
+    tag: 'limel-example-chip-set-input-type-text',
+    shadow: true,
+})
+export class ChipSetInputExample {
+    @State()
+    private value: Chip[];
+
+    @State()
+    private companyValue: Chip[];
+
+    @State()
+    private textValue = '';
+
+    @State()
+    private maxItems = 5;
+
+    @State()
+    private emptyInputOnBlur: boolean = true;
+
+    constructor() {
+        this.value = [
+            this.createChip('Apple'),
+            this.createChip('Pear'),
+            this.createChip('Strawberry'),
+            this.createChip('Banana'),
+        ];
+    }
+
+    public render() {
+        return [
+            <limel-chip-set
+                type="input"
+                inputType="text"
+                label="Type five of your favorite fruits."
+                helperText="For some fruit names, icons are displayed on the chips"
+                value={this.value}
+                maxItems={this.maxItems}
+                onChange={this.handleChange}
+                onInput={this.handleInput}
+                onKeyUp={this.onKeyUp}
+                emptyInputOnBlur={this.emptyInputOnBlur}
+            />,
+        ];
+    }
+
+    private handleInput = (event: CustomEvent<string>) => {
+        this.textValue = event.detail;
+    };
+
+    private onKeyUp = (event: KeyboardEvent) => {
+        if (
+            (event.key === ENTER || event.keyCode === ENTER_KEY_CODE) &&
+            this.textValue.trim()
+        ) {
+            this.value = [
+                ...this.value,
+                this.createChip(this.textValue.trim()),
+            ];
+            this.companyValue = [
+                ...this.companyValue,
+                this.createChip(this.textValue.trim()),
+            ];
+            this.textValue = '';
+        }
+    };
+
+    private handleChange = (event: CustomEvent<Chip[]>) => {
+        this.value = event.detail;
+    };
+
+    private createChip = (name: string): Chip => {
+        return {
+            id: name,
+            text: name,
+            removable: true,
+            icon: `${name}`.toLowerCase(),
+        };
+    };
+}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -242,6 +242,7 @@ export class Picker {
         return [
             <limel-chip-set
                 type="input"
+                inputType="search"
                 label={this.label}
                 helperText={this.helperText}
                 leadingIcon={this.leadingIcon}


### PR DESCRIPTION
fix: #1718

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
