### PR TITLE
fix(form): enable `lint` and `fold` for code editor in form

### DIFF
--- a/src/components/form/widgets/code-editor.ts
+++ b/src/components/form/widgets/code-editor.ts
@@ -24,6 +24,8 @@ export class CodeEditor extends React.Component {
                 value: value,
                 language: 'json',
                 lineNumbers: true,
+                fold: true,
+                lint: true,
             },
             events: {
                 change: this.handleChange,


### PR DESCRIPTION
The linting allows the user to see syntax errors in the JSON code shown in the editor.
Folding makes it possible to collapse pieces of code.

fix https://github.com/Lundalogik/crm-feature/issues/3105

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
