### PR TITLE
fix(code-editor): translate null value to empty string

### DIFF
--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -207,7 +207,7 @@ export class CodeEditor {
 
         return {
             mode: mode,
-            value: this.value,
+            value: this.value || '',
             theme: theme,
             readOnly: this.readonly,
             tabSize: TAB_SIZE,


### PR DESCRIPTION
The code editor fails to render when passing a null value to it, due to a null ref inside CodeMirror.

![Screen Shot 2022-09-01 at 11 46 44](https://user-images.githubusercontent.com/435885/187889855-a0726192-358c-4c6c-ae5a-5d01ecb316ab.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
