### PR TITLE
fix(input-field): fix big prefix overlaps with value

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -90,24 +90,18 @@
 }
 
 .lime-formatted-input {
+    display: none;
     width: calc(100% - #{functions.pxToRem(20)});
     z-index: z-index.$input-field--formatted-value;
 
-    position: absolute;
-    top: 0.9rem;
     pointer-events: none;
 
-    opacity: 0;
     :not(.mdc-text-field--focused):not(.mdc-text-field--invalid) & {
-        opacity: 1;
+        display: block;
     }
 
     + .mdc-text-field__input {
         z-index: z-index.$input-field--input-with-formatted-value;
-    }
-
-    .lime-has-prefix & {
-        margin-left: functions.pxToRem(10);
     }
 }
 

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -305,10 +305,10 @@ export class InputField {
                 {this.renderLeadingIcon()}
                 {this.renderEmptyValueForReadonly()}
                 {this.renderPrefix()}
+                {this.renderFormattedNumber()}
                 {this.renderInput(properties)}
                 {this.renderSuffix()}
                 {this.renderTextarea(properties)}
-                {this.renderFormattedNumber()}
                 {this.renderTrailingLinkOrButton()}
             </label>,
             this.renderHelperLine(),


### PR DESCRIPTION
In input field, prefix overlaps with the input value for type number

fix: #1870

<img width="419" alt="Screenshot 2022-10-18 at 12 04 22 AM" src="https://user-images.githubusercontent.com/41188167/196261958-82f4d0b8-5959-4fb4-8894-90ff128bbe9a.png">
