### PR TITLE
fix(code-editor): update editor when value changes

### DIFF
--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -6,6 +6,7 @@ import {
     Event,
     EventEmitter,
     State,
+    Watch,
 } from '@stencil/core';
 import { ColorScheme, Language } from './code-editor.types';
 import CodeMirror from 'codemirror';
@@ -102,6 +103,22 @@ export class CodeEditor {
         }
 
         this.editor = this.createEditor();
+    }
+
+    @Watch('value')
+    protected watchValue(newValue: string) {
+        if (!this.editor) {
+            return;
+        }
+
+        const currentValue = this.editor.getValue();
+        if (newValue === currentValue) {
+            // Circuit breaker for when the change comes from the editor itself
+            // The caret position will be reset without this
+            return;
+        }
+
+        this.editor.getDoc().setValue(newValue);
     }
 
     private handleChangeDarkMode = () => {


### PR DESCRIPTION
Bug: If you change the value (a state variable for example) given to a limel-code-editor, the CodeMirror component won't reflect the change.

Before:

https://user-images.githubusercontent.com/435885/186658760-295d8617-5643-411c-bbba-430850d6187b.mov



After

https://user-images.githubusercontent.com/435885/186658809-0b7a39bf-23ea-4c81-a0c1-c7c57cd8e413.mov




## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
