### PR TITLE
Feature/#1803/dock

### DIFF
--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -1,0 +1,71 @@
+@use '../../../style/mixins';
+@use '../../../style/functions';
+@use '../../../style/internal/variables';
+
+.button {
+    all: unset;
+
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    position: relative;
+
+    width: 100%;
+    height: var(--dock-item-height);
+
+    border-radius: functions.pxToRem(6);
+    font-size: functions.pxToRem(14);
+    padding: 0 0.5rem;
+    min-width: var(--dock-item-height);
+
+    color: var(--limel-dock-item-text-color);
+    background-color: var(--dock-background-color);
+
+    &:focus-visible {
+        box-shadow: var(--shadow-depth-8-focused);
+    }
+
+    .dock-item:not(.selected) & {
+        &:not(.disabled) {
+            cursor: pointer;
+            @include mixins.is-flat-clickable();
+        }
+    }
+
+    &:hover {
+        z-index: 1;
+    }
+
+    &.selected {
+        color: var(--limel-dock-item-text-color--selected);
+        background-color: var(
+            --dock-item-background-color--selected,
+            rgb(var(--contrast-200))
+        );
+        box-shadow: var(--button-shadow-inset);
+
+        .icon {
+            color: var(--limel-dock-item-text--selected);
+        }
+    }
+}
+
+limel-popover {
+    display: grid; // an ugly hack to make buttons that are wrapped in a popover become fullwidth
+}
+
+.text {
+    @include mixins.truncate-text();
+    padding-left: 0.5rem;
+    padding-right: 0.75rem;
+}
+
+.icon {
+    flex-shrink: 0;
+    width: calc(var(--dock-item-height) - 1rem);
+    height: calc(var(--dock-item-height) - 1rem);
+    color: var(
+        --dock-item-icon-color--deselected,
+        var(--limel-dock-item-text-color)
+    );
+}

--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -1,0 +1,148 @@
+import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+import { createRandomString } from '../../../util/random-string';
+
+/**
+ * @private
+ */
+@Component({
+    tag: 'limel-dock-button',
+    shadow: false,
+    styleUrl: 'dock-button.scss',
+})
+export class DockButton {
+    /**
+     * @inheritdoc
+     */
+    @Prop()
+    public item!: DockItem;
+
+    /**
+     * @inheritdoc
+     */
+    @Prop({ reflect: true })
+    public expanded? = false;
+
+    /**
+     * @inheritdoc
+     */
+    @Prop({ reflect: true })
+    public useMobileLayout? = false;
+
+    /**
+     * Fired when clicking on the flow item.
+     */
+    @Event()
+    private interact: EventEmitter<DockItem>;
+
+    @State()
+    private isOpen = false;
+
+    @Event()
+    public close: EventEmitter<void>;
+
+    private tooltipId: string;
+
+    constructor() {
+        this.tooltipId = createRandomString();
+    }
+
+    public render() {
+        if (this.item?.dockMenu?.componentName) {
+            return this.renderPopover();
+        }
+
+        return this.renderButton(this.handleClick);
+    }
+
+    private renderPopover() {
+        const CustomComponent = this.item?.dockMenu.componentName;
+
+        return (
+            <limel-popover
+                openDirection={this.useMobileLayout ? 'top' : 'right'}
+                open={this.isOpen || this.item.dockMenu.menuOpen}
+                onClose={this.onPopoverClose}
+            >
+                {this.renderButton(this.openPopover, 'trigger')}
+                <CustomComponent
+                    {...(this.item.dockMenu.props || {})}
+                    onClose={this.onPopoverClose}
+                />
+            </limel-popover>
+        );
+    }
+
+    private renderButton(
+        handleClick: (event: MouseEvent) => void,
+        slot?: string
+    ) {
+        return (
+            <button
+                slot={slot}
+                tabindex="0"
+                id={this.tooltipId}
+                type="button"
+                class={{
+                    button: true,
+                    selected: this.item?.selected,
+                }}
+                onClick={handleClick}
+            >
+                {this.renderIcon()}
+                {this.renderLabel()}
+                {this.renderTooltip()}
+            </button>
+        );
+    }
+
+    private openPopover = (event: MouseEvent) => {
+        event.stopPropagation();
+        this.isOpen = true;
+    };
+
+    private onPopoverClose = () => {
+        this.isOpen = false;
+        this.close.emit();
+    };
+
+    private handleClick = (event: MouseEvent) => {
+        event.stopPropagation();
+        this.interact.emit(this.item);
+    };
+
+    private renderIcon() {
+        if (!this.item.icon) {
+            return;
+        }
+
+        return <limel-icon name={this.item.icon} class="icon" />;
+    }
+
+    private renderLabel() {
+        if (this.expanded) {
+            return <span class="text">{this.item.label}</span>;
+        }
+    }
+
+    private renderTooltip() {
+        if (!this.expanded && this.item.label) {
+            return (
+                <limel-tooltip
+                    elementId={this.tooltipId}
+                    label={this.item.label}
+                    helperLabel={this.item.helperLabel}
+                />
+            );
+        }
+
+        if (this.expanded && this.item.helperLabel) {
+            return (
+                <limel-tooltip
+                    elementId={this.tooltipId}
+                    label={this.item.helperLabel}
+                />
+            );
+        }
+    }
+}

