### PR TITLE
Some simple cleanup in limel-menu. (Fixes annoying warning when menu item is selected.)

### DIFF
--- a/src/components/menu-list/menu-list.e2e.ts
+++ b/src/components/menu-list/menu-list.e2e.ts
@@ -207,7 +207,7 @@ describe('limel-menu-list', () => {
             describe('the `change` event', () => {
                 let spy;
                 beforeEach(async () => {
-                    spy = await page.spyOnEvent('change');
+                    spy = await page.spyOnEvent('select');
                 });
                 describe('when an item is selected', () => {
                     let item;

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -80,7 +80,7 @@ export class MenuList {
      * Fired when a new value has been selected from the list. Only fired if selectable is set to true
      */
     @Event()
-    private change: EventEmitter<MenuItem | MenuItem[]>;
+    private change: EventEmitter<MenuItem>;
 
     /**
      * Fired when an action has been selected from the action menu of a list item

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -77,10 +77,10 @@ export class MenuList {
     private mdcMenu: MDCMenu;
 
     /**
-     * Fired when a new value has been selected from the list. Only fired if selectable is set to true
+     * Fired when a new value has been selected from the list.
      */
     @Event()
-    private change: EventEmitter<MenuItem>;
+    private select: EventEmitter<MenuItem>;
 
     public connectedCallback() {
         this.setup();
@@ -177,11 +177,11 @@ export class MenuList {
         });
 
         if (selectedItem) {
-            this.change.emit({ ...selectedItem, selected: false });
+            this.select.emit({ ...selectedItem, selected: false });
         }
 
         if (MenuItems[index] !== selectedItem) {
-            this.change.emit({ ...MenuItems[index], selected: false });
+            this.select.emit({ ...MenuItems[index], selected: false });
         }
     };
 

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -82,12 +82,6 @@ export class MenuList {
     @Event()
     private change: EventEmitter<MenuItem>;
 
-    /**
-     * Fired when an action has been selected from the action menu of a list item
-     */
-    @Event()
-    protected select: EventEmitter<MenuItem | MenuItem[]>;
-
     public connectedCallback() {
         this.setup();
     }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -182,7 +182,7 @@ export class Menu {
         this.open = !this.open;
     };
 
-    private onListChange = (event) => {
+    private onListChange = (event: CustomEvent<MenuItem>) => {
         this.items = this.items.map((item: MenuItem) => {
             if (item === event.detail) {
                 return event.detail;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -92,15 +92,6 @@ export class Menu {
         this.portalId = createRandomString();
     }
 
-    public componentDidLoad() {
-        if (!this.host.querySelector('[slot="trigger"]')) {
-            // eslint-disable-next-line no-console
-            console.warn(
-                'Using limel-menu with the default trigger is deprecated. Please provide your own trigger element.'
-            );
-        }
-    }
-
     @Watch('open')
     protected openWatcher() {
         if (!this.open) {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -137,7 +137,7 @@ export class Menu {
                             items={this.items}
                             type="menu"
                             badgeIcons={this.badgeIcons}
-                            onChange={this.onListChange}
+                            onSelect={this.handleSelect}
                             ref={this.setListElement}
                         />
                     </limel-menu-surface>
@@ -182,7 +182,8 @@ export class Menu {
         this.open = !this.open;
     };
 
-    private onListChange = (event: CustomEvent<MenuItem>) => {
+    private handleSelect = (event: CustomEvent<MenuItem>) => {
+        event.stopPropagation();
         this.items = this.items.map((item: MenuItem) => {
             if (item === event.detail) {
                 return event.detail;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -184,13 +184,6 @@ export class Menu {
 
     private handleSelect = (event: CustomEvent<MenuItem>) => {
         event.stopPropagation();
-        this.items = this.items.map((item: MenuItem) => {
-            if (item === event.detail) {
-                return event.detail;
-            }
-
-            return item;
-        });
         this.select.emit(event.detail);
         this.open = false;
     };


### PR DESCRIPTION
The changes should be easy enough to follow if reviewed commit-by-commit.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
