### PR TITLE
1953 dialog body padding

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -27,6 +27,8 @@
     --header-icon-background-color: var(--dialog-heading-icon-background-color);
 }
 
+$responsive-body-padding: 3vw; // 3% of viewport's width
+
 @include dialog.core-styles;
 
 .mdc-dialog {
@@ -60,6 +62,11 @@
         max-width: var(--dialog-max-width, calc(100vw - 2rem));
         max-height: var(--dialog-max-height, calc(100% - 2rem));
         border-radius: var(--dialog-border-radius, 0.25rem);
+    }
+
+    .mdc-dialog__content {
+        padding: min(1.5rem, $responsive-body-padding)
+            min(1.25rem, $responsive-body-padding);
     }
 }
 
@@ -129,6 +136,7 @@ slot[name='button'] {
         flex-direction: column-reverse;
     }
     .mdc-dialog__actions {
-        padding: 1rem 1.5rem 1.5rem 1.5rem;
+        padding: min(1.5rem, $responsive-body-padding);
+        padding-top: 1rem;
     }
 }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -16,6 +16,8 @@
  * @prop --dialog-max-width: Max width of the dialog.
  * @prop --dialog-max-height: Max height of the dialog.
  * @prop --dialog-border-radius: Border radius of the dialog corners
+ * @prop --dialog-padding-top-bottom: Padding on top and bottom of dialog content. Defaults to `1.5rem`.
+ * @prop --dialog-padding-left-right: Padding on the sides of dialog content. Defaults to `1.25rem`.
  */
 
 :host {
@@ -65,8 +67,14 @@ $responsive-body-padding: 3vw; // 3% of viewport's width
     }
 
     .mdc-dialog__content {
-        padding: min(1.5rem, $responsive-body-padding)
-            min(1.25rem, $responsive-body-padding);
+        padding: var(
+                --dialog-padding-top-bottom,
+                min(1.5rem, $responsive-body-padding)
+            )
+            var(
+                --dialog-padding-left-right,
+                min(1.25rem, $responsive-body-padding)
+            );
     }
 }
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1953

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
