### PR TITLE
fix(split-button): do not emit `click` events when button is disabled

### DIFF
--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -13,6 +13,10 @@
     }
 }
 
+:host([disabled]) {
+    pointer-events: none;
+}
+
 limel-button {
     width: 100%;
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2096

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
