### PR TITLE
docs(shadows): fix typo in documented CSS variable names for inflated…

### DIFF
--- a/src/design-guidelines/shadows/examples/button-shadows.tsx
+++ b/src/design-guidelines/shadows/examples/button-shadows.tsx
@@ -20,7 +20,7 @@ export class ButtonShadowExample {
                     <button class="button hovered">
                         <div class="label">Hover</div>
                     </button>
-                    <code>--button-shadow-hover</code>
+                    <code>--button-shadow-hovered</code>
                     <p>
                         makes the element look raised a bit more, ready to be
                         pressed

--- a/src/design-guidelines/shadows/examples/surface-shadows-inflated.tsx
+++ b/src/design-guidelines/shadows/examples/surface-shadows-inflated.tsx
@@ -13,21 +13,21 @@ export class SurfaceShadowInflatedExample {
                     <div class="surface shadow-inflated-8">
                         <div class="label">Inflated 8</div>
                     </div>
-                    <code>--shadow--inflated-8</code>
+                    <code>--shadow-inflated-8</code>
                     <p></p>
                 </div>
                 <div class="visualization">
                     <div class="surface shadow-inflated-16">
                         <div class="label two">Inflated 16</div>
                     </div>
-                    <code>--shadow--inflated-16</code>
+                    <code>--shadow-inflated-16</code>
                     <p></p>
                 </div>
                 <div class="visualization">
                     <div class="surface shadow-inflated-64">
                         <div class="label two">Inflated 64</div>
                     </div>
-                    <code>--shadow--inflated-64</code>
+                    <code>--shadow-inflated-64</code>
                     <p></p>
                 </div>
             </div>,


### PR DESCRIPTION
… shadows



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
