### PR TITLE
use mixin to visualize keyboard focus

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -20,9 +20,7 @@
 
 button {
     @include mixins.is-elevated-clickable();
-    &:focus-visible {
-        box-shadow: var(--shadow-depth-8-focused);
-    }
+    @include mixins.visualize-keyboard-focus;
 
     &.mdc-button {
         min-width: functions.pxToRem(36);

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -275,6 +275,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 .clear-all-button {
     transition: opacity 0.3s ease;
     @include mixins.clear-all-button;
+    @include mixins.visualize-keyboard-focus;
 
     position: absolute;
     right: functions.pxToRem(8);
@@ -287,10 +288,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     .has-chips:not(.mdc-text-field--disabled).mdc-text-field--focused & {
         opacity: 1;
         outline: none;
-    }
-
-    &:focus-visible {
-        box-shadow: var(--shadow-depth-8-focused);
     }
 
     :not(.has-chips) &,

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -6,7 +6,7 @@
 /**
  * @prop --closed-header-background-color: background color for header when closed
  * @prop --open-header-background-color: background color for header when open
- * @prop --header-stroke-color: color of the animated icons that visulize collapsed or normal states of the headers, as well as the divider line on headers
+ * @prop --header-stroke-color: color of the animated icons that visualize collapsed or normal states of the headers, as well as the divider line on headers
  * @prop --body-background-color: background color for body
  * @prop --body-padding: space around content of the body
  */

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -25,6 +25,8 @@
 }
 
 .section__header {
+    @include mixins.visualize-keyboard-focus;
+
     transition: background-color 0.4s ease, border-radius 0.1s ease;
     cursor: pointer;
 
@@ -56,18 +58,12 @@
             );
         }
     }
+
     &:hover {
         background-color: var(
             --open-header-background-color,
             rgb(var(--contrast-300))
         );
-    }
-
-    &:focus {
-        outline: none;
-    }
-    &:focus-visible {
-        box-shadow: var(--shadow-depth-8-focused);
     }
 }
 

--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -5,6 +5,10 @@
 .button {
     all: unset;
 
+    cursor: pointer;
+    @include mixins.is-flat-clickable();
+    @include mixins.visualize-keyboard-focus;
+
     box-sizing: border-box;
     display: flex;
     align-items: center;
@@ -21,17 +25,6 @@
     color: var(--limel-dock-item-text-color);
     background-color: var(--dock-background-color);
 
-    &:focus-visible {
-        box-shadow: var(--shadow-depth-8-focused);
-    }
-
-    .dock-item:not(.selected) & {
-        &:not(.disabled) {
-            cursor: pointer;
-            @include mixins.is-flat-clickable();
-        }
-    }
-
     &:hover {
         z-index: 1;
     }
@@ -42,7 +35,13 @@
             --dock-item-background-color--selected,
             rgb(var(--contrast-200))
         );
+
         box-shadow: var(--button-shadow-inset);
+
+        &:focus-visible {
+            box-shadow: var(--button-shadow-inset),
+                var(--shadow-depth-8-focused);
+        }
 
         .icon {
             color: var(--limel-dock-item-text--selected);

--- a/src/components/dock/partial-styles/shrink-expand-button.scss
+++ b/src/components/dock/partial-styles/shrink-expand-button.scss
@@ -3,6 +3,8 @@
     box-sizing: border-box;
 
     @include mixins.is-flat-clickable();
+    @include mixins.visualize-keyboard-focus;
+
     cursor: pointer;
 
     display: flex;
@@ -20,10 +22,6 @@
         limel-icon {
             transform: rotateY(180deg);
         }
-    }
-
-    &:focus-visible {
-        box-shadow: var(--shadow-depth-8-focused);
     }
 
     limel-icon {

--- a/src/components/popover-surface/popover-surface.scss
+++ b/src/components/popover-surface/popover-surface.scss
@@ -1,5 +1,6 @@
 @use '../../style/internal/z-index';
 @use '../../style/functions';
+@use '../../style/mixins';
 
 .limel-popover-surface {
     position: relative;
@@ -40,18 +41,12 @@
         );
     }
 
+    @include mixins.visualize-keyboard-focus;
+
     &:focus,
     &:focus-within {
-        outline: none;
-
         &:after {
             opacity: 1;
         }
-    }
-
-    &:focus-visible {
-        // only when non-pointer input is being used,
-        // e.g. tabbed into using keyboard
-        box-shadow: var(--shadow-depth-16-focused);
     }
 }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -63,19 +63,14 @@
     }
 
     .limel-select-trigger {
+        @include mixins.visualize-keyboard-focus;
+
         height: shared_input-select-picker.$height-of-mdc-text-field;
         display: inline-flex;
         align-items: center;
 
         cursor: pointer;
         border-radius: functions.pxToRem(5);
-
-        &:focus {
-            outline: none;
-        }
-        &:focus-visible {
-            box-shadow: var(--shadow-depth-8-focused) !important;
-        }
 
         .mdc-floating-label {
             color: shared_input-select-picker.$label-color;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -1,5 +1,16 @@
 @use './functions';
 
+@mixin visualize-keyboard-focus {
+    &:focus {
+        outline: none;
+    }
+
+    &:focus-visible {
+        outline: none;
+        box-shadow: var(--shadow-depth-8-focused);
+    }
+}
+
 @mixin in($media) {
     @if $media == dark-mode {
         @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
We use the same mixin in crm-components already.


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
