### PR TITLE
Code editor font size

### DIFF
--- a/src/components/code-editor/code-editor.scss
+++ b/src/components/code-editor/code-editor.scss
@@ -2,11 +2,12 @@
 
 /**
  * @prop --code-editor-max-height: Defines how tall the code editor can get before content becomes scrollable, defaults to `10rem`.
+ * @prop --code-editor-font-size: Defines the font size of the code, defaults to `0.875rem`.
  */
 
 :host {
     display: flex;
-    font-size: 0.875rem; // 14px
+    font-size: var(--code-editor-font-size, 0.875rem); // 14px
 }
 
 .editor {

--- a/src/components/code-editor/code-editor.scss
+++ b/src/components/code-editor/code-editor.scss
@@ -6,7 +6,7 @@
 
 :host {
     display: flex;
-    font-size: 1rem;
+    font-size: 0.875rem; // 14px
 }
 
 .editor {


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
