### PR TITLE
fix(dock-button): give back focus when menu is closed

### DIFF
--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -66,6 +66,10 @@ export class DockButton {
     private tooltipId: string;
     private customComponentElement: HTMLElement;
 
+    private buttonElement: HTMLButtonElement;
+
+    private hadVisibleFocus = false;
+
     constructor() {
         this.tooltipId = createRandomString();
     }
@@ -123,7 +127,10 @@ export class DockButton {
                     button: true,
                     selected: this.item?.selected,
                 }}
+                ref={this.setButtonElement}
                 onClick={handleClick}
+                onFocus={this.handleFocus}
+                onBlur={this.handleBlur}
             >
                 {this.renderIcon()}
                 {this.renderLabel()}
@@ -142,7 +149,15 @@ export class DockButton {
         this.customComponentElement = element;
     };
 
+    private setButtonElement = (element: HTMLButtonElement) => {
+        this.buttonElement = element;
+    };
+
     private onPopoverClose = () => {
+        if (this.hadVisibleFocus) {
+            this.buttonElement.focus();
+        }
+
         this.isOpen = false;
         this.close.emit();
     };
@@ -150,6 +165,16 @@ export class DockButton {
     private handleClick = (event: MouseEvent) => {
         event.stopPropagation();
         this.itemSelected.emit(this.item);
+    };
+
+    private handleFocus = () => {
+        this.hadVisibleFocus = this.buttonElement.matches(':focus-visible');
+    };
+
+    private handleBlur = () => {
+        if (!this.isOpen) {
+            this.hadVisibleFocus = false;
+        }
     };
 
     private renderIcon() {


### PR DESCRIPTION
Almost fixes https://github.com/Lundalogik/lime-elements/pull/1820#discussion_r978358996

fix: https://github.com/Lundalogik/crm-feature/issues/2989

The tricky part is we don't know here how the menu was closed. If the user navigated to an item in the menu, we don't expect focus back.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
