### PR TITLE
fix(select): forbid to use the keyboard navigation when `readonly` or…

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -63,6 +63,7 @@
     }
 
     .limel-select-trigger {
+        border: none;
         height: shared_input-select-picker.$height-of-mdc-text-field;
         display: inline-flex;
         align-items: center;

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -82,17 +82,16 @@ const SelectValue: FunctionalComponent<
     };
 
     return (
-        <div
+        <button
             class={anchorClassList}
             tabindex="0"
             onClick={props.open}
             onKeyPress={props.onTriggerPress}
-            role="button"
             aria-haspopup="listbox"
             aria-expanded="false"
             aria-labelledby="s-label s-selected-text"
             aria-required={props.required}
-            aria-disabled={props.disabled}
+            disabled={props.disabled || props.readonly}
         >
             <span id="s-label" class={labelClassList}>
                 {props.label}
@@ -120,7 +119,7 @@ const SelectValue: FunctionalComponent<
                     ></polygon>
                 </svg>
             </span>
-        </div>
+        </button>
     );
 };
 


### PR DESCRIPTION
… `disabled`

fix: https://github.com/Lundalogik/lime-elements/issues/1960


https://user-images.githubusercontent.com/50618208/202512538-fff8011b-58c9-49ac-81f2-edcb6c1221f3.mov


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
