### PR TITLE
feat(info-tile): add `limel-info-tile` component

### DIFF
--- a/src/components/info-tile/examples/info-tile-badge.scss
+++ b/src/components/info-tile/examples/info-tile-badge.scss
@@ -1,0 +1,7 @@
+:host(limel-example-info-tile-badge) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 8rem;
+    gap: 2rem;
+    padding: 2rem;
+}

--- a/src/components/info-tile/examples/info-tile-badge.tsx
+++ b/src/components/info-tile/examples/info-tile-badge.tsx
@@ -1,0 +1,41 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Displaying a notification badge
+ *
+ * The component can display a badge, which could either be a `number` or
+ * a `string`. Read more about how the badge truncates or abbreviates the
+ * provided label [here](#/component/limel-badge/).
+ */
+@Component({
+    tag: 'limel-example-info-tile-badge',
+    shadow: true,
+    styleUrl: 'info-tile-badge.scss',
+})
+export class InfoTileBadgeExample {
+    private NumberBadge: number = 6;
+    private NumberValue: number = 23;
+
+    private StringBadge: string = '···';
+    private StringValue: string = '23,89';
+
+    public render() {
+        return [
+            <limel-info-tile
+                icon="doctors_bag"
+                label="Active support tickets"
+                value={this.NumberValue}
+                badge={this.NumberBadge}
+                link={{ href: '#' }}
+            />,
+            <limel-info-tile
+                icon="water"
+                label="Average weekly usage"
+                value={this.StringValue}
+                suffix="L"
+                badge={this.StringBadge}
+                link={{ href: '#' }}
+            />,
+        ];
+    }
+}

--- a/src/components/info-tile/examples/info-tile-loading.scss
+++ b/src/components/info-tile/examples/info-tile-loading.scss
@@ -1,0 +1,7 @@
+:host(limel-example-info-tile-loading) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 8rem;
+    gap: 2rem;
+    padding: 2rem;
+}

--- a/src/components/info-tile/examples/info-tile-loading.tsx
+++ b/src/components/info-tile/examples/info-tile-loading.tsx
@@ -1,0 +1,58 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Loading state
+ *
+ * Sometimes the value needs to be calculated, updated, or fetched
+ * through a process that requires some time. In such cases, it is
+ * a great idea to let the users know that the data is being updated.
+ *
+ * To do so, set the `loading` property to `true`. The component will then
+ * show an indeterminate progressbar indicating the data is being updated,
+ * while the older value is still being displayed.
+ *
+ * :::note
+ * Note that this does _not_ disable the link, and most probably you
+ * do not need it to be disabled either.
+ * If the link should be disabled while loading, the
+ * `disabled` property should be set to `true` as well.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-info-tile-loading',
+    shadow: true,
+    styleUrl: 'info-tile-loading.scss',
+})
+export class InfoTileLoadingExample {
+    @State()
+    public loading = false;
+
+    public render() {
+        const link = {
+            href: 'https://duckduckgo.com/?q=weather',
+            title: 'Click to see real-time weather forecast',
+        };
+
+        return [
+            <limel-info-tile
+                icon="partly_cloudy_rain"
+                label="Partly cloudy with a risk of rain"
+                prefix="temp"
+                value="23"
+                suffix="°C"
+                link={link}
+                loading={this.loading}
+            />,
+            <limel-checkbox
+                label="Loading"
+                checked={this.loading}
+                onChange={this.setLoading}
+            />,
+        ];
+    }
+
+    private setLoading = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.loading = event.detail;
+    };
+}

--- a/src/components/info-tile/examples/info-tile-progress.scss
+++ b/src/components/info-tile/examples/info-tile-progress.scss
@@ -1,0 +1,6 @@
+:host(limel-example-info-tile-progress) {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+    grid-template-rows: 10rem;
+    gap: 3rem;
+}

