### PR TITLE
fix(button): hide the icon when `has-reduced-presence` class is true …

### DIFF
--- a/src/components/button/partial-styles/_has-reduced-presence.scss
+++ b/src/components/button/partial-styles/_has-reduced-presence.scss
@@ -34,7 +34,8 @@ $speed-of-reducing-presence: 0.3s;
             }
             limel-icon,
             limel-spinner,
-            svg {
+            svg,
+            .mdc-button__icon {
                 transition: all $speed-of-reducing-presence ease;
                 transition-delay: $speed-of-reducing-presence;
 


### PR DESCRIPTION
…& the button is `disabled`

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
