### PR TITLE
docs(kompendium): update kompendium from v0.11.4 to v0.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "jest-cli": "^27.4.5",
         "jsonlint-mod": "^1.7.6",
         "jsx-dom": "^8.0.4",
-        "kompendium": "^0.11.4",
+        "kompendium": "^0.12.1",
         "lodash-es": "^4.17.21",
         "material-components-web": "^13.0.0",
         "moment": "^2.29.4",
@@ -10640,9 +10640,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.4.tgz",
-      "integrity": "sha512-TFtRA5Wnq14boOAh+PnDQsyk/uPgctHKi2m9SMfkiTGv4TNzozn8fhYPf1MX+W3EXnyC4d82yuW0pvKd1HlaKw==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.1.tgz",
+      "integrity": "sha512-T1hMbXSBcmJH3hYRT/W8/L/op+18WhMouZm5WwY92SjXccnP7xfQlmF6HYDyuOWO6IN51wIgUYxXAS5gIMohaw==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -23485,9 +23485,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.11.4.tgz",
-      "integrity": "sha512-TFtRA5Wnq14boOAh+PnDQsyk/uPgctHKi2m9SMfkiTGv4TNzozn8fhYPf1MX+W3EXnyC4d82yuW0pvKd1HlaKw==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.1.tgz",
+      "integrity": "sha512-T1hMbXSBcmJH3hYRT/W8/L/op+18WhMouZm5WwY92SjXccnP7xfQlmF6HYDyuOWO6IN51wIgUYxXAS5gIMohaw==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest-cli": "^27.4.5",
     "jsonlint-mod": "^1.7.6",
     "jsx-dom": "^8.0.4",
-    "kompendium": "^0.11.4",
+    "kompendium": "^0.12.1",
     "lodash-es": "^4.17.21",
     "material-components-web": "^13.0.0",
     "moment": "^2.29.4",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
