### PR TITLE
fix(split-button): don't render the menu if there are no menu items

### DIFF
--- a/src/components/split-button/split-button.e2e.ts
+++ b/src/components/split-button/split-button.e2e.ts
@@ -151,9 +151,8 @@ describe('limel-split-button', () => {
                 limelMenu = await page.find('limel-split-button>>>limel-menu');
             });
 
-            it('limel-memu displays nothing', async () => {
-                const propValue = await limelMenu.getProperty('items');
-                expect(propValue).toEqual([]);
+            it('limel-menu is not displayed', async () => {
+                expect(limelMenu).toEqual(null);
             });
         });
 
@@ -164,7 +163,7 @@ describe('limel-split-button', () => {
             ];
             beforeEach(async () => {
                 page = await createPage(`
-                    <limel-split-button></limel-split-button>
+                    <limel-split-button class="has-menu"></limel-split-button>
                 `);
 
                 splitButton = await page.find('limel-split-button');
@@ -175,7 +174,7 @@ describe('limel-split-button', () => {
                 limelMenu = await page.find('limel-split-button>>>limel-menu');
             });
 
-            it('limel-memu displays the values', async () => {
+            it('limel-menu displays the values', async () => {
                 const propValue = await limelMenu.getProperty('items');
                 expect(propValue).toEqual(items);
             });

--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -1,7 +1,10 @@
 @import '../../style/mixins';
 
-:host(limel-split-button) {
+:host(limel-split-button.has-menu) {
     --button-padding-right: 2rem;
+}
+
+:host(limel-split-button) {
     display: inline-flex;
     isolation: isolate;
 

--- a/src/components/split-button/split-button.spec.tsx
+++ b/src/components/split-button/split-button.spec.tsx
@@ -3,21 +3,29 @@ import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { SplitButton } from './split-button';
 
 let page: SpecPage;
-let splitButton: HTMLLimelSplitButtonElement;
 
-describe('limel-split-button', () => {
-    beforeEach(async () => {
-        page = await newSpecPage({
-            components: [SplitButton],
-            template: () => <limel-split-button />,
-        });
+test('the component renders without menu items', async () => {
+    const splitButton = await createComponent([]);
 
-        splitButton = page.body.querySelector('limel-split-button');
-    });
-
-    it('the component renders', () => {
-        expect(splitButton).toEqualHtml(`
+    expect(splitButton).toEqualHtml(`
             <limel-split-button>
+                <mock:shadow-root>
+                    <limel-button></limel-button>
+                </mock:shadow-root>
+            </limel-split-button>
+        `);
+});
+
+test('the component renders with menu items', async () => {
+    const items = [
+        { text: 'Later today', secondaryText: 'at 16:45' },
+        { separator: true },
+    ];
+
+    const splitButton = await createComponent(items);
+
+    expect(splitButton).toEqualHtml(`
+            <limel-split-button class="has-menu">
                 <mock:shadow-root>
                     <limel-button></limel-button>
                     <limel-menu opendirection="bottom">
@@ -28,5 +36,13 @@ describe('limel-split-button', () => {
                 </mock:shadow-root>
             </limel-split-button>
         `);
-    });
 });
+
+async function createComponent(items: any) {
+    page = await newSpecPage({
+        components: [SplitButton],
+        template: () => <limel-split-button items={items} />,
+    });
+
+    return page.body.querySelector('limel-split-button');
+}

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -61,30 +61,44 @@ export class SplitButton {
 
     render() {
         return (
-            <Host>
+            <Host
+                class={{
+                    'has-menu': !!this.items.length,
+                }}
+            >
                 <limel-button
                     label={this.label}
                     primary={this.primary}
                     icon={this.icon}
                     disabled={this.disabled}
                 />
-                <limel-menu
-                    class={{
-                        primary: this.primary,
-                    }}
-                    disabled={this.disabled}
-                    items={this.items}
-                    openDirection="bottom"
-                >
-                    <button
-                        class="menu-trigger"
-                        slot="trigger"
-                        disabled={this.disabled}
-                    >
-                        ⋮
-                    </button>
-                </limel-menu>
+                {this.renderMenu()}
             </Host>
         );
     }
+
+    private renderMenu = () => {
+        if (!this.items.length) {
+            return;
+        }
+
+        return (
+            <limel-menu
+                class={{
+                    primary: this.primary,
+                }}
+                disabled={this.disabled}
+                items={this.items}
+                openDirection="bottom"
+            >
+                <button
+                    class="menu-trigger"
+                    slot="trigger"
+                    disabled={this.disabled}
+                >
+                    ⋮
+                </button>
+            </limel-menu>
+        );
+    };
 }


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/3086 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
