### PR TITLE
fix(form): use dark mode friendly CSS variable for headline & body text

### DIFF
--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -169,13 +169,17 @@
         margin-bottom: 0.5rem;
     }
     .form-group {
+        .mdc-typography--headline1,
+        .mdc-typography--body1 {
+            color: var(--mdc-theme-on-surface);
+        }
+
         .mdc-typography--headline1 {
             --mdc-typography-headline1-font-size: 1.625rem;
             --mdc-typography-headline1-line-height: 1.25rem;
             --mdc-typography-headline1-font-weight: 300;
             margin-top: 1.25rem;
             margin-bottom: 0.5rem;
-            color: rgb(var(--contrast-1100));
 
             &:before {
                 content: '';


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2055

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
