### PR TITLE
fix(form): make icons in `row` layout visually less dominant

### DIFF
--- a/src/components/form/row/row.scss
+++ b/src/components/form/row/row.scss
@@ -48,6 +48,7 @@
     }
 
     limel-icon {
+        color: rgb(var(--contrast-1200));
         width: var(--limel-form-row-icon-size);
         flex-shrink: 0;
         min-width: 0;


### PR DESCRIPTION
by making their colors more grey.

fix https://github.com/Lundalogik/crm-feature/issues/3197

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
