### PR TITLE
fix(select): visualize keyboard focus

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -63,8 +63,6 @@
     }
 
     .limel-select-trigger {
-        @include mixins.visualize-keyboard-focus;
-
         height: shared_input-select-picker.$height-of-mdc-text-field;
         display: inline-flex;
         align-items: center;
@@ -98,6 +96,7 @@
     &:not(.mdc-select--disabled) {
         .limel-select-trigger {
             @include mixins.is-elevated-clickable;
+            @include mixins.visualize-keyboard-focus;
 
             &.limel-select--focused {
                 background-color: shared_input-select-picker.$background-color-focused;


### PR DESCRIPTION
The keyboard focus works but is not visible👇

https://user-images.githubusercontent.com/50618208/202453694-a7d29331-013f-40a5-9556-6d55d6b7acec.mov


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
