### PR TITLE
fix(menu): do not hide menu to screen readers when menu is open

### DIFF
--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -55,7 +55,7 @@ export class MenuListRenderer {
         return (
             <ul
                 class={classNames}
-                aria-hidden={true}
+                aria-hidden={!this.config.isOpen}
                 role="menu"
                 aria-orientation="vertical"
                 style={{ '--maxLinesSecondaryText': '2' }}


### PR DESCRIPTION
I think MDC used to take of removing this attribute when the menu opened, but it doesn't seem to work anymore, so let's set it correctly ourselves instead.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
