### PR TITLE
chore: remove duplicate rules

### DIFF
--- a/src/components/date-picker/flatpickr-adapter/_flatpickr.scss
+++ b/src/components/date-picker/flatpickr-adapter/_flatpickr.scss
@@ -746,7 +746,6 @@ span.flatpickr-weekday {
 .flatpickr-time {
     text-align: center;
     outline: 0;
-    display: block;
     // height: 0;
     line-height: 40px;
     max-height: 40px;
@@ -835,8 +834,6 @@ span.flatpickr-weekday {
         float: left;
         line-height: inherit;
         // color: #393939;
-        font-weight: bold;
-        width: 2%;
         user-select: none;
         align-self: center;
         outline: 0;


### PR DESCRIPTION
Removes duplicated rules that SonarCloud is nagging about, which causes the commit status to be red.
Let's make sonarcloud status green again.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
