### PR TITLE
fix(list): when `has-interactive-items` is focused and hovered, list …

### DIFF
--- a/src/components/list/partial-styles/custom-styles.scss
+++ b/src/components/list/partial-styles/custom-styles.scss
@@ -27,10 +27,6 @@ $background-color-of-interactive-items-hovered: rgb(var(--contrast-100));
             &:hover {
                 z-index: $list--has-interactive-items--mdc-list-item--hover;
                 background-color: $background-color-of-interactive-items-hovered;
-
-                &:before {
-                    background-color: $background-color-of-interactive-items-hovered;
-                }
             }
         }
     }


### PR DESCRIPTION
…item not getting fully white

fix: https://github.com/Lundalogik/lime-elements/issues/1992

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
