### PR TITLE
ci(pre-release.yml): trigger update in lime-crm-building-blocks when `next` is released

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,6 +44,13 @@ jobs:
         GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN_ads }}
         CI: true
+    - name: Trigger update in lime-crm-building-blocks
+      if: steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'next'
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.PRIVATE_REPO_DISPATCH }}
+        event-type: update-lime-elements
+        repository: Lundalogik/lime-crm-building-blocks
     - name: Trigger update in lime-crm-components
       if: steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'next'
       uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
