### PR TITLE
fix(input-field): do not render unformatted value when field is readonly

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -112,6 +112,25 @@
         color: transparent;
         -webkit-text-fill-color: transparent;
     }
+
+    &.lime-text-field--readonly {
+        .mdc-text-field__input[type='number'] {
+            visibility: hidden;
+            // Not having `visibility: hidden;` makes the unformatted
+            // value selectable; which is not so nice when users
+            // click drag to select content on the screen.
+            // The reason to have it only on `readonly` mode is
+            // 1. This is the use case where it makes most sense
+            // 2. We don't want to repeat the same thing in the
+            // accessibility tree, and make it readable for assistive
+            // technologies.
+            // 3. When not readonly, clicking on the `<input />`
+            // element sets the focus and activates the edit mode.
+            // So we cannot always have it `hidden` on.
+            // which is why we have instead
+            // `color: transparent` a few lines before this.
+        }
+    }
 }
 
 .autocomplete-list-container {


### PR DESCRIPTION
Previously it was rendered, but transparent,
which made it selectable by user, and readable for assistive tech.

fix https://github.com/Lundalogik/lime-elements/issues/1963

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
