### PR TITLE
fix(form): prevent error if `idSchema` is undefined

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -223,7 +223,7 @@ export class SchemaField extends React.Component<FieldProps> {
                 errorSchema: errorSchema,
                 rootValue: registry.formContext.rootValue,
                 name: name,
-                schemaPath: this.getSchemaPath(idSchema.$id),
+                schemaPath: this.getSchemaPath(idSchema?.$id),
             },
         };
     }
@@ -280,6 +280,10 @@ export class SchemaField extends React.Component<FieldProps> {
      * // => ['sections', '0', 'controls', '0', 'name']
      */
     private getSchemaPath(schemaId: string): string[] {
+        if (schemaId === undefined) {
+            return undefined;
+        }
+
         return schemaId.replace('root_', '').split('_');
     }
 }


### PR DESCRIPTION
fix: Lundalogik/crm-feature#3136

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
