### PR TITLE
chore: remove dependency on `lime-icons8`

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -25,11 +25,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: git config --global user.email "$GH_EMAIL"
     - run: git config --global user.name "$GH_USERNAME"
     - run: npm run docs:publish -- --remove=PR-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,11 +28,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: npm run lint:prod
 
   build:
@@ -49,11 +45,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: npm run build
 
   test:
@@ -70,11 +62,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: npm test --if-present
 
   commitlint:
@@ -117,11 +105,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: git config --global user.email "$GH_EMAIL"
     - run: git config --global user.name "$GH_USERNAME"
     - run: npm run docs:publish -- --v=PR-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -132,6 +132,7 @@ jobs:
         script: |
           const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
           await script({github, context});
+        github-token: ${{ secrets.CREATE_RELEASE }}
     - run: npm run docs:build
       if: github.actor == 'dependabot[bot]'
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,11 +20,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: npm run build
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,7 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
-    - name: npm install
-      run: |
-        GH_TOKEN="${{ secrets.READ_PRIVATE_GITHUB_PACKAGES }}" ./generate_npmrc.sh
-        npm ci
-        rm .npmrc
+    - run: npm ci
     - run: npm run build
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v2

--- a/generate_npmrc.sh
+++ b/generate_npmrc.sh
@@ -1,5 +1,0 @@
-cat << EOL >> ".npmrc"
-registry=https://registry.npmjs.org
-@lundalogik:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GH_TOKEN}
-EOL

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/config-conventional": "^16.0.0",
-        "@lundalogik/lime-icons8": "^2.11.0",
         "@popperjs/core": "^2.11.5",
         "@rjsf/core": "^2.4.2",
         "@stencil/core": "^2.15.1",
