### PR TITLE
fix(progress-flow): make it possible to set an icon color

### DIFF
--- a/src/components/progress-flow/examples/progress-flow-colors-css.scss
+++ b/src/components/progress-flow/examples/progress-flow-colors-css.scss
@@ -14,5 +14,5 @@
     --progress-flow-step-text-color: rgb(var(--contrast-200));
     --progress-flow-step-text-color-passed: rgb(var(--contrast-1100));
 
-    --progress-flow-icon-color: rgb(var(--color-lime-default));
+    --progress-flow-icon-color--inactive: rgb(var(--color-lime-default));
 }

--- a/src/components/progress-flow/examples/progress-flow-colors-css.scss
+++ b/src/components/progress-flow/examples/progress-flow-colors-css.scss
@@ -9,7 +9,7 @@
 
     --progress-flow-step-background-color: rgb(var(--contrast-1200));
     --progress-flow-step-background-color--selected: rgb(var(--color-sky-dark));
-    --progress-flow-passed-step-background-color: rgb(var(--contrast-700));
+    --progress-flow-step-background-color--passed: rgb(var(--contrast-700));
 
     --progress-flow-step-text-color: rgb(var(--contrast-200));
     --progress-flow-step-text-color--passed: rgb(var(--contrast-1100));

--- a/src/components/progress-flow/examples/progress-flow-colors-css.scss
+++ b/src/components/progress-flow/examples/progress-flow-colors-css.scss
@@ -12,7 +12,7 @@
     --progress-flow-passed-step-background-color: rgb(var(--contrast-700));
 
     --progress-flow-step-text-color: rgb(var(--contrast-200));
-    --progress-flow-step-text-color-passed: rgb(var(--contrast-1100));
+    --progress-flow-step-text-color--passed: rgb(var(--contrast-1100));
 
     --progress-flow-icon-color--inactive: rgb(var(--color-lime-default));
 }

--- a/src/components/progress-flow/progress-flow-item/partial-styles/_colors.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_colors.scss
@@ -3,7 +3,7 @@
     background-color: var(--step-background);
 
     .icon {
-        color: var(--progress-flow-icon-color, var(--step-text));
+        color: var(--progress-flow-icon-color--inactive, var(--step-text));
     }
 
     .flow-item.selected & {

--- a/src/components/progress-flow/progress-flow.scss
+++ b/src/components/progress-flow/progress-flow.scss
@@ -7,7 +7,7 @@
 * @prop --progress-flow-step-background-color--passed: Background color of passed steps, defaults to the background color the step has when selected.
 * @prop --progress-flow-step-text-color: Text of steps, defaults to `--contrast-1200`.
 * @prop --progress-flow-step-text-color--selected: Text color of selected step, defaults to `--lime-primary-color`.
-* @prop --progress-flow-step-text-color-passed: Text color of passed steps, defaults to the text color the step has when selected.
+* @prop --progress-flow-step-text-color--passed: Text color of passed steps, defaults to the text color the step has when selected.
 * @prop --progress-flow-step-divider-color: Color of the arrow shaped dividers between steps which must be the same as component's background, defaults to `--contrast-100`.
 * @prop --progress-flow-icon-color--inactive: Color of the optional icons used in each step. Only affects inactive steps, defaults to text colors for inactive, active, or passed step.
 */

--- a/src/components/progress-flow/progress-flow.scss
+++ b/src/components/progress-flow/progress-flow.scss
@@ -9,7 +9,7 @@
 * @prop --progress-flow-step-text-color--selected: Text color of selected step, defaults to `--lime-primary-color`.
 * @prop --progress-flow-step-text-color-passed: Text color of passed steps, defaults to the text color the step has when selected.
 * @prop --progress-flow-step-divider-color: Color of the arrow shaped dividers between steps which must be the same as component's background, defaults to `--contrast-100`.
-* @prop --progress-flow-icon-color: Color of the optional icons used in each step. Only affects inactive steps, defaults to text colors for inactive, active, or passed step.
+* @prop --progress-flow-icon-color--inactive: Color of the optional icons used in each step. Only affects inactive steps, defaults to text colors for inactive, active, or passed step.
 */
 
 :host {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2841

<img width="534" alt="Screenshot 2022-06-29 at 11 58 27" src="https://user-images.githubusercontent.com/50618208/176409233-86d31799-3e4d-4a89-b347-2ca266e8029d.png">
<img width="529" alt="Screenshot 2022-06-29 at 11 59 38" src="https://user-images.githubusercontent.com/50618208/176409482-20d0cf91-aebd-4763-b1d9-cdaf9db16d41.png">

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
