### PR TITLE
chore(deps-dev): bump codemirror from 5.65.3 to 5.65.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@typescript-eslint/parser": "^5.40.1",
         "ajv": "^6.12.6",
         "awesome-debounce-promise": "^2.1.0",
-        "codemirror": "^5.65.3",
+        "codemirror": "^5.65.9",
         "cross-env": "^7.0.3",
         "cz-conventional-changelog": "^3.3.0",
         "dayjs": "^1.11.1",
@@ -4463,9 +4463,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.65.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.3.tgz",
-      "integrity": "sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ==",
+      "version": "5.65.9",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.9.tgz",
+      "integrity": "sha512-19Jox5sAKpusTDgqgKB5dawPpQcY+ipQK7xoEI+MVucEF9qqFaXpeqY1KaoyGBso/wHQoDa4HMMxMjdsS3Zzzw==",
       "dev": true
     },
     "node_modules/collapse-white-space": {
@@ -18771,9 +18771,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.65.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.3.tgz",
-      "integrity": "sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ==",
+      "version": "5.65.9",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.9.tgz",
+      "integrity": "sha512-19Jox5sAKpusTDgqgKB5dawPpQcY+ipQK7xoEI+MVucEF9qqFaXpeqY1KaoyGBso/wHQoDa4HMMxMjdsS3Zzzw==",
       "dev": true
     },
     "collapse-white-space": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@typescript-eslint/parser": "^5.40.1",
     "ajv": "^6.12.6",
     "awesome-debounce-promise": "^2.1.0",
-    "codemirror": "^5.65.3",
+    "codemirror": "^5.65.9",
     "cross-env": "^7.0.3",
     "cz-conventional-changelog": "^3.3.0",
     "dayjs": "^1.11.1",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
