### PR TITLE
chore(dock): enable customers of Lime CRM to add their logo to the fi…

### DIFF
--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -73,3 +73,37 @@ limel-badge {
     top: -0.125rem;
     right: -0.125rem;
 }
+
+// 👇 Below is a hidden and private hack
+// only for usage in Lime CRM components.
+// It enables our customers to override
+// the default Home icon, using an external URL
+// or an SVG code.
+.icon {
+    position: relative;
+
+    &:before {
+        text-align: center;
+        pointer-events: none;
+        position: absolute;
+        inset: 0;
+        background: {
+            color: var(--dock-background-color, rgb(var(--contrast-100)));
+            position: center;
+            repeat: no-repeat;
+            size: contain;
+            image: var(--limel-custom-home-icon);
+        }
+        // Since `content` defaults to `undefined`
+        // no pseudo element will be rendered, unless
+        // the consumer defines something.
+        content: var(--limel-custom-home-icon-enabler);
+
+        .button.selected & {
+            background-color: var(
+                --dock-item-background-color--selected,
+                rgb(var(--contrast-200))
+            );
+        }
+    }
+}

--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -84,4 +84,18 @@ nav {
     }
 }
 
+// 👇 Below is a hidden and private prop
+// only for usage in Lime CRM components.
+// It enables our customers to override
+// the default Home icon, using an external URL
+// or an SVG code.
+limel-dock-button {
+    &:first-of-type {
+        // `--crm-custom-home-icon-enabler`: in the CRM must be set to `''`
+        --limel-custom-home-icon-enabler: var(--crm-custom-home-icon-enabler);
+        // `--crm-custom-home-icon` in the CRM must be set to a url to an image file, or an SVG code
+        --limel-custom-home-icon: var(--crm-custom-home-icon);
+    }
+}
+
 @import './partial-styles/shrink-expand-button';


### PR DESCRIPTION
…rst dock button

fix https://github.com/Lundalogik/hack-tuesday/issues/291

# How to test:

Add the following to a container element in the dom

this remote SVG file
```scss
--crm-custom-home-icon-enabler: '';
--crm-custom-home-icon: url(https://lundalogik.github.io/lime-elements/versions/36.2.0/favicon.svg);
```
or this embedded SVG file
```scss
--crm-custom-home-icon-enabler: '';
--crm-custom-home-icon: url(data:image/svg+xml;charset=utf-8, <svg width='100%' height='100%' viewBox='0 0 32 33' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' xml:space='preserve' xmlns:serif='http://www.serif.com/' style='fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;'><g transform='matrix(0.0532218,0,0,0.0530644,3.07091,3.33257)'><circle cx='242.929' cy='248.14' r='225.472' style='fill:white;'/></g><g transform='matrix(0.0503054,0,0,0.0501566,3.12182,3.65988)'><path d='M456.158,125.852C460.99,141.579 463.498,158.208 463.498,175.431C463.498,230.909 436.295,279.681 394.957,310.339C322.9,363.513 217.914,363.602 73.024,409.356C116.688,461.9 182.397,495.251 255.943,495.251C387.709,495.251 494.543,388.185 494.543,256.062C494.543,208.09 480.383,163.38 456.158,125.852Z' style='fill:rgb(59,78,196);fill-rule:nonzero;'/></g><g transform='matrix(0.0503054,0,0,0.0501566,3.12182,3.65988)'><path d='M255.943,16.75C124.173,16.75 17.457,123.872 17.457,256.089C17.457,309.081 32.045,339.377 56.261,378.075C219.076,333.693 351.146,224.926 399.072,64.542C359.229,34.543 309.658,16.75 255.943,16.75Z' style='fill:rgb(229,51,51);fill-rule:nonzero;'/></g></svg>);
```
or this big PNG file
```scss
--crm-custom-home-icon-enabler: '';
--crm-custom-home-icon: url(https://cdn4.iconfinder.com/data/icons/logos-and-brands-1/512/5_Adidas_logo_logos-1024.png);
```

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
