### PR TITLE
Move publishing of docs to reusable workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -80,50 +80,17 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
-    name: Publish Docs
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
-    - uses: actions/setup-node@v2
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
-    - run: node -v && npm -v
-    - run: npm ci
-    - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-    - run: git config --global user.name "${GITHUB_ACTOR}"
-    - name: Publish PR docs
-      # Only publish docs if the PR comes from a repo owned by Lime.
-      # Also, skip publishing if the PR was created by Dependabot.
-      if: github.event.pull_request.head.repo.owner.login == 'Lundalogik' && github.actor != 'dependabot[bot]'
-      run: npm run docs:publish -- --v=PR-${{ github.event.pull_request.number }}
-      env:
-        GH_TOKEN: ${{ secrets.PUBLISH_DOCS }}
-    - name: External PR or Dependabot - build docs, but do not publish
-      # If the PR comes from a repo not owned by Lime, or if the PR was created
-      # by Dependabot, just build the docs, but don't publish them.
-      if: github.event.pull_request.head.repo.owner.login != 'Lundalogik' || github.actor == 'dependabot[bot]'
-      run: npm run docs:build
-
-  docs-link:
-    name: Post link to docs on PR
-    needs: [docs]
-    # Use the same `if` as for the "Publish PR docs" step in the "docs" job.
-    if: github.event.pull_request.head.repo.owner.login == 'Lundalogik' && github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    name: Docs
     permissions:
       contents: read
       pull-requests: write
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/github-script@v3
-      with:
-        script: |
-          const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
-          await script({github, context});
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: "PR-${{ github.event.pull_request.number }}"
+      # Only publish docs if the PR comes from a repo owned by Lime.
+      # Also, skip publishing if the PR was created by Dependabot.
+      buildOnly: ${{ github.event.pull_request.head.repo.owner.login != 'Lundalogik' || github.actor == 'dependabot[bot]' }}
+    secrets: inherit
 
   autoapprove:
     needs: [lint, build, test, autosquash, docs]

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -51,12 +51,15 @@ jobs:
         token: ${{ secrets.CREATE_RELEASE }}
         event-type: update-lime-elements
         repository: Lundalogik/lime-webclient
-    - name: Publish docs for new release
-      if: steps.semantic.outputs.new_release_published == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_USERNAME: lime-ci
-        GH_EMAIL: 617355+lime-ci@users.noreply.github.com
-        GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
-        CI: true
-      run: npm run docs:publish -- --v=NEXT-${{ steps.semantic.outputs.new_release_version }} --forcePush --authorName="lime-ci" --authorEmail="617355+lime-ci@users.noreply.github.com"
+
+  docs:
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new_release_published == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: "NEXT-${{ needs.semantic-release.outputs.new_release_version }}"
+      forcePush: true
+    secrets: inherit

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -46,7 +46,7 @@ jobs:
   link-docs:
     if: github.event_name == 'pull_request'
     name: Post link to docs on PR
-    needs: [docs]
+    needs: [publish-docs]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,61 @@
+name: Pull Request Checks
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'The "name" of the version to be published.'
+        required: true
+        type: string
+      forcePush:
+        description: 'Pass `true` if git push should use `--force`.'
+        required: false
+        default: false
+        type: boolean
+      buildOnly:
+        description: 'Pass `true` to only build the docs, but not publish them. (Used by PR checks for dependabot and external contributors.)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+
+  publish-docs:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Read .nvmrc
+      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+      id: nvm
+    - uses: actions/setup-node@v2
+      with:
+        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+    - run: node -v && npm -v
+    - run: npm ci
+    - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    - run: git config --global user.name "${GITHUB_ACTOR}"
+    - name: Publish docs
+      if: inputs.buildOnly == false
+      run: npm run docs:publish -- --v=${{ inputs.version }} ${{ inputs.forcePush && '--forcePush' }}
+      env:
+        GH_TOKEN: ${{ secrets.PUBLISH_DOCS }}
+    - name: Build docs, but do not publish
+      if: inputs.buildOnly
+      run: npm run docs:build
+
+  link-docs:
+    if: github.event_name == 'pull_request'
+    name: Post link to docs on PR
+    needs: [docs]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/github-script@v3
+      with:
+        script: |
+          const script = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/pr-comment.js`);
+          await script({github, context});
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,15 @@ jobs:
         branch: 'next'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish docs for new release
-      if: steps.semantic.outputs.new_release_published == 'true'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_USERNAME: lime-ci
-        GH_EMAIL: 617355+lime-ci@users.noreply.github.com
-        GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
-        CI: true
-      run: npm run docs:publish -- --v=${{ steps.semantic.outputs.new_release_version }} --forcePush --authorName="lime-ci" --authorEmail="617355+lime-ci@users.noreply.github.com"
+
+  docs:
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new_release_published == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      version: "${{ needs.semantic-release.outputs.new_release_version }}"
+      forcePush: true
+    secrets: inherit


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