--- a/src/components/info-tile/examples/info-tile-progress.tsx
+++ b/src/components/info-tile/examples/info-tile-progress.tsx
@@ -1,0 +1,62 @@
+import { Component, h, State } from '@stencil/core';
+import { InfoTileProgress } from '../info-tile.types';
+
+/**
+ * Displaying a progress bar
+ *
+ * By defining a numeric `progressValue`, you can display
+ * a circular progress bar to visualize more data on the component.
+ * This can for instance help illustrate how much of a
+ * set goal has been reached, which together with the `value` will help users
+ * get a better overview of the provided data.
+ *
+ * When the circular progress is shown, that would become the primary
+ * illustrative element on the component,
+ * which means the icon will be rendered smaller, only as a supportive
+ * contextual visual element.
+ *
+ * :::tip
+ * It is possible to customize the progress bar's suffix, but it is
+ * set to display the percentage sign (**%**) by default.
+ * :::
+ *
+ */
+@Component({
+    tag: 'limel-example-info-tile-progress',
+    shadow: true,
+    styleUrl: 'info-tile-progress.scss',
+})
+export class InfoTileProgressExample {
+    @State()
+    private progress: InfoTileProgress = {
+        value: 76,
+        prefix: '↑',
+    };
+
+    public render() {
+        return [
+            <limel-info-tile
+                label="Won deals this month"
+                icon="money"
+                prefix="Total value"
+                value="70,659"
+                suffix="EUR"
+                link={{ href: '#' }}
+                progress={this.progress}
+            />,
+            <limel-input-field
+                label="Progress value"
+                type="number"
+                value={`${this.progress.value}`}
+                onChange={this.handleChange}
+            />,
+        ];
+    }
+
+    private handleChange = (event) => {
+        this.progress = {
+            ...this.progress,
+            value: +event.detail,
+        };
+    };
+}

--- a/src/components/info-tile/examples/info-tile-styling.scss
+++ b/src/components/info-tile/examples/info-tile-styling.scss
@@ -1,0 +1,31 @@
+:host(limel-example-info-tile-styling) {
+    display: flex;
+    justify-content: space-evenly;
+    gap: 2rem;
+    padding: 2rem;
+    border-radius: 0.5rem;
+    background-color: rgb(var(--contrast-1500));
+}
+
+limel-info-tile {
+    width: 18rem;
+    height: 8rem;
+
+    &:first-of-type {
+        --info-tile-icon-color: rgb(var(--color-cyan-light));
+        --info-tile-text-color: rgb(var(--color-yellow-default));
+        --info-tile-background-color: rgb(var(--color-indigo-dark));
+
+        --info-tile-badge-text-color: rgb(var(--color-indigo-dark));
+        --info-tile-badge-background-color: rgb(var(--color-orange-default));
+    }
+
+    &:last-of-type {
+        --info-tile-border-radius: 0.5rem;
+        --info-tile-icon-color: rgb(var(--color-cyan-dark));
+
+        --info-tile-progress-fill-color: rgb(var(--color-lime-light));
+        --info-tile-progress-prefix-color: rgb(var(--color-red-default));
+        --info-tile-progress-text-color: rgb(var(--color-lime-default));
+    }
+}

--- a/src/components/info-tile/examples/info-tile-styling.tsx
+++ b/src/components/info-tile/examples/info-tile-styling.tsx
@@ -1,0 +1,47 @@
+import { Component, h } from '@stencil/core';
+import { InfoTileProgress } from '../info-tile.types';
+
+/**
+ * How to style the Info tile
+ *
+ * The component offers different CSS variables for styling
+ * the color of the text, background, and it's icon; as well as
+ * radius of it's rounded corners, and colors of the notification badge
+ * and its text.
+ */
+@Component({
+    tag: 'limel-example-info-tile-styling',
+    shadow: true,
+    styleUrl: 'info-tile-styling.scss',
+})
+export class InfoTileStylingExample {
+    private value: string = '4 876';
+    private badge: number = 3;
+
+    private progress: InfoTileProgress = {
+        value: 12,
+        maxValue: 100,
+        suffix: '%',
+        displayPercentageColors: false,
+    };
+
+    public render() {
+        return [
+            <limel-info-tile
+                icon="electricity"
+                label="Average weekly usage"
+                value={this.value}
+                suffix="kWh"
+                badge={this.badge}
+            />,
+            <limel-info-tile
+                label="Average weekly usage"
+                icon="electricity"
+                value={this.value}
+                suffix="kWh"
+                progress={this.progress}
+                prefix="↑"
+            />,
+        ];
+    }
+}

