### PR TITLE
fix(button-group): reduce the label's font-size

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -109,6 +109,7 @@
 }
 
 .mdc-chip__text {
+    font-size: functions.pxToRem(13);
     overflow: hidden;
     text-overflow: ellipsis;
     display: block;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2002

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
