### PR TITLE
ci(sonarcloud): do not run SonarCloud scan on Dependabot PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   sonarcloud:
+    if: github.actor != 'dependabot[bot]'
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Dependabot ought to behave itself, so running SonarCloud's scans on its PRs should hopefully not be necessary.

If we change our minds, and want to run them, the `SONAR_TOKEN` secret needs to be added to the Dependabot secrets in the repo config on GitHub.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