--- a/src/components/info-tile/examples/info-tile.scss
+++ b/src/components/info-tile/examples/info-tile.scss
@@ -1,0 +1,18 @@
+div {
+    resize: both;
+    overflow: auto;
+
+    box-sizing: border-box;
+    position: relative;
+
+    min-width: 8rem;
+    width: 12rem;
+    max-width: 40rem;
+
+    min-height: 8rem;
+    height: 12rem;
+    max-height: 40rem;
+
+    padding: 1rem;
+    border: 0.125rem dashed rgb(var(--contrast-500));
+}

--- a/src/components/info-tile/examples/info-tile.tsx
+++ b/src/components/info-tile/examples/info-tile.tsx
@@ -1,0 +1,52 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Basic example
+ *
+ * This component does its best to offer a responsive layout
+ * that reacts both to the length of text, and size of the container.
+ *
+ * :::note
+ * To use this component properly, you need to define both
+ * a declared `height` and a declared `width` for it. Alternatively,
+ * make sure that its container enforces a width and height,
+ * for instance, use it as a flex or grid child.
+ * :::
+ *
+ * In this example, you can resize the component to see how it
+ * tries to adjust its content to the size of its container.
+ *
+ * :::tip
+ * Try to avoid long textual content to get
+ * the best possible visualization. They can cause
+ * undesired overlapping of the content, depending on the size of the
+ * component.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-info-tile',
+    shadow: true,
+    styleUrl: 'info-tile.scss',
+})
+export class InfoTileExample {
+    public render() {
+        const link = {
+            href: 'https://duckduckgo.com/?q=weather',
+            title: 'Click to see real-time weather forecast',
+            target: '_blank',
+        };
+
+        return (
+            <div>
+                <limel-info-tile
+                    icon="partly_cloudy_rain"
+                    label="Partly cloudy with a risk of rain"
+                    prefix="temp"
+                    value="23"
+                    suffix="°C"
+                    link={link}
+                />
+            </div>
+        );
+    }
+}

