### PR TITLE
feat(header): add named slot `actions` and deprecate unnamed slot

### DIFF
--- a/src/components/header/examples/header-responsive.tsx
+++ b/src/components/header/examples/header-responsive.tsx
@@ -64,7 +64,7 @@ export class HeaderExample {
         }
 
         return (
-            <div class="actions">
+            <div class="actions" slot="actions">
                 {this.actions.map(this.renderActionButton)}
             </div>
         );

--- a/src/components/header/examples/header.tsx
+++ b/src/components/header/examples/header.tsx
@@ -51,7 +51,7 @@ export class HeaderExample {
         }
 
         return (
-            <div class="actions">
+            <div class="actions" slot="actions">
                 {this.actions.map(this.renderActionButton)}
             </div>
         );

--- a/src/components/header/examples/header.tsx
+++ b/src/components/header/examples/header.tsx
@@ -1,5 +1,4 @@
 import { Component, h } from '@stencil/core';
-import { Action } from '@limetech/lime-elements';
 
 /**
  * How default layout of header works
@@ -24,14 +23,6 @@ import { Action } from '@limetech/lime-elements';
     shadow: true,
 })
 export class HeaderExample {
-    private actions = [
-        {
-            id: '1',
-            icon: 'multiply',
-            label: 'Close',
-        },
-    ];
-
     public render() {
         return (
             <limel-header
@@ -40,35 +31,18 @@ export class HeaderExample {
                 subheading="Note"
                 supportingText="Data couldn't be loaded!"
             >
-                {this.renderActions()}
+                <limel-icon-button
+                    slot="actions"
+                    icon="multiply"
+                    label="Close"
+                    onClick={this.handleActionClick()}
+                />
             </limel-header>
         );
     }
 
-    private renderActions() {
-        if (!this.actions) {
-            return;
-        }
-
-        return (
-            <div class="actions" slot="actions">
-                {this.actions.map(this.renderActionButton)}
-            </div>
-        );
-    }
-
-    private renderActionButton = (action: Action) => {
-        return (
-            <limel-icon-button
-                icon={action.icon}
-                label={action.label}
-                onClick={this.handleActionClick(action)}
-            />
-        );
-    };
-
-    private handleActionClick = (action: Action) => (event: MouseEvent) => {
+    private handleActionClick = () => (event: MouseEvent) => {
         event.stopPropagation();
-        console.log(action);
+        console.log('close');
     };
 }

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -75,7 +75,7 @@
     }
 }
 
-.actions {
+slot[name='actions'] {
     flex-shrink: 0;
 }
 
@@ -107,7 +107,7 @@
     .headings {
         padding-right: functions.pxToRem(8);
     }
-    .actions {
+    slot[name='actions'] {
         display: flex;
         justify-content: flex-end;
     }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -44,7 +44,12 @@ import { Component, h, Prop } from '@stencil/core';
  * @exampleComponent limel-example-header-colors
  * @exampleComponent limel-example-header-responsive
  * @exampleComponent limel-example-header-narrow
- * @slot - Content (actions) to be put inside the far right surface of the header
+ * @slot actions - Content (actions) to be put inside the far right surface of
+ * the header
+ * @slot [no name] - DEPRECATED. The `actions` slot used to be unnamed. This
+ * behavior has been deprecated, and support will be dropped in a future
+ * version. Please add `slot="actions"` to your elements to ensure your code
+ * will continue to work with future versions of Lime Elements.
  */
 @Component({
     tag: 'limel-header',
@@ -90,9 +95,9 @@ export class Header {
                     </h2>
                 </div>
             </div>,
-            <div class="actions">
+            <slot name="actions">
                 <slot />
-            </div>,
+            </slot>,
         ];
     }
 


### PR DESCRIPTION
I found this in a six month old branch… it doesn't seem to have been merged. I'm not sure if I never opened a pull request, or if I did but it didn't get merged for some reason… 🤷‍♂️

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
