### PR TITLE
fix(split-button): make sure it stretches in mobile view

### DIFF
--- a/src/components/dialog/examples/dialog-action-buttons.scss
+++ b/src/components/dialog/examples/dialog-action-buttons.scss
@@ -5,7 +5,7 @@
 }
 
 .button {
-    &:first-of-type {
+    &.back {
         // these styles will align the targeted button to the left.
         margin-right: auto;
         margin-top: 0;
@@ -24,7 +24,7 @@
 
 @media screen and (max-width: 760px) {
     .button {
-        &:first-of-type {
+        &.back {
             // these styles will add a gap between "back button" and "discard" in a mobile view
             // and put all buttons in a column.
             margin-top: 1rem;

--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -13,6 +13,10 @@
     }
 }
 
+limel-button {
+    width: 100%;
+}
+
 $distance-around-trigger: 0.125rem;
 
 limel-menu {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2078

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