--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -1,0 +1,80 @@
+@use '../../style/mixins';
+@use '../../style/functions';
+@use '../../style/internal/variables';
+
+/**
+* @prop --dock-expanded-max-width: The maximum width of the Dock when it is expanded. Defaults to `max-content` which means the Dock will adjust its width to the widest dock item.
+* @prop --dock-background-color: Background color of the whole component, defaults to `--contrast-100`.
+* @prop --dock-item-background-color--selected: Background color of selected dock item, defaults to `--contrast-200`.
+* @prop --dock-item-text-color--deselected: Text of dock items, defaults to `--contrast-1100`.
+* @prop --dock-item-text-color--selected: Text color of selected dock item, defaults to `--contrast-1300`.
+* @prop --dock-item-icon-color: Color of the optional icons used in each dock item. Only affects inactive dock items, defaults to text colors for default or selected states.
+* @prop --popover-surface-width: Defines the width of the popover that is opened for dock items with custom components. Defaults to `auto`.
+*/
+
+:host(limel-dock) {
+    --dock-item-height: 2.75rem;
+    --dock-padding: 0.25rem;
+    --dock-expand-shrink-button-height: 1rem;
+
+    --limel-dock-item-text-color: var(
+        --dock-item-text-color--deselected,
+        rgb(var(--contrast-1100))
+    );
+    --limel-dock-item-text-color--selected: var(
+        --dock-item-text-color--selected,
+        rgb(var(--contrast-1300))
+    );
+
+    isolation: isolate;
+    position: relative;
+
+    display: inline-flex;
+    flex-direction: column;
+
+    background-color: var(--dock-background-color, rgb(var(--contrast-100)));
+    box-shadow: #{functions.pxToRem(3)} 0 #{functions.pxToRem(6)} #{functions.pxToRem(
+                -2
+            )} rgba(var(--color-black), 0.15),
+        #{functions.pxToRem(3)} 0 #{functions.pxToRem(10)} #{functions.pxToRem(
+                -2
+            )} rgba(var(--color-black), 0.05);
+}
+
+:host(limel-dock:not(.has-mobile-layout)) {
+    height: 100%;
+    width: calc((var(--dock-padding) * 2) + var(--dock-item-height));
+}
+
+:host(limel-dock.expanded) {
+    width: var(--dock-expanded-max-width, max-content);
+}
+
+.footer-separator {
+    margin-top: auto;
+    justify-self: flex-end;
+}
+
+nav {
+    box-sizing: border-box;
+    display: inline-flex;
+    flex-direction: column;
+    gap: functions.pxToRem(6);
+    flex-grow: 1;
+
+    padding: var(--dock-padding); // needed for the focus effect
+
+    overflow-y: auto;
+    scrollbar-width: none; // This hides the scrollbars appearing under in Firefox
+    -ms-overflow-style: none; // Same as above for IE 11
+    &::-webkit-scrollbar {
+        display: none; // This hides the scrollbars appearing under in Chrome
+    }
+
+    :host(limel-dock.has-mobile-layout) & {
+        justify-content: space-between;
+        flex-direction: row;
+    }
+}
+
+@import './partial-styles/shrink-expand-button';

