### PR TITLE
ci(pr-checks.yml): allow one run per PR even for dependabot PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,15 +2,8 @@ name: Pull Request Checks
 on: [pull_request]
 
 concurrency:
-  # Dependabot rebases all its PRs automatically, which causes all branches to
-  # run again every time something is merged. Then perhaps one of Dependabot's
-  # PRs are merged, then all Dependabot's PRs are rebased and run again, etc.
-  # This causes very many unnecessary workflow runs, so we try to limit this
-  # by having each new run triggered by Dependabot cancel any previous runs
-  # triggered by Dependabot.
-  # For any other users, only runs for the same PR are cancelled when a new run
-  # is started. /Ads
-  group: ${{ github.workflow }}-${{ github.actor == 'dependabot[bot]' && 'dependabot' || github.head_ref || github.run_id }}
+  # Only allow one active run of this workflow, per PR.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
