### PR TITLE
feat(forms): set rjsf collapsible sections id

### DIFF
--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -35,11 +35,26 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
         'limel-collapsible-section',
         {
             header: props.title,
+            id: getSchemaObjectPropertyPath(
+                props.formContext.schema,
+                props.idSchema
+            ),
             'is-open': defaultOpen,
         },
         renderDescription(props.description),
         renderProperties(props.properties, props.schema)
     );
+}
+
+function getSchemaObjectPropertyPath(schema: any, subSchema: LimeJSONSchema) {
+    const refPrefixLength = 2;
+    const matchAllForwardSlashes = /\//g;
+    const rootPath = (schema.$ref as string)
+        .replace(matchAllForwardSlashes, '.')
+        .slice(refPrefixLength);
+    const subSchemaPath = subSchema.$id?.replace('_', '.properties.');
+
+    return subSchemaPath.replace('root', rootPath);
 }
 
 function renderProperties(


### PR DESCRIPTION
Set the React JSON schema form object field collapsible sections id to be equal to the schema object
property path.

fix: Lundalogik/crm-feature#1885

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
