### PR TITLE
Tests for action bar

### DIFF
--- a/src/components/action-bar/action-bar-item/action-bar-overflow-menu.spec.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-overflow-menu.spec.tsx
@@ -1,0 +1,51 @@
+import { h } from '@stencil/core';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
+import { ActionBarOverflowMenu } from './action-bar-overflow-menu';
+
+let page: SpecPage;
+const actionsIn: Array<ActionBarItem | ListSeparator> = [
+    {
+        text: 'Add',
+        icon: 'info',
+    },
+    {
+        text: 'Edit',
+        icon: 'idea',
+    },
+    {
+        text: 'Delete',
+        icon: 'multiply',
+    },
+    {
+        separator: true,
+    },
+    {
+        text: 'Settings',
+        icon: 'external_link',
+    },
+];
+describe('action-bar-overflow-menu', () => {
+    beforeEach(async () => {
+        page = await newSpecPage({
+            components: [ActionBarOverflowMenu],
+            template: () => (
+                <limel-action-bar-overflow-menu items={actionsIn} />
+            ),
+        });
+
+        await page.waitForChanges();
+    });
+
+    it('renders', () => {
+        expect(page.root).toEqualHtml(`
+            <limel-action-bar-overflow-menu open-direction="bottom-end">
+                <limel-menu opendirection="bottom-end">
+                    <button slot="trigger">
+                        +4
+                    </button>
+                </limel-menu>
+            </limel-action-bar-overflow-menu>
+      `);
+    });
+});

