### PR TITLE
Fix date and time formats

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -7,6 +7,7 @@ import { resetDependentFields } from './field-helpers';
 import { FieldTemplate } from '../templates';
 import { getHelpComponent } from '../help';
 import { FormSchema } from '../form.types';
+import { TimePicker } from '../widgets/time-picker';
 
 /**
  * If given a value and schema, check if the value should be translated
@@ -274,6 +275,13 @@ export class SchemaField extends React.Component<FieldProps> {
             ...this.props,
             onChange: this.handleChange,
         };
+
+        if (this.props.schema.format === 'time') {
+            fieldProps.uiSchema = {
+                'ui:widget': TimePicker,
+                ...fieldProps.uiSchema,
+            };
+        }
 
         return React.createElement(JSONSchemaField, fieldProps);
     }

--- a/src/components/form/widgets/date-only-picker.ts
+++ b/src/components/form/widgets/date-only-picker.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+import { DatePicker } from './date-picker';
+import { WidgetProps } from './types';
+
+export const DateOnlyPicker: React.FunctionComponent<WidgetProps> = ({
+    value,
+    ...props
+}) => {
+    // A date-only string is treated as UTC by the Date constructor,
+    // but we want to parse it as local date
+    if (typeof value === 'string' && /-\d\d$/.test(value)) {
+        value += 'T00:00';
+    }
+
+    return React.createElement(DatePicker, {
+        type: 'date',
+        value: value,
+        ...props,
+    });
+};

--- a/src/components/form/widgets/date-picker.ts
+++ b/src/components/form/widgets/date-picker.ts
@@ -1,23 +1,26 @@
 import moment from 'moment/moment';
 import React from 'react';
+import { DateType } from '../../date-picker/date.types';
 import { WidgetProps } from './types';
 import { LimeElementsWidgetAdapter } from '../adapters';
-import { FormSchema } from '../form.types';
 
-export class DatePicker extends React.Component {
+type DateWidgetProps = WidgetProps & {
+    type?: DateType;
+};
+
+export class DatePicker extends React.Component<DateWidgetProps> {
     public refs: any;
     public state = {
         modified: false,
     };
 
-    constructor(public props: WidgetProps) {
+    constructor(public props: DateWidgetProps) {
         super(props);
         this.handleChange = this.handleChange.bind(this);
     }
 
     public render() {
-        const props: WidgetProps = this.props;
-        const additionalProps = getAdditionalProps(props.schema);
+        const { type = 'datetime', ...props } = this.props;
 
         return React.createElement(LimeElementsWidgetAdapter, {
             name: 'limel-date-picker',
@@ -27,7 +30,8 @@ export class DatePicker extends React.Component {
             },
             widgetProps: props,
             extraProps: {
-                ...additionalProps,
+                type: type,
+                ...props.schema.lime?.component?.props,
             },
         });
     }
@@ -64,14 +68,4 @@ export class DatePicker extends React.Component {
         );
         props.onChange(dateString);
     }
-}
-
-function getAdditionalProps(schema: FormSchema) {
-    let props: any = {};
-
-    if (schema.lime?.component?.props) {
-        props = schema.lime.component.props;
-    }
-
-    return props;
 }

--- a/src/components/form/widgets/index.ts
+++ b/src/components/form/widgets/index.ts
@@ -1,4 +1,5 @@
 import { Checkbox } from './checkbox';
+import { DateOnlyPicker } from './date-only-picker';
 import { DatePicker } from './date-picker';
 import { InputField } from './input-field';
 import { Select } from './select';
@@ -28,7 +29,7 @@ export type WidgetType =
 export const widgets: Partial<Record<WidgetType, any>> = {
     CheckboxWidget: Checkbox,
     DateTimeWidget: DatePicker,
-    DateWidget: DatePicker,
+    DateWidget: DateOnlyPicker,
     EmailWidget: InputField,
     TextWidget: InputField,
     SelectWidget: Select,

--- a/src/components/form/widgets/time-picker.ts
+++ b/src/components/form/widgets/time-picker.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+import { DatePicker } from './date-picker';
+import { WidgetProps } from './types';
+
+export const TimePicker: React.FunctionComponent<WidgetProps> = ({
+    value,
+    ...props
+}) => {
+    if (typeof value === 'string' && timeStringPattern.test(value)) {
+        value = new Date('2000-01-01T' + value);
+    }
+
+    return React.createElement(DatePicker, {
+        type: 'time',
+        value: value,
+        ...props,
+    });
+};
+
+const timeStringPattern = /^\d\d:\d\d/;


### PR DESCRIPTION
This fixes some issues in `limel-form` when using the date picker widget or when using a custom component for 
the string formats `date-time`, `date` or `time`.

The `type` date picker prop is now set depending on the schema format (`date-time` or `date`) in the date widget. This has been broken since c290470676896cc965e2ac3b487fae6783100e6e

Fixes #1489
Fixes #2232

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
