### PR TITLE
fix(input-field): make possible to use placeholder in textarea type

### DIFF
--- a/src/components/input-field/examples/input-field-textarea.tsx
+++ b/src/components/input-field/examples/input-field-textarea.tsx
@@ -25,9 +25,10 @@ export class InputFieldTextareaExample {
 
         return [
             <limel-input-field
-                label="Text Field"
+                label="Job description"
                 type="textarea"
-                helperText="Please enter a useful message!"
+                placeholder="What is your dream job? Describe it here..."
+                helperText="This text will be displayed in your profile"
                 maxlength={MAX_LENGTH}
                 value={this.value}
                 required={this.required}

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -406,7 +406,9 @@ export class InputField {
 
         return (
             <span class="mdc-text-field__resizer">
-                <textarea {...properties}>{this.value}</textarea>
+                <textarea {...properties} placeholder={this.placeholder}>
+                    {this.value}
+                </textarea>
             </span>
         );
     };


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2161#issuecomment-1455723243

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
