### PR TITLE
fix(chip-set): rename event from `input` to `chipSetInput`

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -177,7 +177,7 @@ export class ChipSet {
      * Dispatched when the input is changed for type `input`
      */
     @Event()
-    private input: EventEmitter<string>;
+    private chipSetInput: EventEmitter<string>;
 
     @Element()
     private host: HTMLLimelChipSetElement;
@@ -537,7 +537,7 @@ export class ChipSet {
         event.stopPropagation();
         this.inputChipIndexSelected = null;
         this.textValue = event.target.value;
-        this.input.emit(event.target.value && event.target.value.trim());
+        this.chipSetInput.emit(event.target.value && event.target.value.trim());
     }
 
     private handleInteractionEvent(event: MDCChipInteractionEvent) {

--- a/src/components/chip-set/examples/chip-set-input-type-search.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-search.tsx
@@ -43,7 +43,7 @@ export class ChipSetInputExample {
                 maxItems={this.maxItems}
                 value={this.value}
                 onChange={this.handleChange}
-                onInput={this.handleInput}
+                onChipSetInput={this.handleInput}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}
             />,

--- a/src/components/chip-set/examples/chip-set-input-type-text.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-text.tsx
@@ -63,7 +63,7 @@ export class ChipSetInputExample {
                 value={this.value}
                 maxItems={this.maxItems}
                 onChange={this.handleChange}
-                onInput={this.handleInput}
+                onChipSetInput={this.handleInput}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}
             />,

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -63,7 +63,7 @@ export class ChipSetInputExample {
                 leadingIcon={this.hasLeadingIcon ? 'search' : null}
                 maxItems={this.maxItems}
                 onChange={this.handleChange}
-                onInput={this.handleInput}
+                onChipSetInput={this.handleInput}
                 onInteract={this.handleInteraction}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}

--- a/src/components/icon/examples/icon-finder.tsx
+++ b/src/components/icon/examples/icon-finder.tsx
@@ -47,7 +47,7 @@ export class IconFinder {
                 type="input"
                 value={this.value}
                 onChange={this.chipSetOnChange}
-                onInput={this.onInput}
+                onChipSetInput={this.onInput}
                 onKeyUp={this.onKeyUp}
                 searchLabel="Type and press enter to search"
                 emptyInputOnBlur={true}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -262,7 +262,7 @@ export class Picker {
                 readonly={this.readonly}
                 required={this.required}
                 searchLabel={this.searchLabel}
-                onInput={this.handleTextInput}
+                onChipSetInput={this.handleTextInput}
                 onKeyDown={this.handleInputKeyDown}
                 onChange={this.handleChange}
                 onInteract={this.handleInteract}


### PR DESCRIPTION
Stencil has long complained about custom events that shadow native events, that is, have the same name as a native event. When upgrading to Stencil v3, this causes build errors if the event handler uses typed arguments, as the types of the custom events conflict with the types of the native events.

BREAKING CHANGE: The custom event `input` has been renamed to `chipSetInput`.

This change is necessary in order for both us and our consumers to upgrade to StencilJS v3 and beyond, as StencilJS v3 uses strongly typed arguments for the `input` event, and thus causes a build error if the arguments to the event handler used with our custom event uses conflicting types.

Example of code that needs to be changed:

```ts
public render() {
    return (
        <limel-chip-set
            ...
            onInput={this.handleInput}
        />
    );
}
```

Updated code:

```ts
public render() {
    return (
        <limel-chip-set
            ...
            onChipSetInput={this.handleInput}
        />
    );
}
```



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
