### PR TITLE
2063 icon and delimiter color of chip set

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -338,6 +338,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 .delimiter {
     opacity: 0.5;
     padding: 0 functions.pxToRem(2);
+    color: var(--mdc-theme-on-surface);
 }
 
 @import './partial-styles/_readonly';

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -19,6 +19,8 @@ $background-color-disabled: transparent;
 $label-color: rgba(var(--contrast-1200), 1);
 $label-color-disabled: rgba(var(--contrast-1200), 0.5);
 $input-text-color: rgba(var(--contrast-1400), 1);
+$input-text-leading-icon-color: rgb(var(--contrast-900));
+
 $input-text-color-disabled: rgba(var(--contrast-1400), 0.5);
 $helper-text-color: $label-color;
 
@@ -228,12 +230,14 @@ $cropped-label-hack--font-size: 0.875rem; //14px
     }
 
     .mdc-text-field__icon {
+        color: $input-text-leading-icon-color;
         flex-shrink: 0;
     }
 }
 
 @mixin leading-icon {
     .mdc-text-field__icon {
+        color: $input-text-leading-icon-color;
         width: functions.pxToRem(24);
         height: functions.pxToRem(24);
     }


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2063

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
