### PR TITLE
fix(popover): resolve z-index issues by using css `isolation`

### DIFF
--- a/src/components/popover-surface/popover-surface.scss
+++ b/src/components/popover-surface/popover-surface.scss
@@ -1,6 +1,9 @@
-@use '../../style/internal/z-index';
 @use '../../style/functions';
 @use '../../style/mixins';
+
+:host(limel-popover-surface) {
+    isolation: isolate;
+}
 
 .limel-popover-surface {
     position: relative;
@@ -30,7 +33,7 @@
         right: 0;
         bottom: 0;
         left: 0;
-        z-index: z-index.$popover-before;
+        z-index: -1;
 
         opacity: 0.75;
 

--- a/src/style/internal/z-index.scss
+++ b/src/style/internal/z-index.scss
@@ -8,6 +8,5 @@ $input-field--mdc-text-field__input--readonly: 1 !default;
 $tab-bar--active-tab: 2 !default;
 $table--has-interactive-rows--selectable-row--hover: 2 !default;
 $table--limel-table--row-selector: 1 !default;
-$popover-before: -1 !default;
 $button-group-radio-button-keyboard-focused: 1 !default;
 $limel-circular-progress-value: 1 !default;


### PR DESCRIPTION
fix: Lundalogik/lime-elements#1864

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
