### PR TITLE
fix(form): make headline and body text colors darker for nested sections

### DIFF
--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -159,19 +159,24 @@
 }
 
 .form-group {
+    .mdc-typography--headline1,
+    .mdc-typography--body1 {
+        color: rgb(var(--contrast-1100));
+    }
+
     .mdc-typography--headline1 {
         --mdc-typography-headline1-font-size: 2rem;
         --mdc-typography-headline1-line-height: 2.25rem;
         --mdc-typography-headline1-letter-spacing: -0.0625rem;
         --mdc-typography-headline1-font-weight: 400;
-        color: rgb(var(--contrast-1000));
         margin-top: 1.5rem;
         margin-bottom: 0.5rem;
     }
+
     .form-group {
         .mdc-typography--headline1,
         .mdc-typography--body1 {
-            color: var(--mdc-theme-on-surface);
+            color: rgb(var(--contrast-1200));
         }
 
         .mdc-typography--headline1 {
@@ -200,13 +205,17 @@
         }
 
         .form-group {
+            .mdc-typography--headline1,
+            .mdc-typography--body1 {
+                color: rgb(var(--contrast-1300));
+            }
+
             .mdc-typography--headline1 {
                 --mdc-typography-headline1-font-size: 1.375rem;
                 --mdc-typography-headline1-line-height: 1.5rem;
                 --mdc-typography-headline1-font-weight: 300;
                 margin-top: 1rem;
                 margin-bottom: 0.5rem;
-                color: rgb(var(--contrast-1200));
 
                 &:before {
                     display: none;
@@ -214,13 +223,17 @@
             }
 
             .form-group {
+                .mdc-typography--headline1,
+                .mdc-typography--body1 {
+                    color: rgb(var(--contrast-1400));
+                }
+
                 .mdc-typography--headline1 {
                     --mdc-typography-headline1-font-size: 1.25rem;
                     --mdc-typography-headline1-line-height: 1.25rem;
                     --mdc-typography-headline1-font-weight: 300;
                     margin-top: 1rem;
                     margin-bottom: 0.5rem;
-                    color: rgb(var(--contrast-1200));
 
                     &:before {
                         display: none;


### PR DESCRIPTION
A collapsible section in a form can have nested collapsible sections. Since the nested sections get darker background colors, it's important that the text color of headings and body texts has good contrast with the background. Therefore, we cannot use `var(--mdc-theme-on-surface` for both, and have to keep making it darker for each depth level.

<img width="970" alt="Screenshot 2023-01-20 at 12 50 20" src="https://user-images.githubusercontent.com/35954987/213688864-0d35ab29-e5fd-48a5-a877-4de40c8a2abd.png">



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
