### PR TITLE
fix(dock): truncate label of popover dock items & prevent overflow of…

### DIFF
--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -51,7 +51,9 @@
 }
 
 limel-popover {
-    display: grid; // an ugly hack to make buttons that are wrapped in a popover become fullwidth
+    // makes buttons that are wrapped in a popover become fullwidth
+    display: grid;
+    grid-template-columns: 100%;
 }
 
 .text {


### PR DESCRIPTION
… label

fix https://github.com/Lundalogik/crm-feature/issues/2910


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
