### PR TITLE
feat(form): adds schema path to custom components form info

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -197,8 +197,15 @@ export class SchemaField extends React.Component<FieldProps> {
     }
 
     private buildCustomComponentProps() {
-        const { disabled, readonly, name, registry, schema, errorSchema } =
-            this.props;
+        const {
+            disabled,
+            readonly,
+            name,
+            registry,
+            schema,
+            errorSchema,
+            idSchema,
+        } = this.props;
         const factoryProps = getFactoryProps(registry.formContext, schema);
 
         return {
@@ -216,6 +223,7 @@ export class SchemaField extends React.Component<FieldProps> {
                 errorSchema: errorSchema,
                 rootValue: registry.formContext.rootValue,
                 name: name,
+                schemaPath: this.getSchemaPath(idSchema.$id),
             },
         };
     }
@@ -259,5 +267,19 @@ export class SchemaField extends React.Component<FieldProps> {
         };
 
         return React.createElement(JSONSchemaField, fieldProps);
+    }
+
+    /**
+     * Gets the path to the current property within the schema
+     *
+     * @param {string} schemaId the id of the schema
+     * @returns {string[]} an array with the schema path for the current property
+     * @example
+     * const schemaId = 'root_sections_0_controls_0_name';
+     * const schemaPath = getSchemaPath(schemaId);
+     * // => ['sections', '0', 'controls', '0', 'name']
+     */
+    private getSchemaPath(schemaId: string): string[] {
+        return schemaId.replace('root_', '').split('_');
     }
 }

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -115,6 +115,11 @@ export interface FormInfo {
      * The name of the current property
      */
     name?: string;
+
+    /**
+     * Path to the property within the schema
+     */
+    schemaPath?: string[];
 }
 
 /**


### PR DESCRIPTION
fix Lundalogik/crm-feature#3036

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
