### PR TITLE
Add languages to date picker

### DIFF
--- a/src/components/date-picker/date.types.ts
+++ b/src/components/date-picker/date.types.ts
@@ -7,4 +7,4 @@ export type DateType =
     | 'quarter'
     | 'year';
 
-export type Languages = 'da' | 'en' | 'fi' | 'nb' | 'no' | 'nl' | 'sv';
+export type Languages = 'da' | 'en' | 'fi' | 'fr' | 'nb' | 'no' | 'nl' | 'sv';

--- a/src/components/date-picker/date.types.ts
+++ b/src/components/date-picker/date.types.ts
@@ -7,4 +7,13 @@ export type DateType =
     | 'quarter'
     | 'year';
 
-export type Languages = 'da' | 'en' | 'fi' | 'fr' | 'nb' | 'no' | 'nl' | 'sv';
+export type Languages =
+    | 'da'
+    | 'de'
+    | 'en'
+    | 'fi'
+    | 'fr'
+    | 'nb'
+    | 'no'
+    | 'nl'
+    | 'sv';

--- a/src/components/date-picker/dateFormatter.ts
+++ b/src/components/date-picker/dateFormatter.ts
@@ -1,4 +1,5 @@
 import 'moment/locale/da';
+import 'moment/locale/de';
 import 'moment/locale/fi';
 import 'moment/locale/fr';
 import 'moment/locale/nb';

--- a/src/components/date-picker/dateFormatter.ts
+++ b/src/components/date-picker/dateFormatter.ts
@@ -31,7 +31,11 @@ export class DateFormatter {
     }
 
     public getLanguage() {
-        return this.language === 'no' ? 'nb' : this.language;
+        if (this.language === 'no') {
+            return 'nb';
+        }
+
+        return this.language;
     }
 
     public getDateFormat(type: DateType) {

--- a/src/components/date-picker/dateFormatter.ts
+++ b/src/components/date-picker/dateFormatter.ts
@@ -1,9 +1,9 @@
 import 'moment/locale/da';
 import 'moment/locale/fi';
-import 'moment/locale/nb';
-import 'moment/locale/sv';
 import 'moment/locale/fr';
+import 'moment/locale/nb';
 import 'moment/locale/nl';
+import 'moment/locale/sv';
 import moment from 'moment/moment';
 import { DateType } from './date.types';
 

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -96,11 +96,19 @@ export abstract class Picker {
     }
 
     protected getFlatpickrLang() {
-        return this.language === 'nb' ? 'no' : this.language;
+        if (this.language === 'nb') {
+            return 'no';
+        }
+
+        return this.language;
     }
 
     protected getMomentLang() {
-        return this.language === 'no' ? 'nb' : this.language;
+        if (this.language === 'no') {
+            return 'nb';
+        }
+
+        return this.language;
     }
 
     private getPickerDate(selectedDates) {

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -5,6 +5,7 @@ import 'moment/locale/da';
 import 'moment/locale/fi';
 import 'moment/locale/fr';
 import 'moment/locale/nb';
+import 'moment/locale/nl';
 import 'moment/locale/sv';
 import moment from 'moment/moment';
 import { isAndroidDevice, isIOSDevice } from '../../../util/device';

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -3,6 +3,7 @@ import FlatpickrLanguages from 'flatpickr/dist/l10n';
 import { EventEmitter } from '@stencil/core';
 import 'moment/locale/da';
 import 'moment/locale/fi';
+import 'moment/locale/fr';
 import 'moment/locale/nb';
 import 'moment/locale/sv';
 import moment from 'moment/moment';

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -2,6 +2,7 @@ import flatpickr from 'flatpickr';
 import FlatpickrLanguages from 'flatpickr/dist/l10n';
 import { EventEmitter } from '@stencil/core';
 import 'moment/locale/da';
+import 'moment/locale/de';
 import 'moment/locale/fi';
 import 'moment/locale/fr';
 import 'moment/locale/nb';


### PR DESCRIPTION
See individual commits for details. (If you review this commit by commit, you will see that each change is _extremely_ small, and very easy to understand.)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
