### PR TITLE
chore(packages): upgrade kompendium from v.0.11.0 to 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "jest": "^26.6.3",
         "jest-cli": "^27.5.0",
         "jsx-dom": "^7.0.4",
-        "kompendium": "^0.11.0",
+        "kompendium": "^0.11.1",
         "lodash-es": "^4.17.21",
         "material-components-web": "^13.0.0",
         "moment": "^2.29.3",
@@ -10308,9 +10308,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.0.tgz",
-      "integrity": "sha512-yXemMkI56OaOmfK8bno1YRrk1u+CcDTW34vdXtS5D1DSDd/16NRpn45BNpPNZE+TS03uW/krPceV2fZEDELuzw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.1.tgz",
+      "integrity": "sha512-8YLkvv1K2a01R7BKucpG1AqMZiWeN2Z7tHm+m82DMNdroK4EWks8jmlAjVYEGhvLreyY8bNcofzXNGkPY1gqKw==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -22857,9 +22857,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.0.tgz",
-      "integrity": "sha512-yXemMkI56OaOmfK8bno1YRrk1u+CcDTW34vdXtS5D1DSDd/16NRpn45BNpPNZE+TS03uW/krPceV2fZEDELuzw==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.1.tgz",
+      "integrity": "sha512-8YLkvv1K2a01R7BKucpG1AqMZiWeN2Z7tHm+m82DMNdroK4EWks8jmlAjVYEGhvLreyY8bNcofzXNGkPY1gqKw==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^27.5.0",
     "jsx-dom": "^7.0.4",
-    "kompendium": "^0.11.0",
+    "kompendium": "^0.11.1",
     "lodash-es": "^4.17.21",
     "material-components-web": "^13.0.0",
     "moment": "^2.29.3",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
