### PR TITLE
fix(picker): improve look and readability of empty result message

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -434,8 +434,9 @@ export class Picker {
         }
 
         const style = {
-            color: 'var(--lime-light-grey, #{$lime-light-grey})',
+            color: 'rgb(var(--contrast-1100))',
             'text-align': 'center',
+            margin: '0.5rem 1rem',
         };
 
         return <p style={style}>{this.emptyResultMessage}</p>;


### PR DESCRIPTION
Before: 
It's too grey and hard to read. Also no good distance on the sides.
![image](https://user-images.githubusercontent.com/35954987/164476984-92fb46b3-4c6e-47f4-8222-a1a61b60f8fd.png)

After:
![image](https://user-images.githubusercontent.com/35954987/164478043-9f79a1e4-f376-444b-95e4-35b36d74c2e5.png)


fix: https://github.com/Lundalogik/crm-feature/issues/2758
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
