### PR TITLE
revert: "fix(badge): make all number units upper case"

### DIFF
--- a/src/components/badge/badge.spec.ts
+++ b/src/components/badge/badge.spec.ts
@@ -6,11 +6,11 @@ describe('limel-badge', () => {
     });
 
     it('Badge: returns 10k (4 digits)', () => {
-        expect(abbreviate(9960)).toBe('10K');
+        expect(abbreviate(9960)).toBe('10k');
     });
 
     it('Badge: returns 99.9k (5 digits), not round up to 100k', () => {
-        expect(abbreviate(99940)).toBe('99.9K');
+        expect(abbreviate(99940)).toBe('99.9k');
     });
 
     it('Badge: returns 1M (6 digits)', () => {

--- a/src/components/badge/examples/badge-number.tsx
+++ b/src/components/badge/examples/badge-number.tsx
@@ -5,7 +5,7 @@ import { Component, h } from '@stencil/core';
  *
  * Numeric labels larger than 999 will get both rounded and abbreviated.
  * For example, if the label is `1090` the badge will display `1.1K`.
- * Abbreviation units used are `K` (Kilo) that stands for Thousands,
+ * Abbreviation units used are `k` (Kilo) that stands for Thousands,
  * `M` for Millions, `B` for Billions, and `T` for Trillions.
  *
  * When users hover the abbreviated badge, the complete

--- a/src/components/badge/format.ts
+++ b/src/components/badge/format.ts
@@ -11,7 +11,7 @@ export function abbreviate(value: number): string {
         return '';
     }
 
-    const units = ['K', 'M', 'B', 'T'];
+    const units = ['k', 'M', 'B', 'T'];
     const numAbbr = new NumAbbr(units);
 
     return numAbbr.abbreviate(value, 1);


### PR DESCRIPTION
This reverts commit b8ed94897c3fa228d9243c8252b870d0f6a64c17.

`k` means "kilo", which is what we want. `K` means "Kelvin".

We should use the correct unit even if some of our users are unaware of the difference, because it matters to those who _are_ aware of the difference, but not to those who aren't.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
