### PR TITLE
feat(badge): make label optional

### DIFF
--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -16,7 +16,7 @@
     @include lime-typography.base;
     cursor: default;
     box-sizing: border-box;
-    display: flex;
+    display: inline-flex;
     justify-content: center;
     align-items: center;
     flex-shrink: 0;

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -2,8 +2,10 @@ import { Component, Prop, h, Host } from '@stencil/core';
 import { abbreviate } from './format';
 
 /**
- * The Badge component can display both `number` and `string` as `label`.
+ * The Badge component can be used to display a notification badge,
+ * optionally with a number or a text label.
  *
+ * @exampleComponent limel-example-badge
  * @exampleComponent limel-example-badge-number
  * @exampleComponent limel-example-badge-string
  */
@@ -20,7 +22,7 @@ export class Badge {
      * six characters.
      */
     @Prop({ reflect: true })
-    public label: number | string;
+    public label?: number | string;
 
     public render() {
         return (

--- a/src/components/badge/examples/badge.scss
+++ b/src/components/badge/examples/badge.scss
@@ -1,0 +1,3 @@
+:host(limel-example-badge) {
+    --badge-background-color: rgb(var(--color-red-default));
+}

--- a/src/components/badge/examples/badge.tsx
+++ b/src/components/badge/examples/badge.tsx
@@ -1,0 +1,28 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Badge without a `label`
+ * When no `label` is provided, the badge will only render as a circle.
+ * This is a convention which is used in many applications to attract the
+ * user's attention to a certain element on the user interface; typically to
+ * menus or buttons that navigate the user to another pane or screen.
+ *
+ * In such cases, the idea is to provide the users with a "red thread"
+ * and help them find something that requires their attention, but is located
+ * on another place in the app, and not directly visible.
+ *
+ * :::tip
+ * Make sure that the dot is noticeable, by providing an
+ * eye-catching background color, as shown in this example.
+ *:::
+ */
+@Component({
+    tag: 'limel-example-badge',
+    styleUrl: 'badge.scss',
+    shadow: true,
+})
+export class BadgeExample {
+    public render() {
+        return [<limel-badge />];
+    }
+}


### PR DESCRIPTION
This updates the documentation to make the `label` property on limel-badge optional.

fix #2140

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
