### PR TITLE
fix(form): avoid crash if object-field is missing $ref

### DIFF
--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -50,7 +50,7 @@ function getSchemaObjectPropertyPath(schema: any, subSchema: LimeJSONSchema) {
     const refPrefixLength = 2;
     const matchAllForwardSlashes = /\//g;
     const rootPath = (schema.$ref as string)
-        .replace(matchAllForwardSlashes, '.')
+        ?.replace(matchAllForwardSlashes, '.')
         .slice(refPrefixLength);
     const subSchemaPath = subSchema.$id?.replace('_', '.properties.');
 


### PR DESCRIPTION
@BjornOstberg experienced a bug where the application crashes because `$ref` is undefined. By his own admission it may well be that they are using collapsible-section incorrectly, but since the feature is a "nice to have" rather than "system critical", we should fail gracefully instead of crashing hard. This addition of optional chaining should hopefully achieve that…

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
