### PR TITLE
fix(code-editor): stretch to parent

### DIFF
--- a/src/components/code-editor/code-editor.scss
+++ b/src/components/code-editor/code-editor.scss
@@ -10,6 +10,8 @@
 }
 
 .editor {
+    display: flex;
+    align-items: stretch;
     width: 100%;
 
     &.is-light-mode {
@@ -146,6 +148,7 @@
         background-color: rgb(var(--code-editor-background-color));
         border-radius: 0.25rem;
         height: auto;
+        width: 100%;
     }
 
     .CodeMirror-scroll {


### PR DESCRIPTION
The editor works fine with overflow...:
![Screen Shot 2022-08-25 at 18 02 58](https://user-images.githubusercontent.com/435885/186714748-581a7229-5a84-4e1e-8cb1-a536a55a5854.png)

...but not when the content is not making the component to overflow.

Before:

![Screen Shot 2022-08-25 at 18 04 42](https://user-images.githubusercontent.com/435885/186714673-5f63074a-42b8-4892-b5d1-145e07c30e23.png)

After:

![Screen Shot 2022-08-25 at 18 06 20](https://user-images.githubusercontent.com/435885/186715128-d063d53c-8e18-4b30-8b4c-fbabf55b2d4d.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
