### PR TITLE
chore(packages): upgrade icons8 from v.2.9.0 to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/config-conventional": "^16.0.0",
-        "@lundalogik/lime-icons8": "^2.9.0",
+        "@lundalogik/lime-icons8": "^2.10.0",
         "@popperjs/core": "^2.11.5",
         "@rjsf/core": "^2.4.2",
         "@stencil/core": "^2.15.1",
@@ -1657,9 +1657,9 @@
       }
     },
     "node_modules/@lundalogik/lime-icons8": {
-      "version": "2.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.9.0/eef294c84a831c6d04b1f92a71f29ac8f3ca613c8aef3755d89b97b57d4ccd5c",
-      "integrity": "sha512-wECrqH1nQ/PWhhkQVdSQrZBRJfGygzDpWtsrtKZBNDBs06j5Iy1NyitI1yAMqyNNQgRW5ShF+rOmDImnGdriww==",
+      "version": "2.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.10.0/6487d30220cc0a84a2c16ba46c6fbdd1c42aac39",
+      "integrity": "sha512-rDXd+Fr4bIol+EWSga4rEf/fBLgZtctrEm2vwtZf2Uk00cj/M+ShXXOBTw0BQ30OQK8tGjUjGIZlSFwumZV9vQ==",
       "dev": true,
       "license": "UNLICENSED"
     },
@@ -16228,9 +16228,9 @@
       }
     },
     "@lundalogik/lime-icons8": {
-      "version": "2.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@lundalogik/lime-icons8/2.9.0/eef294c84a831c6d04b1f92a71f29ac8f3ca613c8aef3755d89b97b57d4ccd5c",
-      "integrity": "sha512-wECrqH1nQ/PWhhkQVdSQrZBRJfGygzDpWtsrtKZBNDBs06j5Iy1NyitI1yAMqyNNQgRW5ShF+rOmDImnGdriww==",
+      "version": "2.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.10.0/6487d30220cc0a84a2c16ba46c6fbdd1c42aac39",
+      "integrity": "sha512-rDXd+Fr4bIol+EWSga4rEf/fBLgZtctrEm2vwtZf2Uk00cj/M+ShXXOBTw0BQ30OQK8tGjUjGIZlSFwumZV9vQ==",
       "dev": true
     },
     "@material/animation": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^16.0.0",
-    "@lundalogik/lime-icons8": "^2.9.0",
+    "@lundalogik/lime-icons8": "^2.10.0",
     "@popperjs/core": "^2.11.5",
     "@rjsf/core": "^2.4.2",
     "@stencil/core": "^2.15.1",


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-icons8/issues/19
This adds 3 new icons for filters.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
