### PR TITLE
fix(dock): emit event when a dock menu is opened

### DIFF
--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -35,13 +35,13 @@ export class DockButton {
      * Fired when a dock item has been selected from the dock.
      */
     @Event()
-    private itemSelected: EventEmitter<DockItem>;
+    public itemSelected: EventEmitter<DockItem>;
 
     /**
      * Fired when a dock menu is opened.
      */
     @Event()
-    private menuOpen: EventEmitter<DockItem>;
+    public menuOpen: EventEmitter<DockItem>;
 
     /**
      * Indicated whether the popover that renders a component is open.

--- a/src/components/dock/dock.tsx
+++ b/src/components/dock/dock.tsx
@@ -85,6 +85,12 @@ export class Dock {
     public itemSelected: EventEmitter<DockItem>;
 
     /**
+     * Fired when a dock menu is opened.
+     */
+    @Event()
+    public menuOpen: EventEmitter<DockItem>;
+
+    /**
      * Fired when the popover is closed.
      */
     @Event()


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
