### PR TITLE
feat(dock-button): emit event when dock menu is opened

### DIFF
--- a/src/components/dock/dock-button/dock-button.spec.tsx
+++ b/src/components/dock/dock-button/dock-button.spec.tsx
@@ -1,0 +1,33 @@
+import { h } from '@stencil/core';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { DockItem } from '../dock.types';
+import { DockButton } from './dock-button';
+
+let page: SpecPage;
+let item: DockItem;
+
+beforeEach(async () => {
+    item = {
+        id: 'tables',
+        label: 'Tables',
+        icon: 'insert_table',
+        dockMenu: { componentName: 'my-custom-menu' },
+    };
+    page = await newSpecPage({
+        components: [DockButton],
+        template: () => <limel-dock-button item={item} />,
+    });
+    await page.waitForChanges();
+});
+
+test('emits an event when dock menu is opened', async () => {
+    const eventSpy = jest.fn();
+    page.body.addEventListener('menuOpen', eventSpy);
+
+    const button = page.root.querySelector('.button') as HTMLButtonElement;
+    button.click();
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalled();
+    expect(eventSpy.mock.calls[0][0].detail).toEqual(item);
+});

--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -38,6 +38,12 @@ export class DockButton {
     private itemSelected: EventEmitter<DockItem>;
 
     /**
+     * Fired when a dock menu is opened.
+     */
+    @Event()
+    private menuOpen: EventEmitter<DockItem>;
+
+    /**
      * Indicated whether the popover that renders a component is open.
      */
     @State()
@@ -107,6 +113,7 @@ export class DockButton {
     private openPopover = (event: MouseEvent) => {
         event.stopPropagation();
         this.isOpen = true;
+        this.menuOpen.emit(this.item);
     };
 
     private onPopoverClose = () => {


### PR DESCRIPTION
fix Lundalogik/crm-feature#2931

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
