### PR TITLE
refactor(shortcut): fix misspelling

### DIFF
--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -79,7 +79,7 @@ export class Shortcut {
                 href={this.href}
                 target={this.target}
                 tabindex="0"
-                aria-label={this.getAreaLabel()}
+                aria-label={this.getAriaLabel()}
                 title={this.linkTitle}
             >
                 <limel-icon name={this.icon} />
@@ -95,7 +95,7 @@ export class Shortcut {
         }
     };
 
-    private getAreaLabel = () => {
+    private getAriaLabel = () => {
         if (this.label && this.linkTitle) {
             return this.label + '. ' + this.linkTitle;
         }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
