### PR TITLE
fix(list): make action menu accessible with keyboard

### DIFF
--- a/src/components/list/list-renderer.tsx
+++ b/src/components/list/list-renderer.tsx
@@ -249,7 +249,11 @@ export class ListRenderer {
                 items={actions}
                 openDirection="left"
             >
-                <limel-icon slot="trigger" name="menu_2" size="small" />
+                <limel-icon-button
+                    class="action-menu-trigger"
+                    slot="trigger"
+                    icon="menu_2"
+                />
             </limel-menu>
         );
     };

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -249,6 +249,10 @@ $list-mdc-list-item: 0;
     }
 }
 
+.action-menu-trigger {
+    transform: scale(0.9); // otherwise edges of the menu will look cropped
+}
+
 @import '../checkbox/checkbox.scss';
 
 @import './radio-button/radio-button.scss';


### PR DESCRIPTION
Using tab, user can now focus the menu and trigger
it by pressing `enter` or `space` key.

fix https://github.com/Lundalogik/lime-elements/issues/1215

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
