### PR TITLE
fix(dock): remove `--deselected` suffix from CSS vars

### DIFF
--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -64,8 +64,5 @@ limel-popover {
     flex-shrink: 0;
     width: calc(var(--dock-item-height) - 1rem);
     height: calc(var(--dock-item-height) - 1rem);
-    color: var(
-        --dock-item-icon-color--deselected,
-        var(--limel-dock-item-text-color)
-    );
+    color: var(--dock-item-icon-color, var(--limel-dock-item-text-color));
 }

--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -6,7 +6,7 @@
 * @prop --dock-expanded-max-width: The maximum width of the Dock when it is expanded. Defaults to `max-content` which means the Dock will adjust its width to the widest dock item.
 * @prop --dock-background-color: Background color of the whole component, defaults to `--contrast-100`.
 * @prop --dock-item-background-color--selected: Background color of selected dock item, defaults to `--contrast-200`.
-* @prop --dock-item-text-color--deselected: Text of dock items, defaults to `--contrast-1100`.
+* @prop --dock-item-text-color: Text of dock items, defaults to `--contrast-1100`.
 * @prop --dock-item-text-color--selected: Text color of selected dock item, defaults to `--contrast-1300`.
 * @prop --dock-item-icon-color: Color of the optional icons used in each dock item. Only affects inactive dock items, defaults to text colors for default or selected states.
 * @prop --popover-surface-width: Defines the width of the popover that is opened for dock items with custom components. Defaults to `auto`.
@@ -18,7 +18,7 @@
     --dock-expand-shrink-button-height: 1rem;
 
     --limel-dock-item-text-color: var(
-        --dock-item-text-color--deselected,
+        --dock-item-text-color,
         rgb(var(--contrast-1100))
     );
     --limel-dock-item-text-color--selected: var(

--- a/src/components/dock/examples/dock-colors-css.scss
+++ b/src/components/dock/examples/dock-colors-css.scss
@@ -1,8 +1,8 @@
 :host {
     --dock-background-color: rgb(var(--contrast-1500));
-    --dock-item-text-color--deselected: rgb(var(--color-cyan-lighter));
+    --dock-item-text-color: rgb(var(--color-cyan-lighter));
     --dock-item-text-color--selected: rgb(var(--contrast-100));
-    --dock-item-icon-color--deselected: rgb(var(--color-cyan-light));
+    --dock-item-icon-color: rgb(var(--color-cyan-light));
     --dock-item-background-color--selected: rgb(var(--color-cyan-light));
 }
 

--- a/src/components/dock/partial-styles/shrink-expand-button.scss
+++ b/src/components/dock/partial-styles/shrink-expand-button.scss
@@ -28,6 +28,6 @@
 
     limel-icon {
         width: calc(var(--dock-expand-shrink-button-height) - 0.25rem);
-        color: var(--dock-item-icon-color--deselected, var(--button-text));
+        color: var(--dock-item-icon-color, var(--limel-dock-item-text-color));
     }
 }


### PR DESCRIPTION
We have decided that variables that indicate the default state of something
do not need suffixes like `--default` or `--deselected`.

background: https://github.com/Lundalogik/lime-elements/pull/1792#discussion_r929902050

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
