### PR TITLE
feat(dock): enable displaying a notification badge on the buttons

### DIFF
--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -4,6 +4,8 @@
 
 .button {
     all: unset;
+    isolation: isolate;
+    position: relative;
 
     cursor: pointer;
     @include mixins.is-flat-inset-clickable(
@@ -15,7 +17,6 @@
     box-sizing: border-box;
     display: flex;
     align-items: center;
-    position: relative;
 
     width: 100%;
     height: var(--dock-item-height);
@@ -66,4 +67,10 @@ limel-popover {
     width: calc(var(--dock-item-height) - 1rem);
     height: calc(var(--dock-item-height) - 1rem);
     color: var(--dock-item-icon-color, var(--limel-dock-item-text-color));
+}
+
+limel-badge {
+    position: absolute;
+    top: -0.125rem;
+    right: -0.125rem;
 }

--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -124,13 +124,21 @@ export class DockButton {
                     selected: this.item?.selected,
                 }}
                 onClick={handleClick}
+                aria-live={this.item.badge ? 'polite' : 'off'}
             >
                 {this.renderIcon()}
                 {this.renderLabel()}
                 {this.renderTooltip()}
+                {this.renderNotification()}
             </button>
         );
     }
+
+    private renderNotification = () => {
+        if (this.item.badge || this.item.badge === '') {
+            return <limel-badge label={this.item.badge} />;
+        }
+    };
 
     private openPopover = (event: MouseEvent) => {
         event.stopPropagation();

--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -13,6 +13,9 @@
 */
 
 :host(limel-dock) {
+    --badge-background-color: rgb(var(--color-red-default));
+    --badge-text-color: rgb(var(--color-white));
+
     --dock-item-height: 2.75rem;
     --dock-padding: 0.25rem;
     --dock-expand-shrink-button-height: 1rem;

--- a/src/components/dock/dock.tsx
+++ b/src/components/dock/dock.tsx
@@ -14,6 +14,7 @@ const DEFAULT_MOBILE_BREAKPOINT = 700;
 /**
  * @exampleComponent limel-example-dock-basic
  * @exampleComponent limel-example-dock-custom-component
+ * @exampleComponent limel-example-dock-notification
  * @exampleComponent limel-example-dock-mobile
  * @exampleComponent limel-example-dock-expanded
  * @exampleComponent limel-example-dock-colors-css

--- a/src/components/dock/dock.types.ts
+++ b/src/components/dock/dock.types.ts
@@ -40,6 +40,11 @@ export interface DockItem {
      * Used to specify a custom component to render as a menu for the dock item.
      */
     dockMenu?: DockMenu;
+
+    /**
+     * If specified, will display a notification badge on the buttons in the dock.
+     */
+    badge?: number | string;
 }
 
 export interface DockMenu {

--- a/src/components/dock/examples/dock-notification.scss
+++ b/src/components/dock/examples/dock-notification.scss
@@ -1,0 +1,11 @@
+:host {
+    --popover-surface-width: min(100vw, 15rem);
+}
+
+.application {
+    background-color: rgb(var(--contrast-400));
+    border: 1px solid rgb(var(--contrast-500));
+    overflow: hidden;
+    border-radius: 0.5rem;
+    height: 30rem;
+}

--- a/src/components/dock/examples/dock-notification.tsx
+++ b/src/components/dock/examples/dock-notification.tsx
@@ -1,0 +1,101 @@
+import { Component, h, State } from '@stencil/core';
+import { DockItem } from '../dock.types';
+
+/**
+ * Displaying a notification badge
+ *
+ * It is possible to display a notification badge on each individual
+ * button in the Dock. Badges are supposed to inform the user that
+ * there is something in the menu that requires their attention.
+ *
+ * This is typically done by displaying a number, which summarizes
+ * the quantity of the items that require user's attention.
+ *
+ * :::important
+ * The menus are not a part of the Dock. They are individual components
+ * that you develop separately. Make sure that the information
+ * and interactions regarding the notifications are correctly handled.
+ *
+ * For example, when the items that require user's attention are
+ * seen or handled by the user after opening the menu, the badge on the
+ * Dock button should disappear.
+ * :::
+ *
+ * When this quantity is unclear or undefined, you can simply pass an
+ * empty string (`badge: ''`), which will only render a circle on the button.
+ * This is enough to attract user's attention.
+ * However, it is also possible to use a short string such as "·" or "!"
+ * for such cases, if considered necessary.
+ *
+ * :::warning
+ * Do not negatively exploit this possibility and spam users' awareness.
+ * The Dock is the most important and most dominant structural part of
+ * the UI of your application. Therefore crowding it with too much noise
+ * _will_ negatively affect the user experience.
+ * :::
+ *
+ *
+ */
+@Component({
+    tag: 'limel-example-dock-notification',
+    shadow: true,
+    styleUrl: 'dock-notification.scss',
+})
+export class DockNotificationExample {
+    @State()
+    private dockItems: DockItem[] = [
+        {
+            id: 'home',
+            label: 'Home',
+            selected: true,
+            icon: '-lime-logo-go-filled',
+        },
+        {
+            id: 'tables',
+            label: 'Tables',
+            icon: 'insert_table',
+        },
+        {
+            id: 'search',
+            label: 'Search',
+            icon: 'search',
+            badge: '',
+        },
+    ];
+
+    @State()
+    private dockFooterItems: DockItem[] = [
+        {
+            id: 'user',
+            label: 'Account',
+            icon: 'user',
+            badge: 5,
+            dockMenu: { componentName: 'my-custom-menu-with-notifications' },
+        },
+    ];
+
+    public render() {
+        return (
+            <div class="application">
+                <limel-dock
+                    accessibleLabel="Dock Example: dock with notification badges"
+                    dockItems={this.dockItems}
+                    dockFooterItems={this.dockFooterItems}
+                    onItemSelected={this.handleSelected}
+                />
+            </div>
+        );
+    }
+
+    private handleSelected = (event: CustomEvent<DockItem>) => {
+        const setSelection = (item: DockItem) => {
+            return {
+                ...item,
+                selected: item.id === event.detail.id,
+            };
+        };
+
+        this.dockItems = this.dockItems.map(setSelection);
+        this.dockFooterItems = this.dockFooterItems.map(setSelection);
+    };
+}

--- a/src/components/dock/examples/my-custom-menu-with-notifications.scss
+++ b/src/components/dock/examples/my-custom-menu-with-notifications.scss
@@ -1,0 +1,8 @@
+:host(my-custom-menu-with-notifications) {
+    --badge-background-color: rgb(var(--color-red-default));
+    --badge-text-color: rgb(var(--color-white));
+}
+
+limel-list {
+    --gap: 0.25rem;
+}

--- a/src/components/dock/examples/my-custom-menu-with-notifications.tsx
+++ b/src/components/dock/examples/my-custom-menu-with-notifications.tsx
@@ -1,0 +1,55 @@
+import { ListItem } from '@limetech/lime-elements';
+import { Component, h } from '@stencil/core';
+
+@Component({
+    tag: 'my-custom-menu-with-notifications',
+    shadow: { delegatesFocus: true },
+    styleUrl: 'my-custom-menu-with-notifications.scss',
+})
+export class MyCustomMenuWithNotifications {
+    private items: Array<ListItem<number>> = [
+        {
+            text: 'Preferences',
+            icon: 'horizontal_settings_mixer',
+            iconColor: 'rgb(var(--color-blue-default)',
+            primaryComponent: {
+                name: 'limel-badge',
+                props: {
+                    label: 2,
+                    style: {
+                        order: '2',
+                    },
+                },
+            },
+        },
+        {
+            text: "What's new",
+            icon: 'new',
+            iconColor: 'rgb(var(--color-orange-default)',
+            primaryComponent: {
+                name: 'limel-badge',
+                props: {
+                    label: 3,
+                    style: {
+                        order: '2',
+                    },
+                },
+            },
+        },
+        {
+            text: 'Sign out',
+            icon: 'shutdown',
+            iconColor: 'rgb(var(--color-red-default))',
+        },
+    ];
+
+    public render() {
+        return [
+            <limel-header heading="Hi user!" icon="user_male_circle" />,
+            <limel-list
+                items={this.items}
+                class="has-grid-layout has-interactive-items"
+            />,
+        ];
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2070

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