--- a/src/components/info-tile/info-tile.e2e.ts
+++ b/src/components/info-tile/info-tile.e2e.ts
@@ -1,0 +1,36 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('limel-icon-button', () => {
+    let page;
+    describe('smoke test', () => {
+        let value;
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-info-tile value="Test value"></limel-info-tile>
+            `);
+            value = await page.find('limel-info-tile >>> .value-group');
+        });
+        it('displays the correct value', () => {
+            expect(value).toEqualText('Test value');
+        });
+    });
+});
+
+async function createPage(content) {
+    return newE2EPage({ html: content });
+}
+
+// What kinds of tests can we write:
+
+// - component is rendered with a `label`, `value` and an `icon`
+// - `value` and `label` are reflected in `aria-label` on the `a`
+
+// - component is rendered with a `label`, `value`, `prefix` and `suffix`
+// - `value`, `label`, `prefix` and `suffix` are reflected in `aria-label` on the `a`
+
+// - the link can get an `href` class
+// - `is-clickable` class is applied when there is a `href`
+
+// - component can have a `badge` with numeric or string value
+
+// - component can show a circular progress bar, when `progressValue` is defined

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -1,0 +1,344 @@
+/**
+* @prop --info-tile-border-radius: defines the radius of corners of the info-tile. Defaults to `1rem`
+* @prop --info-tile-icon-color: defines the fill color of the info-tile icon. Defaults to `--contrast-1000`
+* @prop --info-tile-text-color: defines the color of the info-tile label. Defaults to `--contrast-1100`
+* @prop --info-tile-background-color: defines the backgrounds color of the info-tile icon. Defaults to `--contrast-100`
+* @prop --info-tile-badge-text-color: Text color of the notification badge. Defaults to `--color-white`
+* @prop --info-tile-badge-background-color: Background color of the notification badge. Defaults to `--color-red-default`
+* @prop --info-tile-progress-fill-color: Determines the color of the progressed section. Defaults to `--lime-primary-color`.
+* @prop --info-tile-progress-background-color: Determines the background color of the central section of the progress bar. Defaults to `--info-tile-background-color`.
+* @prop --info-tile-progress-suffix-color: Determines the color of the progress prefix. Defaults to `--contrast-1000`.
+ * @prop --info-tile-progress-text-color: Determines the color of the progress value. Defaults to `--info-tile-text-color`.
+ * @prop --info-tile-progress-prefix-color: Determines the color of the progress suffix. Defaults to `--contrast-1000`.
+*/
+
+@use '../../style/mixins';
+
+:host(limel-info-tile) {
+    --badge-text-color: var(
+        --info-tile-badge-text-color,
+        rgb(var(--color-white))
+    );
+    --badge-background-color: var(
+        --info-tile-badge-background-color,
+        rgb(var(--color-red-default))
+    );
+
+    --circular-progress-text-color: var(
+        --info-tile-progress-text-color,
+        var(--info-tile-text-color)
+    );
+    --circular-progress-suffix-color: var(--info-tile-progress-suffix-color);
+    --circular-progress-prefix-color: var(--info-tile-progress-prefix-color);
+    --circular-progress-track-color: rgb(var(--contrast-800), 0.3);
+    --circular-progress-fill-color: var(--info-tile-progress-fill-color);
+    --circular-progress-background-color: var(
+        --info-tile-progress-background-color,
+        var(--info-tile-background-color)
+    );
+
+    --label-min-size: 0.75rem;
+    --label-preferred-size: 6cqw;
+    --label-max-size: 1rem;
+
+    --value-min-size: 1rem;
+    --value-preferred-size: 20cqw;
+    --value-max-size: 4rem;
+
+    --suffix-prefix-min-size: 0.75rem;
+    --suffix-prefix-preferred-size: 8cqw;
+    --suffix-prefix-max-size: 1.5rem;
+
+    --icon-min-size: 2rem;
+    --icon-preferred-size: 60cqh;
+    --icon-max-size: calc(100cqw - 0.5rem);
+
+    isolation: isolate;
+    container-type: size;
+    position: relative;
+    display: flex;
+
+    width: 100%;
+    height: 100%;
+
+    * {
+        box-sizing: border-box;
+    }
+}
+
+:host(limel-info-tile[disabled]) {
+    a {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+a {
+    all: unset;
+    overflow: hidden;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: flex-start;
+
+    height: 100%;
+    width: 100%;
+    flex-grow: 1;
+
+    padding: 0.25rem 1rem 0.5rem 1rem;
+    border-radius: var(--info-tile-border-radius, 1rem);
+    background-color: var(
+        --info-tile-background-color,
+        rgb(var(--contrast-100))
+    );
+
+    &.is-clickable {
+        @include mixins.is-elevated-clickable;
+        @include mixins.visualize-keyboard-focus;
+        cursor: pointer;
+    }
+}
+
+.icon {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    padding: 0.25rem;
+
+    display: flex;
+    justify-content: center;
+
+    color: var(--info-tile-icon-color, rgb(var(--contrast-1000)));
+
+    border-radius: 0;
+    height: clamp(
+        var(--icon-min-size),
+        var(--icon-preferred-size),
+        var(--icon-max-size)
+    );
+
+    @supports not (container-type: size) {
+        height: min(60%, var(--icon-max-size));
+    }
+
+    .has-circular-progress & {
+        top: unset;
+        bottom: 0.5rem;
+        --icon-min-size: 1.5rem;
+        --icon-preferred-size: 20cqh;
+    }
+}
+
+.progress {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+
+    --circular-progress-size: min(
+        var(--icon-preferred-size),
+        var(--icon-max-size)
+    );
+}
+
+.label {
+    z-index: 1;
+    color: var(--info-tile-text-color, rgb(var(--contrast-1100)));
+
+    line-height: normal;
+    // white-space: normal;
+    // overflow: hidden;
+    // display: -webkit-box;
+    // -webkit-line-clamp: 2; // max number of lines before truncation
+    // -webkit-box-orient: vertical;
+    font-size: clamp(
+        var(--label-min-size),
+        var(--label-preferred-size),
+        var(--label-max-size)
+    );
+    @supports not (container-type: size) {
+        font-size: 0.875rem;
+    }
+}
+
+limel-badge {
+    position: absolute;
+    top: -0.5rem;
+    right: -0.5rem;
+}
+
+limel-linear-progress {
+    --lime-primary-color: var(--info-tile-text-color);
+    position: absolute;
+    inset: auto 0 0 0;
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.value-group {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    color: var(--info-tile-text-color, rgb(var(--contrast-1100)));
+}
+
+.value-and-suffix,
+.label {
+    text-shadow: 0 0 0.5rem
+            var(--info-tile-background-color, rgb(var(--contrast-100))),
+        0 0 0.25rem var(--info-tile-background-color, rgb(var(--contrast-100)));
+}
+
+.value-and-suffix {
+    display: flex;
+}
+
+.prefix,
+.suffix {
+    font-size: clamp(
+        var(--suffix-prefix-min-size),
+        var(--suffix-prefix-preferred-size),
+        var(--suffix-prefix-max-size)
+    );
+    opacity: 0.7;
+
+    @supports not (container-type: size) {
+        font-size: 0.75rem;
+    }
+}
+
+.prefix {
+    align-self: flex-start;
+    line-height: normal;
+    transform: translateY(40%);
+}
+
+.value {
+    transition: opacity 0.2s ease,
+        transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.95);
+    transform-origin: left;
+    transform: translate3d(0, 0, 0) scale(1);
+
+    @include mixins.truncate-text;
+    font-weight: bold;
+    line-height: normal;
+
+    font-size: clamp(
+        var(--value-min-size),
+        var(--value-preferred-size),
+        var(--value-max-size)
+    );
+    @supports not (container-type: size) {
+        font-size: 2.5rem;
+    }
+
+    :host(limel-info-tile[loading]) & {
+        opacity: 0.3;
+        transform: translate3d(0, 0, 0) scale(0.9);
+    }
+}
+
+.suffix {
+    transform: translateY(10%);
+}
+
+$xs: 8rem; //128px:
+$s: 18.75rem; //300px
+$m: 40.5rem; //648px
+$l: 62.5rem; //1000px
+
+@container (width < #{$xs}) {
+    .progress {
+        top: 0.25rem;
+        right: 0.25rem;
+    }
+    a {
+        padding: 0.375rem;
+        gap: 0.125rem;
+    }
+}
+
+@container (width < #{$s}) {
+    .progress {
+        top: 0.5rem;
+        right: 0.5rem;
+    }
+    .icon {
+        top: 0.25rem;
+        right: 0.5rem;
+        .has-circular-progress & {
+            right: 0.25rem;
+            bottom: 0.25rem;
+        }
+    }
+}
+
+@container (width < #{$m}) {
+    .value {
+        &.ch-1,
+        &.ch-2,
+        &.ch-3,
+        &.ch-4 {
+            --value-preferred-size: 20cqw;
+        }
+        &.ch-5 {
+            --value-preferred-size: 18cqw;
+        }
+        &.ch-6 {
+            --value-preferred-size: 17cqw;
+        }
+        &.ch-7 {
+            --value-preferred-size: 16cqw;
+        }
+        &.ch-8 {
+            --value-preferred-size: 15cqw;
+        }
+        &.ch-9 {
+            --value-preferred-size: 14cqw;
+        }
+        --value-preferred-size: 13cqw;
+    }
+}
+
+@container (height > #{$xs}) {
+    a {
+        padding-top: 0.75rem;
+        padding-bottom: 1rem;
+    }
+}
+
+@container (height < #{$xs}) and (width > #{$xs}) {
+    .value {
+        --value-preferred-size: 32cqh !important;
+    }
+    .suffix,
+    .prefix {
+        --suffix-prefix-preferred-size: 16cqh !important;
+    }
+}
+
+@container (height > #{$s}) {
+    .progress,
+    .icon {
+        position: relative;
+        top: unset;
+        right: unset;
+    }
+    a {
+        align-items: center;
+        justify-content: center;
+    }
+    .label {
+        text-align: center;
+        // -webkit-line-clamp: 3;
+    }
+    .has-circular-progress {
+        .icon {
+            position: absolute;
+            top: 0.5rem;
+            right: 0.5rem;
+            --icon-max-size: 3rem;
+        }
+    }
+}

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -1,0 +1,222 @@
+import { Component, Prop, h } from '@stencil/core';
+import { InfoTileProgress } from './info-tile.types';
+import { Link } from '@limetech/lime-elements';
+
+/**
+ * This component can be used on places such as a start page or a dashboard.
+ * It offers features for visualizing aggregated data along with supplementary
+ * information.
+ *
+ * If clicking on the component should navigate the user to
+ * a new screen or web page, you need to provide a URL,
+ * using the `link` property.
+ *
+ * @exampleComponent limel-example-info-tile
+ * @exampleComponent limel-example-info-tile-badge
+ * @exampleComponent limel-example-info-tile-progress
+ * @exampleComponent limel-example-info-tile-loading
+ * @exampleComponent limel-example-info-tile-styling
+ */
+@Component({
+    tag: 'limel-info-tile',
+    shadow: true,
+    styleUrl: 'info-tile.scss',
+})
+export class InfoTile {
+    /**
+     * A piece of text or number that is the main piece of information
+     * which the component is intended to visualize.
+     */
+    @Prop({ reflect: true })
+    public value: number | string;
+
+    /**
+     * Name of icon for the info tile.
+     */
+    @Prop()
+    public icon?: string;
+
+    /**
+     * The text to show below the info tile. Long labels will be truncated.
+     */
+    @Prop({ reflect: true })
+    public label?: string = null;
+
+    /**
+     * A string of text that is visually placed before the value.
+     */
+    @Prop({ reflect: true })
+    public prefix?: string;
+
+    /**
+     * A string of text that is visually placed after the value.
+     */
+    @Prop({ reflect: true })
+    public suffix?: string;
+
+    /**
+     * Set to `true` if info tile is disabled.
+     */
+    @Prop({ reflect: true })
+    public disabled? = false;
+
+    /**
+     * If supplied, the info tile will display a notification badge.
+     */
+    @Prop({ reflect: true })
+    public badge?: number | string;
+
+    /**
+     * Set to `true` to put the component in the `loading` state.
+     * This does _not_ disable the link. To do so, the
+     * `disabled` property should be set to `true` as well.
+     */
+    @Prop({ reflect: true })
+    public loading? = false;
+
+    /**
+     * If supplied, the info tile will be a clickable link.
+     *
+     * Supplying a value also adds an elevated effect using a shadow,
+     * as well as `cursor: pointer`, which appears on hover.
+     * While we strongly recommend supplying a link whenever the
+     * component should act as a link, if this is not possible, and
+     * you need to provide interaction through a click handler,
+     * you can still get the correct styling by supplying a `Link`
+     * object with the `href` property set to `'#'`.
+     */
+    @Prop()
+    public link?: Link;
+
+    /**
+     * Properties of the optional circular progress bar.
+     *
+     * Defaults:
+     * - `maxValue`: 100
+     * - `suffix`: %
+     * - `percentageColors`: false
+     *
+     * Colors change with intervals of 10 %.
+     */
+    @Prop()
+    public progress?: InfoTileProgress;
+
+    public render() {
+        const extendedAriaLabel =
+            this.checkProps(this?.prefix) +
+            this.value +
+            ' ' +
+            this.checkProps(this?.suffix) +
+            this.checkProps(this?.label) +
+            '. ' +
+            this.checkProps(this?.progress?.prefix) +
+            this.checkProps(this?.progress?.value) +
+            this.checkProps(this?.progress?.suffix) +
+            this.checkProps(this?.link?.title);
+
+        const link = !this.disabled ? this.link?.href : '#';
+
+        return [
+            <a
+                title={this.link?.title}
+                href={link}
+                target={this.link?.target}
+                tabindex="0"
+                aria-label={extendedAriaLabel}
+                aria-disabled={this.disabled}
+                class={{
+                    'is-clickable': !!this.link?.href && !this.disabled,
+                    'has-circular-progress':
+                        !!this.progress?.value || this.progress?.value === 0,
+                }}
+            >
+                {this.renderIcon()}
+                {this.renderProgress()}
+                <div class="value-group">
+                    {this.renderPrefix()}
+                    <div class="value-and-suffix">
+                        {this.renderValue()}
+                        {this.renderSuffix()}
+                    </div>
+                    {this.renderSpinner()}
+                </div>
+                {this.renderLabel()}
+            </a>,
+            this.renderNotification(),
+        ];
+    }
+
+    private checkProps(propValue) {
+        return !propValue ? '' : propValue + ' ';
+    }
+
+    private renderPrefix = () => {
+        if (this.prefix) {
+            return <span class="prefix">{this.prefix}</span>;
+        }
+    };
+
+    private renderValue = () => {
+        const characterCount = this.value.toString().length;
+
+        if (this.value) {
+            return (
+                <span
+                    class={{
+                        value: true,
+                        [`ch-${characterCount}`]: true,
+                    }}
+                >
+                    {this.value}
+                </span>
+            );
+        }
+    };
+
+    private renderSuffix = () => {
+        if (this.suffix) {
+            return <span class="suffix">{this.suffix}</span>;
+        }
+    };
+
+    private renderIcon = () => {
+        if (this.icon) {
+            return <limel-icon class="icon" name={this.icon} />;
+        }
+    };
+
+    private renderProgress = () => {
+        if (this.progress?.value || this.progress?.value === 0) {
+            return (
+                <limel-circular-progress
+                    class="progress"
+                    prefix={this.progress.prefix}
+                    value={this.progress.value}
+                    suffix={this.progress.suffix}
+                    maxValue={this.progress.maxValue}
+                    displayPercentageColors={
+                        this.progress.displayPercentageColors
+                    }
+                />
+            );
+        }
+    };
+
+    private renderLabel = () => {
+        if (this.label) {
+            return <span class="label">{this.label}</span>;
+        }
+    };
+
+    private renderNotification = () => {
+        if (this.badge) {
+            return <limel-badge label={this.badge} />;
+        }
+    };
+
+    private renderSpinner = () => {
+        if (this.loading) {
+            return <limel-linear-progress indeterminate={true} />;
+        }
+    };
+}

--- a/src/components/info-tile/info-tile.types.ts
+++ b/src/components/info-tile/info-tile.types.ts
@@ -1,0 +1,27 @@
+export interface InfoTileProgress {
+    /**
+     * The value of the progress bar.
+     */
+    value: number;
+
+    /**
+     * The maximum value within the scale that the progress bar should visualize.
+     */
+    maxValue?: number;
+
+    /**
+     * The prefix which is displayed before the `progressValue`.
+     * Keep to a few characters at most.
+     */
+    prefix?: string;
+
+    /**
+     * The suffix which is displayed after the `value`, must be one or two characters long.
+     */
+    suffix?: string;
+
+    /**
+     * When set to `true`, the progress bar changes color depending on its current value.
+     */
+    displayPercentageColors?: boolean;
+}

--- a/src/global/shared-types/link.types.ts
+++ b/src/global/shared-types/link.types.ts
@@ -1,0 +1,28 @@
+export interface Link {
+    /**
+     * The url the link should point to.
+     */
+    href: string;
+
+    /**
+     * The text value to use for the link.
+     * Note that this might not be used by all components that use the
+     * Link interface.
+     */
+    text?: string;
+
+    /**
+     * Title for the link. Read by assistive tech and shown when the
+     * link is hovered. Can be used to provide additional information
+     * about the link. It improves accessibility both for sighted users
+     * and users of assistive technologies.
+     */
+    title?: string;
+
+    /**
+     * Target for the link. See
+     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target
+     * for more info.
+     */
+    target?: string;
+}

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -1,4 +1,5 @@
 // Components interfaces
+export * from './global/shared-types/link.types';
 export * from './components/button/button.types';
 export * from './components/chip-set/chip.types';
 export * from './components/collapsible-section/action';
@@ -21,3 +22,4 @@ export * from './components/tab-bar/tab.types';
 export * from './components/tab-panel/tab-panel.types';
 export * from './components/table/table.types';
 export * from './components/dock/dock.types';
+export * from './components/info-tile/info-tile.types';


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/3025

## testing in the web client
Add `limel-info-tile` on the start page as a widget, with the following config, and try different sizes:

```json
{
    "icon": "full_of_shit",
    "label": "Money we earned through some crazy deals this year",
    "value": "20,000",
    "prefix": "earned",
    "suffix": "SEK",
    "href": "https://www.google.com",
    "target": "_blank",
    "progressValue": "24"
}
````
````json
{
    "icon": "poo",
    "label": "Such a wonderful year",
    "value": "4 432",
    "prefix": "money",
    "suffix": "SEK",
    "href": "https://www.google.com",
    "target": "_blank",
    "badge": "2345",
}
````

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
