### PR TITLE
refactor(slider): get rid of nested structure & simplify things

### DIFF
--- a/src/components/slider/partial-styles/_helper-text.scss
+++ b/src/components/slider/partial-styles/_helper-text.scss
@@ -8,6 +8,7 @@
 
 .mdc-slider-helper-line {
     @include shared_input-select-picker.looks-like-helper-line;
+    order: 3;
 }
 .mdc-slider-helper-text {
     @include shared_input-select-picker.looks-like-helper-text;

--- a/src/components/slider/partial-styles/_readonly.scss
+++ b/src/components/slider/partial-styles/_readonly.scss
@@ -1,7 +1,7 @@
 @use '../../../style/internal/lime-theme';
 @use '../../../style/functions';
 
-.lime-slider--readonly {
+:host(limel-slider.readonly) {
     .mdc-slider.mdc-slider--disabled {
         opacity: 1;
 

--- a/src/components/slider/partial-styles/_thumb.scss
+++ b/src/components/slider/partial-styles/_thumb.scss
@@ -80,9 +80,9 @@
     }
 }
 
-.mdc-slider:not(.mdc-slider--disabled),
-.slider.lime-slider--readonly {
-    .mdc-slider__value-indicator {
+.mdc-slider__value-indicator {
+    .mdc-slider:not(.mdc-slider--disabled) &,
+    :host(limel-slider[readonly]) & {
         background-color: var(--mdc-theme-primary);
     }
 }

--- a/src/components/slider/partial-styles/percentage-color.scss
+++ b/src/components/slider/partial-styles/percentage-color.scss
@@ -4,67 +4,63 @@
     transition: background-color 0.5s ease;
 }
 
-:host(.displays-percentage-colors) {
-    .slider.lime-slider--readonly {
-        --mdc-theme-on-surface: var(--mdc-theme-primary);
-    }
+:host(.displays-percentage-colors[readonly]) {
+    --mdc-theme-on-surface: var(--mdc-theme-primary);
+}
 
-    .slider {
-        &.percent-0 {
-            --mdc-theme-primary: var(--color-percent--0);
+:host(.displays-percentage-colors.percent-0) {
+    --mdc-theme-primary: var(--color-percent--0);
+}
+:host(.displays-percentage-colors.percent-0-10) {
+    --mdc-theme-primary: var(--color-percent--0to10);
+}
+:host(.displays-percentage-colors.percent-10-20) {
+    --mdc-theme-primary: var(--color-percent--10to20);
+}
+:host(.displays-percentage-colors.percent-20-30) {
+    --mdc-theme-primary: var(--color-percent--20to30);
+}
+:host(.displays-percentage-colors.percent-30-40) {
+    --mdc-theme-primary: var(--color-percent--30to40);
+}
+:host(.displays-percentage-colors.percent-40-50) {
+    --mdc-theme-primary: var(--color-percent--40to50);
+}
+:host(.displays-percentage-colors.percent-50-60) {
+    --mdc-theme-primary: var(--color-percent--50to60);
+}
+:host(.displays-percentage-colors.percent-60-70) {
+    --mdc-theme-primary: var(--color-percent--60to70);
+}
+:host(.displays-percentage-colors.percent-70-80) {
+    --mdc-theme-primary: var(--color-percent--70to80);
+}
+:host(.displays-percentage-colors.percent-80-90) {
+    --mdc-theme-primary: var(--color-percent--80to90);
+}
+:host(.displays-percentage-colors.percent-90-100) {
+    --mdc-theme-primary: var(--color-percent--90to100);
+}
+:host(.displays-percentage-colors.percent-30-40),
+:host(.displays-percentage-colors.percent-40-50),
+:host(.displays-percentage-colors.percent-70-80) {
+    .mdc-slider__value-indicator-text {
+        color: rgb(var(--color-gray-darker));
+    }
+    .mdc-slider--disabled {
+        .mdc-slider__value-indicator-text {
+            color: rgb(var(--contrast-100));
         }
-        &.percent-0-10 {
-            --mdc-theme-primary: var(--color-percent--0to10);
-        }
-        &.percent-10-20 {
-            --mdc-theme-primary: var(--color-percent--10to20);
-        }
-        &.percent-20-30 {
-            --mdc-theme-primary: var(--color-percent--20to30);
-        }
-        &.percent-30-40 {
-            --mdc-theme-primary: var(--color-percent--30to40);
-        }
-        &.percent-40-50 {
-            --mdc-theme-primary: var(--color-percent--40to50);
-        }
-        &.percent-50-60 {
-            --mdc-theme-primary: var(--color-percent--50to60);
-        }
-        &.percent-60-70 {
-            --mdc-theme-primary: var(--color-percent--60to70);
-        }
-        &.percent-70-80 {
-            --mdc-theme-primary: var(--color-percent--70to80);
-        }
-        &.percent-80-90 {
-            --mdc-theme-primary: var(--color-percent--80to90);
-        }
-        &.percent-90-100 {
-            --mdc-theme-primary: var(--color-percent--90to100);
-        }
-        &.percent-30-40,
-        &.percent-40-50,
-        &.percent-70-80 {
-            .mdc-slider__value-indicator-text {
-                color: rgb(var(--color-gray-darker));
-            }
-            .mdc-slider--disabled {
-                .mdc-slider__value-indicator-text {
-                    color: rgb(var(--contrast-100));
-                }
-            }
-        }
-        &.percent-50-60,
-        &.percent-60-70 {
-            .mdc-slider__value-indicator-text {
-                color: rgb(var(--color-gray-dark));
-            }
-            .mdc-slider--disabled {
-                .mdc-slider__value-indicator-text {
-                    color: rgb(var(--contrast-100));
-                }
-            }
+    }
+}
+:host(.displays-percentage-colors.percent-50-60),
+:host(.displays-percentage-colors.percent-60-70) {
+    .mdc-slider__value-indicator-text {
+        color: rgb(var(--color-gray-dark));
+    }
+    .mdc-slider--disabled {
+        .mdc-slider__value-indicator-text {
+            color: rgb(var(--contrast-100));
         }
     }
 }

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -7,28 +7,25 @@
 @use '@material/slider/styles';
 @use '@material/floating-label/mdc-floating-label';
 
-:host([disabled]:not([readonly])) {
-    .slider__label {
-        color: shared_input-select-picker.$label-color-disabled;
-    }
-}
-
-.slider {
+:host(limel-slider) {
+    isolation: isolate;
     position: relative;
+
+    display: flex;
+    flex-direction: column;
+    margin-top: functions.pxToRem(4);
 }
 
 .slider__label {
-    color: shared_input-select-picker.$label-color;
     padding-left: functions.pxToRem(20);
     top: functions.pxToRem(
         9
     ); // To place its label on the same height as other `floating-label`s in a form
-}
 
-.slider__content {
-    display: flex;
-    flex-direction: column;
-    margin-top: functions.pxToRem(4);
+    color: shared_input-select-picker.$label-color;
+    :host(limel-slider.disabled:not(.readonly)) & {
+        color: shared_input-select-picker.$label-color-disabled;
+    }
 }
 
 .slider__content-range-container {

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -5,6 +5,7 @@ import {
     Event,
     EventEmitter,
     h,
+    Host,
     Prop,
     State,
     Watch,
@@ -177,9 +178,9 @@ export class Slider {
 
     private getContainerClassList() {
         return {
-            slider: true,
-            'lime-slider--readonly': this.readonly,
             [this.percentageClass]: true,
+            disabled: this.disabled || this.readonly,
+            readonly: this.readonly,
         };
     }
 
@@ -194,62 +195,59 @@ export class Slider {
         }
 
         return (
-            <div class={this.getContainerClassList()}>
+            <Host class={this.getContainerClassList()}>
                 <label class="slider__label mdc-floating-label mdc-floating-label--float-above">
                     {this.label}
                 </label>
-                <div class="slider__content">
-                    <div class="slider__content-range-container">
-                        <span class="slider__content-min-label">
-                            {this.multiplyByFactor(this.valuemin)}
-                            {this.unit}
-                        </span>
-                        <span class="slider__content-max-label">
-                            {this.multiplyByFactor(this.valuemax)}
-                            {this.unit}
-                        </span>
+                <div class="slider__content-range-container">
+                    <span class="slider__content-min-label">
+                        {this.multiplyByFactor(this.valuemin)}
+                        {this.unit}
+                    </span>
+                    <span class="slider__content-max-label">
+                        {this.multiplyByFactor(this.valuemax)}
+                        {this.unit}
+                    </span>
+                </div>
+                <div
+                    class={{
+                        'mdc-slider': true,
+                        'mdc-slider--discrete': true,
+                        'mdc-slider--disabled': this.disabled || this.readonly,
+                    }}
+                >
+                    <input
+                        class="mdc-slider__input"
+                        type="range"
+                        min={this.multiplyByFactor(this.valuemin)}
+                        max={this.multiplyByFactor(this.valuemax)}
+                        value={this.multiplyByFactor(this.value)}
+                        name="volume"
+                        aria-label="Discrete slider demo"
+                        {...inputProps}
+                    />
+                    <div class="mdc-slider__track">
+                        <div class="mdc-slider__track--inactive"></div>
+                        <div class="mdc-slider__track--active">
+                            <div class="mdc-slider__track--active_fill"></div>
+                        </div>
                     </div>
-                    <div
-                        class={{
-                            'mdc-slider': true,
-                            'mdc-slider--discrete': true,
-                            'mdc-slider--disabled':
-                                this.disabled || this.readonly,
-                        }}
-                    >
-                        <input
-                            class="mdc-slider__input"
-                            type="range"
-                            min={this.multiplyByFactor(this.valuemin)}
-                            max={this.multiplyByFactor(this.valuemax)}
-                            value={this.multiplyByFactor(this.value)}
-                            name="volume"
-                            aria-label="Discrete slider demo"
-                            {...inputProps}
-                        />
-                        <div class="mdc-slider__track">
-                            <div class="mdc-slider__track--inactive"></div>
-                            <div class="mdc-slider__track--active">
-                                <div class="mdc-slider__track--active_fill"></div>
+                    <div class="mdc-slider__thumb">
+                        <div
+                            class="mdc-slider__value-indicator-container"
+                            aria-hidden="true"
+                        >
+                            <div class="mdc-slider__value-indicator">
+                                <span class="mdc-slider__value-indicator-text">
+                                    {this.multiplyByFactor(this.value)}
+                                </span>
                             </div>
                         </div>
-                        <div class="mdc-slider__thumb">
-                            <div
-                                class="mdc-slider__value-indicator-container"
-                                aria-hidden="true"
-                            >
-                                <div class="mdc-slider__value-indicator">
-                                    <span class="mdc-slider__value-indicator-text">
-                                        {this.multiplyByFactor(this.value)}
-                                    </span>
-                                </div>
-                            </div>
-                            <div class="mdc-slider__thumb-knob"></div>
-                        </div>
+                        <div class="mdc-slider__thumb-knob"></div>
                     </div>
                 </div>
                 {this.renderHelperLine()}
-            </div>
+            </Host>
         );
     }
 


### PR DESCRIPTION
This was an effort to fix some rendering bugs, which would happen when the container of the slider was
resized. While trying to find a solution,
we noticed that there are many nested
containers and hoped that these simplifications
could help solve the issue. We hoped to get something perhaps from the MDC's inbuilt tech. But so far
we don't see a noticeable improvement.
However, the code is simpler now.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
