### PR TITLE
style(icon-cache): fix docstring return

### DIFF
--- a/src/global/icon-cache.ts
+++ b/src/global/icon-cache.ts
@@ -16,7 +16,7 @@ export class IconCache {
      * Get icon data from the cache
      * @param {string} name name of the icon
      * @param {string} path path on the server where the assets are located
-     * @returns {string} svg markup
+     * @returns {Promise<string>} svg markup
      */
     public async get(name: string, path: string = ''): Promise<string> {
         const cache = await this.cache;


### PR DESCRIPTION
Something.I overlooked in a recent review

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
