### PR TITLE
fix(list): correctly enable usage of `--list-margin` variable

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -20,7 +20,7 @@ $list-mdc-list-item: 0;
  * @prop --list-grid-gap: Distance between items in a list that has `has-grid-layout` class. Defaults to `0.75rem`.
  * @prop --list-background-color-of-odd-interactive-items: Background color of odd list items, when `has-striped-rows` class is applied to the component. Defaults to `--contrast-200`.
  * @prop --list-background-color-of-even-interactive-items:  Background color of even list items, when `has-striped-rows` class is applied to the component. Defaults to `transparent`.
- * @prop --list-margin: Space around the list. Default to `0.25rem`;
+ * @prop --list-margin: Space around the list. Defaults to `0.25rem`, which visualizes keyboard-focused items in a better way, as it adds some space for the outline effect;
  */
 
 :host(limel-list) {
@@ -40,7 +40,7 @@ $list-mdc-list-item: 0;
         --icon-color,
         rgb(var(--contrast-900))
     );
-    margin: (
+    margin: var(
         --list-margin,
         0.25rem
     ); // added space to visualize keyboard-focused items


### PR DESCRIPTION
This feature was added here https://github.com/Lundalogik/lime-elements/pull/2337/files#diff-817817636ecff6902e33d23a4566f3ce0c76c4b8c1604695c95b7acc3c40b066R43-R45, but somehow we forgot to type `var`

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
