### PR TITLE
fix(select): toggle `aria-expanded` to improve accessibility

### DIFF
--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -87,7 +87,8 @@ const SelectValue: FunctionalComponent<
             onClick={props.open}
             onKeyPress={props.onTriggerPress}
             aria-haspopup="listbox"
-            aria-expanded="false"
+            aria-expanded={props.isOpen}
+            aria-controls={props.id}
             aria-labelledby="s-label s-selected-text"
             aria-required={props.required}
             disabled={props.disabled || props.readonly}


### PR DESCRIPTION
Sets `aria-expanded` to `true` when the dropdown menu is open, and to `false` when it is closed.

fix https://github.com/Lundalogik/lime-elements/issues/1966

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
