### PR TITLE
fix(shortcut): use `link` interface

### DIFF
--- a/src/components/shortcut/examples/shortcut-with-click-handler.tsx
+++ b/src/components/shortcut/examples/shortcut-with-click-handler.tsx
@@ -9,13 +9,17 @@ import { Component, h } from '@stencil/core';
 })
 export class ShortcutWithClickHandlerExample {
     public render() {
+        const link = {
+            href: '#/component/limel-table',
+            title: 'Open the documentation for limel-table',
+        };
+
         return (
             <limel-shortcut
                 icon="pivot_table"
                 label="limel-table"
-                linkTitle="Open the documentation for limel-table"
-                href="#/component/limel-table"
                 onClick={this.handleClick}
+                link={link}
             />
         );
     }

--- a/src/components/shortcut/examples/shortcut.tsx
+++ b/src/components/shortcut/examples/shortcut.tsx
@@ -9,14 +9,14 @@ import { Component, h } from '@stencil/core';
 })
 export class ShortcutExample {
     public render() {
+        const link = {
+            href: 'https://www.wikipedia.org/',
+            title: 'Open Wikipedia in a new tab.',
+            target: '_blank',
+        };
+
         return (
-            <limel-shortcut
-                icon="wikipedia"
-                label="Wikipedia"
-                linkTitle="Open Wikipedia's website in a new tab."
-                href="https://www.wikipedia.org/"
-                target="_blank"
-            />
+            <limel-shortcut icon="wikipedia" label="Wikipedia" link={link} />
         );
     }
 }

--- a/src/components/shortcut/examples/shortcut.tsx
+++ b/src/components/shortcut/examples/shortcut.tsx
@@ -1,6 +1,19 @@
 import { Component, h } from '@stencil/core';
 /**
  * Basic example
+ *
+ * This component acts as a link, and therefore comes with features
+ * such as `title` and `target`.
+ *
+ * The `title` tag of the hyperlink can be used to
+ * provide additional information about the link.
+ * It improves accessibility both for users with assistive technologies,
+ * and sighted users. Hovering and holding the mouse cursor will
+ * display a tooltip generated with the specified `title`.
+ *
+ * What the `target` does is described well in
+ * [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target).
+ *
  */
 @Component({
     tag: 'limel-example-shortcut',

--- a/src/components/shortcut/shortcut.e2e.ts
+++ b/src/components/shortcut/shortcut.e2e.ts
@@ -37,28 +37,34 @@ describe('limel-shortcut', () => {
         });
     });
 
