### PR TITLE
feat(dashboard-shortcut): add `limel-dashboard-shortcut` component

### DIFF
--- a/src/components/shortcut/examples/shortcut-notification.scss
+++ b/src/components/shortcut/examples/shortcut-notification.scss
@@ -1,0 +1,7 @@
+:host(limel-example-shortcut-notification) {
+    display: grid;
+    grid-template-columns: repeat(3, 5rem);
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+}

--- a/src/components/shortcut/examples/shortcut-notification.tsx
+++ b/src/components/shortcut/examples/shortcut-notification.tsx
@@ -1,0 +1,35 @@
+import { Component, h } from '@stencil/core';
+/**
+ * Displaying a notification badge
+ *
+ * The component can display a notification badge, which could either be
+ * a `number` or a `string`. Read more about how the badge truncates
+ * or abbreviates the provided label [here](#/component/limel-badge/).
+ *
+ */
+@Component({
+    tag: 'limel-example-shortcut-notification',
+    shadow: true,
+    styleUrl: 'shortcut-notification.scss',
+})
+export class ShortcutNotificationExample {
+    private label1: number = 9951;
+    private label2: string = 'NEW';
+    private label3: string = '';
+
+    public render() {
+        return [
+            <limel-shortcut
+                icon="visual_studio"
+                label="Visual Studio Code"
+                badge={this.label1}
+            />,
+            <limel-shortcut
+                icon="skype_copyrighted"
+                label="Skype"
+                badge={this.label2}
+            />,
+            <limel-shortcut icon="slack" label="Slack" badge={this.label3} />,
+        ];
+    }
+}

--- a/src/components/shortcut/examples/shortcut-styling.scss
+++ b/src/components/shortcut/examples/shortcut-styling.scss
@@ -1,0 +1,29 @@
+:host(limel-example-shortcut-styling) {
+    display: grid;
+    grid-template-columns: repeat(3, 7rem);
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+}
+
+limel-shortcut {
+    --shortcut-border-radius: 0.5rem;
+
+    &:nth-of-type(1) {
+        --shortcut-icon-color: rgb(var(--color-blue-dark));
+        --shortcut-label-color: rgb(var(--color-blue-darker));
+        --shortcut-background-color: rgb(var(--color-white));
+    }
+
+    &:nth-of-type(2) {
+        --shortcut-icon-color: rgb(var(--color-white));
+        --shortcut-background-color: rgb(var(--color-blue-default));
+        --shortcut-badge-text-color: rgb(var(--contrast-200));
+        --shortcut-badge-background-color: rgb(var(--contrast-1300));
+    }
+
+    &:nth-of-type(3) {
+        --shortcut-icon-color: rgb(var(--color-cyan-lighter));
+        --shortcut-background-color: rgb(var(--color-pink-default));
+    }
+}

--- a/src/components/shortcut/examples/shortcut-styling.tsx
+++ b/src/components/shortcut/examples/shortcut-styling.tsx
@@ -1,0 +1,30 @@
+import { Component, h } from '@stencil/core';
+/**
+ * How to style the shortcut
+ *
+ * The component offers different CSS variables for styling
+ * the color of the shortcut, and it's icon; as well as
+ * radius of it's rounded corners, and colors of the notification badge
+ * and its text.
+ */
+@Component({
+    tag: 'limel-example-shortcut-styling',
+    shadow: true,
+    styleUrl: 'shortcut-styling.scss',
+})
+export class ShortcutStylingExample {
+    private label1: number = 9951;
+    private label2: string = '⚠️';
+
+    public render() {
+        return [
+            <limel-shortcut icon="visual_studio" label="Visual Studio Code" />,
+            <limel-shortcut
+                icon="skype_copyrighted"
+                label="Skype"
+                badge={this.label1}
+            />,
+            <limel-shortcut icon="slack" label="Slack" badge={this.label2} />,
+        ];
+    }
+}

