### PR TITLE
fix(select): set `aria-required` and `aria-disabled` on trigger eleme…

### DIFF
--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -91,6 +91,8 @@ const SelectValue: FunctionalComponent<
             aria-haspopup="listbox"
             aria-expanded="false"
             aria-labelledby="s-label s-selected-text"
+            aria-required={props.required}
+            aria-disabled={props.disabled}
         >
             <span id="s-label" class={labelClassList}>
                 {props.label}
@@ -201,6 +203,7 @@ const NativeDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
     return (
         <select
             required={props.required}
+            aria-disabled={props.disabled}
             aria-required={props.required}
             onChange={props.onNativeChange}
             onFocus={props.open}


### PR DESCRIPTION
…nts to improve accessibility

Both for default and native trigger elements.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
