### PR TITLE
docs(picker): add documentation for the `Searcher` type

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -110,6 +110,9 @@ export class Picker {
      * A search function that takes a search-string as an argument,
      * and returns a promise that will eventually be resolved with
      * an array of `ListItem`:s.
+     *
+     * See the docs for the type `Searcher` for type information on
+     * the searcher function itself.
      */
     @Prop()
     public searcher: Searcher;

--- a/src/components/picker/searcher.types.ts
+++ b/src/components/picker/searcher.types.ts
@@ -1,3 +1,11 @@
 import { ListItem } from '../list/list-item.types';
 
+/**
+ * A search function that takes a search-string as an argument, and returns
+ * a promise that will eventually be resolved with an array of `ListItem`:s.
+ *
+ * @param {string} query A search query. Typically what the user has written
+ * in the input field of a limel-picker.
+ * @returns {Promise<ListItem[]>} The search result.
+ */
 export type Searcher = (query: string) => Promise<ListItem[]>;


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