--- a/src/components/shortcut/examples/shortcut-with-click-handler.tsx
+++ b/src/components/shortcut/examples/shortcut-with-click-handler.tsx
@@ -1,0 +1,33 @@
+import { Component, h } from '@stencil/core';
+/**
+ * Example with click handler
+ */
+@Component({
+    tag: 'limel-example-shortcut-with-click-handler',
+    shadow: true,
+    styleUrl: 'shortcut.scss',
+})
+export class ShortcutWithClickHandlerExample {
+    public render() {
+        return (
+            <limel-shortcut
+                icon="pivot_table"
+                label="limel-table"
+                linkTitle="Open the documentation for limel-table"
+                href="#/component/limel-table"
+                onClick={this.handleClick}
+            />
+        );
+    }
+
+    private handleClick = (event: PointerEvent) => {
+        if (
+            !(event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
+        ) {
+            event.preventDefault();
+            alert(
+                "No modifier key pressed. Link should open in current window, but we might want to handle the navigation with our application's router, to avoid reloading the whole application (if we're in a single page app, like Lime CRM Web Client).\n\nTry holding down a modifier key, like Shift, while clicking."
+            );
+        }
+    };
+}

--- a/src/components/shortcut/examples/shortcut.scss
+++ b/src/components/shortcut/examples/shortcut.scss
@@ -1,0 +1,3 @@
+limel-shortcut {
+    width: 20%;
+}

--- a/src/components/shortcut/examples/shortcut.tsx
+++ b/src/components/shortcut/examples/shortcut.tsx
@@ -1,0 +1,22 @@
+import { Component, h } from '@stencil/core';
+/**
+ * Basic example
+ */
+@Component({
+    tag: 'limel-example-shortcut',
+    shadow: true,
+    styleUrl: 'shortcut.scss',
+})
+export class ShortcutExample {
+    public render() {
+        return (
+            <limel-shortcut
+                icon="wikipedia"
+                label="Wikipedia"
+                linkTitle="Open Wikipedia's website in a new tab."
+                href="https://www.wikipedia.org/"
+                target="_blank"
+            />
+        );
+    }
+}

--- a/src/components/shortcut/shortcut.e2e.ts
+++ b/src/components/shortcut/shortcut.e2e.ts
@@ -1,0 +1,145 @@
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('limel-shortcut', () => {
+    let page: E2EPage;
+    let limelShortcut: E2EElement;
+    let link: E2EElement;
+    let label: E2EElement;
+    let badge: E2EElement;
+
+    describe('with a label', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-shortcut label="iSpiffy"></limel-shortcut>
+            `);
+            limelShortcut = await page.find('limel-shortcut');
+            link = await page.find('limel-shortcut >>> a');
+            label = await page.find('limel-shortcut >>> span');
+        });
+        it('displays the correct label', () => {
+            expect(label).toEqualText('iSpiffy');
+        });
+        it('includes the label in `aria-label`', () => {
+            expect(link).toEqualAttribute('aria-label', 'iSpiffy');
+        });
+
+        describe('when changing the label', () => {
+            beforeEach(async () => {
+                limelShortcut.setProperty('label', 'imTired');
+                await page.waitForChanges();
+            });
+            it('displays the new label', async () => {
+                expect(label).toEqualText('imTired');
+            });
+            it('updates `aria-label`', () => {
+                expect(link).toEqualAttribute('aria-label', 'imTired');
+            });
+        });
+    });
+
+    describe('with `linkTitle`', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-shortcut link-title="Open the iSpiffy app"></limel-shortcut>
+            `);
+            limelShortcut = await page.find('limel-shortcut');
+            link = await page.find('limel-shortcut >>> a');
+            label = await page.find('limel-shortcut >>> span');
+        });
+        it('sets the `title` attribute on the link', () => {
+            expect(link).toEqualAttribute('title', 'Open the iSpiffy app');
+        });
+        it('includes the label in `aria-label`', () => {
+            expect(link).toEqualAttribute('aria-label', 'Open the iSpiffy app');
+        });
+
+        describe('when changing the `linkTitle`', () => {
+            beforeEach(async () => {
+                limelShortcut.setProperty('linkTitle', 'I need a cup of tea');
+                await page.waitForChanges();
+            });
+            it('uses the new title', async () => {
+                expect(link).toEqualAttribute('title', 'I need a cup of tea');
+            });
+            it('updates `aria-label`', () => {
+                expect(link).toEqualAttribute(
+                    'aria-label',
+                    'I need a cup of tea'
+                );
+            });
+        });
+    });
+
+    describe('with a label and a linkTitle', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-shortcut label="iSpiffy" link-title="Open the iSpiffy app"></limel-shortcut>
+            `);
+            limelShortcut = await page.find('limel-shortcut');
+            link = await page.find('limel-shortcut >>> a');
+            label = await page.find('limel-shortcut >>> span');
+        });
+        it('displays the correct label', () => {
+            expect(label).toEqualText('iSpiffy');
+        });
+        it('uses both the label and the linkTitle to construct the `aria-label`', () => {
+            expect(link).toEqualAttribute(
+                'aria-label',
+                'iSpiffy. Open the iSpiffy app'
+            );
+        });
+
+        describe('when changing the label', () => {
+            beforeEach(async () => {
+                limelShortcut.setProperty('label', 'imTired');
+                await page.waitForChanges();
+            });
+            it('updates `aria-label`', () => {
+                expect(link).toEqualAttribute(
+                    'aria-label',
+                    'imTired. Open the iSpiffy app'
+                );
+            });
+        });
+
+        describe('when changing the linkTitle', () => {
+            beforeEach(async () => {
+                limelShortcut.setProperty('linkTitle', 'I need a cup of tea');
+                await page.waitForChanges();
+            });
+            it('updates `aria-label`', () => {
+                expect(link).toEqualAttribute(
+                    'aria-label',
+                    'iSpiffy. I need a cup of tea'
+                );
+            });
+        });
+    });
+
+    describe('with a value for badge', () => {
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-shortcut badge="NEW"></limel-shortcut>
+            `);
+            limelShortcut = await page.find('limel-shortcut');
+            badge = await page.find('limel-shortcut >>> limel-badge');
+        });
+        it('displays a badge with the correct value', () => {
+            expect(badge).toEqualAttribute('label', 'NEW');
+        });
+
+        describe('when changing the badge value', () => {
+            beforeEach(async () => {
+                limelShortcut.setProperty('badge', '3');
+                await page.waitForChanges();
+            });
+            it('displays the new badge value', async () => {
+                expect(badge).toEqualAttribute('label', '3');
+            });
+        });
+    });
+});
+
+async function createPage(content) {
+    return newE2EPage({ html: content });
+}

