### PR TITLE
feat(packages): upgrade lime-icons8 from 2.7.0 to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/config-conventional": "^16.0.0",
-        "@lundalogik/lime-icons8": "^2.7.0",
+        "@lundalogik/lime-icons8": "^2.8.0",
         "@popperjs/core": "^2.11.5",
         "@rjsf/core": "^2.4.2",
         "@stencil/core": "^2.15.1",
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/@lundalogik/lime-icons8": {
-      "version": "2.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.7.0/a58599fabb94e662abde289323e15c40de2379e9f8640ebcc6b2ed478812cfed",
-      "integrity": "sha512-NB3733+SuihCigjntm/nMCjBQinkKJhbxe5Hh91haw9101tki3e00ZCe6kLR/U+xQDnxCFeQ5O9Sk3Sw/NBzFA==",
+      "version": "2.8.0",
+      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.8.0/c6b9e4086a6e023470830ad1c0a4884477feea7897277cbcbf73537d1dc23bbf",
+      "integrity": "sha512-iRm9vRFviIzycevgiTHfOiIP/YFnofuxkYGauLr4zOh3xKr/F1JQwByLQGV2BBjY2dsDPVAHB7jXP8bv9XjRMg==",
       "dev": true,
       "license": "UNLICENSED"
     },
@@ -16264,9 +16264,9 @@
       }
     },
     "@lundalogik/lime-icons8": {
-      "version": "2.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.7.0/a58599fabb94e662abde289323e15c40de2379e9f8640ebcc6b2ed478812cfed",
-      "integrity": "sha512-NB3733+SuihCigjntm/nMCjBQinkKJhbxe5Hh91haw9101tki3e00ZCe6kLR/U+xQDnxCFeQ5O9Sk3Sw/NBzFA==",
+      "version": "2.8.0",
+      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.8.0/c6b9e4086a6e023470830ad1c0a4884477feea7897277cbcbf73537d1dc23bbf",
+      "integrity": "sha512-iRm9vRFviIzycevgiTHfOiIP/YFnofuxkYGauLr4zOh3xKr/F1JQwByLQGV2BBjY2dsDPVAHB7jXP8bv9XjRMg==",
       "dev": true
     },
     "@material/animation": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^16.0.0",
-    "@lundalogik/lime-icons8": "^2.7.0",
+    "@lundalogik/lime-icons8": "^2.8.0",
     "@popperjs/core": "^2.11.5",
     "@rjsf/core": "^2.4.2",
     "@stencil/core": "^2.15.1",


### PR DESCRIPTION
adds new icons for visualizing widget sizes

fix https://github.com/Lundalogik/crm-feature/issues/2859

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
