### PR TITLE
feat(action bar): fix list item type definition

### DIFF
--- a/src/components/list/list-item.types.ts
+++ b/src/components/list/list-item.types.ts
@@ -48,7 +48,7 @@ export interface ListItem<T = any> {
 }
 
 export interface ListSeparator {
-    separator: true;
+    separator: boolean;
 }
 
 export interface ListComponent {


### PR DESCRIPTION
Currently the interface definition for the ListSeparator is explicitly setting 'true' when it should instead be 'boolean'

Fixes [Fix list-item.types in lime-elements](https://github.com/Lundalogik/crm-feature/issues/3454)

```
export interface ListSeparator {
    separator: true;
}
```

->

```
export interface ListSeparator {
    separator: boolean;
}
```