@@ -1656,13 +1655,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@lundalogik/lime-icons8": {
-      "version": "2.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.11.0/c1b8b9695c81aacf44325ba826c16ce931a6a496",
-      "integrity": "sha512-Fmu+xcAu+1NgGMcDGMfD4lAMlEKw9F4LMNPDcTWgslgxFNyl7gXs2wAS8hWgXPUrGln0ofQoRABsH0GT0rdu3w==",
-      "dev": true,
-      "license": "UNLICENSED"
     },
     "node_modules/@material/animation": {
       "version": "13.0.0",
@@ -16259,12 +16251,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "@lundalogik/lime-icons8": {
-      "version": "2.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@Lundalogik/lime-icons8/2.11.0/c1b8b9695c81aacf44325ba826c16ce931a6a496",
-      "integrity": "sha512-Fmu+xcAu+1NgGMcDGMfD4lAMlEKw9F4LMNPDcTWgslgxFNyl7gXs2wAS8hWgXPUrGln0ofQoRABsH0GT0rdu3w==",
-      "dev": true
     },
     "@material/animation": {
       "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^16.0.0",
-    "@lundalogik/lime-icons8": "^2.11.0",
     "@popperjs/core": "^2.11.5",
     "@rjsf/core": "^2.4.2",
     "@stencil/core": "^2.15.1",

--- a/src/components/button-group/button-group.e2e.ts
+++ b/src/components/button-group/button-group.e2e.ts
@@ -21,7 +21,7 @@ describe('limel-button-group', () => {
                 {
                     id: '2',
                     title: 'Apple',
-                    icon: 'apple',
+                    icon: 'unit-test',
                 },
             ]);
             await page.waitForChanges();

--- a/src/components/collapsible-section/collapsible-section.e2e.ts
+++ b/src/components/collapsible-section/collapsible-section.e2e.ts
@@ -275,7 +275,7 @@ describe('limel-collapsible-section', () => {
                 actions = [
                     {
                         id: 'abc',
-                        icon: 'dog',
+                        icon: 'unit-test',
                     },
                 ];
                 await page.$eval(

--- a/src/components/icon-button/icon-button.e2e.ts
+++ b/src/components/icon-button/icon-button.e2e.ts
@@ -6,7 +6,7 @@ describe('limel-icon-button', () => {
         let mdcIconButton;
         beforeEach(async () => {
             page = await createPage(`
-                <limel-icon-button icon="heart_outlined" label="Add favorite"></limel-switch>
+                <limel-icon-button icon="heart_outlined" label="Add favorite"></limel-icon-button>
             `);
             mdcIconButton = await page.find(
                 'limel-icon-button >>> .mdc-icon-button'

--- a/src/components/icon-button/icon-button.e2e.ts
+++ b/src/components/icon-button/icon-button.e2e.ts
@@ -6,7 +6,7 @@ describe('limel-icon-button', () => {
         let mdcIconButton;
         beforeEach(async () => {
             page = await createPage(`
-                <limel-icon-button icon="heart_outlined" label="Add favorite"></limel-icon-button>
+                <limel-icon-button icon="unit-test" label="Add favorite"></limel-icon-button>
             `);
             mdcIconButton = await page.find(
                 'limel-icon-button >>> .mdc-icon-button'

--- a/src/components/icon/examples/icon-finder.tsx
+++ b/src/components/icon/examples/icon-finder.tsx
@@ -1,5 +1,4 @@
 import { Chip } from '@limetech/lime-elements';
-import * as iconIndex from '@lundalogik/lime-icons8/assets/icon-index.json';
 import { Component, h, State } from '@stencil/core';
 import { ENTER, ENTER_KEY_CODE } from '../../../util/keycodes';
 
@@ -27,7 +26,19 @@ export class IconFinder {
     @State()
     private icons: Icon[] = [];
 
-    private indexedIcons = [...iconIndex['default']]; // eslint-disable-line @typescript-eslint/dot-notation
+    private indexedIcons: any[] = [];
+
+    public componentWillLoad() {
+        this.loadIconIndex();
+    }
+
+    private loadIconIndex = async () => {
+        const response = await fetch(
+            'https://lundalogik.github.io/lime-icons8/assets/icon-index.json'
+        );
+        const json = await response?.json?.();
+        this.indexedIcons = json;
+    };
 
     public render() {
         return [

--- a/src/components/input-field/input-field.e2e.ts
+++ b/src/components/input-field/input-field.e2e.ts
@@ -197,7 +197,7 @@ describe('limel-input-field', () => {
             if (type.name !== 'textarea') {
                 describe('when leadingIcon is set', () => {
                     beforeEach(async () => {
-                        limelInput.setAttribute('leading-icon', 'cat');
+                        limelInput.setAttribute('leading-icon', 'unit-test');
                         await page.waitForChanges();
                     });
                     it('has the correct leading icon', async () => {
@@ -205,12 +205,15 @@ describe('limel-input-field', () => {
                             'limel-input-field>>>i.mdc-text-field__icon.mdc-text-field__icon--leading>limel-icon'
                         );
                         expect(leadingIcon).toBeTruthy();
-                        expect(leadingIcon).toEqualAttribute('name', 'cat');
+                        expect(leadingIcon).toEqualAttribute(
+                            'name',
+                            'unit-test'
+                        );
                     });
                 });
                 describe('when trailingIcon is set', () => {
                     beforeEach(async () => {
-                        limelInput.setAttribute('trailing-icon', 'dog');
+                        limelInput.setAttribute('trailing-icon', 'unit-test');
                         await page.waitForChanges();
                     });
                     it('has the correct trailing icon', async () => {
@@ -218,13 +221,16 @@ describe('limel-input-field', () => {
                             'limel-input-field>>>i.mdc-text-field__icon.mdc-text-field__icon--trailing>limel-icon'
                         );
                         expect(trailingIcon).toBeTruthy();
-                        expect(trailingIcon).toEqualAttribute('name', 'dog');
+                        expect(trailingIcon).toEqualAttribute(
+                            'name',
+                            'unit-test'
+                        );
                     });
                 });
                 describe('when leadingIcon and trailingIcon is set', () => {
                     beforeEach(async () => {
-                        limelInput.setAttribute('leading-icon', 'cat');
-                        limelInput.setAttribute('trailing-icon', 'dog');
+                        limelInput.setAttribute('leading-icon', 'angle_left');
+                        limelInput.setAttribute('trailing-icon', 'angle_right');
                         await page.waitForChanges();
                     });
                     it('has the correct leading icon', async () => {
@@ -232,14 +238,20 @@ describe('limel-input-field', () => {
                             'limel-input-field>>>.mdc-text-field__icon.mdc-text-field__icon--leading>limel-icon'
                         );
                         expect(leadingIcon).toBeTruthy();
-                        expect(leadingIcon).toEqualAttribute('name', 'cat');
+                        expect(leadingIcon).toEqualAttribute(
+                            'name',
+                            'angle_left'
+                        );
                     });
                     it('has the correct trailing icon', async () => {
                         const trailingIcon = await page.find(
                             'limel-input-field>>>.mdc-text-field__icon.mdc-text-field__icon--trailing>limel-icon'
                         );
                         expect(trailingIcon).toBeTruthy();
-                        expect(trailingIcon).toEqualAttribute('name', 'dog');
+                        expect(trailingIcon).toEqualAttribute(
+                            'name',
+                            'angle_right'
+                        );
                     });
                 });
             }

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.e2e.ts
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.e2e.ts
@@ -90,7 +90,7 @@ describe('limel-progress-flow-item', () => {
     describe('when icon is given', () => {
         let icon: E2EElement;
         beforeEach(async () => {
-            flowItem = { text: 'Customer contact', icon: 'phone' };
+            flowItem = { text: 'Customer contact', icon: 'unit-test' };
             progressFlowItem.setProperty('item', flowItem);
             await page.waitForChanges();
             icon = await page.find('limel-icon');
@@ -98,7 +98,7 @@ describe('limel-progress-flow-item', () => {
 
         it('renders the item with the icon', () => {
             expect(icon).toBeTruthy();
-            expect(icon.getAttribute('name')).toEqual('phone');
+            expect(icon.getAttribute('name')).toEqual('unit-test');
         });
     });
 

--- a/src/icons/angle_left.svg
+++ b/src/icons/angle_left.svg
@@ -1,0 +1,593 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg13588"
+   width="800"
+   height="800"
+   viewBox="0 0 800 800"
+   sodipodi:docname="yoga-exercise-5-publicdomainvectors.org.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13592">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13604">
+      <path
+         d="M 0,600 H 600 V 0 H 0 Z"
+         id="path13602" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview13590"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.04625"
+     inkscape:cx="400"
+     inkscape:cy="400.4779"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g13596">
+    <inkscape:page
+       x="0"
+       y="0"
+       id="page13594"
+       width="800"
+       height="800" />
+  </sodipodi:namedview>
+  <g
+     id="g13596"
+     inkscape:groupmode="layer"
+     inkscape:label="Page 1"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,800)">
+    <g
+       id="g13598">
+      <g
+         id="g13600"
+         clip-path="url(#clipPath13604)">
+        <g
+           id="g13606"
+           transform="translate(578.1914,386.9897)">
+          <path
+             d="m 0,0 c -0.485,0.142 -1.749,-0.009 -2.118,-0.805 -0.135,-0.289 -0.265,-0.568 -0.391,-0.84 L 1.248,-2.419 C 1.076,-0.893 0.722,-0.488 0,0"
+             style="fill:#b4281c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13608" />
+        </g>
+        <g
+           id="g13610"
+           transform="translate(516.7393,323.3911)">
+          <path
+             d="m 0,0 c 8.265,6.945 15.04,12.196 19.5,14.237 10.155,4.67 35.493,11.545 39.625,13.864 0.943,0.516 14.303,9.853 14.684,10.425 -0.098,0.981 -0.378,1.987 -0.901,2.823 -2.305,0.126 -4.492,0.99 -5.66,-0.311 -0.594,-0.488 -0.775,-1.254 -1.141,-1.888 -0.596,-0.578 -1.405,-0.848 -2.122,-1.236 -0.458,0.824 -1.155,1.538 -1.358,2.481 -0.084,0.8 -0.041,1.598 0.027,2.396 L -9.285,2.777 Z"
+             style="fill:#ab8fa7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13612" />
+        </g>
+        <g
+           id="g13614"
+           transform="translate(506.0645,314.2578)">
+          <path
+             d="M 0,0 C 3.766,3.255 7.341,6.332 10.675,9.133 L 1.39,11.911 Z"
+             style="fill:#5898c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13616" />
+        </g>
+        <g
+           id="g13618"
+           transform="translate(542.9297,375.9956)">
+          <path
+             d="m 0,0 c 0.396,0.003 0.803,0.003 1.212,0.006 1.118,-6.253 7.396,-9.463 2.804,-18.155 -2.629,2.69 -5.165,5.469 -7.77,8.178 C -2.536,-6.635 -1.227,-3.333 0,0 m 36.464,-9.814 c 0.09,1.05 0.227,2.101 0.194,3.155 C 36.641,2.424 36.741,6.518 36.51,8.575 L 32.753,9.349 C 29.245,1.765 29.028,0.082 29.318,-3.117 c 0.044,-4.188 -0.11,-6.974 -4.405,-8.84 -1.442,-0.683 -3.037,-1.885 -4.11,-1.685 -1.323,0.443 -2.27,2.665 -2.423,4.089 -0.148,2.113 0.974,7.868 -6.611,13.23 C 5.387,7.579 7.566,16.667 -1.915,15.505 -5.617,15.143 -5.384,11.813 -5.531,10.57 -5.709,9.602 -5.59,9.583 -13.534,-4.541 c -6.705,-12.148 -9.663,-11.606 -10.61,-16.477 -0.427,-1.395 0.406,-3.207 -1.485,-4.977 -4.624,-4.6 -8.894,-8.37 -12.996,-11.593 l 3.149,-12.239 z"
+             style="fill:#b28e76;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13620" />
+        </g>
+        <g
+           id="g13622"
+           transform="translate(444.6328,294.9004)">
+          <path
+             d="M 0,0 13.263,-20.008 C 30.065,-7.961 47.111,6.977 61.432,19.357 l 1.389,11.911 z"
+             style="fill:#6dc9cd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13624" />
+        </g>
+        <g
+           id="g13626"
+           transform="translate(507.4541,326.1685)">
+          <path
+             d="M 0,0 -3.149,12.239 C -10.905,6.146 -18.054,2.011 -25.83,-2.068 -44.614,-12.122 -52.949,-16.987 -58.164,-19.485 l -4.657,-11.783 z"
+             style="fill:#abc38b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13628" />
+        </g>
+        <g
+           id="g13630"
+           transform="translate(449.29,306.6836)">
+          <path
+             d="m 0,0 c -3.591,-1.721 -5.704,-2.318 -8.728,-2.715 l 4.071,-9.068 z"
+             style="fill:#c8c46c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13632" />
+        </g>
+        <g
+           id="g13634"
+           transform="translate(418.6631,157.9316)">
+          <path
+             d="M 0,0 C 11.132,9.652 20.939,20.578 29.581,31.682 L 3.797,56.238 Z"
+             style="fill:#0097de;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13636" />
+        </g>
+        <g
+           id="g13638"
+           transform="translate(448.2441,189.6133)">
+          <path
+             d="m 0,0 c 0.379,0.486 0.757,0.973 1.131,1.459 3.886,5.062 3.449,6.111 5.46,8.9 1.073,1.479 5.215,4.541 3.137,11.524 -0.078,0.267 -0.748,2.26 -1.842,4.918 l -33.67,-2.244 z"
+             style="fill:#008dde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13640" />
+        </g>
+        <g
+           id="g13642"
+           transform="translate(456.1299,216.4141)">
+          <path
+             d="m 0,0 c -1.766,4.285 -4.641,10.299 -7.939,13.605 -4.687,4.918 -12.329,9.075 -18.967,8.778 L -33.67,-2.244 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13644" />
+        </g>
+        <g
+           id="g13646"
+           transform="translate(435.6045,262.0293)">
+          <path
+             d="m 0,0 c 4.052,1.113 5.959,3.859 6.686,4.307 3.06,2.017 6.854,2.531 9.904,4.576 1.894,1.283 3.797,2.613 5.701,3.98 L 9.028,32.871 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13648" />
+        </g>
+        <g
+           id="g13650"
+           transform="translate(344.5723,276.9902)">
+          <path
+             d="m 0,0 3.646,9.332 c 0,0.129 0,0.252 10e-4,0.383 1.077,13.767 0.874,7.99 4.692,20.359 0.224,0.184 0.498,0.332 0.634,0.604 7.217,13.488 5.145,10.521 9.594,16.842 l 21.942,56.157 c -0.112,0.141 -0.224,0.283 -0.339,0.42 -6.587,7.817 -12.498,9.928 -18.669,10.813 L -32.406,88.975 Z"
+             style="fill:#dae262;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13652" />
+        </g>
+        <g
+           id="g13654"
+           transform="translate(384.5479,85.0684)">
+          <path
+             d="m 0,0 c 0.72,0.219 1.31,0.449 1.722,0.67 9.897,5.273 7.686,12.971 7.195,24.621 -0.08,0.568 0.076,3.545 -1.021,3.701 -2.269,0.584 -2.601,2.041 -2.583,4.342 -0.311,4.213 0.387,2.619 -6.684,11.029 l -24.96,-12.48 z"
+             style="fill:#008ad9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13656" />
+        </g>
+        <g
+           id="g13658"
+           transform="translate(429.2236,238.7969)">
+          <path
+             d="m 0,0 c -0.978,-0.045 -1.934,-0.184 -2.855,-0.434 0,0 0.9,0.18 -21.882,-6.609 -0.606,-0.205 -1.431,-0.613 -2.411,-1.143 l 20.384,-16.441 z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13660" />
+        </g>
+        <g
+           id="g13662"
+           transform="translate(348.2188,274.0508)">
+          <path
+             d="M 0,0 C -0.009,1.127 -0.015,2.322 -0.017,3.59 L -3.646,2.939 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13664" />
+        </g>
+        <g
+           id="g13666"
+           transform="translate(394.0088,285.8398)">
+          <path
+             d="M 0,0 C 4.135,-3.971 8.962,-8.229 14.681,-12.848 28.211,-24.057 36.56,-25.195 41.596,-23.811 L 50.624,9.061 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13668" />
+        </g>
+        <g
+           id="g13670"
+           transform="translate(364.4443,326.3667)">
+          <path
+             d="m 0,0 c 0.849,-0.372 1.78,-0.771 2.321,-1.565 0.775,-1.99 0.28,-4.357 1.614,-6.159 5.67,-9.397 11.731,-19.461 25.629,-32.803 l 50.624,9.061 -4.07,9.068 c -0.803,-0.103 -1.67,-0.195 -2.646,-0.289 -4.493,-0.166 -4.938,0.219 -8.271,3.572 -9.275,10.226 -14.161,26.168 -20.166,33.657 -2.34,3.004 -4.916,5.839 -6.899,9.101 -5.15,8.855 -7.877,19.108 -10.539,22.186 -1.212,1.427 -2.512,2.773 -3.717,4.206 -1.171,1.352 -2.13,2.869 -3.243,4.266 L -1.305,-1.856 C -0.922,-1.311 -0.49,-0.699 0,0"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13672" />
+        </g>
+        <g
+           id="g13674"
+           transform="translate(348.2021,277.6406)">
+          <path
+             d="M 0,0 C -0.006,2.57 0.001,5.447 0.016,8.682 L -3.63,-0.65 Z"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13676" />
+        </g>
+        <g
+           id="g13678"
+           transform="translate(326.9551,481.7827)">
+          <path
+             d="m 0,0 c -1.489,8.546 -3.643,17.625 -6.05,23.015 -4.362,9.577 -11.904,10.8 -17.282,15.756 -1.261,1.333 -2.633,2.275 -4.04,2.898 l 2.065,-68.797 z"
+             style="fill:#df2200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13680" />
+        </g>
+        <g
+           id="g13682"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 24.96,12.48 c -0.54,0.643 -1.124,1.342 -1.759,2.108 -0.691,0.85 -2.932,3.281 -2.155,4.496 3.416,2.367 5.94,-0.412 12.111,2.818 9.886,5.338 18.958,11.852 27.289,19.078 l 3.797,56.239 z"
+             style="fill:#009be2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13684" />
+        </g>
+        <g
+           id="g13686"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 64.243,97.219 -38.941,7.929 c -1.491,-0.529 -2.939,-1.154 -4.268,-2.031 -6.223,-4.517 -10.297,-2.685 -16.513,-3.756 -3.008,-0.422 -3.884,3.998 -5.599,11.16 l -58.901,11.997 z"
+             style="fill:#14b4ec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13688" />
+        </g>
+        <g
+           id="g13690"
+           transform="translate(327.0127,455.6626)">
+          <path
+             d="M 0,0 C 1.056,1.846 1.834,4.053 2.053,7.606 2.06,11.404 1.262,18.553 -0.058,26.12 L -25.364,-1.008 Z"
+             style="fill:#dc2b00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13692" />
+        </g>
+        <g
+           id="g13694"
+           transform="translate(320.665,444.6831)">
+          <path
+             d="M 0,0 C 2.002,5.78 4.568,7.867 6.348,10.979 L -19.017,9.972 Z"
+             style="fill:#df5e00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13696" />
+        </g>
+        <g
+           id="g13698"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 58.901,-11.996 c -0.567,2.369 -1.225,5.039 -2.084,7.934 -5.329,19.917 -6.67,17.406 -6.836,38.644 l -3.646,2.939 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13700" />
+        </g>
+        <g
+           id="g13702"
+           transform="translate(402.0752,230.6113)">
+          <path
+             d="m 0,0 c -3.558,-1.924 -9.174,-5.475 -13.905,-6.996 -1.537,-0.522 -3.117,-0.969 -4.652,-1.516 l 38.942,-7.929 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13704" />
+        </g>
+        <g
+           id="g13706"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="m 0,0 c 12.19,-3.049 8.91,-3.252 13.257,-5.043 5.149,-2.332 11.83,-1.578 15.342,-0.514 L 2.268,26.326 Z"
+             style="fill:#0074d4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13708" />
+        </g>
+        <g
+           id="g13710"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 53.907,25.935 C 45.898,27.082 37.452,26.165 26.52,32.973 16.573,38.858 5.767,41.569 5.446,51.589 5.408,65.657 6.734,73.622 8.499,78.718 l -19.017,9.971 z"
+             style="fill:#e88200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13712" />
+        </g>
+        <g
+           id="g13714"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 -42.923,-65.096 32.406,-88.975 Z"
+             style="fill:#dcf07c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13716" />
+        </g>
+        <g
+           id="g13718"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="M 0,0 133.035,-21.604 73.056,100.914 Z"
+             style="fill:#31bded;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13720" />
+        </g>
+        <g
+           id="g13722"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="M 0,0 2.268,26.326 -20.757,6.762 c 8,-2.766 15.308,-5.459 19.29,-6.401 C -0.953,0.236 -0.467,0.115 0,0"
+             style="fill:#0069d5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13724" />
+        </g>
+        <g
+           id="g13726"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="m 0,0 8.559,-58.115 c 4.263,0.603 8.996,1.705 14.864,4.004 5.525,2.033 11.453,2.527 17.073,4.213 6.626,2.05 12.966,4.882 19.431,7.369 15.21,6.023 17.269,9.484 22.973,8.716 7.048,-0.658 17.572,-4.058 27.111,-7.355 l 23.024,19.564 z"
+             style="fill:#0181dd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13728" />
+        </g>
+        <g
+           id="g13730"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="M 0,0 9.096,-44.914 82.152,56 Z"
+             style="fill:#8bebdb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13732" />
+        </g>
+        <g
+           id="g13734"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="M 0,0 -36.386,-71.918 10.518,-88.689 Z"
+             style="fill:#f38900;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13736" />
+        </g>
+        <g
+           id="g13738"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="M 0,0 28.995,-61.4 75.33,-23.879 Z"
+             style="fill:#b7f3bb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13740" />
+        </g>
+        <g
+           id="g13742"
+           transform="translate(265.4712,515.9917)">
+          <path
+             d="m 0,0 c -5.74,-5.332 -5.494,-13.276 -7.929,-20.031 -2.488,-6.871 -0.271,-14.435 -3.022,-21.654 -0.332,-0.95 -1.548,-2.81 -1.973,-5.643 l 0.931,-7.638 c 0.022,-0.059 0.041,-0.118 0.064,-0.179 1.682,-4.462 3.688,-6.111 5.816,-8.281 L 14.817,4.458 C 9.663,4.323 5.518,5.767 0,0"
+             style="fill:#ef3500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13744" />
+        </g>
+        <g
+           id="g13746"
+           transform="translate(299.583,523.4517)">
+          <path
+             d="m 0,0 c -3.692,1.637 -7.625,1.069 -10.417,-0.463 -3.42,-2.001 -6.277,-2.471 -8.877,-2.539 l -20.931,-67.884 c 1.127,-1.148 2.288,-2.443 3.454,-4.38 0.842,-1.365 1.515,-2.792 2.068,-4.264 l 36.768,10.733 z"
+             style="fill:#f43800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13748" />
+        </g>
+        <g
+           id="g13750"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="m 0,0 -36.768,-10.733 c 1.894,-5.034 2.391,-10.602 3.426,-16.089 0.347,-1.888 0.184,-3.81 0.224,-5.716 -0.475,-7.014 1.782,-11.357 -6.969,-16.273 l 3.701,-23.107 z"
+             style="fill:#f77700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13752" />
+        </g>
+        <g
+           id="g13754"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 3.98,-81.868 42.923,65.097 z"
+             style="fill:#f2da4a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13756" />
+        </g>
+        <g
+           id="g13758"
+           transform="translate(253.478,461.0259)">
+          <path
+             d="M 0,0 -0.931,7.638 C -1.237,5.602 -1.132,3.064 0,0"
+             style="fill:#fb6100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13760" />
+        </g>
+        <g
+           id="g13762"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="m 0,0 -34.43,-11.291 c 4.375,-19.814 1.914,-25.602 0.369,-32.424 L 28.995,-61.4 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13764" />
+        </g>
+        <g
+           id="g13766"
+           transform="translate(183.2183,271.7305)">
+          <path
+             d="M 0,0 C 0.559,0.451 1.134,0.947 1.728,1.496 L -1.529,0.428 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13768" />
+        </g>
+        <g
+           id="g13770"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 -63.056,17.686 c -0.217,-0.959 -0.416,-1.94 -0.575,-2.981 -4.827,-28.373 -3.895,-27.422 -7.923,-36.496 -0.886,-2.527 -4.431,-1.537 -17.768,3.27 -4.097,1.519 -6.828,2.607 -8.685,3.404 L -82.152,-56 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13772" />
+        </g>
+        <g
+           id="g13774"
+           transform="translate(182.1704,270.9199)">
+          <path
+             d="M 0,0 C 0.343,0.254 0.692,0.523 1.048,0.811 L -0.481,1.238 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13776" />
+        </g>
+        <g
+           id="g13778"
+           transform="translate(178.2236,77.3145)">
+          <path
+             d="m 0,0 c 1.748,-0.338 3.177,-0.359 3.87,-0.437 9.577,-0.79 19.166,-1.26 28.525,0.898 C 41.31,2.6 47.604,2.004 55.517,3.125 L 46.958,61.24 Z"
+             style="fill:#6cb0c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13780" />
+        </g>
+        <g
+           id="g13782"
+           transform="translate(212.9209,392.1343)">
+          <path
+             d="m 0,0 c -7.358,-3.378 -11.848,-9.501 -15.415,-12.913 -3.459,-3.684 -2.798,-1.984 -5.258,-8.591 -1.752,-4.541 -4.212,-8.777 -5.869,-13.361 -0.621,-1.584 -0.969,-3.253 -1.559,-4.849 -3.336,-9.049 -11.784,-15.183 -16.209,-23.89 -10e-4,-10e-4 -0.003,-0.004 -0.004,-0.007 l 13.083,-56.365 36.298,48.028 c 0.446,1.161 0.907,2.314 1.402,3.45 0.192,0.404 0.393,1.573 2.82,2.136 l 43.053,56.964 z"
+             style="fill:#ffd100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13784" />
+        </g>
+        <g
+           id="g13786"
+           transform="translate(184.9458,273.2266)">
+          <path
+             d="m 0,0 c 2.113,1.949 4.474,4.564 7.256,8.246 6.137,7.947 13.187,15.176 18.881,23.467 3.187,4.646 4.897,10.023 6.905,15.246 L -3.256,-1.068 Z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13788" />
+        </g>
+        <g
+           id="g13790"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 -43.053,-56.965 c 0.032,0.007 0.059,0.016 0.092,0.023 1.473,-2.116 3.247,-4.095 4.089,-6.579 4.089,-12.477 6.753,-22.079 8.422,-29.638 l 34.43,11.291 z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13792" />
+        </g>
+        <g
+           id="g13794"
+           transform="translate(261.561,405.8433)">
+          <path
+             d="m 0,0 c -2.75,-1.545 -6.583,-3.145 -11.933,-4.904 -20.513,-6.807 -23.499,-5.765 -29.432,-6.675 -2.707,-0.38 -5.114,-1.138 -7.275,-2.13 l 52.342,-9.398 z"
+             style="fill:#fd9d00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13796" />
+        </g>
+        <g
+           id="g13798"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="m 0,0 -15.855,40.883 c -9.291,3.988 3.366,0.662 -22.866,7.346 L -43.208,6.254 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13800" />
+        </g>
+        <g
+           id="g13802"
+           transform="translate(181.5063,270.4414)">
+          <path
+             d="M 0,0 C 0.219,0.152 0.44,0.312 0.664,0.478 L 0.183,1.717 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13804" />
+        </g>
+        <g
+           id="g13806"
+           transform="translate(208.02,135.877)">
+          <path
+             d="M 0,0 C 3.134,-1.705 5.926,-3.359 7.395,-4.527 6.783,-5.061 6.337,-5.752 5.719,-6.275 c -1.337,-1.192 -23.474,-3.84 -24.076,-4.055 -4.022,-1.281 -13.359,-10.352 -15.739,-14.982 -1.006,-1.821 -1.362,-3.893 -2.164,-5.792 -2.845,-7.011 -8.646,-14.029 -2.605,-21.931 2.726,-3.654 6.299,-4.99 9.069,-5.528 L 17.162,2.678 Z"
+             style="fill:#8bcfa3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13808" />
+        </g>
+        <g
+           id="g13810"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="M 0,0 52.304,-51.168 43.208,-6.254 Z"
+             style="fill:#96eaa2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13812" />
+        </g>
+        <g
+           id="g13814"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="m 0,0 -7.637,-31.27 c 3.667,-2.658 6.324,-4.375 7.192,-4.82 7.389,-3.402 14.389,-7.594 21.821,-10.904 2.728,-1.201 8.696,-4.094 13.767,-6.852 l 17.161,2.678 z"
+             style="fill:#9ae292;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13816" />
+        </g>
+        <g
+           id="g13818"
+           transform="translate(168.6074,328.5229)">
+          <path
+             d="m 0,0 c -11.738,-23.529 -11.302,-31.66 -21.896,-24.757 -18.937,10.683 -32.469,18.709 -42.418,25.002 l -12.992,-20.584 c 4.429,-4.291 9.657,-9.283 15.89,-15.086 l 74.498,-20.94 z"
+             style="fill:#ffce00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13820" />
+        </g>
+        <g
+           id="g13822"
+           transform="translate(137.1387,234.541)">
+          <path
+             d="m 0,0 c -1.537,-1.059 -2.47,-2.176 -3.458,-3.123 -10.068,-10.852 -9.165,-13.883 -9.26,-23.637 0.043,-3.965 0.834,-8.011 2.866,-11.465 1.019,-1.714 2.16,-3.427 3.393,-5.127 l 42.198,-1.466 z"
+             style="fill:#f0d03c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13824" />
+        </g>
+        <g
+           id="g13826"
+           transform="translate(107.1909,293.0977)">
+          <path
+             d="m 0,0 c 7.815,-7.275 17.21,-15.828 28.605,-25.885 9.381,-8.099 9.154,-10.064 19.65,-9.246 3.198,0.342 7.985,1.262 10.469,3.293 6.432,5.234 10.463,5.602 15.591,9.182 l 0.184,1.717 z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13828" />
+        </g>
+        <g
+           id="g13830"
+           transform="translate(177.3643,231.6973)">
+          <path
+             d="M 0,0 C -1.25,0.318 -2.586,0.66 -4.019,1.025 -4.932,1.332 -5.602,2.145 -6.576,2.311 -14.828,4.234 -20.919,7.525 -29.362,6.232 -35.081,5.557 -38.186,4.25 -40.226,2.844 L -4.487,-41.975 Z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13832" />
+        </g>
+        <g
+           id="g13834"
+           transform="translate(130.6802,191.1895)">
+          <path
+             d="m 0,0 c 9.73,-13.412 25.341,-26.055 34.56,-32.736 l 7.637,31.269 z"
+             style="fill:#c7df6f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13836" />
+        </g>
+        <g
+           id="g13838"
+           transform="translate(56.7227,368.0815)">
+          <path
+             d="m 0,0 c -4.445,3.398 -7.547,6.24 -9.778,8.602 l -14.208,-3.612 4.815,-6.731 c 0.309,1.335 0.768,2.766 1.413,4.3 8.121,-3.178 6.81,-9.274 5.773,-14.345 L 3.873,-33.953 c 6.915,-1.379 10.594,-6.458 30.706,-25.945 l 12.992,20.585 C 14.247,-18.236 21.153,-16.635 0,0"
+             style="fill:#feb200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13840" />
+        </g>
+        <g
+           id="g13842"
+           transform="translate(46.9448,376.6831)">
+          <path
+             d="M 0,0 C -6,6.35 -5.693,9.213 -8.216,10.023 L -14.209,-3.611 Z"
+             style="fill:#fe9400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13844" />
+        </g>
+        <g
+           id="g13846"
+           transform="translate(44.2983,353.9419)">
+          <path
+             d="M 0,0 C -4.392,-0.536 -8.714,3.901 -6.747,12.398 L -11.562,19.13 -21.876,4.264 c 0.042,-0.755 0.105,-1.526 0.151,-2.371 0.043,-1.914 -1.115,-3.187 -3.419,-2.41 -0.012,0.005 -0.024,0.011 -0.038,0.016 l -9.97,-14.371 c 3.016,-2.116 5.047,-1.11 7.693,-1.097 11.549,-0.04 11.379,0.704 12.926,-0.741 4.452,-3.88 12.301,-1.605 19.468,-2.537 5.205,-0.057 8.551,-0.006 11.362,-0.567 L 0.439,2.354 C 0.272,1.537 0.112,0.747 0,0"
+             style="fill:#ffa300;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13848" />
+        </g>
+        <g
+           id="g13850"
+           transform="translate(38.729,386.7065)">
+          <path
+             d="M 0,0 C -0.873,0.28 -2.083,0.315 -4.011,0.164 -5.262,0.213 -7.534,0.788 -8.336,-1.61 -9.564,-5.017 -8.434,-5.657 -9.828,-9.336 l 3.835,-4.299 z"
+             style="fill:#fd7700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13852" />
+        </g>
+        <g
+           id="g13854"
+           transform="translate(3.2769,370.0132)">
+          <path
+             d="m 0,0 -3.018,-0.312 c -1.925,-10.076 7.434,-14.539 9.35,-23.095 -1.796,-0.753 -3.579,-1.54 -5.381,-2.269 1.949,-2.675 3.537,-4.299 4.918,-5.267 l 9.97,14.371 C 8.256,-13.681 5.736,-8.311 0,0"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13856" />
+        </g>
+        <g
+           id="g13858"
+           transform="translate(26.4971,372.4243)">
+          <path
+             d="M 0,0 C -4.024,-7.823 -4.262,-10.867 -4.075,-14.219 L 6.239,0.648 Z"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13860" />
+        </g>
+        <g
+           id="g13862"
+           transform="translate(28.9014,377.3706)">
+          <path
+             d="M 0,0 C -0.405,-1.069 -1.022,-2.393 -1.974,-4.117 -2.123,-4.4 -2.265,-4.676 -2.404,-4.946 l 6.239,0.647 z"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13864" />
+        </g>
+        <g
+           id="g13866"
+           transform="translate(1.2061,372.9331)">
+          <path
+             d="M 0,0 C -0.444,-1.142 -0.752,-2.216 -0.947,-3.232 L 2.071,-2.92 C 1.424,-1.983 0.74,-1.012 0,0"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13868" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/icons/angle_right.svg
+++ b/src/icons/angle_right.svg
@@ -1,0 +1,593 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg13588"
+   width="800"
+   height="800"
+   viewBox="0 0 800 800"
+   sodipodi:docname="yoga-exercise-5-publicdomainvectors.org.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13592">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13604">
+      <path
+         d="M 0,600 H 600 V 0 H 0 Z"
+         id="path13602" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview13590"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.04625"
+     inkscape:cx="400"
+     inkscape:cy="400.4779"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g13596">
+    <inkscape:page
+       x="0"
+       y="0"
+       id="page13594"
+       width="800"
+       height="800" />
+  </sodipodi:namedview>
+  <g
+     id="g13596"
+     inkscape:groupmode="layer"
+     inkscape:label="Page 1"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,800)">
+    <g
+       id="g13598">
+      <g
+         id="g13600"
+         clip-path="url(#clipPath13604)">
+        <g
+           id="g13606"
+           transform="translate(578.1914,386.9897)">
+          <path
+             d="m 0,0 c -0.485,0.142 -1.749,-0.009 -2.118,-0.805 -0.135,-0.289 -0.265,-0.568 -0.391,-0.84 L 1.248,-2.419 C 1.076,-0.893 0.722,-0.488 0,0"
+             style="fill:#b4281c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13608" />
+        </g>
+        <g
+           id="g13610"
+           transform="translate(516.7393,323.3911)">
+          <path
+             d="m 0,0 c 8.265,6.945 15.04,12.196 19.5,14.237 10.155,4.67 35.493,11.545 39.625,13.864 0.943,0.516 14.303,9.853 14.684,10.425 -0.098,0.981 -0.378,1.987 -0.901,2.823 -2.305,0.126 -4.492,0.99 -5.66,-0.311 -0.594,-0.488 -0.775,-1.254 -1.141,-1.888 -0.596,-0.578 -1.405,-0.848 -2.122,-1.236 -0.458,0.824 -1.155,1.538 -1.358,2.481 -0.084,0.8 -0.041,1.598 0.027,2.396 L -9.285,2.777 Z"
+             style="fill:#ab8fa7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13612" />
+        </g>
+        <g
+           id="g13614"
+           transform="translate(506.0645,314.2578)">
+          <path
+             d="M 0,0 C 3.766,3.255 7.341,6.332 10.675,9.133 L 1.39,11.911 Z"
+             style="fill:#5898c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13616" />
+        </g>
+        <g
+           id="g13618"
+           transform="translate(542.9297,375.9956)">
+          <path
+             d="m 0,0 c 0.396,0.003 0.803,0.003 1.212,0.006 1.118,-6.253 7.396,-9.463 2.804,-18.155 -2.629,2.69 -5.165,5.469 -7.77,8.178 C -2.536,-6.635 -1.227,-3.333 0,0 m 36.464,-9.814 c 0.09,1.05 0.227,2.101 0.194,3.155 C 36.641,2.424 36.741,6.518 36.51,8.575 L 32.753,9.349 C 29.245,1.765 29.028,0.082 29.318,-3.117 c 0.044,-4.188 -0.11,-6.974 -4.405,-8.84 -1.442,-0.683 -3.037,-1.885 -4.11,-1.685 -1.323,0.443 -2.27,2.665 -2.423,4.089 -0.148,2.113 0.974,7.868 -6.611,13.23 C 5.387,7.579 7.566,16.667 -1.915,15.505 -5.617,15.143 -5.384,11.813 -5.531,10.57 -5.709,9.602 -5.59,9.583 -13.534,-4.541 c -6.705,-12.148 -9.663,-11.606 -10.61,-16.477 -0.427,-1.395 0.406,-3.207 -1.485,-4.977 -4.624,-4.6 -8.894,-8.37 -12.996,-11.593 l 3.149,-12.239 z"
+             style="fill:#b28e76;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13620" />
+        </g>
+        <g
+           id="g13622"
+           transform="translate(444.6328,294.9004)">
+          <path
+             d="M 0,0 13.263,-20.008 C 30.065,-7.961 47.111,6.977 61.432,19.357 l 1.389,11.911 z"
+             style="fill:#6dc9cd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13624" />
+        </g>
+        <g
+           id="g13626"
+           transform="translate(507.4541,326.1685)">
+          <path
+             d="M 0,0 -3.149,12.239 C -10.905,6.146 -18.054,2.011 -25.83,-2.068 -44.614,-12.122 -52.949,-16.987 -58.164,-19.485 l -4.657,-11.783 z"
+             style="fill:#abc38b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13628" />
+        </g>
+        <g
+           id="g13630"
+           transform="translate(449.29,306.6836)">
+          <path
+             d="m 0,0 c -3.591,-1.721 -5.704,-2.318 -8.728,-2.715 l 4.071,-9.068 z"
+             style="fill:#c8c46c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13632" />
+        </g>
+        <g
+           id="g13634"
+           transform="translate(418.6631,157.9316)">
+          <path
+             d="M 0,0 C 11.132,9.652 20.939,20.578 29.581,31.682 L 3.797,56.238 Z"
+             style="fill:#0097de;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13636" />
+        </g>
+        <g
+           id="g13638"
+           transform="translate(448.2441,189.6133)">
+          <path
+             d="m 0,0 c 0.379,0.486 0.757,0.973 1.131,1.459 3.886,5.062 3.449,6.111 5.46,8.9 1.073,1.479 5.215,4.541 3.137,11.524 -0.078,0.267 -0.748,2.26 -1.842,4.918 l -33.67,-2.244 z"
+             style="fill:#008dde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13640" />
+        </g>
+        <g
+           id="g13642"
+           transform="translate(456.1299,216.4141)">
+          <path
+             d="m 0,0 c -1.766,4.285 -4.641,10.299 -7.939,13.605 -4.687,4.918 -12.329,9.075 -18.967,8.778 L -33.67,-2.244 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13644" />
+        </g>
+        <g
+           id="g13646"
+           transform="translate(435.6045,262.0293)">
+          <path
+             d="m 0,0 c 4.052,1.113 5.959,3.859 6.686,4.307 3.06,2.017 6.854,2.531 9.904,4.576 1.894,1.283 3.797,2.613 5.701,3.98 L 9.028,32.871 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13648" />
+        </g>
+        <g
+           id="g13650"
+           transform="translate(344.5723,276.9902)">
+          <path
+             d="m 0,0 3.646,9.332 c 0,0.129 0,0.252 10e-4,0.383 1.077,13.767 0.874,7.99 4.692,20.359 0.224,0.184 0.498,0.332 0.634,0.604 7.217,13.488 5.145,10.521 9.594,16.842 l 21.942,56.157 c -0.112,0.141 -0.224,0.283 -0.339,0.42 -6.587,7.817 -12.498,9.928 -18.669,10.813 L -32.406,88.975 Z"
+             style="fill:#dae262;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13652" />
+        </g>
+        <g
+           id="g13654"
+           transform="translate(384.5479,85.0684)">
+          <path
+             d="m 0,0 c 0.72,0.219 1.31,0.449 1.722,0.67 9.897,5.273 7.686,12.971 7.195,24.621 -0.08,0.568 0.076,3.545 -1.021,3.701 -2.269,0.584 -2.601,2.041 -2.583,4.342 -0.311,4.213 0.387,2.619 -6.684,11.029 l -24.96,-12.48 z"
+             style="fill:#008ad9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13656" />
+        </g>
+        <g
+           id="g13658"
+           transform="translate(429.2236,238.7969)">
+          <path
+             d="m 0,0 c -0.978,-0.045 -1.934,-0.184 -2.855,-0.434 0,0 0.9,0.18 -21.882,-6.609 -0.606,-0.205 -1.431,-0.613 -2.411,-1.143 l 20.384,-16.441 z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13660" />
+        </g>
+        <g
+           id="g13662"
+           transform="translate(348.2188,274.0508)">
+          <path
+             d="M 0,0 C -0.009,1.127 -0.015,2.322 -0.017,3.59 L -3.646,2.939 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13664" />
+        </g>
+        <g
+           id="g13666"
+           transform="translate(394.0088,285.8398)">
+          <path
+             d="M 0,0 C 4.135,-3.971 8.962,-8.229 14.681,-12.848 28.211,-24.057 36.56,-25.195 41.596,-23.811 L 50.624,9.061 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13668" />
+        </g>
+        <g
+           id="g13670"
+           transform="translate(364.4443,326.3667)">
+          <path
+             d="m 0,0 c 0.849,-0.372 1.78,-0.771 2.321,-1.565 0.775,-1.99 0.28,-4.357 1.614,-6.159 5.67,-9.397 11.731,-19.461 25.629,-32.803 l 50.624,9.061 -4.07,9.068 c -0.803,-0.103 -1.67,-0.195 -2.646,-0.289 -4.493,-0.166 -4.938,0.219 -8.271,3.572 -9.275,10.226 -14.161,26.168 -20.166,33.657 -2.34,3.004 -4.916,5.839 -6.899,9.101 -5.15,8.855 -7.877,19.108 -10.539,22.186 -1.212,1.427 -2.512,2.773 -3.717,4.206 -1.171,1.352 -2.13,2.869 -3.243,4.266 L -1.305,-1.856 C -0.922,-1.311 -0.49,-0.699 0,0"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13672" />
+        </g>
+        <g
+           id="g13674"
+           transform="translate(348.2021,277.6406)">
+          <path
+             d="M 0,0 C -0.006,2.57 0.001,5.447 0.016,8.682 L -3.63,-0.65 Z"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13676" />
+        </g>
+        <g
+           id="g13678"
+           transform="translate(326.9551,481.7827)">
+          <path
+             d="m 0,0 c -1.489,8.546 -3.643,17.625 -6.05,23.015 -4.362,9.577 -11.904,10.8 -17.282,15.756 -1.261,1.333 -2.633,2.275 -4.04,2.898 l 2.065,-68.797 z"
+             style="fill:#df2200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13680" />
+        </g>
+        <g
+           id="g13682"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 24.96,12.48 c -0.54,0.643 -1.124,1.342 -1.759,2.108 -0.691,0.85 -2.932,3.281 -2.155,4.496 3.416,2.367 5.94,-0.412 12.111,2.818 9.886,5.338 18.958,11.852 27.289,19.078 l 3.797,56.239 z"
+             style="fill:#009be2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13684" />
+        </g>
+        <g
+           id="g13686"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 64.243,97.219 -38.941,7.929 c -1.491,-0.529 -2.939,-1.154 -4.268,-2.031 -6.223,-4.517 -10.297,-2.685 -16.513,-3.756 -3.008,-0.422 -3.884,3.998 -5.599,11.16 l -58.901,11.997 z"
+             style="fill:#14b4ec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13688" />
+        </g>
+        <g
+           id="g13690"
+           transform="translate(327.0127,455.6626)">
+          <path
+             d="M 0,0 C 1.056,1.846 1.834,4.053 2.053,7.606 2.06,11.404 1.262,18.553 -0.058,26.12 L -25.364,-1.008 Z"
+             style="fill:#dc2b00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13692" />
+        </g>
+        <g
+           id="g13694"
+           transform="translate(320.665,444.6831)">
+          <path
+             d="M 0,0 C 2.002,5.78 4.568,7.867 6.348,10.979 L -19.017,9.972 Z"
+             style="fill:#df5e00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13696" />
+        </g>
+        <g
+           id="g13698"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 58.901,-11.996 c -0.567,2.369 -1.225,5.039 -2.084,7.934 -5.329,19.917 -6.67,17.406 -6.836,38.644 l -3.646,2.939 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13700" />
+        </g>
+        <g
+           id="g13702"
+           transform="translate(402.0752,230.6113)">
+          <path
+             d="m 0,0 c -3.558,-1.924 -9.174,-5.475 -13.905,-6.996 -1.537,-0.522 -3.117,-0.969 -4.652,-1.516 l 38.942,-7.929 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13704" />
+        </g>
+        <g
+           id="g13706"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="m 0,0 c 12.19,-3.049 8.91,-3.252 13.257,-5.043 5.149,-2.332 11.83,-1.578 15.342,-0.514 L 2.268,26.326 Z"
+             style="fill:#0074d4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13708" />
+        </g>
+        <g
+           id="g13710"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 53.907,25.935 C 45.898,27.082 37.452,26.165 26.52,32.973 16.573,38.858 5.767,41.569 5.446,51.589 5.408,65.657 6.734,73.622 8.499,78.718 l -19.017,9.971 z"
+             style="fill:#e88200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13712" />
+        </g>
+        <g
+           id="g13714"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 -42.923,-65.096 32.406,-88.975 Z"
+             style="fill:#dcf07c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13716" />
+        </g>
+        <g
+           id="g13718"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="M 0,0 133.035,-21.604 73.056,100.914 Z"
+             style="fill:#31bded;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13720" />
+        </g>
+        <g
+           id="g13722"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="M 0,0 2.268,26.326 -20.757,6.762 c 8,-2.766 15.308,-5.459 19.29,-6.401 C -0.953,0.236 -0.467,0.115 0,0"
+             style="fill:#0069d5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13724" />
+        </g>
+        <g
+           id="g13726"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="m 0,0 8.559,-58.115 c 4.263,0.603 8.996,1.705 14.864,4.004 5.525,2.033 11.453,2.527 17.073,4.213 6.626,2.05 12.966,4.882 19.431,7.369 15.21,6.023 17.269,9.484 22.973,8.716 7.048,-0.658 17.572,-4.058 27.111,-7.355 l 23.024,19.564 z"
+             style="fill:#0181dd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13728" />
+        </g>
+        <g
+           id="g13730"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="M 0,0 9.096,-44.914 82.152,56 Z"
+             style="fill:#8bebdb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13732" />
+        </g>
+        <g
+           id="g13734"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="M 0,0 -36.386,-71.918 10.518,-88.689 Z"
+             style="fill:#f38900;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13736" />
+        </g>
+        <g
+           id="g13738"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="M 0,0 28.995,-61.4 75.33,-23.879 Z"
+             style="fill:#b7f3bb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13740" />
+        </g>
+        <g
+           id="g13742"
+           transform="translate(265.4712,515.9917)">
+          <path
+             d="m 0,0 c -5.74,-5.332 -5.494,-13.276 -7.929,-20.031 -2.488,-6.871 -0.271,-14.435 -3.022,-21.654 -0.332,-0.95 -1.548,-2.81 -1.973,-5.643 l 0.931,-7.638 c 0.022,-0.059 0.041,-0.118 0.064,-0.179 1.682,-4.462 3.688,-6.111 5.816,-8.281 L 14.817,4.458 C 9.663,4.323 5.518,5.767 0,0"
+             style="fill:#ef3500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13744" />
+        </g>
+        <g
+           id="g13746"
+           transform="translate(299.583,523.4517)">
+          <path
+             d="m 0,0 c -3.692,1.637 -7.625,1.069 -10.417,-0.463 -3.42,-2.001 -6.277,-2.471 -8.877,-2.539 l -20.931,-67.884 c 1.127,-1.148 2.288,-2.443 3.454,-4.38 0.842,-1.365 1.515,-2.792 2.068,-4.264 l 36.768,10.733 z"
+             style="fill:#f43800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13748" />
+        </g>
+        <g
+           id="g13750"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="m 0,0 -36.768,-10.733 c 1.894,-5.034 2.391,-10.602 3.426,-16.089 0.347,-1.888 0.184,-3.81 0.224,-5.716 -0.475,-7.014 1.782,-11.357 -6.969,-16.273 l 3.701,-23.107 z"
+             style="fill:#f77700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13752" />
+        </g>
+        <g
+           id="g13754"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 3.98,-81.868 42.923,65.097 z"
+             style="fill:#f2da4a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13756" />
+        </g>
+        <g
+           id="g13758"
+           transform="translate(253.478,461.0259)">
+          <path
+             d="M 0,0 -0.931,7.638 C -1.237,5.602 -1.132,3.064 0,0"
+             style="fill:#fb6100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13760" />
+        </g>
+        <g
+           id="g13762"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="m 0,0 -34.43,-11.291 c 4.375,-19.814 1.914,-25.602 0.369,-32.424 L 28.995,-61.4 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13764" />
+        </g>
+        <g
+           id="g13766"
+           transform="translate(183.2183,271.7305)">
+          <path
+             d="M 0,0 C 0.559,0.451 1.134,0.947 1.728,1.496 L -1.529,0.428 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13768" />
+        </g>
+        <g
+           id="g13770"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 -63.056,17.686 c -0.217,-0.959 -0.416,-1.94 -0.575,-2.981 -4.827,-28.373 -3.895,-27.422 -7.923,-36.496 -0.886,-2.527 -4.431,-1.537 -17.768,3.27 -4.097,1.519 -6.828,2.607 -8.685,3.404 L -82.152,-56 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13772" />
+        </g>
+        <g
+           id="g13774"
+           transform="translate(182.1704,270.9199)">
+          <path
+             d="M 0,0 C 0.343,0.254 0.692,0.523 1.048,0.811 L -0.481,1.238 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13776" />
+        </g>
+        <g
+           id="g13778"
+           transform="translate(178.2236,77.3145)">
+          <path
+             d="m 0,0 c 1.748,-0.338 3.177,-0.359 3.87,-0.437 9.577,-0.79 19.166,-1.26 28.525,0.898 C 41.31,2.6 47.604,2.004 55.517,3.125 L 46.958,61.24 Z"
+             style="fill:#6cb0c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13780" />
+        </g>
+        <g
+           id="g13782"
+           transform="translate(212.9209,392.1343)">
+          <path
+             d="m 0,0 c -7.358,-3.378 -11.848,-9.501 -15.415,-12.913 -3.459,-3.684 -2.798,-1.984 -5.258,-8.591 -1.752,-4.541 -4.212,-8.777 -5.869,-13.361 -0.621,-1.584 -0.969,-3.253 -1.559,-4.849 -3.336,-9.049 -11.784,-15.183 -16.209,-23.89 -10e-4,-10e-4 -0.003,-0.004 -0.004,-0.007 l 13.083,-56.365 36.298,48.028 c 0.446,1.161 0.907,2.314 1.402,3.45 0.192,0.404 0.393,1.573 2.82,2.136 l 43.053,56.964 z"
+             style="fill:#ffd100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13784" />
+        </g>
+        <g
+           id="g13786"
+           transform="translate(184.9458,273.2266)">
+          <path
+             d="m 0,0 c 2.113,1.949 4.474,4.564 7.256,8.246 6.137,7.947 13.187,15.176 18.881,23.467 3.187,4.646 4.897,10.023 6.905,15.246 L -3.256,-1.068 Z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13788" />
+        </g>
+        <g
+           id="g13790"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 -43.053,-56.965 c 0.032,0.007 0.059,0.016 0.092,0.023 1.473,-2.116 3.247,-4.095 4.089,-6.579 4.089,-12.477 6.753,-22.079 8.422,-29.638 l 34.43,11.291 z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13792" />
+        </g>
+        <g
+           id="g13794"
+           transform="translate(261.561,405.8433)">
+          <path
+             d="m 0,0 c -2.75,-1.545 -6.583,-3.145 -11.933,-4.904 -20.513,-6.807 -23.499,-5.765 -29.432,-6.675 -2.707,-0.38 -5.114,-1.138 -7.275,-2.13 l 52.342,-9.398 z"
+             style="fill:#fd9d00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13796" />
+        </g>
+        <g
+           id="g13798"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="m 0,0 -15.855,40.883 c -9.291,3.988 3.366,0.662 -22.866,7.346 L -43.208,6.254 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13800" />
+        </g>
+        <g
+           id="g13802"
+           transform="translate(181.5063,270.4414)">
+          <path
+             d="M 0,0 C 0.219,0.152 0.44,0.312 0.664,0.478 L 0.183,1.717 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13804" />
+        </g>
+        <g
+           id="g13806"
+           transform="translate(208.02,135.877)">
+          <path
+             d="M 0,0 C 3.134,-1.705 5.926,-3.359 7.395,-4.527 6.783,-5.061 6.337,-5.752 5.719,-6.275 c -1.337,-1.192 -23.474,-3.84 -24.076,-4.055 -4.022,-1.281 -13.359,-10.352 -15.739,-14.982 -1.006,-1.821 -1.362,-3.893 -2.164,-5.792 -2.845,-7.011 -8.646,-14.029 -2.605,-21.931 2.726,-3.654 6.299,-4.99 9.069,-5.528 L 17.162,2.678 Z"
+             style="fill:#8bcfa3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13808" />
+        </g>
+        <g
+           id="g13810"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="M 0,0 52.304,-51.168 43.208,-6.254 Z"
+             style="fill:#96eaa2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13812" />
+        </g>
+        <g
+           id="g13814"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="m 0,0 -7.637,-31.27 c 3.667,-2.658 6.324,-4.375 7.192,-4.82 7.389,-3.402 14.389,-7.594 21.821,-10.904 2.728,-1.201 8.696,-4.094 13.767,-6.852 l 17.161,2.678 z"
+             style="fill:#9ae292;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13816" />
+        </g>
+        <g
+           id="g13818"
+           transform="translate(168.6074,328.5229)">
+          <path
+             d="m 0,0 c -11.738,-23.529 -11.302,-31.66 -21.896,-24.757 -18.937,10.683 -32.469,18.709 -42.418,25.002 l -12.992,-20.584 c 4.429,-4.291 9.657,-9.283 15.89,-15.086 l 74.498,-20.94 z"
+             style="fill:#ffce00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13820" />
+        </g>
+        <g
+           id="g13822"
+           transform="translate(137.1387,234.541)">
+          <path
+             d="m 0,0 c -1.537,-1.059 -2.47,-2.176 -3.458,-3.123 -10.068,-10.852 -9.165,-13.883 -9.26,-23.637 0.043,-3.965 0.834,-8.011 2.866,-11.465 1.019,-1.714 2.16,-3.427 3.393,-5.127 l 42.198,-1.466 z"
+             style="fill:#f0d03c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13824" />
+        </g>
+        <g
+           id="g13826"
+           transform="translate(107.1909,293.0977)">
+          <path
+             d="m 0,0 c 7.815,-7.275 17.21,-15.828 28.605,-25.885 9.381,-8.099 9.154,-10.064 19.65,-9.246 3.198,0.342 7.985,1.262 10.469,3.293 6.432,5.234 10.463,5.602 15.591,9.182 l 0.184,1.717 z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13828" />
+        </g>
+        <g
+           id="g13830"
+           transform="translate(177.3643,231.6973)">
+          <path
+             d="M 0,0 C -1.25,0.318 -2.586,0.66 -4.019,1.025 -4.932,1.332 -5.602,2.145 -6.576,2.311 -14.828,4.234 -20.919,7.525 -29.362,6.232 -35.081,5.557 -38.186,4.25 -40.226,2.844 L -4.487,-41.975 Z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13832" />
+        </g>
+        <g
+           id="g13834"
+           transform="translate(130.6802,191.1895)">
+          <path
+             d="m 0,0 c 9.73,-13.412 25.341,-26.055 34.56,-32.736 l 7.637,31.269 z"
+             style="fill:#c7df6f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13836" />
+        </g>
+        <g
+           id="g13838"
+           transform="translate(56.7227,368.0815)">
+          <path
+             d="m 0,0 c -4.445,3.398 -7.547,6.24 -9.778,8.602 l -14.208,-3.612 4.815,-6.731 c 0.309,1.335 0.768,2.766 1.413,4.3 8.121,-3.178 6.81,-9.274 5.773,-14.345 L 3.873,-33.953 c 6.915,-1.379 10.594,-6.458 30.706,-25.945 l 12.992,20.585 C 14.247,-18.236 21.153,-16.635 0,0"
+             style="fill:#feb200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13840" />
+        </g>
+        <g
+           id="g13842"
+           transform="translate(46.9448,376.6831)">
+          <path
+             d="M 0,0 C -6,6.35 -5.693,9.213 -8.216,10.023 L -14.209,-3.611 Z"
+             style="fill:#fe9400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13844" />
+        </g>
+        <g
+           id="g13846"
+           transform="translate(44.2983,353.9419)">
+          <path
+             d="M 0,0 C -4.392,-0.536 -8.714,3.901 -6.747,12.398 L -11.562,19.13 -21.876,4.264 c 0.042,-0.755 0.105,-1.526 0.151,-2.371 0.043,-1.914 -1.115,-3.187 -3.419,-2.41 -0.012,0.005 -0.024,0.011 -0.038,0.016 l -9.97,-14.371 c 3.016,-2.116 5.047,-1.11 7.693,-1.097 11.549,-0.04 11.379,0.704 12.926,-0.741 4.452,-3.88 12.301,-1.605 19.468,-2.537 5.205,-0.057 8.551,-0.006 11.362,-0.567 L 0.439,2.354 C 0.272,1.537 0.112,0.747 0,0"
+             style="fill:#ffa300;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13848" />
+        </g>
+        <g
+           id="g13850"
+           transform="translate(38.729,386.7065)">
+          <path
+             d="M 0,0 C -0.873,0.28 -2.083,0.315 -4.011,0.164 -5.262,0.213 -7.534,0.788 -8.336,-1.61 -9.564,-5.017 -8.434,-5.657 -9.828,-9.336 l 3.835,-4.299 z"
+             style="fill:#fd7700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13852" />
+        </g>
+        <g
+           id="g13854"
+           transform="translate(3.2769,370.0132)">
+          <path
+             d="m 0,0 -3.018,-0.312 c -1.925,-10.076 7.434,-14.539 9.35,-23.095 -1.796,-0.753 -3.579,-1.54 -5.381,-2.269 1.949,-2.675 3.537,-4.299 4.918,-5.267 l 9.97,14.371 C 8.256,-13.681 5.736,-8.311 0,0"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13856" />
+        </g>
+        <g
+           id="g13858"
+           transform="translate(26.4971,372.4243)">
+          <path
+             d="M 0,0 C -4.024,-7.823 -4.262,-10.867 -4.075,-14.219 L 6.239,0.648 Z"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13860" />
+        </g>
+        <g
+           id="g13862"
+           transform="translate(28.9014,377.3706)">
+          <path
+             d="M 0,0 C -0.405,-1.069 -1.022,-2.393 -1.974,-4.117 -2.123,-4.4 -2.265,-4.676 -2.404,-4.946 l 6.239,0.647 z"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13864" />
+        </g>
+        <g
+           id="g13866"
+           transform="translate(1.2061,372.9331)">
+          <path
+             d="M 0,0 C -0.444,-1.142 -0.752,-2.216 -0.947,-3.232 L 2.071,-2.92 C 1.424,-1.983 0.74,-1.012 0,0"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13868" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/icons/external_link.svg
+++ b/src/icons/external_link.svg
@@ -1,0 +1,593 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg13588"
+   width="800"
+   height="800"
+   viewBox="0 0 800 800"
+   sodipodi:docname="yoga-exercise-5-publicdomainvectors.org.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13592">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13604">
+      <path
+         d="M 0,600 H 600 V 0 H 0 Z"
+         id="path13602" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview13590"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.04625"
+     inkscape:cx="400"
+     inkscape:cy="400.4779"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g13596">
+    <inkscape:page
+       x="0"
+       y="0"
+       id="page13594"
+       width="800"
+       height="800" />
+  </sodipodi:namedview>
+  <g
+     id="g13596"
+     inkscape:groupmode="layer"
+     inkscape:label="Page 1"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,800)">
+    <g
+       id="g13598">
+      <g
+         id="g13600"
+         clip-path="url(#clipPath13604)">
+        <g
+           id="g13606"
+           transform="translate(578.1914,386.9897)">
+          <path
+             d="m 0,0 c -0.485,0.142 -1.749,-0.009 -2.118,-0.805 -0.135,-0.289 -0.265,-0.568 -0.391,-0.84 L 1.248,-2.419 C 1.076,-0.893 0.722,-0.488 0,0"
+             style="fill:#b4281c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13608" />
+        </g>
+        <g
+           id="g13610"
+           transform="translate(516.7393,323.3911)">
+          <path
+             d="m 0,0 c 8.265,6.945 15.04,12.196 19.5,14.237 10.155,4.67 35.493,11.545 39.625,13.864 0.943,0.516 14.303,9.853 14.684,10.425 -0.098,0.981 -0.378,1.987 -0.901,2.823 -2.305,0.126 -4.492,0.99 -5.66,-0.311 -0.594,-0.488 -0.775,-1.254 -1.141,-1.888 -0.596,-0.578 -1.405,-0.848 -2.122,-1.236 -0.458,0.824 -1.155,1.538 -1.358,2.481 -0.084,0.8 -0.041,1.598 0.027,2.396 L -9.285,2.777 Z"
+             style="fill:#ab8fa7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13612" />
+        </g>
+        <g
+           id="g13614"
+           transform="translate(506.0645,314.2578)">
+          <path
+             d="M 0,0 C 3.766,3.255 7.341,6.332 10.675,9.133 L 1.39,11.911 Z"
+             style="fill:#5898c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13616" />
+        </g>
+        <g
+           id="g13618"
+           transform="translate(542.9297,375.9956)">
+          <path
+             d="m 0,0 c 0.396,0.003 0.803,0.003 1.212,0.006 1.118,-6.253 7.396,-9.463 2.804,-18.155 -2.629,2.69 -5.165,5.469 -7.77,8.178 C -2.536,-6.635 -1.227,-3.333 0,0 m 36.464,-9.814 c 0.09,1.05 0.227,2.101 0.194,3.155 C 36.641,2.424 36.741,6.518 36.51,8.575 L 32.753,9.349 C 29.245,1.765 29.028,0.082 29.318,-3.117 c 0.044,-4.188 -0.11,-6.974 -4.405,-8.84 -1.442,-0.683 -3.037,-1.885 -4.11,-1.685 -1.323,0.443 -2.27,2.665 -2.423,4.089 -0.148,2.113 0.974,7.868 -6.611,13.23 C 5.387,7.579 7.566,16.667 -1.915,15.505 -5.617,15.143 -5.384,11.813 -5.531,10.57 -5.709,9.602 -5.59,9.583 -13.534,-4.541 c -6.705,-12.148 -9.663,-11.606 -10.61,-16.477 -0.427,-1.395 0.406,-3.207 -1.485,-4.977 -4.624,-4.6 -8.894,-8.37 -12.996,-11.593 l 3.149,-12.239 z"
+             style="fill:#b28e76;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13620" />
+        </g>
+        <g
+           id="g13622"
+           transform="translate(444.6328,294.9004)">
+          <path
+             d="M 0,0 13.263,-20.008 C 30.065,-7.961 47.111,6.977 61.432,19.357 l 1.389,11.911 z"
+             style="fill:#6dc9cd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13624" />
+        </g>
+        <g
+           id="g13626"
+           transform="translate(507.4541,326.1685)">
+          <path
+             d="M 0,0 -3.149,12.239 C -10.905,6.146 -18.054,2.011 -25.83,-2.068 -44.614,-12.122 -52.949,-16.987 -58.164,-19.485 l -4.657,-11.783 z"
+             style="fill:#abc38b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13628" />
+        </g>
+        <g
+           id="g13630"
+           transform="translate(449.29,306.6836)">
+          <path
+             d="m 0,0 c -3.591,-1.721 -5.704,-2.318 -8.728,-2.715 l 4.071,-9.068 z"
+             style="fill:#c8c46c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13632" />
+        </g>
+        <g
+           id="g13634"
+           transform="translate(418.6631,157.9316)">
+          <path
+             d="M 0,0 C 11.132,9.652 20.939,20.578 29.581,31.682 L 3.797,56.238 Z"
+             style="fill:#0097de;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13636" />
+        </g>
+        <g
+           id="g13638"
+           transform="translate(448.2441,189.6133)">
+          <path
+             d="m 0,0 c 0.379,0.486 0.757,0.973 1.131,1.459 3.886,5.062 3.449,6.111 5.46,8.9 1.073,1.479 5.215,4.541 3.137,11.524 -0.078,0.267 -0.748,2.26 -1.842,4.918 l -33.67,-2.244 z"
+             style="fill:#008dde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13640" />
+        </g>
+        <g
+           id="g13642"
+           transform="translate(456.1299,216.4141)">
+          <path
+             d="m 0,0 c -1.766,4.285 -4.641,10.299 -7.939,13.605 -4.687,4.918 -12.329,9.075 -18.967,8.778 L -33.67,-2.244 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13644" />
+        </g>
+        <g
+           id="g13646"
+           transform="translate(435.6045,262.0293)">
+          <path
+             d="m 0,0 c 4.052,1.113 5.959,3.859 6.686,4.307 3.06,2.017 6.854,2.531 9.904,4.576 1.894,1.283 3.797,2.613 5.701,3.98 L 9.028,32.871 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13648" />
+        </g>
+        <g
+           id="g13650"
+           transform="translate(344.5723,276.9902)">
+          <path
+             d="m 0,0 3.646,9.332 c 0,0.129 0,0.252 10e-4,0.383 1.077,13.767 0.874,7.99 4.692,20.359 0.224,0.184 0.498,0.332 0.634,0.604 7.217,13.488 5.145,10.521 9.594,16.842 l 21.942,56.157 c -0.112,0.141 -0.224,0.283 -0.339,0.42 -6.587,7.817 -12.498,9.928 -18.669,10.813 L -32.406,88.975 Z"
+             style="fill:#dae262;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13652" />
+        </g>
+        <g
+           id="g13654"
+           transform="translate(384.5479,85.0684)">
+          <path
+             d="m 0,0 c 0.72,0.219 1.31,0.449 1.722,0.67 9.897,5.273 7.686,12.971 7.195,24.621 -0.08,0.568 0.076,3.545 -1.021,3.701 -2.269,0.584 -2.601,2.041 -2.583,4.342 -0.311,4.213 0.387,2.619 -6.684,11.029 l -24.96,-12.48 z"
+             style="fill:#008ad9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13656" />
+        </g>
+        <g
+           id="g13658"
+           transform="translate(429.2236,238.7969)">
+          <path
+             d="m 0,0 c -0.978,-0.045 -1.934,-0.184 -2.855,-0.434 0,0 0.9,0.18 -21.882,-6.609 -0.606,-0.205 -1.431,-0.613 -2.411,-1.143 l 20.384,-16.441 z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13660" />
+        </g>
+        <g
+           id="g13662"
+           transform="translate(348.2188,274.0508)">
+          <path
+             d="M 0,0 C -0.009,1.127 -0.015,2.322 -0.017,3.59 L -3.646,2.939 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13664" />
+        </g>
+        <g
+           id="g13666"
+           transform="translate(394.0088,285.8398)">
+          <path
+             d="M 0,0 C 4.135,-3.971 8.962,-8.229 14.681,-12.848 28.211,-24.057 36.56,-25.195 41.596,-23.811 L 50.624,9.061 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13668" />
+        </g>
+        <g
+           id="g13670"
+           transform="translate(364.4443,326.3667)">
+          <path
+             d="m 0,0 c 0.849,-0.372 1.78,-0.771 2.321,-1.565 0.775,-1.99 0.28,-4.357 1.614,-6.159 5.67,-9.397 11.731,-19.461 25.629,-32.803 l 50.624,9.061 -4.07,9.068 c -0.803,-0.103 -1.67,-0.195 -2.646,-0.289 -4.493,-0.166 -4.938,0.219 -8.271,3.572 -9.275,10.226 -14.161,26.168 -20.166,33.657 -2.34,3.004 -4.916,5.839 -6.899,9.101 -5.15,8.855 -7.877,19.108 -10.539,22.186 -1.212,1.427 -2.512,2.773 -3.717,4.206 -1.171,1.352 -2.13,2.869 -3.243,4.266 L -1.305,-1.856 C -0.922,-1.311 -0.49,-0.699 0,0"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13672" />
+        </g>
+        <g
+           id="g13674"
+           transform="translate(348.2021,277.6406)">
+          <path
+             d="M 0,0 C -0.006,2.57 0.001,5.447 0.016,8.682 L -3.63,-0.65 Z"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13676" />
+        </g>
+        <g
+           id="g13678"
+           transform="translate(326.9551,481.7827)">
+          <path
+             d="m 0,0 c -1.489,8.546 -3.643,17.625 -6.05,23.015 -4.362,9.577 -11.904,10.8 -17.282,15.756 -1.261,1.333 -2.633,2.275 -4.04,2.898 l 2.065,-68.797 z"
+             style="fill:#df2200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13680" />
+        </g>
+        <g
+           id="g13682"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 24.96,12.48 c -0.54,0.643 -1.124,1.342 -1.759,2.108 -0.691,0.85 -2.932,3.281 -2.155,4.496 3.416,2.367 5.94,-0.412 12.111,2.818 9.886,5.338 18.958,11.852 27.289,19.078 l 3.797,56.239 z"
+             style="fill:#009be2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13684" />
+        </g>
+        <g
+           id="g13686"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 64.243,97.219 -38.941,7.929 c -1.491,-0.529 -2.939,-1.154 -4.268,-2.031 -6.223,-4.517 -10.297,-2.685 -16.513,-3.756 -3.008,-0.422 -3.884,3.998 -5.599,11.16 l -58.901,11.997 z"
+             style="fill:#14b4ec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13688" />
+        </g>
+        <g
+           id="g13690"
+           transform="translate(327.0127,455.6626)">
+          <path
+             d="M 0,0 C 1.056,1.846 1.834,4.053 2.053,7.606 2.06,11.404 1.262,18.553 -0.058,26.12 L -25.364,-1.008 Z"
+             style="fill:#dc2b00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13692" />
+        </g>
+        <g
+           id="g13694"
+           transform="translate(320.665,444.6831)">
+          <path
+             d="M 0,0 C 2.002,5.78 4.568,7.867 6.348,10.979 L -19.017,9.972 Z"
+             style="fill:#df5e00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13696" />
+        </g>
+        <g
+           id="g13698"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 58.901,-11.996 c -0.567,2.369 -1.225,5.039 -2.084,7.934 -5.329,19.917 -6.67,17.406 -6.836,38.644 l -3.646,2.939 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13700" />
+        </g>
+        <g
+           id="g13702"
+           transform="translate(402.0752,230.6113)">
+          <path
+             d="m 0,0 c -3.558,-1.924 -9.174,-5.475 -13.905,-6.996 -1.537,-0.522 -3.117,-0.969 -4.652,-1.516 l 38.942,-7.929 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13704" />
+        </g>
+        <g
+           id="g13706"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="m 0,0 c 12.19,-3.049 8.91,-3.252 13.257,-5.043 5.149,-2.332 11.83,-1.578 15.342,-0.514 L 2.268,26.326 Z"
+             style="fill:#0074d4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13708" />
+        </g>
+        <g
+           id="g13710"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 53.907,25.935 C 45.898,27.082 37.452,26.165 26.52,32.973 16.573,38.858 5.767,41.569 5.446,51.589 5.408,65.657 6.734,73.622 8.499,78.718 l -19.017,9.971 z"
+             style="fill:#e88200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13712" />
+        </g>
+        <g
+           id="g13714"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 -42.923,-65.096 32.406,-88.975 Z"
+             style="fill:#dcf07c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13716" />
+        </g>
+        <g
+           id="g13718"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="M 0,0 133.035,-21.604 73.056,100.914 Z"
+             style="fill:#31bded;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13720" />
+        </g>
+        <g
+           id="g13722"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="M 0,0 2.268,26.326 -20.757,6.762 c 8,-2.766 15.308,-5.459 19.29,-6.401 C -0.953,0.236 -0.467,0.115 0,0"
+             style="fill:#0069d5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13724" />
+        </g>
+        <g
+           id="g13726"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="m 0,0 8.559,-58.115 c 4.263,0.603 8.996,1.705 14.864,4.004 5.525,2.033 11.453,2.527 17.073,4.213 6.626,2.05 12.966,4.882 19.431,7.369 15.21,6.023 17.269,9.484 22.973,8.716 7.048,-0.658 17.572,-4.058 27.111,-7.355 l 23.024,19.564 z"
+             style="fill:#0181dd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13728" />
+        </g>
+        <g
+           id="g13730"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="M 0,0 9.096,-44.914 82.152,56 Z"
+             style="fill:#8bebdb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13732" />
+        </g>
+        <g
+           id="g13734"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="M 0,0 -36.386,-71.918 10.518,-88.689 Z"
+             style="fill:#f38900;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13736" />
+        </g>
+        <g
+           id="g13738"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="M 0,0 28.995,-61.4 75.33,-23.879 Z"
+             style="fill:#b7f3bb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13740" />
+        </g>
+        <g
+           id="g13742"
+           transform="translate(265.4712,515.9917)">
+          <path
+             d="m 0,0 c -5.74,-5.332 -5.494,-13.276 -7.929,-20.031 -2.488,-6.871 -0.271,-14.435 -3.022,-21.654 -0.332,-0.95 -1.548,-2.81 -1.973,-5.643 l 0.931,-7.638 c 0.022,-0.059 0.041,-0.118 0.064,-0.179 1.682,-4.462 3.688,-6.111 5.816,-8.281 L 14.817,4.458 C 9.663,4.323 5.518,5.767 0,0"
+             style="fill:#ef3500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13744" />
+        </g>
+        <g
+           id="g13746"
+           transform="translate(299.583,523.4517)">
+          <path
+             d="m 0,0 c -3.692,1.637 -7.625,1.069 -10.417,-0.463 -3.42,-2.001 -6.277,-2.471 -8.877,-2.539 l -20.931,-67.884 c 1.127,-1.148 2.288,-2.443 3.454,-4.38 0.842,-1.365 1.515,-2.792 2.068,-4.264 l 36.768,10.733 z"
+             style="fill:#f43800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13748" />
+        </g>
+        <g
+           id="g13750"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="m 0,0 -36.768,-10.733 c 1.894,-5.034 2.391,-10.602 3.426,-16.089 0.347,-1.888 0.184,-3.81 0.224,-5.716 -0.475,-7.014 1.782,-11.357 -6.969,-16.273 l 3.701,-23.107 z"
+             style="fill:#f77700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13752" />
+        </g>
+        <g
+           id="g13754"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 3.98,-81.868 42.923,65.097 z"
+             style="fill:#f2da4a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13756" />
+        </g>
+        <g
+           id="g13758"
+           transform="translate(253.478,461.0259)">
+          <path
+             d="M 0,0 -0.931,7.638 C -1.237,5.602 -1.132,3.064 0,0"
+             style="fill:#fb6100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13760" />
+        </g>
+        <g
+           id="g13762"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="m 0,0 -34.43,-11.291 c 4.375,-19.814 1.914,-25.602 0.369,-32.424 L 28.995,-61.4 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13764" />
+        </g>
+        <g
+           id="g13766"
+           transform="translate(183.2183,271.7305)">
+          <path
+             d="M 0,0 C 0.559,0.451 1.134,0.947 1.728,1.496 L -1.529,0.428 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13768" />
+        </g>
+        <g
+           id="g13770"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 -63.056,17.686 c -0.217,-0.959 -0.416,-1.94 -0.575,-2.981 -4.827,-28.373 -3.895,-27.422 -7.923,-36.496 -0.886,-2.527 -4.431,-1.537 -17.768,3.27 -4.097,1.519 -6.828,2.607 -8.685,3.404 L -82.152,-56 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13772" />
+        </g>
+        <g
+           id="g13774"
+           transform="translate(182.1704,270.9199)">
+          <path
+             d="M 0,0 C 0.343,0.254 0.692,0.523 1.048,0.811 L -0.481,1.238 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13776" />
+        </g>
+        <g
+           id="g13778"
+           transform="translate(178.2236,77.3145)">
+          <path
+             d="m 0,0 c 1.748,-0.338 3.177,-0.359 3.87,-0.437 9.577,-0.79 19.166,-1.26 28.525,0.898 C 41.31,2.6 47.604,2.004 55.517,3.125 L 46.958,61.24 Z"
+             style="fill:#6cb0c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13780" />
+        </g>
+        <g
+           id="g13782"
+           transform="translate(212.9209,392.1343)">
+          <path
+             d="m 0,0 c -7.358,-3.378 -11.848,-9.501 -15.415,-12.913 -3.459,-3.684 -2.798,-1.984 -5.258,-8.591 -1.752,-4.541 -4.212,-8.777 -5.869,-13.361 -0.621,-1.584 -0.969,-3.253 -1.559,-4.849 -3.336,-9.049 -11.784,-15.183 -16.209,-23.89 -10e-4,-10e-4 -0.003,-0.004 -0.004,-0.007 l 13.083,-56.365 36.298,48.028 c 0.446,1.161 0.907,2.314 1.402,3.45 0.192,0.404 0.393,1.573 2.82,2.136 l 43.053,56.964 z"
+             style="fill:#ffd100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13784" />
+        </g>
+        <g
+           id="g13786"
+           transform="translate(184.9458,273.2266)">
+          <path
+             d="m 0,0 c 2.113,1.949 4.474,4.564 7.256,8.246 6.137,7.947 13.187,15.176 18.881,23.467 3.187,4.646 4.897,10.023 6.905,15.246 L -3.256,-1.068 Z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13788" />
+        </g>
+        <g
+           id="g13790"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 -43.053,-56.965 c 0.032,0.007 0.059,0.016 0.092,0.023 1.473,-2.116 3.247,-4.095 4.089,-6.579 4.089,-12.477 6.753,-22.079 8.422,-29.638 l 34.43,11.291 z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13792" />
+        </g>
+        <g
+           id="g13794"
+           transform="translate(261.561,405.8433)">
+          <path
+             d="m 0,0 c -2.75,-1.545 -6.583,-3.145 -11.933,-4.904 -20.513,-6.807 -23.499,-5.765 -29.432,-6.675 -2.707,-0.38 -5.114,-1.138 -7.275,-2.13 l 52.342,-9.398 z"
+             style="fill:#fd9d00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13796" />
+        </g>
+        <g
+           id="g13798"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="m 0,0 -15.855,40.883 c -9.291,3.988 3.366,0.662 -22.866,7.346 L -43.208,6.254 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13800" />
+        </g>
+        <g
+           id="g13802"
+           transform="translate(181.5063,270.4414)">
+          <path
+             d="M 0,0 C 0.219,0.152 0.44,0.312 0.664,0.478 L 0.183,1.717 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13804" />
+        </g>
+        <g
+           id="g13806"
+           transform="translate(208.02,135.877)">
+          <path
+             d="M 0,0 C 3.134,-1.705 5.926,-3.359 7.395,-4.527 6.783,-5.061 6.337,-5.752 5.719,-6.275 c -1.337,-1.192 -23.474,-3.84 -24.076,-4.055 -4.022,-1.281 -13.359,-10.352 -15.739,-14.982 -1.006,-1.821 -1.362,-3.893 -2.164,-5.792 -2.845,-7.011 -8.646,-14.029 -2.605,-21.931 2.726,-3.654 6.299,-4.99 9.069,-5.528 L 17.162,2.678 Z"
+             style="fill:#8bcfa3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13808" />
+        </g>
+        <g
+           id="g13810"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="M 0,0 52.304,-51.168 43.208,-6.254 Z"
+             style="fill:#96eaa2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13812" />
+        </g>
+        <g
+           id="g13814"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="m 0,0 -7.637,-31.27 c 3.667,-2.658 6.324,-4.375 7.192,-4.82 7.389,-3.402 14.389,-7.594 21.821,-10.904 2.728,-1.201 8.696,-4.094 13.767,-6.852 l 17.161,2.678 z"
+             style="fill:#9ae292;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13816" />
+        </g>
+        <g
+           id="g13818"
+           transform="translate(168.6074,328.5229)">
+          <path
+             d="m 0,0 c -11.738,-23.529 -11.302,-31.66 -21.896,-24.757 -18.937,10.683 -32.469,18.709 -42.418,25.002 l -12.992,-20.584 c 4.429,-4.291 9.657,-9.283 15.89,-15.086 l 74.498,-20.94 z"
+             style="fill:#ffce00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13820" />
+        </g>
+        <g
+           id="g13822"
+           transform="translate(137.1387,234.541)">
+          <path
+             d="m 0,0 c -1.537,-1.059 -2.47,-2.176 -3.458,-3.123 -10.068,-10.852 -9.165,-13.883 -9.26,-23.637 0.043,-3.965 0.834,-8.011 2.866,-11.465 1.019,-1.714 2.16,-3.427 3.393,-5.127 l 42.198,-1.466 z"
+             style="fill:#f0d03c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13824" />
+        </g>
+        <g
+           id="g13826"
+           transform="translate(107.1909,293.0977)">
+          <path
+             d="m 0,0 c 7.815,-7.275 17.21,-15.828 28.605,-25.885 9.381,-8.099 9.154,-10.064 19.65,-9.246 3.198,0.342 7.985,1.262 10.469,3.293 6.432,5.234 10.463,5.602 15.591,9.182 l 0.184,1.717 z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13828" />
+        </g>
+        <g
+           id="g13830"
+           transform="translate(177.3643,231.6973)">
+          <path
+             d="M 0,0 C -1.25,0.318 -2.586,0.66 -4.019,1.025 -4.932,1.332 -5.602,2.145 -6.576,2.311 -14.828,4.234 -20.919,7.525 -29.362,6.232 -35.081,5.557 -38.186,4.25 -40.226,2.844 L -4.487,-41.975 Z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13832" />
+        </g>
+        <g
+           id="g13834"
+           transform="translate(130.6802,191.1895)">
+          <path
+             d="m 0,0 c 9.73,-13.412 25.341,-26.055 34.56,-32.736 l 7.637,31.269 z"
+             style="fill:#c7df6f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13836" />
+        </g>
+        <g
+           id="g13838"
+           transform="translate(56.7227,368.0815)">
+          <path
+             d="m 0,0 c -4.445,3.398 -7.547,6.24 -9.778,8.602 l -14.208,-3.612 4.815,-6.731 c 0.309,1.335 0.768,2.766 1.413,4.3 8.121,-3.178 6.81,-9.274 5.773,-14.345 L 3.873,-33.953 c 6.915,-1.379 10.594,-6.458 30.706,-25.945 l 12.992,20.585 C 14.247,-18.236 21.153,-16.635 0,0"
+             style="fill:#feb200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13840" />
+        </g>
+        <g
+           id="g13842"
+           transform="translate(46.9448,376.6831)">
+          <path
+             d="M 0,0 C -6,6.35 -5.693,9.213 -8.216,10.023 L -14.209,-3.611 Z"
+             style="fill:#fe9400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13844" />
+        </g>
+        <g
+           id="g13846"
+           transform="translate(44.2983,353.9419)">
+          <path
+             d="M 0,0 C -4.392,-0.536 -8.714,3.901 -6.747,12.398 L -11.562,19.13 -21.876,4.264 c 0.042,-0.755 0.105,-1.526 0.151,-2.371 0.043,-1.914 -1.115,-3.187 -3.419,-2.41 -0.012,0.005 -0.024,0.011 -0.038,0.016 l -9.97,-14.371 c 3.016,-2.116 5.047,-1.11 7.693,-1.097 11.549,-0.04 11.379,0.704 12.926,-0.741 4.452,-3.88 12.301,-1.605 19.468,-2.537 5.205,-0.057 8.551,-0.006 11.362,-0.567 L 0.439,2.354 C 0.272,1.537 0.112,0.747 0,0"
+             style="fill:#ffa300;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13848" />
+        </g>
+        <g
+           id="g13850"
+           transform="translate(38.729,386.7065)">
+          <path
+             d="M 0,0 C -0.873,0.28 -2.083,0.315 -4.011,0.164 -5.262,0.213 -7.534,0.788 -8.336,-1.61 -9.564,-5.017 -8.434,-5.657 -9.828,-9.336 l 3.835,-4.299 z"
+             style="fill:#fd7700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13852" />
+        </g>
+        <g
+           id="g13854"
+           transform="translate(3.2769,370.0132)">
+          <path
+             d="m 0,0 -3.018,-0.312 c -1.925,-10.076 7.434,-14.539 9.35,-23.095 -1.796,-0.753 -3.579,-1.54 -5.381,-2.269 1.949,-2.675 3.537,-4.299 4.918,-5.267 l 9.97,14.371 C 8.256,-13.681 5.736,-8.311 0,0"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13856" />
+        </g>
+        <g
+           id="g13858"
+           transform="translate(26.4971,372.4243)">
+          <path
+             d="M 0,0 C -4.024,-7.823 -4.262,-10.867 -4.075,-14.219 L 6.239,0.648 Z"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13860" />
+        </g>
+        <g
+           id="g13862"
+           transform="translate(28.9014,377.3706)">
+          <path
+             d="M 0,0 C -0.405,-1.069 -1.022,-2.393 -1.974,-4.117 -2.123,-4.4 -2.265,-4.676 -2.404,-4.946 l 6.239,0.647 z"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13864" />
+        </g>
+        <g
+           id="g13866"
+           transform="translate(1.2061,372.9331)">
+          <path
+             d="M 0,0 C -0.444,-1.142 -0.752,-2.216 -0.947,-3.232 L 2.071,-2.92 C 1.424,-1.983 0.74,-1.012 0,0"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13868" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/icons/high_importance.svg
+++ b/src/icons/high_importance.svg
@@ -1,0 +1,593 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg13588"
+   width="800"
+   height="800"
+   viewBox="0 0 800 800"
+   sodipodi:docname="yoga-exercise-5-publicdomainvectors.org.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13592">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13604">
+      <path
+         d="M 0,600 H 600 V 0 H 0 Z"
+         id="path13602" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview13590"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.04625"
+     inkscape:cx="400"
+     inkscape:cy="400.4779"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g13596">
+    <inkscape:page
+       x="0"
+       y="0"
+       id="page13594"
+       width="800"
+       height="800" />
+  </sodipodi:namedview>
+  <g
+     id="g13596"
+     inkscape:groupmode="layer"
+     inkscape:label="Page 1"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,800)">
+    <g
+       id="g13598">
+      <g
+         id="g13600"
+         clip-path="url(#clipPath13604)">
+        <g
+           id="g13606"
+           transform="translate(578.1914,386.9897)">
+          <path
+             d="m 0,0 c -0.485,0.142 -1.749,-0.009 -2.118,-0.805 -0.135,-0.289 -0.265,-0.568 -0.391,-0.84 L 1.248,-2.419 C 1.076,-0.893 0.722,-0.488 0,0"
+             style="fill:#b4281c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13608" />
+        </g>
+        <g
+           id="g13610"
+           transform="translate(516.7393,323.3911)">
+          <path
+             d="m 0,0 c 8.265,6.945 15.04,12.196 19.5,14.237 10.155,4.67 35.493,11.545 39.625,13.864 0.943,0.516 14.303,9.853 14.684,10.425 -0.098,0.981 -0.378,1.987 -0.901,2.823 -2.305,0.126 -4.492,0.99 -5.66,-0.311 -0.594,-0.488 -0.775,-1.254 -1.141,-1.888 -0.596,-0.578 -1.405,-0.848 -2.122,-1.236 -0.458,0.824 -1.155,1.538 -1.358,2.481 -0.084,0.8 -0.041,1.598 0.027,2.396 L -9.285,2.777 Z"
+             style="fill:#ab8fa7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13612" />
+        </g>
+        <g
+           id="g13614"
+           transform="translate(506.0645,314.2578)">
+          <path
+             d="M 0,0 C 3.766,3.255 7.341,6.332 10.675,9.133 L 1.39,11.911 Z"
+             style="fill:#5898c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13616" />
+        </g>
+        <g
+           id="g13618"
+           transform="translate(542.9297,375.9956)">
+          <path
+             d="m 0,0 c 0.396,0.003 0.803,0.003 1.212,0.006 1.118,-6.253 7.396,-9.463 2.804,-18.155 -2.629,2.69 -5.165,5.469 -7.77,8.178 C -2.536,-6.635 -1.227,-3.333 0,0 m 36.464,-9.814 c 0.09,1.05 0.227,2.101 0.194,3.155 C 36.641,2.424 36.741,6.518 36.51,8.575 L 32.753,9.349 C 29.245,1.765 29.028,0.082 29.318,-3.117 c 0.044,-4.188 -0.11,-6.974 -4.405,-8.84 -1.442,-0.683 -3.037,-1.885 -4.11,-1.685 -1.323,0.443 -2.27,2.665 -2.423,4.089 -0.148,2.113 0.974,7.868 -6.611,13.23 C 5.387,7.579 7.566,16.667 -1.915,15.505 -5.617,15.143 -5.384,11.813 -5.531,10.57 -5.709,9.602 -5.59,9.583 -13.534,-4.541 c -6.705,-12.148 -9.663,-11.606 -10.61,-16.477 -0.427,-1.395 0.406,-3.207 -1.485,-4.977 -4.624,-4.6 -8.894,-8.37 -12.996,-11.593 l 3.149,-12.239 z"
+             style="fill:#b28e76;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13620" />
+        </g>
+        <g
+           id="g13622"
+           transform="translate(444.6328,294.9004)">
+          <path
+             d="M 0,0 13.263,-20.008 C 30.065,-7.961 47.111,6.977 61.432,19.357 l 1.389,11.911 z"
+             style="fill:#6dc9cd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13624" />
+        </g>
+        <g
+           id="g13626"
+           transform="translate(507.4541,326.1685)">
+          <path
+             d="M 0,0 -3.149,12.239 C -10.905,6.146 -18.054,2.011 -25.83,-2.068 -44.614,-12.122 -52.949,-16.987 -58.164,-19.485 l -4.657,-11.783 z"
+             style="fill:#abc38b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13628" />
+        </g>
+        <g
+           id="g13630"
+           transform="translate(449.29,306.6836)">
+          <path
+             d="m 0,0 c -3.591,-1.721 -5.704,-2.318 -8.728,-2.715 l 4.071,-9.068 z"
+             style="fill:#c8c46c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13632" />
+        </g>
+        <g
+           id="g13634"
+           transform="translate(418.6631,157.9316)">
+          <path
+             d="M 0,0 C 11.132,9.652 20.939,20.578 29.581,31.682 L 3.797,56.238 Z"
+             style="fill:#0097de;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13636" />
+        </g>
+        <g
+           id="g13638"
+           transform="translate(448.2441,189.6133)">
+          <path
+             d="m 0,0 c 0.379,0.486 0.757,0.973 1.131,1.459 3.886,5.062 3.449,6.111 5.46,8.9 1.073,1.479 5.215,4.541 3.137,11.524 -0.078,0.267 -0.748,2.26 -1.842,4.918 l -33.67,-2.244 z"
+             style="fill:#008dde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13640" />
+        </g>
+        <g
+           id="g13642"
+           transform="translate(456.1299,216.4141)">
+          <path
+             d="m 0,0 c -1.766,4.285 -4.641,10.299 -7.939,13.605 -4.687,4.918 -12.329,9.075 -18.967,8.778 L -33.67,-2.244 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13644" />
+        </g>
+        <g
+           id="g13646"
+           transform="translate(435.6045,262.0293)">
+          <path
+             d="m 0,0 c 4.052,1.113 5.959,3.859 6.686,4.307 3.06,2.017 6.854,2.531 9.904,4.576 1.894,1.283 3.797,2.613 5.701,3.98 L 9.028,32.871 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13648" />
+        </g>
+        <g
+           id="g13650"
+           transform="translate(344.5723,276.9902)">
+          <path
+             d="m 0,0 3.646,9.332 c 0,0.129 0,0.252 10e-4,0.383 1.077,13.767 0.874,7.99 4.692,20.359 0.224,0.184 0.498,0.332 0.634,0.604 7.217,13.488 5.145,10.521 9.594,16.842 l 21.942,56.157 c -0.112,0.141 -0.224,0.283 -0.339,0.42 -6.587,7.817 -12.498,9.928 -18.669,10.813 L -32.406,88.975 Z"
+             style="fill:#dae262;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13652" />
+        </g>
+        <g
+           id="g13654"
+           transform="translate(384.5479,85.0684)">
+          <path
+             d="m 0,0 c 0.72,0.219 1.31,0.449 1.722,0.67 9.897,5.273 7.686,12.971 7.195,24.621 -0.08,0.568 0.076,3.545 -1.021,3.701 -2.269,0.584 -2.601,2.041 -2.583,4.342 -0.311,4.213 0.387,2.619 -6.684,11.029 l -24.96,-12.48 z"
+             style="fill:#008ad9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13656" />
+        </g>
+        <g
+           id="g13658"
+           transform="translate(429.2236,238.7969)">
+          <path
+             d="m 0,0 c -0.978,-0.045 -1.934,-0.184 -2.855,-0.434 0,0 0.9,0.18 -21.882,-6.609 -0.606,-0.205 -1.431,-0.613 -2.411,-1.143 l 20.384,-16.441 z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13660" />
+        </g>
+        <g
+           id="g13662"
+           transform="translate(348.2188,274.0508)">
+          <path
+             d="M 0,0 C -0.009,1.127 -0.015,2.322 -0.017,3.59 L -3.646,2.939 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13664" />
+        </g>
+        <g
+           id="g13666"
+           transform="translate(394.0088,285.8398)">
+          <path
+             d="M 0,0 C 4.135,-3.971 8.962,-8.229 14.681,-12.848 28.211,-24.057 36.56,-25.195 41.596,-23.811 L 50.624,9.061 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13668" />
+        </g>
+        <g
+           id="g13670"
+           transform="translate(364.4443,326.3667)">
+          <path
+             d="m 0,0 c 0.849,-0.372 1.78,-0.771 2.321,-1.565 0.775,-1.99 0.28,-4.357 1.614,-6.159 5.67,-9.397 11.731,-19.461 25.629,-32.803 l 50.624,9.061 -4.07,9.068 c -0.803,-0.103 -1.67,-0.195 -2.646,-0.289 -4.493,-0.166 -4.938,0.219 -8.271,3.572 -9.275,10.226 -14.161,26.168 -20.166,33.657 -2.34,3.004 -4.916,5.839 -6.899,9.101 -5.15,8.855 -7.877,19.108 -10.539,22.186 -1.212,1.427 -2.512,2.773 -3.717,4.206 -1.171,1.352 -2.13,2.869 -3.243,4.266 L -1.305,-1.856 C -0.922,-1.311 -0.49,-0.699 0,0"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13672" />
+        </g>
+        <g
+           id="g13674"
+           transform="translate(348.2021,277.6406)">
+          <path
+             d="M 0,0 C -0.006,2.57 0.001,5.447 0.016,8.682 L -3.63,-0.65 Z"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13676" />
+        </g>
+        <g
+           id="g13678"
+           transform="translate(326.9551,481.7827)">
+          <path
+             d="m 0,0 c -1.489,8.546 -3.643,17.625 -6.05,23.015 -4.362,9.577 -11.904,10.8 -17.282,15.756 -1.261,1.333 -2.633,2.275 -4.04,2.898 l 2.065,-68.797 z"
+             style="fill:#df2200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13680" />
+        </g>
+        <g
+           id="g13682"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 24.96,12.48 c -0.54,0.643 -1.124,1.342 -1.759,2.108 -0.691,0.85 -2.932,3.281 -2.155,4.496 3.416,2.367 5.94,-0.412 12.111,2.818 9.886,5.338 18.958,11.852 27.289,19.078 l 3.797,56.239 z"
+             style="fill:#009be2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13684" />
+        </g>
+        <g
+           id="g13686"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 64.243,97.219 -38.941,7.929 c -1.491,-0.529 -2.939,-1.154 -4.268,-2.031 -6.223,-4.517 -10.297,-2.685 -16.513,-3.756 -3.008,-0.422 -3.884,3.998 -5.599,11.16 l -58.901,11.997 z"
+             style="fill:#14b4ec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13688" />
+        </g>
+        <g
+           id="g13690"
+           transform="translate(327.0127,455.6626)">
+          <path
+             d="M 0,0 C 1.056,1.846 1.834,4.053 2.053,7.606 2.06,11.404 1.262,18.553 -0.058,26.12 L -25.364,-1.008 Z"
+             style="fill:#dc2b00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13692" />
+        </g>
+        <g
+           id="g13694"
+           transform="translate(320.665,444.6831)">
+          <path
+             d="M 0,0 C 2.002,5.78 4.568,7.867 6.348,10.979 L -19.017,9.972 Z"
+             style="fill:#df5e00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13696" />
+        </g>
+        <g
+           id="g13698"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 58.901,-11.996 c -0.567,2.369 -1.225,5.039 -2.084,7.934 -5.329,19.917 -6.67,17.406 -6.836,38.644 l -3.646,2.939 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13700" />
+        </g>
+        <g
+           id="g13702"
+           transform="translate(402.0752,230.6113)">
+          <path
+             d="m 0,0 c -3.558,-1.924 -9.174,-5.475 -13.905,-6.996 -1.537,-0.522 -3.117,-0.969 -4.652,-1.516 l 38.942,-7.929 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13704" />
+        </g>
+        <g
+           id="g13706"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="m 0,0 c 12.19,-3.049 8.91,-3.252 13.257,-5.043 5.149,-2.332 11.83,-1.578 15.342,-0.514 L 2.268,26.326 Z"
+             style="fill:#0074d4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13708" />
+        </g>
+        <g
+           id="g13710"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 53.907,25.935 C 45.898,27.082 37.452,26.165 26.52,32.973 16.573,38.858 5.767,41.569 5.446,51.589 5.408,65.657 6.734,73.622 8.499,78.718 l -19.017,9.971 z"
+             style="fill:#e88200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13712" />
+        </g>
+        <g
+           id="g13714"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 -42.923,-65.096 32.406,-88.975 Z"
+             style="fill:#dcf07c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13716" />
+        </g>
+        <g
+           id="g13718"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="M 0,0 133.035,-21.604 73.056,100.914 Z"
+             style="fill:#31bded;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13720" />
+        </g>
+        <g
+           id="g13722"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="M 0,0 2.268,26.326 -20.757,6.762 c 8,-2.766 15.308,-5.459 19.29,-6.401 C -0.953,0.236 -0.467,0.115 0,0"
+             style="fill:#0069d5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13724" />
+        </g>
+        <g
+           id="g13726"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="m 0,0 8.559,-58.115 c 4.263,0.603 8.996,1.705 14.864,4.004 5.525,2.033 11.453,2.527 17.073,4.213 6.626,2.05 12.966,4.882 19.431,7.369 15.21,6.023 17.269,9.484 22.973,8.716 7.048,-0.658 17.572,-4.058 27.111,-7.355 l 23.024,19.564 z"
+             style="fill:#0181dd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13728" />
+        </g>
+        <g
+           id="g13730"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="M 0,0 9.096,-44.914 82.152,56 Z"
+             style="fill:#8bebdb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13732" />
+        </g>
+        <g
+           id="g13734"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="M 0,0 -36.386,-71.918 10.518,-88.689 Z"
+             style="fill:#f38900;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13736" />
+        </g>
+        <g
+           id="g13738"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="M 0,0 28.995,-61.4 75.33,-23.879 Z"
+             style="fill:#b7f3bb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13740" />
+        </g>
+        <g
+           id="g13742"
+           transform="translate(265.4712,515.9917)">
+          <path
+             d="m 0,0 c -5.74,-5.332 -5.494,-13.276 -7.929,-20.031 -2.488,-6.871 -0.271,-14.435 -3.022,-21.654 -0.332,-0.95 -1.548,-2.81 -1.973,-5.643 l 0.931,-7.638 c 0.022,-0.059 0.041,-0.118 0.064,-0.179 1.682,-4.462 3.688,-6.111 5.816,-8.281 L 14.817,4.458 C 9.663,4.323 5.518,5.767 0,0"
+             style="fill:#ef3500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13744" />
+        </g>
+        <g
+           id="g13746"
+           transform="translate(299.583,523.4517)">
+          <path
+             d="m 0,0 c -3.692,1.637 -7.625,1.069 -10.417,-0.463 -3.42,-2.001 -6.277,-2.471 -8.877,-2.539 l -20.931,-67.884 c 1.127,-1.148 2.288,-2.443 3.454,-4.38 0.842,-1.365 1.515,-2.792 2.068,-4.264 l 36.768,10.733 z"
+             style="fill:#f43800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13748" />
+        </g>
+        <g
+           id="g13750"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="m 0,0 -36.768,-10.733 c 1.894,-5.034 2.391,-10.602 3.426,-16.089 0.347,-1.888 0.184,-3.81 0.224,-5.716 -0.475,-7.014 1.782,-11.357 -6.969,-16.273 l 3.701,-23.107 z"
+             style="fill:#f77700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13752" />
+        </g>
+        <g
+           id="g13754"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 3.98,-81.868 42.923,65.097 z"
+             style="fill:#f2da4a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13756" />
+        </g>
+        <g
+           id="g13758"
+           transform="translate(253.478,461.0259)">
+          <path
+             d="M 0,0 -0.931,7.638 C -1.237,5.602 -1.132,3.064 0,0"
+             style="fill:#fb6100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13760" />
+        </g>
+        <g
+           id="g13762"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="m 0,0 -34.43,-11.291 c 4.375,-19.814 1.914,-25.602 0.369,-32.424 L 28.995,-61.4 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13764" />
+        </g>
+        <g
+           id="g13766"
+           transform="translate(183.2183,271.7305)">
+          <path
+             d="M 0,0 C 0.559,0.451 1.134,0.947 1.728,1.496 L -1.529,0.428 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13768" />
+        </g>
+        <g
+           id="g13770"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 -63.056,17.686 c -0.217,-0.959 -0.416,-1.94 -0.575,-2.981 -4.827,-28.373 -3.895,-27.422 -7.923,-36.496 -0.886,-2.527 -4.431,-1.537 -17.768,3.27 -4.097,1.519 -6.828,2.607 -8.685,3.404 L -82.152,-56 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13772" />
+        </g>
+        <g
+           id="g13774"
+           transform="translate(182.1704,270.9199)">
+          <path
+             d="M 0,0 C 0.343,0.254 0.692,0.523 1.048,0.811 L -0.481,1.238 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13776" />
+        </g>
+        <g
+           id="g13778"
+           transform="translate(178.2236,77.3145)">
+          <path
+             d="m 0,0 c 1.748,-0.338 3.177,-0.359 3.87,-0.437 9.577,-0.79 19.166,-1.26 28.525,0.898 C 41.31,2.6 47.604,2.004 55.517,3.125 L 46.958,61.24 Z"
+             style="fill:#6cb0c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13780" />
+        </g>
+        <g
+           id="g13782"
+           transform="translate(212.9209,392.1343)">
+          <path
+             d="m 0,0 c -7.358,-3.378 -11.848,-9.501 -15.415,-12.913 -3.459,-3.684 -2.798,-1.984 -5.258,-8.591 -1.752,-4.541 -4.212,-8.777 -5.869,-13.361 -0.621,-1.584 -0.969,-3.253 -1.559,-4.849 -3.336,-9.049 -11.784,-15.183 -16.209,-23.89 -10e-4,-10e-4 -0.003,-0.004 -0.004,-0.007 l 13.083,-56.365 36.298,48.028 c 0.446,1.161 0.907,2.314 1.402,3.45 0.192,0.404 0.393,1.573 2.82,2.136 l 43.053,56.964 z"
+             style="fill:#ffd100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13784" />
+        </g>
+        <g
+           id="g13786"
+           transform="translate(184.9458,273.2266)">
+          <path
+             d="m 0,0 c 2.113,1.949 4.474,4.564 7.256,8.246 6.137,7.947 13.187,15.176 18.881,23.467 3.187,4.646 4.897,10.023 6.905,15.246 L -3.256,-1.068 Z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13788" />
+        </g>
+        <g
+           id="g13790"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 -43.053,-56.965 c 0.032,0.007 0.059,0.016 0.092,0.023 1.473,-2.116 3.247,-4.095 4.089,-6.579 4.089,-12.477 6.753,-22.079 8.422,-29.638 l 34.43,11.291 z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13792" />
+        </g>
+        <g
+           id="g13794"
+           transform="translate(261.561,405.8433)">
+          <path
+             d="m 0,0 c -2.75,-1.545 -6.583,-3.145 -11.933,-4.904 -20.513,-6.807 -23.499,-5.765 -29.432,-6.675 -2.707,-0.38 -5.114,-1.138 -7.275,-2.13 l 52.342,-9.398 z"
+             style="fill:#fd9d00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13796" />
+        </g>
+        <g
+           id="g13798"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="m 0,0 -15.855,40.883 c -9.291,3.988 3.366,0.662 -22.866,7.346 L -43.208,6.254 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13800" />
+        </g>
+        <g
+           id="g13802"
+           transform="translate(181.5063,270.4414)">
+          <path
+             d="M 0,0 C 0.219,0.152 0.44,0.312 0.664,0.478 L 0.183,1.717 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13804" />
+        </g>
+        <g
+           id="g13806"
+           transform="translate(208.02,135.877)">
+          <path
+             d="M 0,0 C 3.134,-1.705 5.926,-3.359 7.395,-4.527 6.783,-5.061 6.337,-5.752 5.719,-6.275 c -1.337,-1.192 -23.474,-3.84 -24.076,-4.055 -4.022,-1.281 -13.359,-10.352 -15.739,-14.982 -1.006,-1.821 -1.362,-3.893 -2.164,-5.792 -2.845,-7.011 -8.646,-14.029 -2.605,-21.931 2.726,-3.654 6.299,-4.99 9.069,-5.528 L 17.162,2.678 Z"
+             style="fill:#8bcfa3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13808" />
+        </g>
+        <g
+           id="g13810"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="M 0,0 52.304,-51.168 43.208,-6.254 Z"
+             style="fill:#96eaa2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13812" />
+        </g>
+        <g
+           id="g13814"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="m 0,0 -7.637,-31.27 c 3.667,-2.658 6.324,-4.375 7.192,-4.82 7.389,-3.402 14.389,-7.594 21.821,-10.904 2.728,-1.201 8.696,-4.094 13.767,-6.852 l 17.161,2.678 z"
+             style="fill:#9ae292;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13816" />
+        </g>
+        <g
+           id="g13818"
+           transform="translate(168.6074,328.5229)">
+          <path
+             d="m 0,0 c -11.738,-23.529 -11.302,-31.66 -21.896,-24.757 -18.937,10.683 -32.469,18.709 -42.418,25.002 l -12.992,-20.584 c 4.429,-4.291 9.657,-9.283 15.89,-15.086 l 74.498,-20.94 z"
+             style="fill:#ffce00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13820" />
+        </g>
+        <g
+           id="g13822"
+           transform="translate(137.1387,234.541)">
+          <path
+             d="m 0,0 c -1.537,-1.059 -2.47,-2.176 -3.458,-3.123 -10.068,-10.852 -9.165,-13.883 -9.26,-23.637 0.043,-3.965 0.834,-8.011 2.866,-11.465 1.019,-1.714 2.16,-3.427 3.393,-5.127 l 42.198,-1.466 z"
+             style="fill:#f0d03c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13824" />
+        </g>
+        <g
+           id="g13826"
+           transform="translate(107.1909,293.0977)">
+          <path
+             d="m 0,0 c 7.815,-7.275 17.21,-15.828 28.605,-25.885 9.381,-8.099 9.154,-10.064 19.65,-9.246 3.198,0.342 7.985,1.262 10.469,3.293 6.432,5.234 10.463,5.602 15.591,9.182 l 0.184,1.717 z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13828" />
+        </g>
+        <g
+           id="g13830"
+           transform="translate(177.3643,231.6973)">
+          <path
+             d="M 0,0 C -1.25,0.318 -2.586,0.66 -4.019,1.025 -4.932,1.332 -5.602,2.145 -6.576,2.311 -14.828,4.234 -20.919,7.525 -29.362,6.232 -35.081,5.557 -38.186,4.25 -40.226,2.844 L -4.487,-41.975 Z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13832" />
+        </g>
+        <g
+           id="g13834"
+           transform="translate(130.6802,191.1895)">
+          <path
+             d="m 0,0 c 9.73,-13.412 25.341,-26.055 34.56,-32.736 l 7.637,31.269 z"
+             style="fill:#c7df6f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13836" />
+        </g>
+        <g
+           id="g13838"
+           transform="translate(56.7227,368.0815)">
+          <path
+             d="m 0,0 c -4.445,3.398 -7.547,6.24 -9.778,8.602 l -14.208,-3.612 4.815,-6.731 c 0.309,1.335 0.768,2.766 1.413,4.3 8.121,-3.178 6.81,-9.274 5.773,-14.345 L 3.873,-33.953 c 6.915,-1.379 10.594,-6.458 30.706,-25.945 l 12.992,20.585 C 14.247,-18.236 21.153,-16.635 0,0"
+             style="fill:#feb200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13840" />
+        </g>
+        <g
+           id="g13842"
+           transform="translate(46.9448,376.6831)">
+          <path
+             d="M 0,0 C -6,6.35 -5.693,9.213 -8.216,10.023 L -14.209,-3.611 Z"
+             style="fill:#fe9400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13844" />
+        </g>
+        <g
+           id="g13846"
+           transform="translate(44.2983,353.9419)">
+          <path
+             d="M 0,0 C -4.392,-0.536 -8.714,3.901 -6.747,12.398 L -11.562,19.13 -21.876,4.264 c 0.042,-0.755 0.105,-1.526 0.151,-2.371 0.043,-1.914 -1.115,-3.187 -3.419,-2.41 -0.012,0.005 -0.024,0.011 -0.038,0.016 l -9.97,-14.371 c 3.016,-2.116 5.047,-1.11 7.693,-1.097 11.549,-0.04 11.379,0.704 12.926,-0.741 4.452,-3.88 12.301,-1.605 19.468,-2.537 5.205,-0.057 8.551,-0.006 11.362,-0.567 L 0.439,2.354 C 0.272,1.537 0.112,0.747 0,0"
+             style="fill:#ffa300;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13848" />
+        </g>
+        <g
+           id="g13850"
+           transform="translate(38.729,386.7065)">
+          <path
+             d="M 0,0 C -0.873,0.28 -2.083,0.315 -4.011,0.164 -5.262,0.213 -7.534,0.788 -8.336,-1.61 -9.564,-5.017 -8.434,-5.657 -9.828,-9.336 l 3.835,-4.299 z"
+             style="fill:#fd7700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13852" />
+        </g>
+        <g
+           id="g13854"
+           transform="translate(3.2769,370.0132)">
+          <path
+             d="m 0,0 -3.018,-0.312 c -1.925,-10.076 7.434,-14.539 9.35,-23.095 -1.796,-0.753 -3.579,-1.54 -5.381,-2.269 1.949,-2.675 3.537,-4.299 4.918,-5.267 l 9.97,14.371 C 8.256,-13.681 5.736,-8.311 0,0"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13856" />
+        </g>
+        <g
+           id="g13858"
+           transform="translate(26.4971,372.4243)">
+          <path
+             d="M 0,0 C -4.024,-7.823 -4.262,-10.867 -4.075,-14.219 L 6.239,0.648 Z"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13860" />
+        </g>
+        <g
+           id="g13862"
+           transform="translate(28.9014,377.3706)">
+          <path
+             d="M 0,0 C -0.405,-1.069 -1.022,-2.393 -1.974,-4.117 -2.123,-4.4 -2.265,-4.676 -2.404,-4.946 l 6.239,0.647 z"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13864" />
+        </g>
+        <g
+           id="g13866"
+           transform="translate(1.2061,372.9331)">
+          <path
+             d="M 0,0 C -0.444,-1.142 -0.752,-2.216 -0.947,-3.232 L 2.071,-2.92 C 1.424,-1.983 0.74,-1.012 0,0"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13868" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/icons/unit-test.svg
+++ b/src/icons/unit-test.svg
@@ -1,0 +1,593 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg13588"
+   width="800"
+   height="800"
+   viewBox="0 0 800 800"
+   sodipodi:docname="yoga-exercise-5-publicdomainvectors.org.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13592">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13604">
+      <path
+         d="M 0,600 H 600 V 0 H 0 Z"
+         id="path13602" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview13590"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.04625"
+     inkscape:cx="400"
+     inkscape:cy="400.4779"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g13596">
+    <inkscape:page
+       x="0"
+       y="0"
+       id="page13594"
+       width="800"
+       height="800" />
+  </sodipodi:namedview>
+  <g
+     id="g13596"
+     inkscape:groupmode="layer"
+     inkscape:label="Page 1"
+     transform="matrix(1.3333333,0,0,-1.3333333,0,800)">
+    <g
+       id="g13598">
+      <g
+         id="g13600"
+         clip-path="url(#clipPath13604)">
+        <g
+           id="g13606"
+           transform="translate(578.1914,386.9897)">
+          <path
+             d="m 0,0 c -0.485,0.142 -1.749,-0.009 -2.118,-0.805 -0.135,-0.289 -0.265,-0.568 -0.391,-0.84 L 1.248,-2.419 C 1.076,-0.893 0.722,-0.488 0,0"
+             style="fill:#b4281c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13608" />
+        </g>
+        <g
+           id="g13610"
+           transform="translate(516.7393,323.3911)">
+          <path
+             d="m 0,0 c 8.265,6.945 15.04,12.196 19.5,14.237 10.155,4.67 35.493,11.545 39.625,13.864 0.943,0.516 14.303,9.853 14.684,10.425 -0.098,0.981 -0.378,1.987 -0.901,2.823 -2.305,0.126 -4.492,0.99 -5.66,-0.311 -0.594,-0.488 -0.775,-1.254 -1.141,-1.888 -0.596,-0.578 -1.405,-0.848 -2.122,-1.236 -0.458,0.824 -1.155,1.538 -1.358,2.481 -0.084,0.8 -0.041,1.598 0.027,2.396 L -9.285,2.777 Z"
+             style="fill:#ab8fa7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13612" />
+        </g>
+        <g
+           id="g13614"
+           transform="translate(506.0645,314.2578)">
+          <path
+             d="M 0,0 C 3.766,3.255 7.341,6.332 10.675,9.133 L 1.39,11.911 Z"
+             style="fill:#5898c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13616" />
+        </g>
+        <g
+           id="g13618"
+           transform="translate(542.9297,375.9956)">
+          <path
+             d="m 0,0 c 0.396,0.003 0.803,0.003 1.212,0.006 1.118,-6.253 7.396,-9.463 2.804,-18.155 -2.629,2.69 -5.165,5.469 -7.77,8.178 C -2.536,-6.635 -1.227,-3.333 0,0 m 36.464,-9.814 c 0.09,1.05 0.227,2.101 0.194,3.155 C 36.641,2.424 36.741,6.518 36.51,8.575 L 32.753,9.349 C 29.245,1.765 29.028,0.082 29.318,-3.117 c 0.044,-4.188 -0.11,-6.974 -4.405,-8.84 -1.442,-0.683 -3.037,-1.885 -4.11,-1.685 -1.323,0.443 -2.27,2.665 -2.423,4.089 -0.148,2.113 0.974,7.868 -6.611,13.23 C 5.387,7.579 7.566,16.667 -1.915,15.505 -5.617,15.143 -5.384,11.813 -5.531,10.57 -5.709,9.602 -5.59,9.583 -13.534,-4.541 c -6.705,-12.148 -9.663,-11.606 -10.61,-16.477 -0.427,-1.395 0.406,-3.207 -1.485,-4.977 -4.624,-4.6 -8.894,-8.37 -12.996,-11.593 l 3.149,-12.239 z"
+             style="fill:#b28e76;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13620" />
+        </g>
+        <g
+           id="g13622"
+           transform="translate(444.6328,294.9004)">
+          <path
+             d="M 0,0 13.263,-20.008 C 30.065,-7.961 47.111,6.977 61.432,19.357 l 1.389,11.911 z"
+             style="fill:#6dc9cd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13624" />
+        </g>
+        <g
+           id="g13626"
+           transform="translate(507.4541,326.1685)">
+          <path
+             d="M 0,0 -3.149,12.239 C -10.905,6.146 -18.054,2.011 -25.83,-2.068 -44.614,-12.122 -52.949,-16.987 -58.164,-19.485 l -4.657,-11.783 z"
+             style="fill:#abc38b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13628" />
+        </g>
+        <g
+           id="g13630"
+           transform="translate(449.29,306.6836)">
+          <path
+             d="m 0,0 c -3.591,-1.721 -5.704,-2.318 -8.728,-2.715 l 4.071,-9.068 z"
+             style="fill:#c8c46c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13632" />
+        </g>
+        <g
+           id="g13634"
+           transform="translate(418.6631,157.9316)">
+          <path
+             d="M 0,0 C 11.132,9.652 20.939,20.578 29.581,31.682 L 3.797,56.238 Z"
+             style="fill:#0097de;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13636" />
+        </g>
+        <g
+           id="g13638"
+           transform="translate(448.2441,189.6133)">
+          <path
+             d="m 0,0 c 0.379,0.486 0.757,0.973 1.131,1.459 3.886,5.062 3.449,6.111 5.46,8.9 1.073,1.479 5.215,4.541 3.137,11.524 -0.078,0.267 -0.748,2.26 -1.842,4.918 l -33.67,-2.244 z"
+             style="fill:#008dde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13640" />
+        </g>
+        <g
+           id="g13642"
+           transform="translate(456.1299,216.4141)">
+          <path
+             d="m 0,0 c -1.766,4.285 -4.641,10.299 -7.939,13.605 -4.687,4.918 -12.329,9.075 -18.967,8.778 L -33.67,-2.244 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13644" />
+        </g>
+        <g
+           id="g13646"
+           transform="translate(435.6045,262.0293)">
+          <path
+             d="m 0,0 c 4.052,1.113 5.959,3.859 6.686,4.307 3.06,2.017 6.854,2.531 9.904,4.576 1.894,1.283 3.797,2.613 5.701,3.98 L 9.028,32.871 Z"
+             style="fill:#169ee2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13648" />
+        </g>
+        <g
+           id="g13650"
+           transform="translate(344.5723,276.9902)">
+          <path
+             d="m 0,0 3.646,9.332 c 0,0.129 0,0.252 10e-4,0.383 1.077,13.767 0.874,7.99 4.692,20.359 0.224,0.184 0.498,0.332 0.634,0.604 7.217,13.488 5.145,10.521 9.594,16.842 l 21.942,56.157 c -0.112,0.141 -0.224,0.283 -0.339,0.42 -6.587,7.817 -12.498,9.928 -18.669,10.813 L -32.406,88.975 Z"
+             style="fill:#dae262;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13652" />
+        </g>
+        <g
+           id="g13654"
+           transform="translate(384.5479,85.0684)">
+          <path
+             d="m 0,0 c 0.72,0.219 1.31,0.449 1.722,0.67 9.897,5.273 7.686,12.971 7.195,24.621 -0.08,0.568 0.076,3.545 -1.021,3.701 -2.269,0.584 -2.601,2.041 -2.583,4.342 -0.311,4.213 0.387,2.619 -6.684,11.029 l -24.96,-12.48 z"
+             style="fill:#008ad9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13656" />
+        </g>
+        <g
+           id="g13658"
+           transform="translate(429.2236,238.7969)">
+          <path
+             d="m 0,0 c -0.978,-0.045 -1.934,-0.184 -2.855,-0.434 0,0 0.9,0.18 -21.882,-6.609 -0.606,-0.205 -1.431,-0.613 -2.411,-1.143 l 20.384,-16.441 z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13660" />
+        </g>
+        <g
+           id="g13662"
+           transform="translate(348.2188,274.0508)">
+          <path
+             d="M 0,0 C -0.009,1.127 -0.015,2.322 -0.017,3.59 L -3.646,2.939 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13664" />
+        </g>
+        <g
+           id="g13666"
+           transform="translate(394.0088,285.8398)">
+          <path
+             d="M 0,0 C 4.135,-3.971 8.962,-8.229 14.681,-12.848 28.211,-24.057 36.56,-25.195 41.596,-23.811 L 50.624,9.061 Z"
+             style="fill:#74e0e0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13668" />
+        </g>
+        <g
+           id="g13670"
+           transform="translate(364.4443,326.3667)">
+          <path
+             d="m 0,0 c 0.849,-0.372 1.78,-0.771 2.321,-1.565 0.775,-1.99 0.28,-4.357 1.614,-6.159 5.67,-9.397 11.731,-19.461 25.629,-32.803 l 50.624,9.061 -4.07,9.068 c -0.803,-0.103 -1.67,-0.195 -2.646,-0.289 -4.493,-0.166 -4.938,0.219 -8.271,3.572 -9.275,10.226 -14.161,26.168 -20.166,33.657 -2.34,3.004 -4.916,5.839 -6.899,9.101 -5.15,8.855 -7.877,19.108 -10.539,22.186 -1.212,1.427 -2.512,2.773 -3.717,4.206 -1.171,1.352 -2.13,2.869 -3.243,4.266 L -1.305,-1.856 C -0.922,-1.311 -0.49,-0.699 0,0"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13672" />
+        </g>
+        <g
+           id="g13674"
+           transform="translate(348.2021,277.6406)">
+          <path
+             d="M 0,0 C -0.006,2.57 0.001,5.447 0.016,8.682 L -3.63,-0.65 Z"
+             style="fill:#afdf7b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13676" />
+        </g>
+        <g
+           id="g13678"
+           transform="translate(326.9551,481.7827)">
+          <path
+             d="m 0,0 c -1.489,8.546 -3.643,17.625 -6.05,23.015 -4.362,9.577 -11.904,10.8 -17.282,15.756 -1.261,1.333 -2.633,2.275 -4.04,2.898 l 2.065,-68.797 z"
+             style="fill:#df2200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13680" />
+        </g>
+        <g
+           id="g13682"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 24.96,12.48 c -0.54,0.643 -1.124,1.342 -1.759,2.108 -0.691,0.85 -2.932,3.281 -2.155,4.496 3.416,2.367 5.94,-0.412 12.111,2.818 9.886,5.338 18.958,11.852 27.289,19.078 l 3.797,56.239 z"
+             style="fill:#009be2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13684" />
+        </g>
+        <g
+           id="g13686"
+           transform="translate(358.2168,116.9512)">
+          <path
+             d="m 0,0 64.243,97.219 -38.941,7.929 c -1.491,-0.529 -2.939,-1.154 -4.268,-2.031 -6.223,-4.517 -10.297,-2.685 -16.513,-3.756 -3.008,-0.422 -3.884,3.998 -5.599,11.16 l -58.901,11.997 z"
+             style="fill:#14b4ec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13688" />
+        </g>
+        <g
+           id="g13690"
+           transform="translate(327.0127,455.6626)">
+          <path
+             d="M 0,0 C 1.056,1.846 1.834,4.053 2.053,7.606 2.06,11.404 1.262,18.553 -0.058,26.12 L -25.364,-1.008 Z"
+             style="fill:#dc2b00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13692" />
+        </g>
+        <g
+           id="g13694"
+           transform="translate(320.665,444.6831)">
+          <path
+             d="M 0,0 C 2.002,5.78 4.568,7.867 6.348,10.979 L -19.017,9.972 Z"
+             style="fill:#df5e00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13696" />
+        </g>
+        <g
+           id="g13698"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 58.901,-11.996 c -0.567,2.369 -1.225,5.039 -2.084,7.934 -5.329,19.917 -6.67,17.406 -6.836,38.644 l -3.646,2.939 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13700" />
+        </g>
+        <g
+           id="g13702"
+           transform="translate(402.0752,230.6113)">
+          <path
+             d="m 0,0 c -3.558,-1.924 -9.174,-5.475 -13.905,-6.996 -1.537,-0.522 -3.117,-0.969 -4.652,-1.516 l 38.942,-7.929 z"
+             style="fill:#67d7ef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13704" />
+        </g>
+        <g
+           id="g13706"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="m 0,0 c 12.19,-3.049 8.91,-3.252 13.257,-5.043 5.149,-2.332 11.83,-1.578 15.342,-0.514 L 2.268,26.326 Z"
+             style="fill:#0074d4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13708" />
+        </g>
+        <g
+           id="g13710"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 53.907,25.935 C 45.898,27.082 37.452,26.165 26.52,32.973 16.573,38.858 5.767,41.569 5.446,51.589 5.408,65.657 6.734,73.622 8.499,78.718 l -19.017,9.971 z"
+             style="fill:#e88200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13712" />
+        </g>
+        <g
+           id="g13714"
+           transform="translate(312.166,365.9653)">
+          <path
+             d="M 0,0 -42.923,-65.096 32.406,-88.975 Z"
+             style="fill:#dcf07c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13716" />
+        </g>
+        <g
+           id="g13718"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="M 0,0 133.035,-21.604 73.056,100.914 Z"
+             style="fill:#31bded;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13720" />
+        </g>
+        <g
+           id="g13722"
+           transform="translate(355.9492,90.625)">
+          <path
+             d="M 0,0 2.268,26.326 -20.757,6.762 c 8,-2.766 15.308,-5.459 19.29,-6.401 C -0.953,0.236 -0.467,0.115 0,0"
+             style="fill:#0069d5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13724" />
+        </g>
+        <g
+           id="g13726"
+           transform="translate(225.1816,138.5547)">
+          <path
+             d="m 0,0 8.559,-58.115 c 4.263,0.603 8.996,1.705 14.864,4.004 5.525,2.033 11.453,2.527 17.073,4.213 6.626,2.05 12.966,4.882 19.431,7.369 15.21,6.023 17.269,9.484 22.973,8.716 7.048,-0.658 17.572,-4.058 27.111,-7.355 l 23.024,19.564 z"
+             style="fill:#0181dd;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13728" />
+        </g>
+        <g
+           id="g13730"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="M 0,0 9.096,-44.914 82.152,56 Z"
+             style="fill:#8bebdb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13732" />
+        </g>
+        <g
+           id="g13734"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="M 0,0 -36.386,-71.918 10.518,-88.689 Z"
+             style="fill:#f38900;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13736" />
+        </g>
+        <g
+           id="g13738"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="M 0,0 28.995,-61.4 75.33,-23.879 Z"
+             style="fill:#b7f3bb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13740" />
+        </g>
+        <g
+           id="g13742"
+           transform="translate(265.4712,515.9917)">
+          <path
+             d="m 0,0 c -5.74,-5.332 -5.494,-13.276 -7.929,-20.031 -2.488,-6.871 -0.271,-14.435 -3.022,-21.654 -0.332,-0.95 -1.548,-2.81 -1.973,-5.643 l 0.931,-7.638 c 0.022,-0.059 0.041,-0.118 0.064,-0.179 1.682,-4.462 3.688,-6.111 5.816,-8.281 L 14.817,4.458 C 9.663,4.323 5.518,5.767 0,0"
+             style="fill:#ef3500;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13744" />
+        </g>
+        <g
+           id="g13746"
+           transform="translate(299.583,523.4517)">
+          <path
+             d="m 0,0 c -3.692,1.637 -7.625,1.069 -10.417,-0.463 -3.42,-2.001 -6.277,-2.471 -8.877,-2.539 l -20.931,-67.884 c 1.127,-1.148 2.288,-2.443 3.454,-4.38 0.842,-1.365 1.515,-2.792 2.068,-4.264 l 36.768,10.733 z"
+             style="fill:#f43800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13748" />
+        </g>
+        <g
+           id="g13750"
+           transform="translate(301.6484,454.6548)">
+          <path
+             d="m 0,0 -36.768,-10.733 c 1.894,-5.034 2.391,-10.602 3.426,-16.089 0.347,-1.888 0.184,-3.81 0.224,-5.716 -0.475,-7.014 1.782,-11.357 -6.969,-16.273 l 3.701,-23.107 z"
+             style="fill:#f77700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13752" />
+        </g>
+        <g
+           id="g13754"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 3.98,-81.868 42.923,65.097 z"
+             style="fill:#f2da4a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13756" />
+        </g>
+        <g
+           id="g13758"
+           transform="translate(253.478,461.0259)">
+          <path
+             d="M 0,0 -0.931,7.638 C -1.237,5.602 -1.132,3.064 0,0"
+             style="fill:#fb6100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13760" />
+        </g>
+        <g
+           id="g13762"
+           transform="translate(269.2427,300.8691)">
+          <path
+             d="m 0,0 -34.43,-11.291 c 4.375,-19.814 1.914,-25.602 0.369,-32.424 L 28.995,-61.4 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13764" />
+        </g>
+        <g
+           id="g13766"
+           transform="translate(183.2183,271.7305)">
+          <path
+             d="M 0,0 C 0.559,0.451 1.134,0.947 1.728,1.496 L -1.529,0.428 Z"
+             style="fill:#d8f890;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13768" />
+        </g>
+        <g
+           id="g13770"
+           transform="translate(298.2373,239.4687)">
+          <path
+             d="m 0,0 -63.056,17.686 c -0.217,-0.959 -0.416,-1.94 -0.575,-2.981 -4.827,-28.373 -3.895,-27.422 -7.923,-36.496 -0.886,-2.527 -4.431,-1.537 -17.768,3.27 -4.097,1.519 -6.828,2.607 -8.685,3.404 L -82.152,-56 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13772" />
+        </g>
+        <g
+           id="g13774"
+           transform="translate(182.1704,270.9199)">
+          <path
+             d="M 0,0 C 0.343,0.254 0.692,0.523 1.048,0.811 L -0.481,1.238 Z"
+             style="fill:#c5f5c1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13776" />
+        </g>
+        <g
+           id="g13778"
+           transform="translate(178.2236,77.3145)">
+          <path
+             d="m 0,0 c 1.748,-0.338 3.177,-0.359 3.87,-0.437 9.577,-0.79 19.166,-1.26 28.525,0.898 C 41.31,2.6 47.604,2.004 55.517,3.125 L 46.958,61.24 Z"
+             style="fill:#6cb0c4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13780" />
+        </g>
+        <g
+           id="g13782"
+           transform="translate(212.9209,392.1343)">
+          <path
+             d="m 0,0 c -7.358,-3.378 -11.848,-9.501 -15.415,-12.913 -3.459,-3.684 -2.798,-1.984 -5.258,-8.591 -1.752,-4.541 -4.212,-8.777 -5.869,-13.361 -0.621,-1.584 -0.969,-3.253 -1.559,-4.849 -3.336,-9.049 -11.784,-15.183 -16.209,-23.89 -10e-4,-10e-4 -0.003,-0.004 -0.004,-0.007 l 13.083,-56.365 36.298,48.028 c 0.446,1.161 0.907,2.314 1.402,3.45 0.192,0.404 0.393,1.573 2.82,2.136 l 43.053,56.964 z"
+             style="fill:#ffd100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13784" />
+        </g>
+        <g
+           id="g13786"
+           transform="translate(184.9458,273.2266)">
+          <path
+             d="m 0,0 c 2.113,1.949 4.474,4.564 7.256,8.246 6.137,7.947 13.187,15.176 18.881,23.467 3.187,4.646 4.897,10.023 6.905,15.246 L -3.256,-1.068 Z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13788" />
+        </g>
+        <g
+           id="g13790"
+           transform="translate(265.2627,382.7368)">
+          <path
+             d="m 0,0 -43.053,-56.965 c 0.032,0.007 0.059,0.016 0.092,0.023 1.473,-2.116 3.247,-4.095 4.089,-6.579 4.089,-12.477 6.753,-22.079 8.422,-29.638 l 34.43,11.291 z"
+             style="fill:#f9ed2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13792" />
+        </g>
+        <g
+           id="g13794"
+           transform="translate(261.561,405.8433)">
+          <path
+             d="m 0,0 c -2.75,-1.545 -6.583,-3.145 -11.933,-4.904 -20.513,-6.807 -23.499,-5.765 -29.432,-6.675 -2.707,-0.38 -5.114,-1.138 -7.275,-2.13 l 52.342,-9.398 z"
+             style="fill:#fd9d00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13796" />
+        </g>
+        <g
+           id="g13798"
+           transform="translate(216.0854,183.4687)">
+          <path
+             d="m 0,0 -15.855,40.883 c -9.291,3.988 3.366,0.662 -22.866,7.346 L -43.208,6.254 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13800" />
+        </g>
+        <g
+           id="g13802"
+           transform="translate(181.5063,270.4414)">
+          <path
+             d="M 0,0 C 0.219,0.152 0.44,0.312 0.664,0.478 L 0.183,1.717 Z"
+             style="fill:#cbf387;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13804" />
+        </g>
+        <g
+           id="g13806"
+           transform="translate(208.02,135.877)">
+          <path
+             d="M 0,0 C 3.134,-1.705 5.926,-3.359 7.395,-4.527 6.783,-5.061 6.337,-5.752 5.719,-6.275 c -1.337,-1.192 -23.474,-3.84 -24.076,-4.055 -4.022,-1.281 -13.359,-10.352 -15.739,-14.982 -1.006,-1.821 -1.362,-3.893 -2.164,-5.792 -2.845,-7.011 -8.646,-14.029 -2.605,-21.931 2.726,-3.654 6.299,-4.99 9.069,-5.528 L 17.162,2.678 Z"
+             style="fill:#8bcfa3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13808" />
+        </g>
+        <g
+           id="g13810"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="M 0,0 52.304,-51.168 43.208,-6.254 Z"
+             style="fill:#96eaa2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13812" />
+        </g>
+        <g
+           id="g13814"
+           transform="translate(172.8774,189.7227)">
+          <path
+             d="m 0,0 -7.637,-31.27 c 3.667,-2.658 6.324,-4.375 7.192,-4.82 7.389,-3.402 14.389,-7.594 21.821,-10.904 2.728,-1.201 8.696,-4.094 13.767,-6.852 l 17.161,2.678 z"
+             style="fill:#9ae292;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13816" />
+        </g>
+        <g
+           id="g13818"
+           transform="translate(168.6074,328.5229)">
+          <path
+             d="m 0,0 c -11.738,-23.529 -11.302,-31.66 -21.896,-24.757 -18.937,10.683 -32.469,18.709 -42.418,25.002 l -12.992,-20.584 c 4.429,-4.291 9.657,-9.283 15.89,-15.086 l 74.498,-20.94 z"
+             style="fill:#ffce00;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13820" />
+        </g>
+        <g
+           id="g13822"
+           transform="translate(137.1387,234.541)">
+          <path
+             d="m 0,0 c -1.537,-1.059 -2.47,-2.176 -3.458,-3.123 -10.068,-10.852 -9.165,-13.883 -9.26,-23.637 0.043,-3.965 0.834,-8.011 2.866,-11.465 1.019,-1.714 2.16,-3.427 3.393,-5.127 l 42.198,-1.466 z"
+             style="fill:#f0d03c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13824" />
+        </g>
+        <g
+           id="g13826"
+           transform="translate(107.1909,293.0977)">
+          <path
+             d="m 0,0 c 7.815,-7.275 17.21,-15.828 28.605,-25.885 9.381,-8.099 9.154,-10.064 19.65,-9.246 3.198,0.342 7.985,1.262 10.469,3.293 6.432,5.234 10.463,5.602 15.591,9.182 l 0.184,1.717 z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13828" />
+        </g>
+        <g
+           id="g13830"
+           transform="translate(177.3643,231.6973)">
+          <path
+             d="M 0,0 C -1.25,0.318 -2.586,0.66 -4.019,1.025 -4.932,1.332 -5.602,2.145 -6.576,2.311 -14.828,4.234 -20.919,7.525 -29.362,6.232 -35.081,5.557 -38.186,4.25 -40.226,2.844 L -4.487,-41.975 Z"
+             style="fill:#f6e63a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13832" />
+        </g>
+        <g
+           id="g13834"
+           transform="translate(130.6802,191.1895)">
+          <path
+             d="m 0,0 c 9.73,-13.412 25.341,-26.055 34.56,-32.736 l 7.637,31.269 z"
+             style="fill:#c7df6f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13836" />
+        </g>
+        <g
+           id="g13838"
+           transform="translate(56.7227,368.0815)">
+          <path
+             d="m 0,0 c -4.445,3.398 -7.547,6.24 -9.778,8.602 l -14.208,-3.612 4.815,-6.731 c 0.309,1.335 0.768,2.766 1.413,4.3 8.121,-3.178 6.81,-9.274 5.773,-14.345 L 3.873,-33.953 c 6.915,-1.379 10.594,-6.458 30.706,-25.945 l 12.992,20.585 C 14.247,-18.236 21.153,-16.635 0,0"
+             style="fill:#feb200;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13840" />
+        </g>
+        <g
+           id="g13842"
+           transform="translate(46.9448,376.6831)">
+          <path
+             d="M 0,0 C -6,6.35 -5.693,9.213 -8.216,10.023 L -14.209,-3.611 Z"
+             style="fill:#fe9400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13844" />
+        </g>
+        <g
+           id="g13846"
+           transform="translate(44.2983,353.9419)">
+          <path
+             d="M 0,0 C -4.392,-0.536 -8.714,3.901 -6.747,12.398 L -11.562,19.13 -21.876,4.264 c 0.042,-0.755 0.105,-1.526 0.151,-2.371 0.043,-1.914 -1.115,-3.187 -3.419,-2.41 -0.012,0.005 -0.024,0.011 -0.038,0.016 l -9.97,-14.371 c 3.016,-2.116 5.047,-1.11 7.693,-1.097 11.549,-0.04 11.379,0.704 12.926,-0.741 4.452,-3.88 12.301,-1.605 19.468,-2.537 5.205,-0.057 8.551,-0.006 11.362,-0.567 L 0.439,2.354 C 0.272,1.537 0.112,0.747 0,0"
+             style="fill:#ffa300;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13848" />
+        </g>
+        <g
+           id="g13850"
+           transform="translate(38.729,386.7065)">
+          <path
+             d="M 0,0 C -0.873,0.28 -2.083,0.315 -4.011,0.164 -5.262,0.213 -7.534,0.788 -8.336,-1.61 -9.564,-5.017 -8.434,-5.657 -9.828,-9.336 l 3.835,-4.299 z"
+             style="fill:#fd7700;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13852" />
+        </g>
+        <g
+           id="g13854"
+           transform="translate(3.2769,370.0132)">
+          <path
+             d="m 0,0 -3.018,-0.312 c -1.925,-10.076 7.434,-14.539 9.35,-23.095 -1.796,-0.753 -3.579,-1.54 -5.381,-2.269 1.949,-2.675 3.537,-4.299 4.918,-5.267 l 9.97,14.371 C 8.256,-13.681 5.736,-8.311 0,0"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13856" />
+        </g>
+        <g
+           id="g13858"
+           transform="translate(26.4971,372.4243)">
+          <path
+             d="M 0,0 C -4.024,-7.823 -4.262,-10.867 -4.075,-14.219 L 6.239,0.648 Z"
+             style="fill:#ff8800;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13860" />
+        </g>
+        <g
+           id="g13862"
+           transform="translate(28.9014,377.3706)">
+          <path
+             d="M 0,0 C -0.405,-1.069 -1.022,-2.393 -1.974,-4.117 -2.123,-4.4 -2.265,-4.676 -2.404,-4.946 l 6.239,0.647 z"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13864" />
+        </g>
+        <g
+           id="g13866"
+           transform="translate(1.2061,372.9331)">
+          <path
+             d="M 0,0 C -0.444,-1.142 -0.752,-2.216 -0.947,-3.232 L 2.071,-2.92 C 1.424,-1.983 0.74,-1.012 0,0"
+             style="fill:#fd7400;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path13868" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -27,8 +27,12 @@ export const config: Config = {
                 { src: 'style/color-palette-extended-light-mode-only.css' },
                 { src: 'style/color-palette-extended.css' },
                 {
-                    src: '../node_modules/@lundalogik/lime-icons8/assets/',
-                    dest: 'assets/',
+                    /*
+                     * Public domain svg files that can be used in tests
+                     * https://freesvg.org/yoga-exercise-low-poly-silhouette
+                     */
+                    src: 'icons/',
+                    dest: 'assets/icons/',
                 },
                 {
                     src: '../node_modules/kompendium/dist/',


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
