### PR TITLE
fix(input-field): show "clear all" button when field is not empty

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -167,13 +167,16 @@ input.mdc-text-field__input {
         -webkit-appearance: none;
 
         position: absolute;
-        right: functions.pxToRem(8);
+        right: 0;
         top: 0;
         bottom: 0;
         margin: auto;
 
         &:active {
             transform: none; //Makes the "clear-all button" work
+        }
+        .mdc-text-field--label-floating & {
+            opacity: 1;
         }
     }
 }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
