### PR TITLE
feat(tab): allow string labels in badge

### DIFF
--- a/src/components/tab-bar/examples/tab-bar.tsx
+++ b/src/components/tab-bar/examples/tab-bar.tsx
@@ -60,6 +60,11 @@ export class TabBarExample {
             iconColor: 'var(--lime-deep-red)',
             badge: 4,
         },
+        {
+            id: 8,
+            text: 'Inception',
+            badge: 'NEW',
+        },
     ];
 
     public render() {

--- a/src/components/tab-bar/tab.types.ts
+++ b/src/components/tab-bar/tab.types.ts
@@ -27,5 +27,5 @@ export interface Tab {
     /**
      * Shows a badge within the tab with a specified label
      */
-    badge?: number;
+    badge?: number | string;
 }


### PR DESCRIPTION
We added the possibility to have string labels in badges in this release: https://github.com/Lundalogik/lime-elements/releases/tag/v36.1.0-next.1
However, it is not possible to use it in tabs because we didn't update the Tab interface.

Use case: 
![Skärmavbild 2022-10-13 kl  15 51 41](https://user-images.githubusercontent.com/21986391/195615719-b31d8e9d-c8ff-44e4-aadf-054030b96a68.png)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
