### PR TITLE
fix(table): make pagination buttons fully support dark mode

### DIFF
--- a/src/components/table/partial-styles/tabulator-paginator.scss
+++ b/src/components/table/partial-styles/tabulator-paginator.scss
@@ -34,7 +34,7 @@
                 border: none;
                 border-radius: functions.pxToRem(40);
 
-                background-color: transparent;
+                background-color: transparent; // has to be here, otherwise disabled buttons will also get a background
 
                 &.active {
                     background-color: var(--mdc-theme-surface);
@@ -54,43 +54,55 @@
 }
 
 // Interactivity effects for buttons
-.tabulator-page {
+button.tabulator-page {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+
     &[data-page='first'],
     &[data-page='prev'],
     &[data-page='next'],
     &[data-page='last'] {
         font-size: 0;
         color: transparent !important;
+
+        &:before,
         &:after {
+            content: '';
             transition: transform 0.2s ease;
             display: block;
-            opacity: 0.7;
 
             position: absolute;
-            top: functions.pxToRem(2);
-            right: functions.pxToRem(2);
-            bottom: functions.pxToRem(2);
-            left: functions.pxToRem(2);
         }
-    }
 
-    &[data-page='prev'],
-    &[data-page='next'] {
         &:after {
-            content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2' clip-rule='evenodd' viewBox='0 0 100 100'><defs/><path d='M68.714 50L37.286 70V30l31.428 20z'/></svg>");
-            @media (prefers-color-scheme: dark) {
-                content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2' clip-rule='evenodd' viewBox='0 0 100 100'><defs/><path fill='rgb(255,255,255)' d='M68.714 50L37.286 70V30l31.428 20z'/></svg>");
+            border: {
+                style: solid;
+                color: transparent;
+                width: 0.25rem 0 0.25rem 0.4rem;
+                left-color: var(--mdc-theme-on-surface);
             }
         }
     }
 
     &[data-page='first'],
     &[data-page='last'] {
-        &:after {
-            content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2' clip-rule='evenodd' viewBox='0 0 100 100'><defs/><path d='M60.714 50L29.286 70V30l31.428 20zM64.714 30h6v40h-6z'/></svg>");
-            @media (prefers-color-scheme: dark) {
-                content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2' clip-rule='evenodd' viewBox='0 0 100 100'><defs/><path fill='rgb(255,255,255)' d='M60.714 50L29.286 70V30l31.428 20zM64.714 30h6v40h-6z'/></svg>");
-            }
+        &:before {
+            height: 0.5rem;
+            width: 0.125rem;
+            background-color: var(--mdc-theme-on-surface);
+        }
+    }
+
+    &[data-page='first'] {
+        &:before {
+            left: 0.375rem;
+        }
+    }
+
+    &[data-page='last'] {
+        &:before {
+            right: 0.375rem;
         }
     }
 


### PR DESCRIPTION
We don't use SVGs in the CSS anymore.
Instead we draw the arrow icons, using CSS
and colors that react to color-scheme.



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
