### PR TITLE
fix(info-tiles): adjust the layout if no container queries support

### DIFF
--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -112,6 +112,7 @@ a {
 }
 
 .icon {
+    z-index: 1;
     position: absolute;
     top: 0.5rem;
     right: 0.75rem;

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -158,12 +158,7 @@ a {
     z-index: 1;
     color: var(--info-tile-text-color, rgb(var(--contrast-1100)));
 
-    line-height: normal;
-    // white-space: normal;
-    // overflow: hidden;
-    // display: -webkit-box;
-    // -webkit-line-clamp: 2; // max number of lines before truncation
-    // -webkit-box-orient: vertical;
+    line-height: 1.2;
     font-size: clamp(
         var(--label-min-size),
         var(--label-preferred-size),

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -129,7 +129,7 @@ a {
     );
 
     @supports not (container-type: size) {
-        height: min(60%, var(--icon-max-size));
+        height: min(20%, 5rem);
     }
 
     .has-circular-progress & {
@@ -149,6 +149,9 @@ a {
         var(--icon-preferred-size),
         var(--icon-max-size)
     );
+    @supports not (container-type: size) {
+        --circular-progress-size: initial;
+    }
 }
 
 .label {
@@ -240,7 +243,7 @@ limel-linear-progress {
         var(--value-max-size)
     );
     @supports not (container-type: size) {
-        font-size: 2.5rem;
+        font-size: 1.5rem;
     }
 
     :host(limel-info-tile[loading]) & {

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -117,8 +117,7 @@ a {
     right: 0.75rem;
     padding: 0.25rem;
 
-    display: flex;
-    justify-content: center;
+    aspect-ratio: 1/1;
 
     color: var(--info-tile-icon-color, rgb(var(--contrast-1000)));
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/3144

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
