### PR TITLE
docs(packages): upgrade Kompendium from `0.12.2` to `0.12.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "jest-cli": "^27.4.5",
         "jsonlint-mod": "^1.7.6",
         "jsx-dom": "^8.0.5",
-        "kompendium": "^0.12.2",
+        "kompendium": "^0.12.3",
         "lodash-es": "^4.17.21",
         "material-components-web": "^13.0.0",
         "moment": "^2.29.4",
@@ -10043,9 +10043,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.2.tgz",
-      "integrity": "sha512-7Y/u2tdMk6uDek3YIPwN+hTV9tMGjjteTicbwE+IFereBDwdJvOCdN46AU1Dpykac1wCq883eMvdcNXZ3IS6vA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.3.tgz",
+      "integrity": "sha512-u1D8F55EHSgRRMo948TuP0U399JgSAfRoasvUJ6MXOri5Z8kxYPXSX9Cu6yuvIxyAkYnU6zB01ztr+2kmfb4ag==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -22103,9 +22103,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.2.tgz",
-      "integrity": "sha512-7Y/u2tdMk6uDek3YIPwN+hTV9tMGjjteTicbwE+IFereBDwdJvOCdN46AU1Dpykac1wCq883eMvdcNXZ3IS6vA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.3.tgz",
+      "integrity": "sha512-u1D8F55EHSgRRMo948TuP0U399JgSAfRoasvUJ6MXOri5Z8kxYPXSX9Cu6yuvIxyAkYnU6zB01ztr+2kmfb4ag==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jest-cli": "^27.4.5",
     "jsonlint-mod": "^1.7.6",
     "jsx-dom": "^8.0.5",
-    "kompendium": "^0.12.2",
+    "kompendium": "^0.12.3",
     "lodash-es": "^4.17.21",
     "material-components-web": "^13.0.0",
     "moment": "^2.29.4",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