--- a/src/components/dock/dock.tsx
+++ b/src/components/dock/dock.tsx
@@ -1,0 +1,178 @@
+import {
+    Component,
+    Event,
+    EventEmitter,
+    h,
+    Host,
+    Prop,
+    State,
+} from '@stencil/core';
+import { DockItem } from './dock.types';
+
+const DEFAULT_MOBILE_BREAKPOINT = 700;
+
+/**
+ * @exampleComponent limel-example-dock-basic
+ * @exampleComponent limel-example-dock-custom-component
+ * @exampleComponent limel-example-dock-mobile
+ * @exampleComponent limel-example-dock-expanded
+ * @exampleComponent limel-example-dock-colors-css
+ * @private
+ */
+@Component({
+    tag: 'limel-dock',
+    shadow: true,
+    styleUrl: 'dock.scss',
+})
+export class Dock {
+    /**
+     * Items that are placed in the dock.
+     */
+    @Prop()
+    public dockItems: DockItem[] = [];
+
+    /**
+     * Items that are placed at the bottom of the dock. (Or at the end in mobile
+     * layout.)
+     */
+    @Prop()
+    public dockFooterItems?: DockItem[] = [];
+
+    /**
+     * A label used to describe the purpose of the navigation element to users
+     * of assistive technologies, like screen readers. Especially useful when
+     * there are multiple navigation elements in the user interface.
+     * Example value: "Primary navigation"
+     */
+    @Prop({ reflect: true })
+    public accessibleLabel?: string;
+
+    /**
+     * Defines the width of the component, when it loads.
+     * - `true`: shows both icons and labels of the Dock items.
+     * - `false`: only shows icons of the doc items, and displays
+     * their labels as tooltip.
+     *
+     * Note: when `useMobileLayout` is `true`, labels will always
+     * be shown as tooltips. Read more below…
+     */
+    @Prop({ reflect: true })
+    public expanded? = false;
+
+    /**
+     * Set to `false` if you do not want to allow end-users
+     * to exapnd or shrink the Dock. This will hide the
+     * expand/shrink button, and the only things that defines
+     * the layout will be the `expanded` property, and
+     * the `mobileBreakPoint`.
+     */
+    @Prop({ reflect: true })
+    public allowResize? = true;
+
+    /**
+     * Defines the breakpoint in pixles, at which the component will be rendered
+     * in a hoizontal layout. Default breakpoint is `700` pixels, which means
+     * when the screen size is smaller than `700px`, the component will automatically
+     * switch to a horizontal layout.
+     */
+    @Prop({ reflect: true })
+    public mobileBreakPoint?: number = DEFAULT_MOBILE_BREAKPOINT;
+
+    /**
+     * Fired when a Dock item has been selected from the dock.
+     */
+    @Event()
+    private itemSelected: EventEmitter<DockItem>;
+
+    /**
+     * Is used to render the component horizontally, and place
+     * the Dock items in a row.
+     */
+    @State()
+    private useMobileLayout = false;
+
+    private resizeObserver: ResizeObserver;
+
+    public componentDidLoad() {
+        this.resizeObserver = new ResizeObserver(this.handleResize);
+        this.resizeObserver.observe(document.body);
+    }
+
+    disconnectedCallback() {
+        this.resizeObserver.disconnect();
+    }
+
+    public render() {
+        return (
+            <Host
+                class={{
+                    dock: true,
+                    expanded: this.expanded,
+                    'has-mobile-layout': this.useMobileLayout,
+                }}
+            >
+                <nav aria-label={this.accessibleLabel}>
+                    {this.dockItems.map(this.renderDockItem)}
+                    {this.renderSeparator()}
+                    {this.dockFooterItems.map(this.renderDockItem)}
+                </nav>
+                {this.renderExpandShrinkToggle()}
+            </Host>
+        );
+    }
+
+    private renderSeparator = () => {
+        return this.useMobileLayout ? null : <span class="footer-separator" />;
+    };
+
+    private renderDockItem = (item: DockItem) => {
+        return (
+            <limel-dock-button
+                class={{
+                    'dock-item': true,
+                    selected: item.selected,
+                }}
+                item={item}
+                expanded={this.expanded && !this.useMobileLayout}
+                useMobileLayout={this.useMobileLayout}
+                onInteract={this.handleDockItemClick}
+            />
+        );
+    };
+
+    private handleDockItemClick = (event: CustomEvent<DockItem>) => {
+        if (!event.detail.selected) {
+            this.itemSelected.emit(event.detail);
+        }
+    };
+
+    private handleResize = () => {
+        if (window.innerWidth <= this.mobileBreakPoint) {
+            this.useMobileLayout = true;
+        } else {
+            this.useMobileLayout = false;
+        }
+    };
+
+    private renderExpandShrinkToggle() {
+        if (this.useMobileLayout || !this.allowResize) {
+            return;
+        }
+
+        return (
+            <button
+                class={{
+                    'expand-shrink': true,
+                    expanded: this.expanded,
+                }}
+                onClick={this.toggleDockWidth}
+            >
+                <limel-icon name="angle_right" />
+            </button>
+        );
+    }
+
+    private toggleDockWidth = () => {
+        this.expanded = !this.expanded;
+    };
+}

