### PR TITLE
fix(shortcut): keep the same custom background color when hovered

### DIFF
--- a/src/components/shortcut/shortcut.scss
+++ b/src/components/shortcut/shortcut.scss
@@ -45,6 +45,11 @@ a {
             var(
                 --shortcut-background-color,
                 var(--lime-elevated-surface-background-color)
+            ),
+        $background-color--hovered:
+            var(
+                --shortcut-background-color,
+                var(--lime-elevated-surface-background-color)
             )
     );
     @include mixins.visualize-keyboard-focus;


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2308

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
