### PR TITLE
Backport info tile fix

### DIFF
--- a/src/components/info-tile/info-tile.e2e.ts
+++ b/src/components/info-tile/info-tile.e2e.ts
@@ -1,9 +1,9 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 
-describe('limel-icon-button', () => {
-    let page;
+describe('limel-info-tile', () => {
+    let page: E2EPage;
     describe('smoke test', () => {
-        let value;
+        let value: E2EElement;
         beforeEach(async () => {
             page = await createPage(`
                 <limel-info-tile value="Test value"></limel-info-tile>

--- a/src/components/info-tile/info-tile.e2e.ts
+++ b/src/components/info-tile/info-tile.e2e.ts
@@ -14,6 +14,19 @@ describe('limel-info-tile', () => {
             expect(value).toEqualText('Test value');
         });
     });
+
+    describe('when value is empty', () => {
+        let label: E2EElement;
+        beforeEach(async () => {
+            page = await createPage(`
+                <limel-info-tile label="Test label"></limel-info-tile>
+            `);
+            label = await page.find('limel-info-tile >>> .label');
+        });
+        it('does not crash', () => {
+            expect(label).toEqualText('Test label');
+        });
+    });
 });
 
 async function createPage(content) {

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -157,7 +157,7 @@ export class InfoTile {
     };
 
     private renderValue = () => {
-        const characterCount = this.value.toString().length;
+        const characterCount = (this.value ?? '').toString().length;
 
         if (this.value) {
             return (


### PR DESCRIPTION
Backport of fix for #2022

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
