### PR TITLE
fix(progress-flow): prevent `z-index` overlapping problems by isolating the component

### DIFF
--- a/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
@@ -2,7 +2,7 @@
     &:after {
         pointer-events: none;
         box-sizing: border-box;
-        z-index: z-index.$limel-progress-flow-step-content;
+        z-index: $limel-progress-flow-step-content;
         position: absolute;
         right: var(--selected-indicator-right);
 

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
@@ -1,7 +1,9 @@
 @use '../../../style/mixins';
 @use '../../../style/functions';
 @use '../../../style/internal/variables';
-@use '../../../style/internal/z-index';
+
+$limel-progress-flow-step-content: 2;
+$limel-progress-flow-divider: 1;
 
 .flow-item {
     --step-background: var(
@@ -133,7 +135,7 @@
     height: var(--step-height);
 
     position: absolute;
-    z-index: z-index.$limel-progress-flow-divider;
+    z-index: $limel-progress-flow-divider;
     right: calc(var(--step-height) / 2 * -1);
     overflow: hidden;
 
@@ -164,7 +166,7 @@
 .secondary-text {
     @include mixins.truncate-text();
     max-width: var(--max-text-width);
-    z-index: z-index.$limel-progress-flow-step-content;
+    z-index: $limel-progress-flow-step-content;
 }
 
 .secondary-text {
@@ -175,7 +177,7 @@
 
 .icon {
     margin: 0 functions.pxToRem(8) 0 functions.pxToRem(4);
-    z-index: z-index.$limel-progress-flow-step-content;
+    z-index: $limel-progress-flow-step-content;
 }
 
 @import './partial-styles/_selected-indicator';

--- a/src/components/progress-flow/progress-flow.scss
+++ b/src/components/progress-flow/progress-flow.scss
@@ -17,6 +17,7 @@
     --selected-indicator-right: -0.5rem;
     --max-text-width: 10rem;
 
+    isolation: isolate;
     box-sizing: border-box;
     width: 100%;
     display: flex;

--- a/src/style/internal/z-index.scss
+++ b/src/style/internal/z-index.scss
@@ -14,6 +14,4 @@ $table--limel-table--row-selector: 1 !default;
 $popover-before: -1 !default;
 $button-group-radio-button-keyboard-focused: 1 !default;
 $list-mdc-list-item: 0 !default;
-$limel-progress-flow-step-content: 2 !default;
-$limel-progress-flow-divider: 1 !default;
 $limel-circular-progress-value: 1 !default;


### PR DESCRIPTION
The progress-flow component will now have its own stacking content.
So if other elements in the dom have z-index, they will not be covered by
elements of the component which have a z-index.



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
