### PR TITLE
ci(publish-docs.yml): update check for whether to run `link-docs` job

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -44,7 +44,7 @@ jobs:
       run: npm run docs:build
 
   link-docs:
-    if: github.event_name == 'pull_request'
+    if: inputs.buildOnly == false
     name: Post link to docs on PR
     needs: [publish-docs]
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