--- a/src/components/shortcut/shortcut.scss
+++ b/src/components/shortcut/shortcut.scss
@@ -1,0 +1,80 @@
+/**
+* @prop --shortcut-border-radius: defines the radius of corners of the shortcut. Defaults to `1rem`
+* @prop --shortcut-icon-color: defines the fill color of the shortcut icon. Defaults to `--contrast-1000`
+* @prop --shortcut-label-color: defines the color of the shortcut label. Defaults to `--contrast-1100`
+* @prop --shortcut-background-color: defines the backgrounds color of the shortcut icon. Defaults to `--contrast-100`
+* @prop --shortcut-badge-text-color: Text color of the notification badge. Defaults to `--color-white`
+* @prop --shortcut-badge-background-color: Background color of the notification badge. Defaults to `--color-red-default`
+*/
+
+@use '../../style/mixins';
+
+:host(limel-shortcut) {
+    --badge-text-color: var(
+        --shortcut-badge-text-color,
+        rgb(var(--color-white))
+    );
+    --badge-background-color: var(
+        --shortcut-badge-background-color,
+        rgb(var(--color-red-default))
+    );
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    row-gap: 0.0625rem; //1px
+
+    * {
+        box-sizing: border-box;
+    }
+}
+
+:host(limel-shortcut[disabled]) {
+    a {
+        opacity: 0.5;
+        box-shadow: unset;
+        cursor: not-allowed;
+    }
+}
+
+a {
+    all: unset;
+    @include mixins.is-elevated-clickable;
+    @include mixins.visualize-keyboard-focus;
+    cursor: pointer;
+    text-align: center;
+
+    height: calc(100% - 1rem);
+    width: calc(100% - 1rem);
+    padding: 0.5rem;
+
+    border-radius: var(--shortcut-border-radius, 1rem);
+    background-color: var(
+        --shortcut-background-color,
+        rgb(var(--contrast-100))
+    );
+}
+
+limel-icon {
+    display: flex;
+    height: 100%;
+    width: 100%;
+    justify-content: center;
+    color: var(--shortcut-icon-color, rgb(var(--contrast-1000)));
+    border-radius: var(--shortcut-border-radius, 1rem);
+}
+
+span {
+    @include mixins.truncate-text;
+    width: 100%;
+    color: var(--shortcut-label-color, rgb(var(--contrast-1100)));
+    font-size: 0.75rem;
+    text-align: center;
+}
+
+limel-badge {
+    position: absolute;
+    top: -0.5rem;
+    right: 0;
+}

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -1,0 +1,119 @@
+import { Component, Prop, h } from '@stencil/core';
+
+/**
+ * This component can be used on places such as a start page or a dashboard.
+ * Clicking on the component should navigate the user to a new screen,
+ * to which you need to provide a URL, using the `href` property.
+ *
+ * By default, this navigation will happen within the same browser tab.
+ * However, it is possible to override that behavior, using the `target` property.
+ *
+ * @exampleComponent limel-example-shortcut
+ * @exampleComponent limel-example-shortcut-notification
+ * @exampleComponent limel-example-shortcut-styling
+ * @exampleComponent limel-example-shortcut-with-click-handler
+ */
+
+@Component({
+    tag: 'limel-shortcut',
+    shadow: true,
+    styleUrl: 'shortcut.scss',
+})
+export class Shortcut {
+    /**
+     * Name of icon for the shortcut.
+     */
+    @Prop({ reflect: true })
+    public icon: string;
+
+    /**
+     * The text to show below the shortcut. Long label will be truncated.
+     */
+    @Prop({ reflect: true })
+    public label?: string = null;
+
+    /**
+     * The `title` tag of the hyperlink, which can be used to
+     * provide additional information about the link.
+     * It improves accessibility both for sighted users
+     * and users with assistive technologies.
+     */
+    @Prop({ reflect: true })
+    public linkTitle?: string = null;
+
+    /**
+     * Set to `true` if shortcut is disabled.
+     */
+    @Prop({ reflect: true })
+    public disabled?: boolean = false;
+
+    /**
+     * The url that the shortcut leads to.
+     */
+    @Prop({ reflect: true })
+    public href?: string = null;
+
+    /**
+     * Where to load the linked URL, as the name for a browsing context:
+     * - `_self`: in the current browsing context. (Default)
+     * - `_blank`: in a new tab.
+     * - `_parent`: in the parent browsing context of the current one.
+     * If no parent, behaves as `_self`.
+     * - `_top`: the topmost browsing context (the "highest" context
+     * that's an ancestor of the current one). If no ancestors, behaves as `_self`.
+     */
+    @Prop({ reflect: true })
+    public target: '_self' | '_blank' | '_parent' | '_top' = '_self';
+
+    /**
+     * If specified, will display a notification badge
+     * on the shortcut.
+     */
+    @Prop({ reflect: true })
+    public badge?: number | string;
+
+    public render() {
+        return [
+            <a
+                aria-disabled={this.disabled}
+                href={this.href}
+                target={this.target}
+                tabindex="0"
+                aria-label={this.getAreaLabel()}
+                title={this.linkTitle}
+            >
+                <limel-icon name={this.icon} />
+            </a>,
+            this.renderLabel(),
+            this.renderNotification(),
+        ];
+    }
+
+    private renderLabel = () => {
+        if (this.label) {
+            return <span aria-hidden="true">{this.label}</span>;
+        }
+    };
+
+    private getAreaLabel = () => {
+        if (this.label && this.linkTitle) {
+            return this.label + '. ' + this.linkTitle;
+        }
+
+        if (this.label) {
+            return this.label;
+        }
+
+        if (this.linkTitle) {
+            return this.linkTitle;
+        }
+
+        return undefined;
+    };
+
+    private renderNotification = () => {
+        if (this.badge) {
+            return <limel-badge label={this.badge} />;
+        }
+    };
+}


### PR DESCRIPTION
Fix: https://github.com/Lundalogik/crm-feature/issues/3025

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
