### PR TITLE
fix(relation-picker): option-queries are not applied to column filter pickers

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -599,7 +599,7 @@ export class Picker {
     private async handleInputFieldFocus() {
         this.loading = true;
         const query = this.textValue;
-        const result = await this.searcher(query);
+        const result = await this.searcher(query, false);
         this.handleSearchResult(query, result);
     }
 

--- a/src/components/picker/searcher.types.ts
+++ b/src/components/picker/searcher.types.ts
@@ -8,4 +8,7 @@ import { ListItem } from '../list/list-item.types';
  * in the input field of a limel-picker.
  * @returns {Promise<ListItem[]>} The search result.
  */
-export type Searcher = (query: string) => Promise<ListItem[]>;
+export type Searcher = (
+    query: string,
+    useOptionQuery?: boolean
+) => Promise<ListItem[]>;


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#3153

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
