### PR TITLE
fix(code-editor): indent with spaces

### DIFF
--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -169,6 +169,17 @@ export class CodeEditor {
 
         editor.on('change', this.handleChange);
 
+        // Replace tab with spaces and use the actual indent setting for
+        // the space count
+        editor.setOption('extraKeys', {
+            Tab: (codeMirror) => {
+                const spaces = Array(
+                    codeMirror.getOption('indentUnit') + 1
+                ).join(' ');
+                codeMirror.replaceSelection(spaces);
+            },
+        });
+
         return editor;
     }
 


### PR DESCRIPTION
Backport of feature from the Lime Angular code editor. When a user hits tab it will indent with spaces instead of tabs.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