--- a/src/components/dock/dock.types.ts
+++ b/src/components/dock/dock.types.ts
@@ -1,0 +1,63 @@
+export interface DockItem {
+    /**
+     * A non-changing value to uniquely identify each item.
+     */
+    id: string;
+
+    /**
+     * Text to display for the item.
+     */
+    label: string;
+
+    /**
+     * Name of the icon to use.
+     */
+    icon: string;
+
+    /**
+     * Additional helper text for the dock item.
+     * Example usage can be a keyboard shortcut to activate the dock item.
+     */
+    helperLabel?: string;
+
+    /* eslint-disable no-irregular-whitespace */
+    /**
+     * Whether the dock item should indicate it is selected.
+     * These dock items normally take the user to a top-level location within
+     * the navigation tree; for example "Home", "Search" or "My Account".
+     * Set `selected` to `true`, when:
+     * - the user interface is showing the same top-level location as the dock
+     * item is pointing at, or
+     * - the user interface is showing a page which is a sub-location of the
+     * top-level location. For example, when user is at
+     * _My Account > Notification Settings_, the dock item of _My Account_
+     * should have the `selected` state.
+     */
+    selected?: boolean;
+    /* eslint-enable no-irregular-whitespace */
+
+    /**
+     * Used to specify a custom component to render as a menu for the dock item.
+     */
+    dockMenu?: DockMenu;
+}
+
+export interface DockMenu {
+    /**
+     * The tag name of a custom component to be displayed in a popover when
+     * clicking on the dock item this menu belongs to.
+     */
+    componentName: string;
+
+    /**
+     * Whether the menu is open.
+     */
+    menuOpen?: boolean;
+
+    /**
+     * Any properties that should be set on the custom component.
+     */
+    props?: {
+        [key: string]: any;
+    };
+}

--- a/src/components/dock/examples/dock-basic.scss
+++ b/src/components/dock/examples/dock-basic.scss
@@ -1,0 +1,11 @@
+:host {
+    --popover-surface-width: min(100vw, 40rem);
+}
+
+.application {
+    background-color: rgb(var(--contrast-400));
+    border: 1px solid rgb(var(--contrast-700));
+    overflow: hidden;
+    border-radius: 0.5rem;
+    height: 30rem;
+}

