### PR TITLE
fix(common): avoid crashes when no name/title and required prop given

### DIFF
--- a/src/components/form/templates/common.spec.ts
+++ b/src/components/form/templates/common.spec.ts
@@ -49,6 +49,7 @@ const schema = {
                 },
             ],
         },
+        props: { type: 'object' },
     },
 };
 
@@ -182,6 +183,10 @@ describe('findTitle()', () => {
                 schema,
             ],
             output: 'test',
+        },
+        {
+            input: [{ props: { limetype: 'deal' } }, schema, schema],
+            output: null,
         },
     ].forEach(({ input, output }) => {
         const inputJson = JSON.stringify(input[1]);

--- a/src/components/form/templates/common.ts
+++ b/src/components/form/templates/common.ts
@@ -60,6 +60,10 @@ export function findTitle(data: any, fieldSchema: any, formSchema: any) {
         return null;
     }
 
+    if (!subSchema.properties) {
+        return null;
+    }
+
     const [key, value] = firstEntry;
 
     return findTitle(value, subSchema.properties[key], formSchema);


### PR DESCRIPTION
When an object has a title or a name, the function returns the title or a name. If no title or
name given, it will return the required property value as a title. In our case the property is
neither a title/name nor a required property which caused the crash. This PR solves the issue

fix Lundalogik/crm-feature#2857



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