--- a/src/components/action-bar/action-bar.spec.tsx
+++ b/src/components/action-bar/action-bar.spec.tsx
@@ -1,0 +1,188 @@
+import { h } from '@stencil/core';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
+import { ActionBar } from './action-bar';
+
+let page: SpecPage;
+let intersectionObserverMockedFunctions;
+let intersectionObserverMock;
+let intersectionCallback;
+const actionsIn: Array<ActionBarItem | ListSeparator> = [
+    {
+        text: 'Add',
+        icon: 'info',
+    },
+    {
+        text: 'Edit',
+        icon: 'idea',
+    },
+    {
+        text: 'Delete',
+        icon: 'multiply',
+    },
+    {
+        separator: true,
+    },
+    {
+        text: 'Settings',
+        icon: 'external_link',
+    },
+];
+describe('action-bar', () => {
+    beforeEach(async () => {
+        intersectionObserverMockedFunctions = {
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        };
+        intersectionObserverMock = jest.fn((callback) => {
+            intersectionCallback = callback;
+
+            return intersectionObserverMockedFunctions;
+        }) as any;
+        global.IntersectionObserver = intersectionObserverMock;
+
+        page = await newSpecPage({
+            components: [ActionBar],
+            template: () => <limel-action-bar actions={actionsIn} />,
+        });
+
+        await page.waitForChanges();
+    });
+
+    it('renders', () => {
+        expect(page.root).toEqualHtml(`
+            <limel-action-bar>
+                <mock:shadow-root>
+                    <div class=items>
+                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
+                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
+                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
+                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
+                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
+                    </div>
+                </mock:shadow-root>
+            </limel-action-bar>
+      `);
+    });
+
+    it('observes all actions in the intersection observer', () => {
+        expect(
+            intersectionObserverMockedFunctions.observe
+        ).toHaveBeenCalledTimes(5);
+    });
+
+    it('disconnects the instersection observer when destroyed', async () => {
+        page.body.removeChild(page.root);
+        await page.waitForChanges();
+
+        expect(
+            intersectionObserverMockedFunctions.disconnect
+        ).toHaveBeenCalledTimes(1);
+    });
+
+    it('observes all actions again if reconnected', async () => {
+        page.body.removeChild(page.root);
+        await page.waitForChanges();
+
+        intersectionObserverMockedFunctions.observe.mockClear();
+        page.body.appendChild(page.root);
+        await page.waitForChanges();
+        expect(
+            intersectionObserverMockedFunctions.observe
+        ).toHaveBeenCalledTimes(5);
+    });
+
+    it('hides non-visable items in the menu', async () => {
+        triggerIntersection([true, true, false, false, false]);
+
+        await page.waitForChanges();
+        expect(getNumVisibleActions()).toBe(2);
+        expect(hasOverflowMenu()).toBeTruthy();
+    });
+
+    it('does not show the menu when all actions intersect', async () => {
+        triggerIntersection([true, true, true, true, true]);
+
+        await page.waitForChanges();
+        expect(hasOverflowMenu()).toBeFalsy();
+    });
+
+    it('hides the menu when all actions intersect once more', async () => {
+        // Set some of the actions visible as a start
+        triggerIntersection([true, true, true, false, false]);
+
+        await page.waitForChanges();
+        expect(hasOverflowMenu()).toBeTruthy();
+
+        // Now add two more actions intersecting
+        triggerIntersection([true, true]);
+
+        // The menu should no longer be needed, all actions intersect
+        await page.waitForChanges();
+        expect(hasOverflowMenu()).toBeFalsy();
+    });
+
+    it('handles one more intersecting actions', async () => {
+        // Set some of the actions visible as a start
+        triggerIntersection([true, true, false, false, false]);
+
+        // Make one more item intersect
+        triggerIntersection([true]);
+
+        await page.waitForChanges();
+        expect(getNumVisibleActions()).toBe(3);
+    });
+
+    it('handles one less intersecting actions', async () => {
+        // Set some of the actions visible as a start
+        triggerIntersection([true, true, true, true, false]);
+
+        // Make one less item intersect
+        triggerIntersection([false]);
+
+        await page.waitForChanges();
+        expect(getNumVisibleActions()).toBe(3);
+    });
+
+    it('handles zero intersecting actions', async () => {
+        triggerIntersection([false, false, false, false, false]);
+
+        await page.waitForChanges();
+        expect(getNumVisibleActions()).toBe(0);
+    });
+
+    it('handles all actions intersecting', async () => {
+        triggerIntersection([true, true, true, true, true]);
+
+        await page.waitForChanges();
+        expect(getNumVisibleActions()).toBe(5);
+    });
+});
+
+const triggerIntersection = (intersectingElements: boolean[]) => {
+    const entries = intersectingElements.map((entry) => ({
+        isIntersecting: entry,
+    }));
+
+    intersectionCallback(entries);
+};
+
+const getNumVisibleActions = (): number => {
+    const actions = page.root.shadowRoot.querySelectorAll(
+        'limel-action-bar-item'
+    );
+    const visibleActions = Array.from(actions).filter((action) =>
+        action.hasAttribute('isvisible')
+    );
+
+    return visibleActions.length;
+};
+
+const hasOverflowMenu = () => {
+    const overflowMenu = page.root.shadowRoot.querySelector(
+        'limel-action-bar-overflow-menu'
+    );
+
+    return !!overflowMenu;
+};

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -118,6 +118,8 @@ export class ActionBar {
         );
     }
 
+    public connectedCallback() {}
+
     public componentDidRender() {
         if (this.haveItemsChanged()) {
             this.intersectionObserver?.disconnect();
@@ -127,7 +129,9 @@ export class ActionBar {
 
     public disconnectedCallback() {
         this.intersectionObserver?.disconnect();
+        this.intersectionObserver = undefined;
         this.actionBarItems = [];
+        this.connectedCallback = () => this.createIntersectionObserver();
     }
 
     private renderActionBarItem = (item: ActionBarItem, index: number) => {
@@ -194,6 +198,9 @@ export class ActionBar {
             rootMargin: '0px',
             threshold: 1.0,
         };
+
+        this.overflowCutoff = this.actions.length;
+        this.firstRender = true;
 
         this.actionBarItems = [];
 


### PR DESCRIPTION
This PR adds unit tests for the `limel-action-bar`. It's mostly concerned about how we handle overflow of the `limel-action-bar-items` into the `limel-action-bar-overflow-menu`.

The reason for creating a follow up PR for this was due to the large size of PR containing the action bar.

Fixes Lundalogik/crm-feature#3379
Connected to Lundalogik/lime-elements#2315
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
