### PR TITLE
feat(progress-flow): update some internals to enable tracking using Heap 

### DIFF
--- a/src/components/progress-flow/progress-flow.tsx
+++ b/src/components/progress-flow/progress-flow.tsx
@@ -99,6 +99,7 @@ export class ProgressFlow {
                 readonly={this.readonly}
                 item={item}
                 onInteract={this.handleFlowItemClick(item)}
+                data-tracking-value={item.value}
             />
         );
     };
@@ -122,6 +123,7 @@ export class ProgressFlow {
                 readonly={this.readonly}
                 item={item}
                 onInteract={this.handleFlowItemClick(item)}
+                data-tracking-value={item.value}
             />
         );
     };


### PR DESCRIPTION
## Description

We want to add `value` to each `progress-flow-item` element just like a `select` element have a `value` on each `option` element.
This is for two reasons.

1. I think it's expected behavior.
2. We need it to track a specific flow in Heap (Product analytics).


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