--- a/src/components/dock/examples/dock-basic.tsx
+++ b/src/components/dock/examples/dock-basic.tsx
@@ -1,0 +1,107 @@
+import { Component, h, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+
+/**
+ * Basic Example
+ *
+ * The Dock component can be used as a place for displaying the app's
+ * primary navigation.
+ *
+ * :::important
+ * Avoid having too many items in the Dock, because it will become
+ * problematic on mobile devices, when the component is rendered horizontally.
+ * :::
+ *
+ * It is possible to split the dock items into two sections and place one or
+ * more items at the bottom of the column. To do so, you can use `isFooterStart`
+ * on one of the items, which will act as a separator between the two sections,
+ * pushing itself and preceding to the bottom.
+ *
+ * :::important
+ * You must provide `label`s for to improve accesibility! Without labels,
+ * screen-readers cannot tell visually impared persons about the content
+ * of the Dock.
+ * :::
+ *
+ * It is possible to add extra information about the items using `helperLabel`.
+ *
+ * When the component is expanded, only the `helpeLabel` is used
+ * in the tooltip, when items are hovered.
+ * When the component is shrunk, both `label` and `helperLabel` are displayed
+ * inside the tooltip.
+ *
+ * Keep in mind that on a mobile phone, the component will be displayed horizontally
+ * and no labels are displayed! Instead, both `label` and `helperLabel` will be used
+ * as a tooltip to improve accessibility for screen-reader technologies.
+ *
+ * However, since hovering is not possible on touch-only mobile devices, users who
+ * rely on their vision to navigate the app will only see your chosen icons.
+ * So pick them carefully.
+ *
+ */
+@Component({
+    tag: 'limel-example-dock-basic',
+    shadow: true,
+    styleUrl: 'dock-basic.scss',
+})
+export class DockBasicExample {
+    @State()
+    private dockItems: DockItem[] = [
+        {
+            id: 'home',
+            label: 'Lime',
+            helperLabel: 'Cmd + H',
+            selected: true,
+            icon: '-lime-logo-outlined-colored',
+        },
+        {
+            id: 'tables',
+            label: 'Tables',
+            icon: 'insert_table',
+        },
+        {
+            id: 'search',
+            label: 'Search',
+            icon: 'search',
+        },
+    ];
+
+    @State()
+    private dockFooterItems: DockItem[] = [
+        {
+            id: 'user',
+            label: 'Preferences',
+            icon: 'user',
+        },
+        {
+            id: 'settings',
+            label: 'Settings',
+            icon: 'settings',
+        },
+    ];
+
+    public render() {
+        return (
+            <div class="application">
+                <limel-dock
+                    accessibleLabel="Dock Example: basic dock"
+                    dockItems={this.dockItems}
+                    dockFooterItems={this.dockFooterItems}
+                    onItemSelected={this.handleSelected}
+                />
+            </div>
+        );
+    }
+
+    private handleSelected = (event: CustomEvent<DockItem>) => {
+        const setSelection = (item: DockItem) => {
+            return {
+                ...item,
+                selected: item.id === event.detail.id,
+            };
+        };
+
+        this.dockItems = this.dockItems.map(setSelection);
+        this.dockFooterItems = this.dockFooterItems.map(setSelection);
+    };
+}

--- a/src/components/dock/examples/dock-colors-css.scss
+++ b/src/components/dock/examples/dock-colors-css.scss
@@ -1,0 +1,14 @@
+:host {
+    --dock-background-color: rgb(var(--contrast-1500));
+    --dock-item-text-color--deselected: rgb(var(--color-cyan-lighter));
+    --dock-item-text-color--selected: rgb(var(--contrast-100));
+    --dock-item-icon-color--deselected: rgb(var(--color-cyan-light));
+    --dock-item-background-color--selected: rgb(var(--color-cyan-light));
+}
+
+.application {
+    background-color: rgb(var(--contrast-1600));
+    overflow: hidden;
+    border-radius: 0.5rem;
+    height: 30rem;
+}

--- a/src/components/dock/examples/dock-colors-css.tsx
+++ b/src/components/dock/examples/dock-colors-css.tsx
@@ -1,0 +1,84 @@
+import { Component, h, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+
+/**
+ * Using CSS color variables for theming the Dock
+ *
+ * A few CSS variables can be used to customize the look and feel of the steps.
+ *
+ * :::note
+ * Using CSS variables to tweak the colors, applies the colors globally to the
+ * component, not to individual Dock items!
+ * :::
+ * :::important
+ * Make sure that:
+ * - text has enough contrast with its background and is readable.
+ * :::
+ */
+
+@Component({
+    tag: 'limel-example-dock-colors-css',
+    shadow: true,
+    styleUrl: 'dock-colors-css.scss',
+})
+export class DockColorsCssExample {
+    @State()
+    private dockItems: DockItem[] = [
+        {
+            id: '1',
+            label: 'Home',
+            selected: true,
+            icon: 'home',
+        },
+        {
+            id: '2',
+            label: 'Search',
+            icon: 'search',
+        },
+        {
+            id: '3',
+            label: 'Calls',
+            icon: 'phone',
+        },
+        {
+            id: '4',
+            label: 'Chats',
+            icon: 'chat',
+        },
+    ];
+
+    @State()
+    private dockFooterItems: DockItem[] = [
+        {
+            id: '5',
+            label: 'Settings',
+            icon: 'settings',
+        },
+    ];
+
+    public render() {
+        return (
+            <div class="application">
+                <limel-dock
+                    accessibleLabel="Dock Example: CSS color variables"
+                    dockItems={this.dockItems}
+                    dockFooterItems={this.dockFooterItems}
+                    onItemSelected={this.handleSelected}
+                    expanded={true}
+                />
+            </div>
+        );
+    }
+
+    private handleSelected = (event: CustomEvent<DockItem>) => {
+        const setSelection = (item: DockItem) => {
+            return {
+                ...item,
+                selected: item.id === event.detail.id,
+            };
+        };
+
+        this.dockItems = this.dockItems.map(setSelection);
+        this.dockFooterItems = this.dockFooterItems.map(setSelection);
+    };
+}

--- a/src/components/dock/examples/dock-custom-component.tsx
+++ b/src/components/dock/examples/dock-custom-component.tsx
@@ -1,0 +1,63 @@
+import { Component, h, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+
+/**
+ * Displaying a custom component after Dock item is clicked
+ *
+ * It is possible to display a custom component in a popover,
+ * when the Dock item is clicked. This enables you to design
+ * the content of the menu as you wish, independently from the Dock.
+ *
+ * :::note
+ * Pay attention to the `--popover-surface-width` variable in the
+ * `.SCSS` file. That defines the width the popover component, which is `auto`
+ * by default. But modifying it may be helpful depending on the usage.
+ * :::
+ *
+ * @link my-custom-menu.tsx
+ */
+
+@Component({
+    tag: 'limel-example-dock-custom-component',
+    shadow: true,
+    styleUrl: 'dock-basic.scss',
+})
+export class DockCustomComponentExample {
+    @State()
+    private dockItems: DockItem[] = [
+        {
+            id: 'home',
+            label: 'Lime',
+            helperLabel: 'Cmd + H',
+            selected: true,
+            icon: '-lime-logo-outlined-colored',
+        },
+        {
+            id: 'tables',
+            label: 'Tables',
+            icon: 'insert_table',
+            dockMenu: { componentName: 'my-custom-menu' },
+        },
+    ];
+
+    public render() {
+        return (
+            <div class="application">
+                <limel-dock
+                    accessibleLabel="Dock Example: item with custom menu"
+                    dockItems={this.dockItems}
+                    onItemSelected={this.handleSelected}
+                />
+            </div>
+        );
+    }
+
+    private handleSelected = (event: CustomEvent<DockItem>) => {
+        this.dockItems = this.dockItems.map((item: DockItem) => {
+            return {
+                ...item,
+                selected: item.id === event.detail.id,
+            };
+        });
+    };
+}

--- a/src/components/dock/examples/dock-expanded.tsx
+++ b/src/components/dock/examples/dock-expanded.tsx
@@ -1,0 +1,75 @@
+import { Component, h, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+
+/**
+ * Basic Example expanded
+ */
+@Component({
+    tag: 'limel-example-dock-expanded',
+    shadow: true,
+    styleUrl: 'dock-basic.scss',
+})
+export class DockExpandedExample {
+    @State()
+    private dockItems: DockItem[] = [
+        {
+            id: 'home',
+            label: 'Lime',
+            helperLabel: 'Cmd + H',
+            selected: true,
+            icon: '-lime-logo-outlined-colored',
+        },
+        {
+            id: 'tables',
+            label: 'Tables',
+            icon: 'insert_table',
+            dockMenu: { componentName: 'my-custom-menu' },
+        },
+        {
+            id: 'search',
+            label: 'Search',
+            icon: 'search',
+        },
+    ];
+
+    @State()
+    private dockFooterItems: DockItem[] = [
+        {
+            id: 'create',
+            label: 'Create object',
+            icon: 'plus_math',
+        },
+        {
+            id: 'settings',
+            label: 'Settings',
+            icon: 'settings',
+        },
+    ];
+
+    public render() {
+        return (
+            <div class="application">
+                <limel-dock
+                    accessibleLabel="Dock Example: expanded"
+                    dockItems={this.dockItems}
+                    dockFooterItems={this.dockFooterItems}
+                    onItemSelected={this.handleSelected}
+                    allowResize={false}
+                    expanded={true}
+                />
+            </div>
+        );
+    }
+
+    private handleSelected = (event: CustomEvent<DockItem>) => {
+        const setSelection = (item: DockItem) => {
+            return {
+                ...item,
+                selected: item.id === event.detail.id,
+            };
+        };
+
+        this.dockItems = this.dockItems.map(setSelection);
+        this.dockFooterItems = this.dockFooterItems.map(setSelection);
+    };
+}

--- a/src/components/dock/examples/dock-mobile.scss
+++ b/src/components/dock/examples/dock-mobile.scss
@@ -1,0 +1,19 @@
+:host {
+    --popover-surface-width: min(100vw, 40rem);
+}
+
+.application {
+    position: relative;
+    background-color: rgb(var(--contrast-400));
+    border: 1px solid rgb(var(--contrast-700));
+    overflow: hidden;
+    border-radius: 0.5rem;
+    height: 30rem;
+    width: 20rem;
+    margin: 0 auto;
+}
+
+limel-dock {
+    position: absolute;
+    inset: auto 0 0 0;
+}

--- a/src/components/dock/examples/dock-mobile.tsx
+++ b/src/components/dock/examples/dock-mobile.tsx
@@ -1,0 +1,98 @@
+import { Component, h, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+
+/**
+ * Setting a horizontal layout for mobile devices.
+ *
+ * By default, the component has a vertical layout, placing the
+ * Dock items in a column. However, the component will render the
+ * Dock items in a horizontal layout when the screen width is smaller
+ * than `700px`.
+ *
+ * If you prefer the component to switch to the horizontal mobile layout
+ * at another breakpoint, use the `mobileBreakPoint` property and give it
+ * a desired value in pixels (without `px`).
+ *
+ * In this example, we have chosen a very large number (`5000`) to force
+ * the component to be rendered in mobile layout here in the documentation,
+ * no matter how large the reader's screen size is.
+ *
+ * :::important
+ * Triggering the mobile layout does not automatically adjust the position
+ * of the component at the bottom of the screen. You should do that manually
+ * yourself in a proper way, depending on where the component is used;
+ * for example by using CSS media queries, and setting `position: fixed`.
+ * :::
+ *
+ * :::note
+ * Labels are not displayed in horizontal layout, but they will be instead
+ * displayed as tooltips.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-dock-mobile',
+    shadow: true,
+    styleUrl: 'dock-mobile.scss',
+})
+export class DockMobileExample {
+    @State()
+    private dockItems: DockItem[] = [
+        {
+            id: 'home',
+            label: 'Lime',
+            selected: true,
+            icon: '-lime-logo-outlined-colored',
+        },
+        {
+            id: 'tables',
+            label: 'Tables',
+            icon: 'insert_table',
+            dockMenu: { componentName: 'my-custom-menu' },
+        },
+        {
+            id: 'search',
+            label: 'Search',
+            icon: 'search',
+        },
+    ];
+
+    @State()
+    private dockFooterItems: DockItem[] = [
+        {
+            id: 'create',
+            label: 'Create object',
+            icon: 'plus_math',
+        },
+        {
+            id: 'settings',
+            label: 'Settings',
+            icon: 'settings',
+        },
+    ];
+
+    public render() {
+        return (
+            <div class="application">
+                <limel-dock
+                    accessibleLabel="Dock Example: mobile layout"
+                    dockItems={this.dockItems}
+                    dockFooterItems={this.dockFooterItems}
+                    onItemSelected={this.handleSelected}
+                    mobileBreakPoint={5000}
+                />
+            </div>
+        );
+    }
+
+    private handleSelected = (event: CustomEvent<DockItem>) => {
+        const setSelection = (item: DockItem) => {
+            return {
+                ...item,
+                selected: item.id === event.detail.id,
+            };
+        };
+
+        this.dockItems = this.dockItems.map(setSelection);
+        this.dockFooterItems = this.dockFooterItems.map(setSelection);
+    };
+}

--- a/src/components/dock/examples/my-custom-menu.tsx
+++ b/src/components/dock/examples/my-custom-menu.tsx
@@ -1,0 +1,60 @@
+import { ListItem } from '@limetech/lime-elements';
+import { Component, h } from '@stencil/core';
+
+@Component({
+    tag: 'my-custom-menu',
+    shadow: true,
+})
+export class MyCustomMenu {
+    private items: Array<ListItem<number>> = [
+        {
+            text: 'Companies',
+            icon: 'organization',
+            iconColor: 'rgb(var(--color-blue-default)',
+        },
+        {
+            text: 'Deals',
+            icon: 'money',
+            iconColor: 'rgb(var(--color-green-default))',
+        },
+        {
+            text: 'Agreements',
+            icon: 'handshake',
+            iconColor: 'rgb(var(--color-pink-default))',
+        },
+        {
+            text: 'Todos',
+            icon: 'today',
+            iconColor: 'rgb(var(--color-teal-default))',
+        },
+        {
+            text: 'History',
+            icon: 'comments',
+            iconColor: 'rgb(var(--color-grey-light))',
+        },
+        {
+            text: 'Coworkers',
+            icon: 'gender_neutral_user',
+            iconColor: 'rgb(var(--color-orange-light))',
+        },
+        {
+            text: 'Persons',
+            icon: 'user_group_man_man',
+            iconColor: 'rgb(var(--color-yellow-dark)',
+        },
+    ];
+
+    public render() {
+        return [
+            <limel-header
+                heading="Navigate to a table"
+                subheading="Showing 7 of 12"
+                supportingText="Show all…"
+            />,
+            <limel-list
+                items={this.items}
+                class="has-grid-layout has-interactive-items"
+            />,
+        ];
+    }
+}

--- a/src/components/dock/partial-styles/shrink-expand-button.scss
+++ b/src/components/dock/partial-styles/shrink-expand-button.scss
@@ -1,0 +1,33 @@
+.expand-shrink {
+    all: unset;
+    box-sizing: border-box;
+
+    @include mixins.is-flat-clickable();
+    cursor: pointer;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    height: var(--dock-expand-shrink-button-height);
+    padding: 0 0.5rem;
+    margin: var(--dock-padding);
+    border-radius: functions.pxToRem(6);
+
+    &.expanded {
+        justify-content: flex-end;
+
+        limel-icon {
+            transform: rotateY(180deg);
+        }
+    }
+
+    &:focus-visible {
+        box-shadow: var(--shadow-depth-8-focused);
+    }
+
+    limel-icon {
+        width: calc(var(--dock-expand-shrink-button-height) - 0.25rem);
+        color: var(--dock-item-icon-color--deselected, var(--button-text));
+    }
+}

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -20,3 +20,4 @@ export * from './components/spinner/spinner.types';
 export * from './components/tab-bar/tab.types';
 export * from './components/tab-panel/tab-panel.types';
 export * from './components/table/table.types';
+export * from './components/dock/dock.types';


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/1803


### Todo:

- [x] make it possible to shrink and expand the dock (get rid of labels and show tooltips instead of labels)
- [x] make possible to align several dock items to end
- [x] responsive design: for mobile view
- [x] allow consumer to set their own **mobile** breakpoint (component should automatically switch to mobile view after a default breakpoint, but also react to consumer's defined breakpoint. 
- [x] is popover part good?
- [x] add docs
- [x] split and clean up css
- [x] add css vars for max-width of dock
- [x] add docs to `types`
- [ ] emit and tell the outside world that the dock is expanded or not
- [ ] Add labels optionally on mobile devices
- [ ] unit test


#### Todo outside Lime Elements:
- [ ] Remember user's choice for expanded / shrunk
- [x] add a feature switch and use the new dock
- [x] hotkeys? :/ 


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