-    describe('with `linkTitle`', () => {
+    describe('with `link` `title`', () => {
         beforeEach(async () => {
             page = await createPage(`
-                <limel-shortcut link-title="Open the iSpiffy app"></limel-shortcut>
+                <limel-shortcut></limel-shortcut>
             `);
             limelShortcut = await page.find('limel-shortcut');
+            limelShortcut.setProperty('link', {
+                title: 'Open the iSpiffy app',
+            });
+            await page.waitForChanges();
             link = await page.find('limel-shortcut >>> a');
             label = await page.find('limel-shortcut >>> span');
         });
-        it('sets the `title` attribute on the link', () => {
+        it('sets the `title` attribute on the `link`', () => {
             expect(link).toEqualAttribute('title', 'Open the iSpiffy app');
         });
-        it('includes the label in `aria-label`', () => {
+        it('includes the `title` in `aria-label`', () => {
             expect(link).toEqualAttribute('aria-label', 'Open the iSpiffy app');
         });
 
-        describe('when changing the `linkTitle`', () => {
+        describe('when changing the `link` `title`', () => {
             beforeEach(async () => {
-                limelShortcut.setProperty('linkTitle', 'I need a cup of tea');
+                limelShortcut.setProperty('link', {
+                    title: 'I need a cup of tea',
+                });
                 await page.waitForChanges();
             });
-            it('uses the new title', async () => {
+            it('uses the new `title`', async () => {
                 expect(link).toEqualAttribute('title', 'I need a cup of tea');
             });
             it('updates `aria-label`', () => {
@@ -70,26 +76,30 @@ describe('limel-shortcut', () => {
         });
     });
 
-    describe('with a label and a linkTitle', () => {
+    describe('with a label and a `link` `title`', () => {
         beforeEach(async () => {
             page = await createPage(`
-                <limel-shortcut label="iSpiffy" link-title="Open the iSpiffy app"></limel-shortcut>
+                <limel-shortcut label="iSpiffy"></limel-shortcut>
             `);
             limelShortcut = await page.find('limel-shortcut');
+            limelShortcut.setProperty('link', {
+                title: 'Open the iSpiffy app',
+            });
+            await page.waitForChanges();
             link = await page.find('limel-shortcut >>> a');
             label = await page.find('limel-shortcut >>> span');
         });
-        it('displays the correct label', () => {
+        it('displays the correct `label`', () => {
             expect(label).toEqualText('iSpiffy');
         });
-        it('uses both the label and the linkTitle to construct the `aria-label`', () => {
+        it('uses both the `label` and the `link` `title` to construct the `aria-label`', () => {
             expect(link).toEqualAttribute(
                 'aria-label',
                 'iSpiffy. Open the iSpiffy app'
             );
         });
 
-        describe('when changing the label', () => {
+        describe('when changing the `label`', () => {
             beforeEach(async () => {
                 limelShortcut.setProperty('label', 'imTired');
                 await page.waitForChanges();
@@ -102,9 +112,11 @@ describe('limel-shortcut', () => {
             });
         });
 
-        describe('when changing the linkTitle', () => {
+        describe('when changing the `link` `title`', () => {
             beforeEach(async () => {
-                limelShortcut.setProperty('linkTitle', 'I need a cup of tea');
+                limelShortcut.setProperty('link', {
+                    title: 'I need a cup of tea',
+                });
                 await page.waitForChanges();
             });
             it('updates `aria-label`', () => {

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -1,4 +1,5 @@
 import { Component, Prop, h } from '@stencil/core';
+import { Link } from '@limetech/lime-elements';
 
 /**
  * This component can be used on places such as a start page or a dashboard.
@@ -33,37 +34,10 @@ export class Shortcut {
     public label?: string = null;
 
     /**
-     * The `title` tag of the hyperlink, which can be used to
-     * provide additional information about the link.
-     * It improves accessibility both for sighted users
-     * and users with assistive technologies.
-     */
-    @Prop({ reflect: true })
-    public linkTitle?: string = null;
-
-    /**
      * Set to `true` if shortcut is disabled.
      */
     @Prop({ reflect: true })
     public disabled?: boolean = false;
-
-    /**
-     * The url that the shortcut leads to.
-     */
-    @Prop({ reflect: true })
-    public href?: string = null;
-
-    /**
-     * Where to load the linked URL, as the name for a browsing context:
-     * - `_self`: in the current browsing context. (Default)
-     * - `_blank`: in a new tab.
-     * - `_parent`: in the parent browsing context of the current one.
-     * If no parent, behaves as `_self`.
-     * - `_top`: the topmost browsing context (the "highest" context
-     * that's an ancestor of the current one). If no ancestors, behaves as `_self`.
-     */
-    @Prop({ reflect: true })
-    public target: '_self' | '_blank' | '_parent' | '_top' = '_self';
 
     /**
      * If specified, will display a notification badge
@@ -72,15 +46,21 @@ export class Shortcut {
     @Prop({ reflect: true })
     public badge?: number | string;
 
+    /**
+     * If supplied, the shortcut will be a clickable link.
+     */
+    @Prop()
+    public link?: Link;
+
     public render() {
         return [
             <a
                 aria-disabled={this.disabled}
-                href={this.href}
-                target={this.target}
+                href={this.link?.href}
+                target={this.link?.target}
                 tabindex="0"
                 aria-label={this.getAriaLabel()}
-                title={this.linkTitle}
+                title={this.link?.title}
             >
                 <limel-icon name={this.icon} />
             </a>,
@@ -96,16 +76,16 @@ export class Shortcut {
     };
 
     private getAriaLabel = () => {
-        if (this.label && this.linkTitle) {
-            return this.label + '. ' + this.linkTitle;
+        if (this.label && this.link?.title) {
+            return this.label + '. ' + this.link.title;
         }
 
         if (this.label) {
             return this.label;
         }
 
-        if (this.linkTitle) {
-            return this.linkTitle;
+        if (this.link?.title) {
+            return this.link.title;
         }
 
         return undefined;

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -4,10 +4,11 @@ import { Link } from '@limetech/lime-elements';
 /**
  * This component can be used on places such as a start page or a dashboard.
  * Clicking on the component should navigate the user to a new screen,
- * to which you need to provide a URL, using the `href` property.
+ * to which you need to provide a URL, by specifying an `href` for the `link` property.
  *
  * By default, this navigation will happen within the same browser tab.
- * However, it is possible to override that behavior, using the `target` property.
+ * However, it is possible to override that behavior, by specifying a `target`
+ * for the `link` property
  *
  * @exampleComponent limel-example-shortcut
  * @exampleComponent limel-example-shortcut-notification


### PR DESCRIPTION
Now `target`, `href` and `title`, are set
using the `link` interface.

BREAKING CHANGES
Instead of individual props for `target`, `href` and `linkTitle`,
the component now only has one prop for `link`.
Check out the documentations for more info.

fix https://github.com/Lundalogik/lime-elements/issues/1977

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
