### PR TITLE
fix(select): select with multiple values doesn't show the empty value (-) when readonly

### DIFF
--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -253,7 +253,7 @@ function createMenuItems(
 }
 
 function getSelectedText(value: Option | Option[], readonly: boolean): string {
-    if (!value && readonly) {
+    if ((!value || (isMultiple(value) && !value.length)) && readonly) {
         return '–';
     }
 


### PR DESCRIPTION
`limel-select` with multiple values doesn't show `-` when no value is selected in the `readonly` mode.

Closes #1862.