### PR TITLE
fix(progress-flow): visualize disabled steps better

### DIFF
--- a/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
@@ -6,11 +6,7 @@
         position: absolute;
         right: var(--selected-indicator-right);
 
-        background-color: var(--step-divider-color);
-        width: functions.pxToRem(6);
-        height: functions.pxToRem(6);
         border-radius: 50%;
-        opacity: 0.7;
     }
 
     .last & {
@@ -25,6 +21,24 @@
         &.selected {
             &:after {
                 content: '';
+                width: functions.pxToRem(6);
+                height: functions.pxToRem(6);
+                background-color: var(--step-divider-color);
+                opacity: 0.7;
+            }
+        }
+        &.disabled {
+            &:after {
+                content: '';
+                width: functions.pxToRem(12);
+                height: functions.pxToRem(12);
+                background: {
+                    image: url("data:image/svg+xml;charset=utf-8, <svg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg' xml:space='preserve' fill-rule='evenodd' clip-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2'><path fill='rgba(127,127,127,0.7)' d='M32.18 13.711c0-2.207-1.793-4-4.002-4H11.821c-2.208 0-4 1.793-4 4V28.29a4 4 0 0 0 4 4h16.357a4.002 4.002 0 0 0 4.001-4V13.711Z'/><path fill='rgba(127,127,127,0.7)' d='M11.211 9.758V7.673A7.489 7.489 0 0 1 18.696.188h2.608a7.489 7.489 0 0 1 7.485 7.485v2.085h-3V7.673a4.488 4.488 0 0 0-4.485-4.485h-2.608a4.488 4.488 0 0 0-4.485 4.485v2.085h-3Z'/></svg>");
+                    size: 90%;
+                    repeat: no-repeat;
+                    position: center;
+                }
+                mix-blend-mode: difference;
             }
         }
     }

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.scss
@@ -74,7 +74,6 @@ $limel-progress-flow-divider: 1;
     font-size: functions.pxToRem(14);
 
     &.disabled {
-        opacity: 0.75;
         cursor: not-allowed;
 
         &.readonly {


### PR DESCRIPTION
Disabled but passed steps will not look bad.
There is no transparency, and instead there is a
lock icon to visualize disabled state.

fix https://github.com/Lundalogik/lime-elements/issues/1770

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
