### PR TITLE
fix(split-button): prevent unintentionally activating the default act…

### DIFF
--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -13,13 +13,15 @@
     }
 }
 
+$distance-around-trigger: 0.125rem;
+
 limel-menu {
     display: flex;
     justify-content: flex-end;
     position: relative;
     z-index: 1;
 
-    padding: 0.125rem;
+    padding: $distance-around-trigger;
     margin-left: calc(var(--button-padding-right) * -1);
     width: var(--button-padding-right);
 
@@ -79,5 +81,16 @@ limel-menu {
         &:hover {
             background-color: rgb(var(--color-white), 0.1);
         }
+    }
+
+    &:before {
+        // prevents unintentionally activating the default action,
+        // by clicking on the edge of menu trigger,
+        // which would be activating the default onClick action
+        // on `limel-button`.
+        content: '';
+        position: absolute;
+        inset: -$distance-around-trigger * 2;
+        z-index: -1;
     }
 }


### PR DESCRIPTION
…ion, by clicking on the edge of menu trigger

Such click would be on the main button, activating the default onClick action unintentionally.

fix https://github.com/Lundalogik/lime-elements/issues/1952

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
