### PR TITLE
docs(button): fix description of `loading` property to match updated behaviour

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -51,9 +51,7 @@ export class Button {
 
     /**
      * Set to `true` to put the button in the `loading` state.
-     * Please note that this does _not_ disable the button.
-     * If the button should be disabled while loading, the
-     * `disabled` property should be set to `true` as well.
+     * This also disables the button.
      */
     @Prop({ reflect: true })
     public loading = false;


### PR DESCRIPTION
Since v36.0.0-next.5, setting the `loading` property to `true` also disables the button, but the documentation had not been updated to reflect this new behaviour.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
