### PR TITLE
feat(form): add errors to formInfo

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -2,9 +2,11 @@ import { LimeElementsAdapter } from '../adapters';
 import JSONSchemaField from '@rjsf/core/lib/components/fields/SchemaField';
 import React from 'react';
 import { FieldProps } from './types';
-import { isEmpty, capitalize } from 'lodash-es';
+import { isEmpty, capitalize, mapValues } from 'lodash-es';
 import { resetDependentFields } from './field-helpers';
 import { FieldTemplate } from '../templates';
+import { ValidationError } from '../form.types';
+import { ExtraError } from '../form';
 
 /**
  * If given a value and schema, check if the value should be translated
@@ -214,6 +216,9 @@ export class SchemaField extends React.Component<FieldProps> {
                 schema: schema,
                 rootSchema: registry.formContext.schema,
                 errorSchema: errorSchema,
+                get errors() {
+                    return toValidationErrors(errorSchema);
+                },
                 rootValue: registry.formContext.rootValue,
                 name: name,
             },
@@ -260,4 +265,9 @@ export class SchemaField extends React.Component<FieldProps> {
 
         return React.createElement(JSONSchemaField, fieldProps);
     }
+}
+
+function toValidationErrors(errorSchema: ExtraError): ValidationError {
+    // eslint-disable-next-line no-underscore-dangle
+    return errorSchema.__errors || mapValues(errorSchema, toValidationErrors);
 }

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -304,7 +304,7 @@ export class Form {
     }
 }
 
-interface ExtraError {
+export interface ExtraError {
     [key: string]:
         | ExtraError
         | {

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -106,6 +106,8 @@ export interface FormInfo {
      */
     errorSchema?: object;
 
+    errors: ValidationError;
+
     /**
      * The value of the whole form
      */


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
