### PR TITLE
fix(slider): make min & max labels react to dark mode

### DIFF
--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -46,6 +46,7 @@
     opacity: 0.7;
     font-size: functions.pxToRem(12);
     top: functions.pxToRem(20);
+    color: shared_input-select-picker.$helper-text-color;
 
     .slider:hover & {
         opacity: 1;


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2087

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
