### PR TITLE
fix(callout): support custom types

### DIFF
--- a/src/components/callout/callout.scss
+++ b/src/components/callout/callout.scss
@@ -9,6 +9,10 @@
     border-radius: 0.5rem;
     overflow: hidden;
 
+    --limel-callout-tint-color: var(
+        --callout-color,
+        rgb(var(--color-contrast-100))
+    );
     color: var(--callout-text-color, rgb(var(--contrast-1100)));
 }
 :host([type='note']) {

--- a/src/components/callout/callout.tsx
+++ b/src/components/callout/callout.tsx
@@ -27,6 +27,7 @@ import { Languages } from '@limetech/lime-elements';
  * @exampleComponent limel-example-callout-custom-heading
  * @exampleComponent limel-example-callout-custom-icon
  * @exampleComponent limel-example-callout-styles
+ * @exampleComponent limel-example-custom-type
  * @exampleComponent limel-example-callout-composite
  */
 @Component({

--- a/src/components/callout/examples/callout-custom-type.scss
+++ b/src/components/callout/examples/callout-custom-type.scss
@@ -1,0 +1,4 @@
+limel-callout[type='success'] {
+    --callout-color: rgb(var(--color-green-default));
+    --callout-text-color: rgb(var(--color-green-dark));
+}

--- a/src/components/callout/examples/callout-custom-type.tsx
+++ b/src/components/callout/examples/callout-custom-type.tsx
@@ -1,0 +1,26 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Custom type
+ *
+ * It is possible to send in a custom type,
+ * and provide it with custom, icon, heading and styles
+ */
+@Component({
+    tag: 'limel-example-custom-type',
+    shadow: true,
+    styleUrl: 'callout-custom-type.scss',
+})
+export class CalloutCustomTypeExample {
+    public render() {
+        return [
+            <limel-callout
+                icon="checked"
+                heading="Success"
+                type={'success' as any}
+            >
+                This is a custom type that we call success
+            </limel-callout>,
+        ];
+    }
+}

--- a/src/components/callout/examples/callout-styles.scss
+++ b/src/components/callout/examples/callout-styles.scss
@@ -3,7 +3,7 @@
     gap: 1rem;
 }
 
-limel-callout[type='example'] {
+limel-callout[type='caution'] {
     --callout-color: rgb(var(--color-pink-default));
     --callout-text-color: rgb(var(--color-orange-lighter));
     --callout-background-color: rgb(var(--color-pink-dark));

--- a/src/components/callout/examples/callout-styles.tsx
+++ b/src/components/callout/examples/callout-styles.tsx
@@ -15,7 +15,7 @@ import { Component, h } from '@stencil/core';
 export class CalloutStylesExample {
     public render() {
         return [
-            <limel-callout type="caution">
+            <limel-callout heading="Example" type={'example' as any}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla
                 et euismod nulla. Curabitur feugiat, tortor non consequat
                 finibus, justo purus auctor massa, nec semper lorem quam in

--- a/src/components/callout/examples/callout-styles.tsx
+++ b/src/components/callout/examples/callout-styles.tsx
@@ -15,7 +15,7 @@ import { Component, h } from '@stencil/core';
 export class CalloutStylesExample {
     public render() {
         return [
-            <limel-callout heading="Example" type={'example' as any}>
+            <limel-callout type="caution">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla
                 et euismod nulla. Curabitur feugiat, tortor non consequat
                 finibus, justo purus auctor massa, nec semper lorem quam in


### PR DESCRIPTION
If using a custom type let's say "success", then it wasn't possible to use `--callout-color` to style the component because the `--limel-callout-tint-color` variable was undefined. So I added a default value for it



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
