### PR TITLE
fix(date-picker): remove warning "trailingIcon" changed during rendering

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -185,6 +185,7 @@ export class DatePicker {
     public render() {
         const inputProps: any = {
             onAction: this.clearValue,
+            trailingIcon: null,
         };
 
         if (this.value && !this.readonly) {


### PR DESCRIPTION
This warning occurs when clearing the value from the date picker. When clearing the value from the
date picker the trailingIcon becomes undefined and then changes to null while rendering. See the
attached video for more details.



https://user-images.githubusercontent.com/22968497/183623735-77115138-1843-44ea-9566-883afba0e24d.mov


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
