### PR TITLE
fix(switch): specify color for label to support dark mode better

### DIFF
--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -70,6 +70,7 @@ $scale-factor: 0.8;
 
 label {
     @include lime-typography.typography(body2);
+    color: var(--mdc-theme-on-surface);
 
     cursor: pointer;
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2056 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
