### PR TITLE
chore(packages): upgrade Kompendium from 0.11.1 to 0.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "jest": "^26.6.3",
         "jest-cli": "^28.0.2",
         "jsx-dom": "^7.0.4",
-        "kompendium": "^0.11.1",
+        "kompendium": "^0.11.3",
         "lodash-es": "^4.17.21",
         "material-components-web": "^13.0.0",
         "moment": "^2.29.3",
@@ -10719,9 +10719,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.1.tgz",
-      "integrity": "sha512-8YLkvv1K2a01R7BKucpG1AqMZiWeN2Z7tHm+m82DMNdroK4EWks8jmlAjVYEGhvLreyY8bNcofzXNGkPY1gqKw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.3.tgz",
+      "integrity": "sha512-40RNkLW2kBZms5DkXzt/Z2orGHPrBdL6XzCR14EtWiFX4ixolfh/8jvREKKLkzcc0aUGJBqPEbx3NPNsy8kN1Q==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -23582,9 +23582,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.1.tgz",
-      "integrity": "sha512-8YLkvv1K2a01R7BKucpG1AqMZiWeN2Z7tHm+m82DMNdroK4EWks8jmlAjVYEGhvLreyY8bNcofzXNGkPY1gqKw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.3.tgz",
+      "integrity": "sha512-40RNkLW2kBZms5DkXzt/Z2orGHPrBdL6XzCR14EtWiFX4ixolfh/8jvREKKLkzcc0aUGJBqPEbx3NPNsy8kN1Q==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jest": "^26.6.3",
     "jest-cli": "^28.0.2",
     "jsx-dom": "^7.0.4",
-    "kompendium": "^0.11.1",
+    "kompendium": "^0.11.3",
     "lodash-es": "^4.17.21",
     "material-components-web": "^13.0.0",
     "moment": "^2.29.3",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
