### PR TITLE
feat(callout): add support for custom heading and icon

### DIFF
--- a/src/components/callout/callout.e2e.ts
+++ b/src/components/callout/callout.e2e.ts
@@ -12,6 +12,23 @@ describe('limel-callout', () => {
         expect(icon.getAttribute('name')).toEqual('info');
     });
 
+    it('renders a callout with the provided heading', async () => {
+        const page = await newE2EPage({
+            html: '<limel-callout heading="Important"></limel-callout>',
+        });
+        const heading = await page.find('limel-callout>>>.heading');
+        expect(heading.textContent).toEqual('Important');
+    });
+
+    it('renders a callout with the provided icon', async () => {
+        const page = await newE2EPage({
+            html: '<limel-callout icon="unit-test"></limel-callout>',
+        });
+
+        const icon = await page.find('limel-callout>>>limel-icon');
+        expect(icon.getAttribute('name')).toEqual('unit-test');
+    });
+
     it('renders a callout with the correct icon based on type', async () => {
         const page = await newE2EPage({
             html: '<limel-callout type="tip"></limel-callout>',

--- a/src/components/callout/callout.helpers.ts
+++ b/src/components/callout/callout.helpers.ts
@@ -8,14 +8,23 @@ const calloutIcons: Record<string, string> = {
     warning: 'error',
 };
 
-export function getIcon(type: string = 'info'): string {
+export function getIcon(icon: string, type: string = 'note'): string {
+    if (icon) {
+        return icon;
+    }
+
     return calloutIcons[type] ?? calloutIcons.note;
 }
 
 export function getHeading(
+    heading: string,
     type: string = 'note',
     language: string = 'en'
 ): string {
+    if (heading) {
+        return heading;
+    }
+
     const key = `callout.${type}`;
 
     try {

--- a/src/components/callout/callout.tsx
+++ b/src/components/callout/callout.tsx
@@ -25,7 +25,10 @@ import { Languages } from '@limetech/lime-elements';
  * @exampleComponent limel-example-callout-caution
  * @exampleComponent limel-example-callout-warning
  * @exampleComponent limel-example-callout-rich-content
+ * @exampleComponent limel-example-callout-custom-heading
+ * @exampleComponent limel-example-callout-custom-icon
  * @exampleComponent limel-example-callout-styles
+ * @exampleComponent limel-example-callout-composite
  */
 @Component({
     tag: 'limel-callout',
@@ -33,6 +36,20 @@ import { Languages } from '@limetech/lime-elements';
     styleUrl: 'callout.scss',
 })
 export class Callout {
+    /**
+     * Heading of the callout, which can be used to override the
+     * default heading which is displayed based on the chosen `type`.
+     */
+    @Prop({ reflect: true })
+    public heading?: string;
+
+    /**
+     * Icon of the callout, which can be used to override the
+     * default icon which is displayed based on the chosen `type`.
+     */
+    @Prop({ reflect: true })
+    public icon?: string;
+
     /**
      * Defines how the component is visualized, for example
      * which heading, color or icon is used in its user interface.
@@ -42,7 +59,7 @@ export class Callout {
 
     /**
      * Defines the language for translations.
-     * Will translate the headings for supported languages.
+     * Will translate the default headings for supported languages.
      */
     @Prop()
     public language: Languages = 'en';
@@ -50,10 +67,12 @@ export class Callout {
     public render() {
         return [
             <div class="side" role="presentation">
-                <limel-icon name={getIcon(this.type)} />
+                <limel-icon name={getIcon(this.icon, this.type)} />
             </div>,
             <div class="main">
-                <h1 class="heading">{getHeading(this.type, this.language)}</h1>
+                <h1 class="heading">
+                    {getHeading(this.heading, this.type, this.language)}
+                </h1>
                 <slot />
             </div>,
         ];

--- a/src/components/callout/examples/callout-composite.tsx
+++ b/src/components/callout/examples/callout-composite.tsx
@@ -1,0 +1,85 @@
+import { Component, h, Prop, State } from '@stencil/core';
+
+/**
+ * Composite
+ */
+@Component({
+    tag: 'limel-example-callout-composite',
+    shadow: true,
+})
+export class CalloutCompositeExample {
+    @Prop()
+    public schema: any;
+
+    @State()
+    private props: any = {
+        heading: '',
+        icon: '',
+        content: 'This is my very nice [type]',
+        type: 'tip',
+        language: 'en',
+    };
+
+    public componentWillLoad() {
+        const properties = {
+            ...this.schema.properties,
+            content: {
+                type: 'string',
+                title: 'Content',
+                lime: {
+                    layout: {
+                        rowSpan: 2,
+                        colSpan: 'all',
+                    },
+                    component: {
+                        props: {
+                            type: 'textarea',
+                        },
+                    },
+                },
+            },
+        };
+
+        this.schema = {
+            ...this.schema,
+            properties: properties,
+            lime: {
+                layout: {
+                    type: 'grid',
+                },
+            },
+        };
+    }
+
+    public render() {
+        const content = this.props?.content?.replace(
+            '[type]',
+            this.props?.type ?? ''
+        );
+
+        return [
+            <limel-callout {...this.props}>
+                <div innerHTML={content} />
+            </limel-callout>,
+            this.renderForm(),
+        ];
+    }
+
+    private renderForm() {
+        return (
+            <limel-example-controls
+                style={{ '--example-controls-column-layout': 'auto-fit' }}
+            >
+                <limel-form
+                    schema={this.schema}
+                    value={this.props}
+                    onChange={this.handleFormChange}
+                />
+            </limel-example-controls>
+        );
+    }
+
+    private handleFormChange = (event: CustomEvent) => {
+        this.props = { ...event.detail };
+    };
+}

--- a/src/components/callout/examples/callout-custom-heading.tsx
+++ b/src/components/callout/examples/callout-custom-heading.tsx
@@ -1,0 +1,41 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * With custom `heading`
+ *
+ * By default, the title will equal the `type` qualifier.
+ * However, it is possible to use a `type` just to get the desired visualisation
+ * (icon and color), but override the default heading, using the `heading` prop.
+ */
+@Component({
+    tag: 'limel-example-callout-custom-heading',
+    shadow: true,
+})
+export class CalloutCustomTitleExample {
+    public render() {
+        return (
+            <limel-callout heading="🥳 yeay!">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Vestibulum viverra magna non pretium condimentum. Integer a
+                    nunc magna. In commodo elit turpis, porttitor vulputate odio
+                    pretium a. Ut at sapien a massa convallis commodo eu sed
+                    ligula. Curabitur non sodales neque. Sed id nisl vel ex
+                    tempor euismod. Nulla nec lorem dui. Cras tincidunt urna nec
+                    velit pretium maximus.
+                </p>
+
+                <p>
+                    Praesent sed cursus lorem. Phasellus lobortis dolor vitae
+                    pretium bibendum. Vivamus non augue in urna consequat
+                    dapibus at quis diam. Duis tristique lacinia felis, quis
+                    condimentum urna interdum sit amet. Suspendisse facilisis
+                    pulvinar suscipit. Pellentesque quis velit feugiat, bibendum
+                    erat at, ornare tortor. Nullam sed risus a enim tempor
+                    eleifend nec quis nulla. Cras quis pellentesque justo.
+                    Maecenas id justo a eros consequat auctor.
+                </p>
+            </limel-callout>
+        );
+    }
+}

--- a/src/components/callout/examples/callout-custom-icon.tsx
+++ b/src/components/callout/examples/callout-custom-icon.tsx
@@ -1,0 +1,25 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * With custom `icon`
+ *
+ * By default, the icon will be defined by the `type` qualifier.
+ * However, it is possible to use a `type` just to get the desired visualisation
+ * (color and heading), but override the default icon, using the `icon` prop.
+ */
+@Component({
+    tag: 'limel-example-callout-custom-icon',
+    shadow: true,
+})
+export class CalloutCustomIconExample {
+    public render() {
+        return (
+            <limel-callout icon="pokemon">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla
+                et euismod nulla. Curabitur feugiat, tortor non consequat
+                finibus, justo purus auctor massa, nec semper lorem quam in
+                massa.
+            </limel-callout>
+        );
+    }
+}


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
