### PR TITLE
Menu item badge

### DIFF
--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -124,7 +124,7 @@ export class DockButton {
                     selected: this.item?.selected,
                 }}
                 onClick={handleClick}
-                aria-live={this.item.badge ? 'polite' : 'off'}
+                aria-live="polite"
             >
                 {this.renderIcon()}
                 {this.renderLabel()}
@@ -135,7 +135,7 @@ export class DockButton {
     }
 
     private renderNotification = () => {
-        if (this.item.badge || this.item.badge === '') {
+        if (this.item.badge !== undefined) {
             return <limel-badge label={this.item.badge} />;
         }
     };

--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -136,6 +136,7 @@ export class MenuListRenderer {
             >
                 {item.icon ? this.renderIcon(this.config, item) : null}
                 {this.renderText(item)}
+                {this.renderNotification(item)}
                 {this.twoLines && this.avatarList ? this.renderDivider() : null}
             </li>
         );
@@ -215,6 +216,12 @@ export class MenuListRenderer {
                 size={config.iconSize}
             />
         );
+    };
+
+    private renderNotification = (item: MenuItem) => {
+        if (item.badge !== undefined) {
+            return <limel-badge label={item.badge} />;
+        }
     };
 
     private renderDivider = () => {

--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -4,6 +4,14 @@
 
 :host(limel-menu-list) {
     display: block;
+    --badge-background-color: var(
+        --notification-badge-background-color,
+        rgb(var(--color-red-default))
+    );
+    --badge-text-color: var(
+        --notification-badge-text-color,
+        rgb(var(--color-white))
+    );
 }
 
 .mdc-menu {
@@ -26,4 +34,8 @@
             display: none;
         }
     }
+}
+
+limel-badge {
+    transform: translateX(0.75rem);
 }

--- a/src/components/menu/examples/menu-notification.tsx
+++ b/src/components/menu/examples/menu-notification.tsx
@@ -1,0 +1,68 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, h } from '@stencil/core';
+
+/**
+ * With notification
+ *
+ * It is possible to display a notification badge on each individual
+ * list item inside the menu's dropdown.
+ *
+ * These notification badges are supposed to inform the user that
+ * there is something in the menu item that requires their attention.
+ *
+ * This is typically done by displaying a number, which summarizes
+ * the quantity of the items that require user's attention.
+ * However, if a number is not meaningful, it is possible to send an
+ * empty string (`badge: ''`), which will display a circle on the
+ * list item.
+ *
+ * Since list items in the menu are hidden away, users would not
+ * realize that there is something inside the menu which requires their
+ * attention. Which is why the trigger automatically displays a
+ * notification badge on its top-right corner,
+ * when the menu contains badges.
+ *
+ * By default, the badge is red and its text is white.
+ * This is to attract users' attention. However, this is possible to override using
+ * [provided style variables](/#/component/limel-menu/styles/).
+ *
+ * :::warning
+ * - Do not negatively exploit this possibility and spam users' attention.
+ * Crowding the UI with too much noise _will_ negatively affect the user experience.
+ * - Notification badges *must* be cleared as soon as the list item is clicked by the user!
+ * :::
+ */
+@Component({
+    tag: 'limel-example-menu-notification',
+    shadow: true,
+})
+export class MenuNotificationExample {
+    private items: Array<MenuItem | ListSeparator> = [
+        { text: 'Profile', icon: 'cat_profile' },
+        { text: 'Settings', icon: 'horizontal_settings_mixer', badge: '' },
+        { text: 'Notifications', icon: 'bell', badge: 7 },
+        { separator: true },
+        { text: 'Log out' },
+    ];
+
+    public render() {
+        return (
+            <limel-menu items={this.items} onSelect={this.handleSelect}>
+                <limel-icon-button
+                    slot="trigger"
+                    icon="gender_neutral_user"
+                    label="User Menu"
+                    elevated={true}
+                />
+            </limel-menu>
+        );
+    }
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        console.log(event.detail.text);
+    };
+}

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -8,10 +8,22 @@
  * @prop --list-grid-item-max-width: Maximum width of items in the menu list when `gridLayout={true}`. Defaults to `10rem`.
  * @prop --list-grid-item-min-width: Minimum width of items in the menu list when `gridLayout={true}`. Defaults to `7.5rem`.
  * @prop --list-grid-gap: Distance between the items in the menu list when `gridLayout={true}`. Defaults to `0.75rem`.
+ * @prop --notification-badge-text-color: Defines the text color of notification badges. Defaults to `--color-white`.
+ * @prop --notification-badge-background-color: Defines the background color of notification badges. Defaults to `--color-red-default`.
  */
 
-:host {
+:host(limel-menu) {
+    isolation: isolate;
+    position: relative;
     display: inline-block;
+    --badge-background-color: var(
+        --notification-badge-background-color,
+        rgb(var(--color-red-default))
+    );
+    --badge-text-color: var(
+        --notification-badge-text-color,
+        rgb(var(--color-white))
+    );
 }
 
 :host([hidden]) {
@@ -36,4 +48,10 @@
 
 .mdc-menu-surface--anchor {
     position: relative;
+}
+
+limel-badge {
+    position: absolute;
+    top: -0.125rem;
+    right: -0.125rem;
 }

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -25,6 +25,7 @@ import {
  * @exampleComponent limel-example-menu-grid
  * @exampleComponent limel-example-menu-hotkeys
  * @exampleComponent limel-example-menu-secondary-text
+ * @exampleComponent limel-example-menu-notification
  * @exampleComponent limel-example-menu-composite
  */
 @Component({
@@ -114,6 +115,7 @@ export class Menu {
         return (
             <div class="mdc-menu-surface--anchor" onClick={this.onTriggerClick}>
                 <slot name="trigger" />
+                {this.renderNotificationBadge()}
                 <limel-portal
                     visible={this.open}
                     containerId={this.portalId}
@@ -194,6 +196,8 @@ export class Menu {
             '--list-grid-item-max-width',
             '--list-grid-item-min-width',
             '--list-grid-gap',
+            '--notification-badge-background-color',
+            '--notification-badge-text-color',
         ];
         const style = getComputedStyle(this.host);
         const values = propertyNames.map((property) => {
@@ -225,4 +229,13 @@ export class Menu {
     private isMenuItem(item: MenuItem | ListSeparator): item is MenuItem {
         return !('separator' in item);
     }
+
+    private renderNotificationBadge = () => {
+        const hasNotificationBadge = (item) =>
+            'badge' in item && item.badge !== undefined;
+
+        if (this.items.some(hasNotificationBadge)) {
+            return <limel-badge />;
+        }
+    };
 }

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -49,6 +49,11 @@ export interface MenuItem<T = any> {
     selected?: boolean;
 
     /**
+     * If specified, will display a notification badge on the buttons in the dock.
+     */
+    badge?: number | string;
+
+    /**
      * Value of the menu item.
      */
     value?: T;


### PR DESCRIPTION
Makes it possible to add a notification badge to menu items when using Menu.

fixes: Lundalogik/crm-feature#3215

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
