### PR TITLE
Replace instances of `lime-ci` with `lime-opensource`, and use `lime-opensource` when publishing docs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_USERNAME: lime-ci
-      GH_EMAIL: 617355+lime-ci@users.noreply.github.com
+      GH_USERNAME: lime-opensource
       GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
       CI: true
     steps:
@@ -26,6 +25,6 @@ jobs:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
     - run: npm ci
-    - run: git config --global user.email "$GH_EMAIL"
-    - run: git config --global user.name "$GH_USERNAME"
+    - run: git config --global user.email "93315277+lime-opensource@users.noreply.github.com"
+    - run: git config --global user.name "Lime Technologies OSS"
     - run: npm run docs:publish -- --remove=PR-${{ github.event.pull_request.number }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,7 +40,7 @@ jobs:
           conventional-changelog-conventionalcommits@5.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.CREATE_RELEASE }}
-        GH_USERNAME: lime-ci
+        GH_USERNAME: lime-opensource
         GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN_ads }}
         CI: true

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,8 +37,8 @@ jobs:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - run: node -v && npm -v
     - run: npm ci
-    - run: git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-    - run: git config --global user.name "${GITHUB_ACTOR}"
+    - run: git config --global user.email "93315277+lime-opensource@users.noreply.github.com"
+    - run: git config --global user.name "Lime Technologies OSS"
     - name: Publish docs
       if: inputs.buildOnly == false
       run: npm run docs:publish -- --v=${{ inputs.version }} ${{ inputs.forcePush && '--forcePush' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           conventional-changelog-conventionalcommits@5.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.CREATE_RELEASE }}
-        GH_USERNAME: lime-ci
+        GH_USERNAME: lime-opensource
         GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN_ads }}
         CI: true
@@ -56,7 +56,7 @@ jobs:
         token: ${{ secrets.CREATE_RELEASE }}
     - name: Set Git config
       run: |
-          git config --local user.email "lime-opensource@users.noreply.github.com"
+          git config --local user.email "93315277+lime-opensource@users.noreply.github.com"
           git config --local user.name "Lime Technologies OSS"
     - run: git fetch --unshallow
     - run: git checkout next


### PR DESCRIPTION


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
