### PR TITLE
chore(style): use our CSS variables instead of HEX values for Lime br…

### DIFF
--- a/src/style/colors.scss
+++ b/src/style/colors.scss
@@ -1,17 +1,15 @@
-@use './brand-colors';
-
 :root {
-    --lime-deep-red: #{brand-colors.$lime-deep-red};
-    --lime-red: #{brand-colors.$lime-red};
-    --lime-orange: #{brand-colors.$lime-orange};
-    --lime-yellow: #{brand-colors.$lime-yellow};
-    --lime-green: #{brand-colors.$lime-green};
-    --lime-turquoise: #{brand-colors.$lime-turquoise};
-    --lime-blue: #{brand-colors.$lime-blue};
-    --lime-dark-blue: #{brand-colors.$lime-dark-blue};
-    --lime-magenta: #{brand-colors.$lime-magenta};
-    --lime-light-grey: #{brand-colors.$lime-light-grey};
-    --lime-dark-grey: #{brand-colors.$lime-dark-grey};
+    --lime-deep-red: rgb(var(--lime-brand-color-deep-red));
+    --lime-red: rgb(var(--lime-brand-color-sellable-orange));
+    --lime-orange: rgb(var(--lime-brand-color-orange));
+    --lime-yellow: rgb(var(--lime-brand-color-yellow));
+    --lime-green: rgb(var(--lime-brand-color-lime-green));
+    --lime-turquoise: rgb(var(--lime-brand-color-flexible-turquoise));
+    --lime-blue: rgb(var(--lime-brand-color-simple-blue));
+    --lime-dark-blue: rgb(var(--lime-brand-color-dark-blue));
+    --lime-magenta: rgb(var(--lime-brand-color-loving-magenta));
+    --lime-light-grey: rgb(var(--lime-brand-color-light-grey));
+    --lime-dark-grey: rgb(var(--lime-brand-color-grey));
 
     --color-percent--0: rgb(var(--color-gray-default));
     --color-percent--0to10: rgb(var(--color-red-dark));


### PR DESCRIPTION
…and colors

The old brand color CSS variables are still found here and there in the CRM web client. However, those old variables used HEX values. Now we simply use our new variable names instead.
This makes it easier to keep things up-to-date and in sync, in case we update one of these color variables.

## ⚠️ is this safe?
Since these variables have always been used directly in CSS as they are, there shouldn't be any reasons to worry. For example, they could have never been used in some Lime CRM app or add-on in a SCSS function, they could have never been combined with other SCSS functions like `lighten($color, $amount)`. Or they could have never been used as RGB with alpha channel, like the way we do with out own color variables. 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
