### PR TITLE
docs(info-tiles): correctly declare the prop name of `displayPercenta…

### DIFF
--- a/src/components/info-tile/examples/info-tile-progress.tsx
+++ b/src/components/info-tile/examples/info-tile-progress.tsx
@@ -31,6 +31,7 @@ export class InfoTileProgressExample {
     private progress: InfoTileProgress = {
         value: 76,
         prefix: '↑',
+        displayPercentageColors: true,
     };
 
     public render() {

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -93,7 +93,7 @@ export class InfoTile {
      * Defaults:
      * - `maxValue`: 100
      * - `suffix`: %
-     * - `percentageColors`: false
+     * - `displayPercentageColors`: false
      *
      * Colors change with intervals of 10 %.
      */


### PR DESCRIPTION
…geColors`



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
