### PR TITLE
fix(select): prevent truncation in dropdown options, when the compone…

### DIFF
--- a/src/components/select/examples/select-narrow.scss
+++ b/src/components/select/examples/select-narrow.scss
@@ -4,6 +4,5 @@ limel-header {
 }
 
 limel-select {
-    min-width: 12rem;
     margin-right: 0.25rem;
 }

--- a/src/components/select/examples/select-narrow.tsx
+++ b/src/components/select/examples/select-narrow.tsx
@@ -46,6 +46,11 @@ export class SelectExample {
             value: 'leia',
             icon: 'businesswoman',
         },
+        {
+            text: 'R2',
+            value: 'r2',
+            icon: 'robot',
+        },
     ];
 
     public render() {

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -189,6 +189,8 @@ const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
                     '--mdc-menu-min-width': '100%',
                     'max-height': 'inherit',
                     display: 'flex',
+                    'min-width': '100%',
+                    width: 'fit-content',
                 }}
             >
                 <limel-list


### PR DESCRIPTION
…nt has small width

In the select component, width of the chosen option displayed in the trigger element, used to define the width of dropdown list that opens below it. This naturally caused truncation of text in all of available options in the list, when the dropdown list was opened. If the chosen option was too small in width, other options would be unreadable. This is why the consumers kept setting a `min-width` where they used `limel-select`, which resulted in more layout issues.

fix https://github.com/Lundalogik/lime-elements/issues/2040

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
