### PR TITLE
fix(button): remove the extra left margin of the icon

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -58,6 +58,15 @@ button {
                 border-color: rgba(var(--contrast-1700), 0.2);
             }
         }
+
+        .mdc-button__icon {
+            flex-shrink: 0;
+            margin-left: functions.pxToRem(-4);
+
+            &.no-label {
+                margin-right: functions.pxToRem(-4);
+            }
+        }
     }
 
     .label {
@@ -68,15 +77,6 @@ button {
         opacity: 0;
         display: none;
         position: absolute;
-    }
-
-    .mdc-button__icon {
-        flex-shrink: 0;
-    }
-
-    .mdc-button__icon.no-label {
-        margin-right: functions.pxToRem(-4);
-        margin-left: functions.pxToRem(-4);
     }
 
     limel-icon {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1837

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
