### PR TITLE
ci(workflows): fix docs publish fail because it tries to post link on non-existing PR

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,6 +87,7 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       version: "PR-${{ github.event.pull_request.number }}"
+      linkToPR: true
       # Only publish docs if the PR comes from a repo owned by Lime.
       # Also, skip publishing if the PR was created by Dependabot.
       buildOnly: ${{ github.event.pull_request.head.repo.owner.login != 'Lundalogik' || github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      linkToPR:
+        description: 'Pass `true` if these docs are for a pull request. A link to the docs will be posted in a comment on the PR.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
 
@@ -44,7 +49,7 @@ jobs:
       run: npm run docs:build
 
   link-docs:
-    if: inputs.buildOnly == false
+    if: inputs.buildOnly == false && inputs.linkToPR == true
     name: Post link to docs on PR
     needs: [publish-docs]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
