### PR TITLE
Use the new `limel-helper-line` component (which is `@private`) in different input fileds

### DIFF
--- a/src/components/checkbox/checkbox.template.tsx
+++ b/src/components/checkbox/checkbox.template.tsx
@@ -76,11 +76,5 @@ const HelperText: FunctionalComponent<{ text: string }> = (props) => {
         return;
     }
 
-    return (
-        <div class="limel-checkbox-helper-line">
-            <p class="limel-checkbox-helper-text" aria-hidden="true">
-                {props.text.trim()}
-            </p>
-        </div>
-    );
+    return <limel-helper-line helperText={props.text.trim()} />;
 };

--- a/src/components/checkbox/partial-styles/_helper-text.scss
+++ b/src/components/checkbox/partial-styles/_helper-text.scss
@@ -1,23 +1,18 @@
-@use '../../../style/internal/shared_input-select-picker';
-
-.limel-checkbox-helper-line {
-    @include shared_input-select-picker.looks-like-helper-line;
-}
-
-.limel-checkbox-helper-text {
-    @include shared_input-select-picker.looks-like-helper-text;
-    color: shared_input-select-picker.$helper-text-color;
-
-    :host(:hover) &,
-    :host(:focus) &,
-    :host(:focus-within) & {
-        opacity: 1;
-    }
+limel-helper-line {
+    opacity: 0;
 }
 
 @media (pointer: coarse) {
     // touchscreen devices
-    .limel-checkbox-helper-text {
+    limel-helper-line {
+        opacity: 1;
+    }
+}
+
+:host(:focus),
+:host(:focus-visible),
+:host(:focus-within) {
+    limel-helper-line {
         opacity: 1;
     }
 }

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -613,33 +613,21 @@ export class ChipSet {
         );
     }
 
+    private hasHelperText = () => {
+        return this.helperText !== null && this.helperText !== undefined;
+    };
+
     private renderHelperLine = () => {
-        if (!this.hasHelperText()) {
+        if (!this.maxItems && !this.hasHelperText()) {
             return;
         }
 
         return (
-            <div tabIndex={-1} class="mdc-text-field-helper-line">
-                {this.renderHelperText()}
-            </div>
+            <limel-helper-line
+                helperText={this.helperText}
+                invalid={this.isInvalid()}
+            />
         );
-    };
-
-    private renderHelperText = () => {
-        if (!this.hasHelperText()) {
-            return;
-        }
-
-        const classList = {
-            'mdc-text-field-helper-text': true,
-            'mdc-text-field-helper-text--validation-msg': this.isInvalid(),
-        };
-
-        return <p class={classList}>{this.helperText}</p>;
-    };
-
-    private hasHelperText = () => {
-        return this.helperText !== null && this.helperText !== undefined;
     };
 
     private renderFilterChip(chip: Chip) {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -624,6 +624,8 @@ export class ChipSet {
 
         return (
             <limel-helper-line
+                length={this.value.length}
+                maxLength={this.maxItems}
                 helperText={this.helperText}
                 invalid={this.isInvalid()}
             />

--- a/src/components/chip-set/partial-styles/_helper-text.scss
+++ b/src/components/chip-set/partial-styles/_helper-text.scss
@@ -1,12 +1,7 @@
-.mdc-text-field-helper-line {
-    flex-basis: 100%;
-}
-
-@include shared_input-select-picker.helper-text-color;
-
-.mdc-text-field-helper-text {
-    &:before {
-        @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
+:not(.mdc-text-field--focused):not(.mdc-text-field--invalid) {
+    + limel-helper-line {
+        // TODO: remove when helper-line is displayed in portal
+        opacity: 0;
     }
 }
 
@@ -16,7 +11,7 @@
         &:focus,
         &:focus-visible,
         &:focus-within {
-            .mdc-text-field-helper-text {
+            limel-helper-line {
                 opacity: 1;
             }
         }
@@ -26,10 +21,8 @@
 @media (pointer: coarse) {
     // touchscreen devices
     :host(:not([type='input'])) {
-        .mdc-chip-set {
-            .mdc-text-field-helper-text {
-                opacity: 1;
-            }
+        limel-helper-line {
+            opacity: 1;
         }
     }
 }

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -40,6 +40,7 @@
         }
 
         &.has-helper-line {
+            // TODO: remove this when helper-line is displayed in portal
             --heightOfHelperText: 0.9375rem;
             height: calc(
                 var(--textarea-height, 100%) - var(--heightOfHelperText)
@@ -109,6 +110,11 @@
 }
 
 :not(.mdc-text-field--focused):not(.mdc-text-field--invalid) {
+    + limel-helper-line {
+        // TODO: remove when helper-line is displayed in portal
+        opacity: 0;
+    }
+
     .mdc-text-field__input[type='number'] {
         color: transparent;
         -webkit-text-fill-color: transparent;
@@ -169,25 +175,6 @@ input.mdc-text-field__input {
         &:active {
             transform: none; //Makes the "clear-all button" work
         }
-    }
-}
-
-.mdc-text-field-character-counter {
-    transition: opacity 0.2s ease;
-    opacity: 0;
-
-    .mdc-text-field--focused + .mdc-text-field-helper-line & {
-        opacity: 1;
-    }
-
-    &:before {
-        height: shared_input-select-picker.$height-of-helper-text-pseudo-before;
-    }
-}
-
-.mdc-text-field-helper-text {
-    &:before {
-        height: shared_input-select-picker.$height-of-helper-text-pseudo-before;
     }
 }
 

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -454,15 +454,21 @@ export class InputField {
     };
 
     private renderHelperLine = () => {
+        const text: string = this.value || '';
+        const length = text.length;
+
         if (!this.maxlength && !this.hasHelperText()) {
             return;
         }
 
         return (
-            <div tabIndex={-1} class="mdc-text-field-helper-line">
-                {this.renderHelperText()}
-                {this.renderCharacterCounter()}
-            </div>
+            <limel-helper-line
+                helperTextId={helperTextId}
+                helperText={this.helperText}
+                length={length}
+                maxLength={this.maxlength}
+                invalid={this.isInvalid()}
+            />
         );
     };
 
@@ -474,23 +480,6 @@ export class InputField {
                 </span>
             );
         }
-    };
-
-    private renderHelperText = () => {
-        if (!this.hasHelperText()) {
-            return;
-        }
-
-        const classList = {
-            'mdc-text-field-helper-text': true,
-            'mdc-text-field-helper-text--validation-msg': this.isInvalid(),
-        };
-
-        return (
-            <p class={classList} id={helperTextId}>
-                {this.helperText}
-            </p>
-        );
     };
 
     private hasHelperText = () => {
@@ -529,17 +518,6 @@ export class InputField {
 
     private hasPrefix = () => {
         return this.prefix !== null && this.prefix !== undefined;
-    };
-
-    private renderCharacterCounter = () => {
-        if (!this.maxlength || this.type === 'number') {
-            return;
-        }
-
-        const text: string = this.value || '';
-        const label = `${text.length} / ${this.maxlength}`;
-
-        return <div class="mdc-text-field-character-counter">{label}</div>;
     };
 
     private isInvalid = () => {

--- a/src/components/select/partial-styles/_helper-text.scss
+++ b/src/components/select/partial-styles/_helper-text.scss
@@ -1,28 +1,19 @@
-:host(:focus),
-:host(:focus-visible),
-:host(:focus-within) {
-    .mdc-select-helper-text {
-        opacity: 1;
-    }
+limel-helper-line {
+    opacity: 0;
 }
 
 .limel-select--focused {
-    + .mdc-select-helper-line .mdc-select-helper-text {
+    // TODO: remove when helper-line is displayed in portal
+    + limel-helper-line {
         opacity: 1;
     }
 }
 
-.mdc-select-helper-line {
-    @include shared_input-select-picker.looks-like-helper-line;
-}
-
-.mdc-select-helper-text {
-    margin-left: 0;
-    margin-right: 0;
-
-    @include shared_input-select-picker.looks-like-helper-text;
-
-    &:before {
-        @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
+:host(:focus),
+:host(:focus-visible),
+:host(:focus-within),
+.limel-select--invalid {
+    limel-helper-line {
+        opacity: 1;
     }
 }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -3,7 +3,6 @@
 @use '../../style/mixins';
 
 @use '@material/select/styles';
-@use '@material/select/helper-text/mdc-select-helper-text';
 @use '@material/floating-label';
 @use '@material/floating-label/mdc-floating-label';
 
@@ -142,8 +141,7 @@
     &.limel-select--invalid {
         .mdc-floating-label,
         .limel-select__selected-option,
-        .invalid-icon,
-        + .mdc-select-helper-line .mdc-select-helper-text {
+        .invalid-icon {
             color: var(--lime-error-text-color);
         }
         .mdc-floating-label:not(.mdc-floating-label--float-above) {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -139,8 +139,7 @@
     }
 
     &.limel-select--invalid {
-        .mdc-floating-label,
-        .limel-select__selected-option,
+        .limel-select__selected-option__text,
         .invalid-icon {
             color: var(--lime-error-text-color);
         }

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -154,16 +154,7 @@ const HelperText: FunctionalComponent<{ text: string }> = (props) => {
         return;
     }
 
-    return (
-        <div class="mdc-select-helper-line">
-            <p
-                class="mdc-select-helper-text mdc-select-helper-text--persistent"
-                aria-hidden="true"
-            >
-                {props.text.trim()}
-            </p>
-        </div>
-    );
+    return <limel-helper-line helperText={props.text.trim()} />;
 };
 
 const SelectDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -65,7 +65,7 @@ export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = (
                 isValid={isValid}
                 hasEmptyText={hasEmptyText}
             />
-            <HelperText text={props.helperText} />
+            <HelperText text={props.helperText} isValid={!props.invalid} />
             <SelectDropdown {...props} />
         </div>
     );
@@ -149,12 +149,19 @@ const ShowIcon: FunctionalComponent<
     );
 };
 
-const HelperText: FunctionalComponent<{ text: string }> = (props) => {
+const HelperText: FunctionalComponent<{ text: string; isValid: boolean }> = (
+    props
+) => {
     if (typeof props.text !== 'string') {
         return;
     }
 
-    return <limel-helper-line helperText={props.text.trim()} />;
+    return (
+        <limel-helper-line
+            helperText={props.text.trim()}
+            invalid={!props.isValid}
+        />
+    );
 };
 
 const SelectDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {

--- a/src/components/slider/partial-styles/_helper-text.scss
+++ b/src/components/slider/partial-styles/_helper-text.scss
@@ -1,19 +1,12 @@
+limel-helper-line {
+    opacity: 0;
+    order: 3;
+}
+
 :host(:focus),
 :host(:focus-visible),
 :host(:focus-within) {
-    .mdc-slider-helper-text {
+    limel-helper-line {
         opacity: 1;
-    }
-}
-
-.mdc-slider-helper-line {
-    @include shared_input-select-picker.looks-like-helper-line;
-    order: 3;
-}
-.mdc-slider-helper-text {
-    @include shared_input-select-picker.looks-like-helper-text;
-
-    &:before {
-        @include shared_input-select-picker.looks-like-helper-text-pseudo-before;
     }
 }

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -256,11 +256,7 @@ export class Slider {
             return;
         }
 
-        return (
-            <div class="mdc-slider-helper-line">
-                <p class="mdc-slider-helper-text">{this.helperText}</p>
-            </div>
-        );
+        return <limel-helper-line helperText={this.helperText} />;
     }
 
     @Watch('disabled')


### PR DESCRIPTION
related to: https://github.com/Lundalogik/crm-feature/issues/3334
waiting for: https://github.com/Lundalogik/lime-elements/pull/2269

fix: https://github.com/Lundalogik/lime-elements/issues/2257
fix: https://github.com/Lundalogik/lime-elements/issues/2258
fix: https://github.com/Lundalogik/lime-elements/issues/2263

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
