### PR TITLE
fix(button): remove the `ripple` div & add our own keyboard focus styles

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -20,6 +20,9 @@
 
 button {
     @include mixins.is-elevated-clickable();
+    &:focus-visible {
+        box-shadow: var(--shadow-depth-8-focused);
+    }
 
     &.mdc-button {
         min-width: functions.pxToRem(36);

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -83,7 +83,6 @@ export class Button {
                 }}
                 disabled={this.disabled || this.loading}
             >
-                <div class="mdc-button__ripple" />
                 {this.renderIcon()}
                 <span class="label mdc-button__label">{this.label}</span>
                 <limel-spinner limeBranded={false} />


### PR DESCRIPTION
We have removed the ripple effect from almost all elements.
This will unify our styles more.
In this component, the original Material Design ripple was not
showing at all when clicking. Probably due to lack of some `import`s.
The div was only used to add a not-so-visible highlight
when the button was focused using keyboard.



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
