### PR TITLE
chore(packages): upgrade @lundalogik/lime-icons8 from 2.10.0 to 2.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/config-conventional": "^16.0.0",
-        "@lundalogik/lime-icons8": "^2.10.0",
+        "@lundalogik/lime-icons8": "^2.11.0",
         "@popperjs/core": "^2.11.5",
         "@rjsf/core": "^2.4.2",
         "@stencil/core": "^2.15.1",
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/@lundalogik/lime-icons8": {
-      "version": "2.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.10.0/6487d30220cc0a84a2c16ba46c6fbdd1c42aac39",
-      "integrity": "sha512-rDXd+Fr4bIol+EWSga4rEf/fBLgZtctrEm2vwtZf2Uk00cj/M+ShXXOBTw0BQ30OQK8tGjUjGIZlSFwumZV9vQ==",
+      "version": "2.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.11.0/c1b8b9695c81aacf44325ba826c16ce931a6a496",
+      "integrity": "sha512-Fmu+xcAu+1NgGMcDGMfD4lAMlEKw9F4LMNPDcTWgslgxFNyl7gXs2wAS8hWgXPUrGln0ofQoRABsH0GT0rdu3w==",
       "dev": true,
       "license": "UNLICENSED"
     },
@@ -16261,9 +16261,9 @@
       }
     },
     "@lundalogik/lime-icons8": {
-      "version": "2.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.10.0/6487d30220cc0a84a2c16ba46c6fbdd1c42aac39",
-      "integrity": "sha512-rDXd+Fr4bIol+EWSga4rEf/fBLgZtctrEm2vwtZf2Uk00cj/M+ShXXOBTw0BQ30OQK8tGjUjGIZlSFwumZV9vQ==",
+      "version": "2.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.11.0/c1b8b9695c81aacf44325ba826c16ce931a6a496",
+      "integrity": "sha512-Fmu+xcAu+1NgGMcDGMfD4lAMlEKw9F4LMNPDcTWgslgxFNyl7gXs2wAS8hWgXPUrGln0ofQoRABsH0GT0rdu3w==",
       "dev": true
     },
     "@material/animation": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^16.0.0",
-    "@lundalogik/lime-icons8": "^2.10.0",
+    "@lundalogik/lime-icons8": "^2.11.0",
     "@popperjs/core": "^2.11.5",
     "@rjsf/core": "^2.4.2",
     "@stencil/core": "^2.15.1",


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/2969

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
