### PR TITLE
feat(callout): add support for custom colors

### DIFF
--- a/src/components/callout/callout.scss
+++ b/src/components/callout/callout.scss
@@ -1,24 +1,45 @@
+/**
+ * @prop --callout-text-color: Text color of the component. Defaults to `--contrast-1100`.
+ * @prop --callout-background-color: Background color of the component. Defaults to `--contrast-300`.
+ * @prop --callout-color: Color used in the UI to add more contextual meaning about the type of the information. This color is different based on the chosen `type`, but you can override it using this prop.
+*/
+
 :host(limel-callout) {
     display: flex;
     border-radius: 0.5rem;
     overflow: hidden;
 
-    color: rgb(var(--contrast-1100));
+    color: var(--callout-text-color, rgb(var(--contrast-1100)));
 }
 :host([type='note']) {
-    --limel-callout-tint-color: rgb(var(--color-gray-default));
+    --limel-callout-tint-color: var(
+        --callout-color,
+        rgb(var(--color-gray-default))
+    );
 }
 :host([type='important']) {
-    --limel-callout-tint-color: rgb(var(--color-sky-default));
+    --limel-callout-tint-color: var(
+        --callout-color,
+        rgb(var(--color-sky-default))
+    );
 }
 :host([type='tip']) {
-    --limel-callout-tint-color: rgb(var(--color-green-default));
+    --limel-callout-tint-color: var(
+        --callout-color,
+        rgb(var(--color-green-default))
+    );
 }
 :host([type='caution']) {
-    --limel-callout-tint-color: rgb(var(--color-orange-light));
+    --limel-callout-tint-color: var(
+        --callout-color,
+        rgb(var(--color-orange-light))
+    );
 }
 :host([type='warning']) {
-    --limel-callout-tint-color: rgb(var(--color-red-dark));
+    --limel-callout-tint-color: var(
+        --callout-color,
+        rgb(var(--color-red-dark))
+    );
 }
 
 .side {
@@ -46,7 +67,7 @@
     flex-direction: column;
     gap: 0.5rem;
     padding: 0.25rem 0.5rem 0.5rem 0.5rem;
-    background-color: rgb(var(--contrast-300));
+    background-color: var(--callout-background-color, rgb(var(--contrast-300)));
 }
 
 .heading {

--- a/src/components/callout/callout.tsx
+++ b/src/components/callout/callout.tsx
@@ -25,6 +25,7 @@ import { Languages } from '@limetech/lime-elements';
  * @exampleComponent limel-example-callout-caution
  * @exampleComponent limel-example-callout-warning
  * @exampleComponent limel-example-callout-rich-content
+ * @exampleComponent limel-example-callout-styles
  */
 @Component({
     tag: 'limel-callout',

--- a/src/components/callout/callout.types.ts
+++ b/src/components/callout/callout.types.ts
@@ -1,5 +1,6 @@
 /**
  * Each of the supported callout types has a distinct color and icon.
+ * The colors can be changed using the provided CSS variables.
  *
  * - `note`: You might read this, you might not.
  * - `important`: You should read this.

--- a/src/components/callout/examples/callout-styles.scss
+++ b/src/components/callout/examples/callout-styles.scss
@@ -1,0 +1,16 @@
+:host(limel-example-callout-styles) {
+    display: flex;
+    gap: 1rem;
+}
+
+limel-callout[type='example'] {
+    --callout-color: rgb(var(--color-pink-default));
+    --callout-text-color: rgb(var(--color-orange-lighter));
+    --callout-background-color: rgb(var(--color-pink-dark));
+}
+
+limel-callout[type='note'] {
+    --callout-color: rgb(var(--color-cyan-default));
+    --callout-text-color: rgb(var(--color-teal-dark));
+    --callout-background-color: rgb(var(--color-teal-lighter));
+}

--- a/src/components/callout/examples/callout-styles.tsx
+++ b/src/components/callout/examples/callout-styles.tsx
@@ -1,0 +1,32 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Styling
+ *
+ * It is possible to change the default colors using the provided CSS
+ * variables. Just make sure to have good contrast between the text and
+ * background color, to provide good readability.
+ */
+@Component({
+    tag: 'limel-example-callout-styles',
+    shadow: true,
+    styleUrl: 'callout-styles.scss',
+})
+export class CalloutStylesExample {
+    public render() {
+        return [
+            <limel-callout type="caution">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla
+                et euismod nulla. Curabitur feugiat, tortor non consequat
+                finibus, justo purus auctor massa, nec semper lorem quam in
+                massa.
+            </limel-callout>,
+            <limel-callout type="note">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla
+                et euismod nulla. Curabitur feugiat, tortor non consequat
+                finibus, justo purus auctor massa, nec semper lorem quam in
+                massa.
+            </limel-callout>,
+        ];
+    }
+}


### PR DESCRIPTION
it is needed because we have a minimalistic flat UI design language. It means elements are usually perceived and differentiated from each other by very minimal visual details, such as their background colors (and not-so-often by the shadows around them, or borders). So not being able to change the default hard-coded background color from --contrast-300 means you can not use this component on a background color that is --contrast-200, --contrast-300 or --contrast-400, due to lack of contrast between the surrounding UI and this component. So, the consumer should have the possibility to tune that color. And with that, there comes a natural need to tune the contrast of the text too (to make it readable on a darker or lighter background).

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
