### PR TITLE
fix(input-field): align `-` when the textarea is empty and readonly

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -77,8 +77,10 @@
 }
 
 .lime-empty-value-for-readonly {
-    width: calc(100% - #{functions.pxToRem(20)});
     z-index: z-index.$input-field--formatted-value;
+    position: absolute;
+    top: 0.875rem; // 14px
+    left: 1rem;
 }
 
 .lime-looks-like-input-value {

--- a/src/components/input-field/partial-styles/_readonly.scss
+++ b/src/components/input-field/partial-styles/_readonly.scss
@@ -29,3 +29,13 @@
         }
     }
 }
+
+:host([type='textarea']) {
+    .mdc-text-field {
+        &.lime-text-field--readonly {
+            .mdc-text-field__resizer {
+                pointer-events: all; //allows resize
+            }
+        }
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1883

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
