### PR TITLE
fix(collapsible-section): make header title color respect dark mode

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -69,6 +69,7 @@
 
 .section__header__title {
     @include lime-typography.typography(headline2);
+    color: var(--mdc-theme-on-surface);
 
     justify-self: flex-start;
     padding-right: functions.pxToRem(12);


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2060

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
