### PR TITLE
fix(info-tile): ensure loading indicator is displayed when `value` & …

### DIFF
--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -159,6 +159,10 @@ export class InfoTile {
     private renderValue = () => {
         const characterCount = (this.value ?? '').toString().length;
 
+        if (!this.value && this.loading) {
+            return <span class="value">···</span>;
+        }
+
         if (this.value) {
             return (
                 <span


### PR DESCRIPTION
…`suffix` are empty

fix https://github.com/Lundalogik/lime-elements/issues/2133

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
