### PR TITLE
fix(code-editor): avoid null reference in codemirror

### DIFF
--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -136,7 +136,7 @@ export class CodeEditor {
             return;
         }
 
-        this.editor.getDoc().setValue(newValue);
+        this.editor.getDoc().setValue(newValue || '');
     }
 
     private handleChangeDarkMode = () => {


### PR DESCRIPTION
Continuation of #1824, which only fixed the initial render and not when the component is re-rendered.

Changing the value prop to null after the initial render gives the following error, which this PR will fix:
<img width="802" alt="Screen Shot 2022-09-02 at 13 22 13" src="https://user-images.githubusercontent.com/435885/188129335-2e1fa14c-8b51-45e4-a10e-b62cb22aa825.png">

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
