### PR TITLE
feat(select): add `secondaryText` to dropdown options

### DIFF
--- a/src/components/select/option.types.ts
+++ b/src/components/select/option.types.ts
@@ -10,6 +10,11 @@ export interface Option<T extends string = string> {
     text: string;
 
     /**
+     * Additional supporting text to display in under the option text.
+     */
+    secondaryText?: string;
+
+    /**
      * The unique value of the option. Should always be the same for any given
      * option, regardless of localization. The type `T` defaults to `string`,
      * but can be set to any type that extends `string` (using `Option<type>`),


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2104
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
