### PR TITLE
fix(input-field): prevent visual defects if no label is provided

### DIFF
--- a/src/components/input-field/examples/input-field-placeholder.tsx
+++ b/src/components/input-field/examples/input-field-placeholder.tsx
@@ -28,6 +28,17 @@ import { Component, h, State } from '@stencil/core';
  * for example after submitting. Instructions that are not visible anymore will make it
  * hard for the user to realize what the problem is or how to solve it.
  * :::
+ * :::warning
+ * If no `label` is provided, then the placeholder text will be displayed even if the
+ * input field is not focused.
+ *
+ * However, this does not mean that you should use this
+ * as a hack, to create a minimalistic and clean user interface. Not providing labels
+ * will cause accessibility issues for users of assistive technologies,
+ * and strains users’ short-term memory as explained above.
+ * Additionally, users may confuse the placeholder text, as an automatically
+ * inputted value, and skip filling in information.
+ * :::
  */
 @Component({
     tag: 'limel-example-input-field-placeholder',

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -295,21 +295,11 @@ export class InputField {
             properties['aria-describedby'] = helperTextId;
         }
 
-        const labelClassList = {
-            'mdc-floating-label': true,
-            'mdc-floating-label--float-above':
-                !!this.value || this.isFocused || this.readonly,
-        };
-
         return [
             <label class={this.getContainerClassList()}>
                 <span class="mdc-notched-outline" tabindex="-1">
                     <span class="mdc-notched-outline__leading"></span>
-                    <span class="mdc-notched-outline__notch">
-                        <span class={labelClassList} id={labelId}>
-                            {this.label}
-                        </span>
-                    </span>
+                    {this.renderLabel(labelId)}
                     <span class="mdc-notched-outline__trailing"></span>
                 </span>
                 {this.renderLeadingIcon()}
@@ -361,6 +351,7 @@ export class InputField {
     private getContainerClassList = () => {
         const classList = {
             'mdc-text-field': true,
+            'mdc-text-field--no-label': !this.label,
             'mdc-text-field--outlined': true,
             'mdc-text-field--invalid': this.isInvalid(),
             'mdc-text-field--disabled': this.disabled || this.readonly,
@@ -579,6 +570,26 @@ export class InputField {
         }
 
         return this.limelInputField.shadowRoot.querySelector(elementName);
+    };
+
+    private renderLabel = (labelId: string) => {
+        const labelClassList = {
+            'mdc-floating-label': true,
+            'mdc-floating-label--float-above':
+                !!this.value || this.isFocused || this.readonly,
+        };
+
+        if (!this.label) {
+            return;
+        }
+
+        return (
+            <span class="mdc-notched-outline__notch">
+                <span class={labelClassList} id={labelId}>
+                    {this.label}
+                </span>
+            </span>
+        );
     };
 
     private renderLeadingIcon = () => {


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2921

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
