### PR TITLE
Deprecrate events

### DIFF
--- a/src/components/action-bar/action-bar-item/action-bar-item.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-item.tsx
@@ -22,7 +22,7 @@ export class ActionBarButton {
      * Fired when a action bar item has been clicked.
      */
     @Event()
-    public select: EventEmitter<ActionBarItem | ListSeparator>;
+    public limelSelect: EventEmitter<ActionBarItem | ListSeparator>;
 
     /**
      * When the item is displayed in the available width,
@@ -61,7 +61,7 @@ export class ActionBarButton {
 
     private handleClick = (event: MouseEvent) => {
         event.stopPropagation();
-        this.select.emit(this.item);
+        this.limelSelect.emit(this.item);
     };
 
     private isItem(item: ActionBarItem | ListSeparator): item is ActionBarItem {

--- a/src/components/action-bar/action-bar-item/action-bar-overflow-menu.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-overflow-menu.tsx
@@ -32,7 +32,7 @@ export class ActionBarOverflowMenu {
     public openDirection: OpenDirection = 'bottom-end';
 
     @Event()
-    public select: EventEmitter<ActionBarItem>;
+    public limelSelect: EventEmitter<ActionBarItem>;
 
     public render() {
         return [
@@ -52,7 +52,7 @@ export class ActionBarOverflowMenu {
 
     private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
         event.stopPropagation();
-        this.select.emit(event.detail);
+        this.limelSelect.emit(event.detail);
     };
 
     private get numberOfMenuItems() {

--- a/src/components/action-bar/action-bar-item/action-bar-overflow-menu.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-overflow-menu.tsx
@@ -39,7 +39,7 @@ export class ActionBarOverflowMenu {
             <limel-menu
                 openDirection={this.openDirection}
                 items={this.items}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
             >
                 <button slot="trigger">{this.countOverflowedItems()}</button>
             </limel-menu>,

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -138,7 +138,7 @@ export class ActionBar {
         return (
             <limel-action-bar-item
                 item={item}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
                 isVisible={this.isVisible(index)}
             />
         );

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -153,7 +153,7 @@ export class ActionBar {
             <limel-action-bar-overflow-menu
                 openDirection={this.openDirection}
                 items={items}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
             />
         );
     };

--- a/src/components/button-group/button-group.e2e.ts
+++ b/src/components/button-group/button-group.e2e.ts
@@ -4,6 +4,7 @@ describe('limel-button-group', () => {
     let page: E2EPage;
     let buttonGroup: E2EElement;
     let buttons: E2EElement[];
+    let spyForDeprecatedEvent;
     let spy;
 
     describe('basic button group', () => {
@@ -33,7 +34,8 @@ describe('limel-button-group', () => {
 
             buttons = await page.findAll('limel-button-group >>> .mdc-chip');
 
-            spy = await buttonGroup.spyOnEvent('change');
+            spyForDeprecatedEvent = await buttonGroup.spyOnEvent('change');
+            spy = await buttonGroup.spyOnEvent('limelChange');
         });
 
         it('renders the buttons', () => {
@@ -46,7 +48,15 @@ describe('limel-button-group', () => {
                 await buttons[0].click();
             });
 
-            it('emits a change event', () => {
+            it('emits a change event (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(1);
+                expect(spyForDeprecatedEvent).toHaveReceivedEventDetail({
+                    id: '1',
+                    title: 'Lime',
+                });
+            });
+
+            it('emits a limelChange event', () => {
                 expect(spy).toHaveReceivedEventTimes(1);
                 expect(spy).toHaveReceivedEventDetail({
                     id: '1',

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -64,10 +64,16 @@ export class ButtonGroup {
     public disabled: boolean = false;
 
     /**
-     * Dispatched when a button is selected/deselected
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<Button>;
+
+    /**
+     * Dispatched when a button is selected/deselected
+     */
+    @Event()
+    private limelChange: EventEmitter<Button>;
 
     @State()
     private selectedButtonId: string;
@@ -178,6 +184,7 @@ export class ButtonGroup {
             return item.id === this.selectedButtonId;
         });
         this.change.emit(button);
+        this.limelChange.emit(button);
     }
 
     private setSelectedButton = () => {

--- a/src/components/button-group/examples/button-group-badges.tsx
+++ b/src/components/button-group/examples/button-group-badges.tsx
@@ -46,7 +46,7 @@ export class ButtonGroupBadgesExample {
     public render() {
         return [
             <limel-button-group
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.buttons}
             />,
         ];

--- a/src/components/button-group/examples/button-group-composite.tsx
+++ b/src/components/button-group/examples/button-group-composite.tsx
@@ -70,7 +70,7 @@ export class ButtonCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/button-group/examples/button-group-composite.tsx
+++ b/src/components/button-group/examples/button-group-composite.tsx
@@ -51,7 +51,10 @@ export class ButtonCompositeExample {
 
     public render() {
         return [
-            <limel-button-group {...this.props} onChange={this.handleChange} />,
+            <limel-button-group
+                {...this.props}
+                onLimelChange={this.handleChange}
+            />,
             this.renderForm(),
             <limel-example-event-printer
                 ref={(el) => (this.eventPrinter = el)}

--- a/src/components/button-group/examples/button-group-icons.tsx
+++ b/src/components/button-group/examples/button-group-icons.tsx
@@ -64,7 +64,7 @@ export class ButtonGroupIconsExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.toggleEnabled}
+                    onLimelChange={this.toggleEnabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/button-group/examples/button-group-icons.tsx
+++ b/src/components/button-group/examples/button-group-icons.tsx
@@ -58,7 +58,7 @@ export class ButtonGroupIconsExample {
         return [
             <limel-button-group
                 disabled={this.disabled}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.buttons}
             />,
             <limel-example-controls>

--- a/src/components/button-group/examples/button-group-mix.tsx
+++ b/src/components/button-group/examples/button-group-mix.tsx
@@ -46,7 +46,7 @@ export class ButtonGroupMixExample {
         return [
             <limel-button-group
                 disabled={this.disabled}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.buttons}
             />,
             <limel-example-controls>

--- a/src/components/button-group/examples/button-group-mix.tsx
+++ b/src/components/button-group/examples/button-group-mix.tsx
@@ -52,7 +52,7 @@ export class ButtonGroupMixExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.toggleEnabled}
+                    onLimelChange={this.toggleEnabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/button-group/examples/button-group.tsx
+++ b/src/components/button-group/examples/button-group.tsx
@@ -42,7 +42,7 @@ export class ButtonGroupExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.toggleEnabled}
+                    onLimelChange={this.toggleEnabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/button-group/examples/button-group.tsx
+++ b/src/components/button-group/examples/button-group.tsx
@@ -36,7 +36,7 @@ export class ButtonGroupExample {
         return [
             <limel-button-group
                 disabled={this.disabled}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.buttons}
             />,
             <limel-example-controls>

--- a/src/components/button/examples/button-composite.tsx
+++ b/src/components/button/examples/button-composite.tsx
@@ -58,7 +58,7 @@ export class ButtonCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/callout/examples/callout-composite.tsx
+++ b/src/components/callout/examples/callout-composite.tsx
@@ -114,7 +114,7 @@ export class CalloutCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -72,10 +72,16 @@ export class Checkbox {
     private modified = false;
 
     /**
-     * Emitted when the input value is changed.
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<boolean>;
+
+    /**
+     * Emitted when the input value is changed.
+     */
+    @Event()
+    private limelChange: EventEmitter<boolean>;
 
     @Element()
     private limelCheckbox: HTMLLimelCheckboxElement;
@@ -156,6 +162,7 @@ export class Checkbox {
     private onChange = (event: Event) => {
         event.stopPropagation();
         this.change.emit(this.mdcCheckbox.checked);
+        this.limelChange.emit(this.mdcCheckbox.checked);
         this.modified = true;
     };
 }

--- a/src/components/checkbox/examples/checkbox.tsx
+++ b/src/components/checkbox/examples/checkbox.tsx
@@ -32,34 +32,34 @@ export class CheckboxExample {
                 checked={this.value}
                 indeterminate={this.indeterminate}
                 required={this.required}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 readonly={this.readonly}
             />,
             <limel-example-controls>
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
                 <limel-checkbox
                     checked={this.value}
                     label="Checked"
-                    onChange={this.setChecked}
+                    onLimelChange={this.setChecked}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.indeterminate}
                     label="Indeterminate"
-                    onChange={this.setIndeterminate}
+                    onLimelChange={this.setIndeterminate}
                 />
             </limel-example-controls>,
             <limel-example-value label="Checked" value={this.value} />,

--- a/src/components/chip-set/chip-set.e2e.ts
+++ b/src/components/chip-set/chip-set.e2e.ts
@@ -5,6 +5,7 @@ describe('limel-chip-set', () => {
     let chipSet: E2EElement;
     let label: E2EElement;
     let chips: E2EElement[];
+    let spyForDeprecatedEvent;
     let spy;
 
     describe('basic chip set', () => {
@@ -275,7 +276,8 @@ describe('limel-chip-set', () => {
 
         describe('when typing in the input field', () => {
             beforeEach(async () => {
-                spy = await chipSet.spyOnEvent('input');
+                spyForDeprecatedEvent = await chipSet.spyOnEvent('input');
+                spy = await chipSet.spyOnEvent('limelInput');
 
                 const input: E2EElement = await page.find(
                     'limel-chip-set >>> input'
@@ -285,7 +287,15 @@ describe('limel-chip-set', () => {
                 await page.waitForChanges();
             });
 
-            it('emits an input event', () => {
+            it('emits an input event (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(6);
+                expect(spyForDeprecatedEvent.events[0].detail).toEqual('B');
+                expect(spyForDeprecatedEvent.events[5].detail).toEqual(
+                    'Banana'
+                );
+            });
+
+            it('emits a limelInput event', () => {
                 expect(spy).toHaveReceivedEventTimes(6);
                 expect(spy.events[0].detail).toEqual('B');
                 expect(spy.events[5].detail).toEqual('Banana');

--- a/src/components/chip-set/chip-set.e2e.ts
+++ b/src/components/chip-set/chip-set.e2e.ts
@@ -320,11 +320,22 @@ describe('limel-chip-set', () => {
 
         describe('when a chip delete button is clicked', () => {
             beforeEach(async () => {
-                spy = await chipSet.spyOnEvent('change');
+                spyForDeprecatedEvent = await chipSet.spyOnEvent('change');
+                spy = await chipSet.spyOnEvent('limelChange');
                 await firstChipRemoveButton.click();
             });
 
-            it('emits a change event where the removed chip is not present', () => {
+            it('emits a change event where the removed chip is not present (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(1);
+                expect(spyForDeprecatedEvent.events[0].detail).toEqual([
+                    {
+                        id: '2',
+                        text: 'Apple',
+                    },
+                ]);
+            });
+
+            it('emits a limelChange event where the removed chip is not present', () => {
                 expect(spy).toHaveReceivedEventTimes(1);
                 expect(spy.events[0].detail).toEqual([
                     {
@@ -383,7 +394,8 @@ describe('limel-chip-set', () => {
 
         describe('when the clear chips button is pressed', () => {
             beforeEach(async () => {
-                spy = await page.spyOnEvent('change');
+                spyForDeprecatedEvent = await page.spyOnEvent('change');
+                spy = await page.spyOnEvent('limelChange');
                 const deleteAllIconButton: E2EElement = await page.find(
                     'limel-chip-set >>> .clear-all-button'
                 );
@@ -391,7 +403,12 @@ describe('limel-chip-set', () => {
                 await deleteAllIconButton.click();
             });
 
-            it('emits a change event where the all chips are removed', () => {
+            it('emits a change event where the all chips are removed (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(1);
+                expect(spyForDeprecatedEvent.events[0].detail).toEqual([]);
+            });
+
+            it('emits a limelChange event where the all chips are removed', () => {
                 expect(spy).toHaveReceivedEventTimes(1);
                 expect(spy.events[0].detail).toEqual([]);
             });

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -156,10 +156,16 @@ export class ChipSet {
     private interact: EventEmitter<Chip>;
 
     /**
-     * Dispatched when a chip is selected/deselected
+     * @deprecated Use `limelChange` instead
      */
     @Event()
     private change: EventEmitter<Chip | Chip[]>;
+
+    /**
+     * Dispatched when a chip is selected/deselected
+     */
+    @Event()
+    private limelChange: EventEmitter<Chip | Chip[]>;
 
     /**
      * Emitted when an input chip set has received focus and editing in the text field has started
@@ -565,6 +571,7 @@ export class ChipSet {
         });
         chip = { ...chip, selected: event.detail.selected };
         this.change.emit(chip);
+        this.limelChange.emit(chip);
     }
 
     private removeChip(id: string | number) {
@@ -572,6 +579,7 @@ export class ChipSet {
             return `${chip.id}` !== `${id}`;
         });
         this.change.emit(newValue);
+        this.limelChange.emit(newValue);
     }
 
     private renderChip(chip: Chip) {
@@ -780,6 +788,7 @@ export class ChipSet {
     private handleDeleteAllIconClick(event: Event) {
         event.preventDefault();
         this.change.emit([]);
+        this.limelChange.emit([]);
     }
 
     private renderDelimiter() {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -174,10 +174,16 @@ export class ChipSet {
     private stopEdit: EventEmitter<void>;
 
     /**
-     * Dispatched when the input is changed for type `input`
+     * @deprecated Use `limelInput` instead
      */
     @Event()
     private input: EventEmitter<string>;
+
+    /**
+     * Dispatched when the input is changed for type `input`
+     */
+    @Event()
+    private limelInput: EventEmitter<string>;
 
     @Element()
     private host: HTMLLimelChipSetElement;
@@ -537,7 +543,9 @@ export class ChipSet {
         event.stopPropagation();
         this.inputChipIndexSelected = null;
         this.textValue = event.target.value;
-        this.input.emit(event.target.value && event.target.value.trim());
+        const eventValue = event.target.value && event.target.value.trim();
+        this.input.emit(eventValue);
+        this.limelInput.emit(eventValue);
     }
 
     private handleInteractionEvent(event: MDCChipInteractionEvent) {

--- a/src/components/chip-set/examples/chip-set-choice.tsx
+++ b/src/components/chip-set/examples/chip-set-choice.tsx
@@ -48,7 +48,7 @@ export class ChipSetChoiceExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/chip-set/examples/chip-set-choice.tsx
+++ b/src/components/chip-set/examples/chip-set-choice.tsx
@@ -42,7 +42,7 @@ export class ChipSetChoiceExample {
                 disabled={this.disabled}
                 type="choice"
                 label="Thirst quencher with a twist of"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.chips}
             />,
             <limel-example-controls>

--- a/src/components/chip-set/examples/chip-set-composite.tsx
+++ b/src/components/chip-set/examples/chip-set-composite.tsx
@@ -55,7 +55,10 @@ export class ChipSetCompositeExample {
 
     public render() {
         return [
-            <limel-chip-set {...this.props} onChange={this.handleChange} />,
+            <limel-chip-set
+                {...this.props}
+                onLimelChange={this.handleChange}
+            />,
             this.renderForm(),
             <limel-example-event-printer
                 ref={(el) => (this.eventPrinter = el)}

--- a/src/components/chip-set/examples/chip-set-composite.tsx
+++ b/src/components/chip-set/examples/chip-set-composite.tsx
@@ -74,7 +74,7 @@ export class ChipSetCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/chip-set/examples/chip-set-filter-badge.tsx
+++ b/src/components/chip-set/examples/chip-set-filter-badge.tsx
@@ -48,7 +48,7 @@ export class ChipSetFilterBadgeExample {
                 label="Include fruits of type:"
                 disabled={this.disabled}
                 type="filter"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.chips}
             />,
             <limel-example-controls>

--- a/src/components/chip-set/examples/chip-set-filter-badge.tsx
+++ b/src/components/chip-set/examples/chip-set-filter-badge.tsx
@@ -54,7 +54,7 @@ export class ChipSetFilterBadgeExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/chip-set/examples/chip-set-filter.tsx
+++ b/src/components/chip-set/examples/chip-set-filter.tsx
@@ -44,7 +44,7 @@ export class ChipSetFilterExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/chip-set/examples/chip-set-filter.tsx
+++ b/src/components/chip-set/examples/chip-set-filter.tsx
@@ -38,7 +38,7 @@ export class ChipSetFilterExample {
                 label="Include fruits of type:"
                 disabled={this.disabled}
                 type="filter"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.chips}
             />,
             <limel-example-controls>

--- a/src/components/chip-set/examples/chip-set-input-type-search.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-search.tsx
@@ -43,7 +43,7 @@ export class ChipSetInputExample {
                 maxItems={this.maxItems}
                 value={this.value}
                 onChange={this.handleChange}
-                onInput={this.handleInput}
+                onLimelInput={this.handleInput}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}
             />,

--- a/src/components/chip-set/examples/chip-set-input-type-search.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-search.tsx
@@ -42,7 +42,7 @@ export class ChipSetInputExample {
                 label="Suggest three unique names for our newly founded company"
                 maxItems={this.maxItems}
                 value={this.value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onLimelInput={this.handleInput}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}

--- a/src/components/chip-set/examples/chip-set-input-type-text.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-text.tsx
@@ -59,7 +59,7 @@ export class ChipSetInputExample {
                 helperText="For some fruit names, icons are displayed on the chips"
                 value={this.value}
                 maxItems={this.maxItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onLimelInput={this.handleInput}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}

--- a/src/components/chip-set/examples/chip-set-input-type-text.tsx
+++ b/src/components/chip-set/examples/chip-set-input-type-text.tsx
@@ -60,7 +60,7 @@ export class ChipSetInputExample {
                 value={this.value}
                 maxItems={this.maxItems}
                 onChange={this.handleChange}
-                onInput={this.handleInput}
+                onLimelInput={this.handleInput}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}
             />,

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -80,32 +80,32 @@ export class ChipSetInputExample {
                 />
                 <limel-checkbox
                     label="Empty input on blur"
-                    onChange={this.setEmptyInputOnBlur}
+                    onLimelChange={this.setEmptyInputOnBlur}
                     checked={this.emptyInputOnBlur}
                 />
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                     checked={this.disabled}
                 />
                 <limel-checkbox
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                     checked={this.readonly}
                 />
                 <limel-checkbox
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                     checked={this.required}
                 />
                 <limel-checkbox
                     label={'Leading icon'}
-                    onChange={this.setLeadingIcon}
+                    onLimelChange={this.setLeadingIcon}
                     checked={this.hasLeadingIcon}
                 />
                 <limel-checkbox
                     label="Use delimiters"
-                    onChange={this.useDelimiters}
+                    onLimelChange={this.useDelimiters}
                     checked={this.delimiter !== null}
                 />
             </limel-example-controls>,

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -76,7 +76,7 @@ export class ChipSetInputExample {
                     label="Max items"
                     value={this.maxItems.toString()}
                     type="number"
-                    onChange={this.setMaxItems}
+                    onLimelChange={this.setMaxItems}
                 />
                 <limel-checkbox
                     label="Empty input on blur"

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -63,7 +63,7 @@ export class ChipSetInputExample {
                 leadingIcon={this.hasLeadingIcon ? 'search' : null}
                 maxItems={this.maxItems}
                 onChange={this.handleChange}
-                onInput={this.handleInput}
+                onLimelInput={this.handleInput}
                 onInteract={this.handleInteraction}
                 onKeyUp={this.onKeyUp}
                 emptyInputOnBlur={this.emptyInputOnBlur}

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -62,7 +62,7 @@ export class ChipSetInputExample {
                 disabled={this.disabled}
                 leadingIcon={this.hasLeadingIcon ? 'search' : null}
                 maxItems={this.maxItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onLimelInput={this.handleInput}
                 onInteract={this.handleInteraction}
                 onKeyUp={this.onKeyUp}

--- a/src/components/chip-set/examples/chip-set.tsx
+++ b/src/components/chip-set/examples/chip-set.tsx
@@ -42,7 +42,7 @@ export class ChipSetExample {
             <limel-example-controls>
                 <limel-checkbox
                     label="Disabled"
-                    onChange={this.toggleEnabled}
+                    onLimelChange={this.toggleEnabled}
                     checked={this.disabled}
                 />
             </limel-example-controls>,

--- a/src/components/circular-progress/circular-progress.tsx
+++ b/src/components/circular-progress/circular-progress.tsx
@@ -46,10 +46,16 @@ export class CircularProgress {
     public maxValue: number = PERCENT;
 
     /**
-     * The prefix which is displayed before the `value`, must be a few characters characters long.
+     * @deprecated Use `limelPrefix` instead.
      */
     @Prop({ reflect: true })
     public prefix?: string = null;
+
+    /**
+     * The prefix which is displayed before the `value`, must be a few characters characters long.
+     */
+    @Prop({ reflect: true })
+    public limelPrefix?: string = null;
 
     /**
      * The suffix which is displayed after the `value`, must be one or two characters long. Defaults to `%`
@@ -97,8 +103,10 @@ export class CircularProgress {
         );
     }
     private renderPrefix = () => {
-        if (this.prefix) {
-            return <span class="prefix">{this.prefix}</span>;
+        if (this.limelPrefix || this.prefix) {
+            return (
+                <span class="prefix">{this.limelPrefix || this.prefix}</span>
+            );
         }
     };
 }

--- a/src/components/circular-progress/examples/circular-progress-css-variables.tsx
+++ b/src/components/circular-progress/examples/circular-progress-css-variables.tsx
@@ -24,6 +24,6 @@ export class CircularProgressCssVariablesExample {
     private value = 90;
 
     public render() {
-        return <limel-circular-progress prefix="↗" value={this.value} />;
+        return <limel-circular-progress limelPrefix="↗" value={this.value} />;
     }
 }

--- a/src/components/circular-progress/examples/circular-progress-percentage-colors.tsx
+++ b/src/components/circular-progress/examples/circular-progress-percentage-colors.tsx
@@ -27,7 +27,7 @@ export class CircularProgressPercentageColorsExample {
                 label="Value"
                 type="number"
                 value={value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-circular-progress
                 value={this.value}

--- a/src/components/circular-progress/examples/circular-progress-props.tsx
+++ b/src/components/circular-progress/examples/circular-progress-props.tsx
@@ -3,7 +3,12 @@ import { Component, h } from '@stencil/core';
  * Using the props
  * This component is initially designed to visualize a percentage on a scale of
  * zero to 100. However, you can easily visualize a progress in other scales,
- * simply by setting `maxValue`, `prefix` and `suffix`.
+ * simply by setting `maxValue`, `limelPrefix` and `suffix`.
+ *
+ * :::note
+ * Use `limelPrefix` rather than `prefix`. `prefix` is a "reserved public name",
+ * and has therefore been deprecated. It will be removed in a future version.
+ * :::
  *
  * Look at this example to see how the component displays an angle in a
  * 360-degrees scale, a 60-seconds scale, and a 5-stars rating.
@@ -56,7 +61,7 @@ export class CircularProgressPropsExample {
                 value={this.budget}
                 maxValue={this.maxBudget}
                 suffix={this.currency}
-                prefix={this.increase}
+                limelPrefix={this.increase}
             />,
         ];
     }

--- a/src/components/circular-progress/examples/circular-progress.tsx
+++ b/src/components/circular-progress/examples/circular-progress.tsx
@@ -17,7 +17,7 @@ export class CircularProgressExample {
                 label="Value"
                 type="number"
                 value={value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-circular-progress value={this.value} />,
         ];

--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -75,11 +75,17 @@ export class CodeEditor {
     public colorScheme: ColorScheme = 'auto';
 
     /**
+     * @deprecated Use `limelChange` instead
+     */
+    @Event()
+    public change: EventEmitter<string>;
+
+    /**
      * Emitted when the code has changed. Will only be emitted when the code
      * area has lost focus
      */
     @Event()
-    public change: EventEmitter<string>;
+    public limelChange: EventEmitter<string>;
 
     @Element()
     private host: HTMLLimelCodeEditorElement;

--- a/src/components/code-editor/examples/code-editor-with-linting-and-folding.tsx
+++ b/src/components/code-editor/examples/code-editor-with-linting-and-folding.tsx
@@ -30,7 +30,7 @@ export class CodeFoldAndLintExample {
                 lineNumbers={true}
                 lint={true}
                 fold={true}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/code-editor/examples/code-editor.tsx
+++ b/src/components/code-editor/examples/code-editor.tsx
@@ -27,7 +27,7 @@ export class CodeExample {
             <limel-code-editor
                 value={this.json}
                 language="json"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -37,9 +37,16 @@ export class Palette implements FormComponent {
 
     /**
      * Emits chosen value to the parent component
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     public change: EventEmitter<string>;
+
+    /**
+     * Emits chosen value to the parent component
+     */
+    @Event()
+    public limelChange: EventEmitter<string>;
 
     public render() {
         const background = this.value ? { '--background': this.value } : {};
@@ -85,6 +92,7 @@ export class Palette implements FormComponent {
     private handleChange = (event: CustomEvent<string>) => {
         event.stopPropagation();
         this.change.emit(event.detail);
+        this.limelChange.emit(event.detail);
     };
 
     private handleClick =
@@ -92,5 +100,6 @@ export class Palette implements FormComponent {
             const value = getCssColor(color, brightness);
             event.stopPropagation();
             this.change.emit(value);
+            this.limelChange.emit(value);
         };
 }

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -58,7 +58,7 @@ export class Palette implements FormComponent {
                     label={this.label}
                     helperText={this.helperText}
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                     required={this.required}
                 />
                 <div class="chosen-color-preview" style={background} />

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -12,7 +12,10 @@ beforeEach(async () => {
     page = await newSpecPage({
         components: [ColorPicker, Palette],
         template: () => (
-            <limel-color-picker label="Hair color" onChange={handleChange} />
+            <limel-color-picker
+                label="Hair color"
+                onLimelChange={handleChange}
+            />
         ),
     });
 

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -111,7 +111,7 @@ export class ColorPicker implements FormComponent {
                     value={this.value}
                     label={this.label}
                     helperText={this.helperText}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                     required={this.required}
                 />
             </limel-popover>

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -59,9 +59,16 @@ export class ColorPicker implements FormComponent {
 
     /**
      * Emits chosen value to the parent component
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     public change: EventEmitter<string>;
+
+    /**
+     * Emits chosen value to the parent component
+     */
+    @Event()
+    public limelChange: EventEmitter<string>;
 
     @State()
     private isOpen = false;
@@ -147,5 +154,6 @@ export class ColorPicker implements FormComponent {
     private handleChange = (event: CustomEvent<string>) => {
         event.stopPropagation();
         this.change.emit(event.detail);
+        this.limelChange.emit(event.detail);
     };
 }

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -83,7 +83,7 @@ export class ColorPicker implements FormComponent {
                     label={this.label}
                     helperText={this.helperText}
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                     required={this.required}
                     readonly={this.readonly}
                     class="chosen-color-input"

--- a/src/components/color-picker/examples/color-picker.tsx
+++ b/src/components/color-picker/examples/color-picker.tsx
@@ -14,7 +14,7 @@ export class ColorPickerExample {
                 tooltipLabel="Click to pick a color"
                 helperText="You can also type a color name or value to preview it here"
                 label="Chosen color"
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
             />
         );
     }

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -140,10 +140,16 @@ export class DatePicker {
     public formatter?: (date: Date) => string;
 
     /**
-     * Emitted when the date picker value is changed.
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<Date>;
+
+    /**
+     * Emitted when the date picker value is changed.
+     */
+    @Event()
+    private limelChange: EventEmitter<Date>;
 
     @Element()
     private host: HTMLLimelDatePickerElement;
@@ -285,6 +291,7 @@ export class DatePicker {
         );
         this.formattedValue = event.detail;
         this.change.emit(date);
+        this.limelChange.emit(date);
     }
 
     private showCalendar(event) {
@@ -370,6 +377,7 @@ export class DatePicker {
         }
 
         this.change.emit(date);
+        this.limelChange.emit(date);
     }
 
     private onInputClick(event) {
@@ -399,6 +407,7 @@ export class DatePicker {
     private clearValue() {
         this.formattedValue = '';
         this.change.emit(null);
+        this.limelChange.emit(null);
     }
 
     private formatValue = (value: Date): string =>

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -255,7 +255,7 @@ export class DatePicker {
                     ref={(el) => (this.datePickerCalendar = el)}
                     isOpen={this.showPortal}
                     formatter={this.formatValue}
-                    onChange={this.handleCalendarChange}
+                    onLimelChange={this.handleCalendarChange}
                 />
             </limel-portal>,
         ];

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -216,7 +216,7 @@ export class DatePicker {
                     required={this.required}
                     value={this.formattedValue}
                     type={this.nativeType}
-                    onChange={this.nativeChangeHandler}
+                    onLimelChange={this.nativeChangeHandler}
                 />
             );
         }
@@ -238,7 +238,7 @@ export class DatePicker {
                 onFocus={this.showCalendar}
                 onBlur={this.hideCalendar}
                 onClick={this.onInputClick}
-                onChange={this.handleInputElementChange}
+                onLimelChange={this.handleInputElementChange}
                 ref={(el) => (this.textField = el)}
                 {...inputProps}
             />,

--- a/src/components/date-picker/examples/date-picker-composite.tsx
+++ b/src/components/date-picker/examples/date-picker-composite.tsx
@@ -45,7 +45,7 @@ export class DatePickerCompositeExample {
             <limel-date-picker
                 key={`updateOnFormChange-${this.key}`}
                 {...this.props}
-                onChange={this.handlePickerChange}
+                onLimelChange={this.handlePickerChange}
             />,
             this.renderForm(),
             <limel-example-event-printer

--- a/src/components/date-picker/examples/date-picker-composite.tsx
+++ b/src/components/date-picker/examples/date-picker-composite.tsx
@@ -62,7 +62,7 @@ export class DatePickerCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/date-picker/examples/date-picker-custom-formatter.tsx
+++ b/src/components/date-picker/examples/date-picker-custom-formatter.tsx
@@ -21,7 +21,7 @@ export class DatePickerExample {
                     label="date"
                     value={this.value}
                     formatter={this.myCustomFormatter}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-date.tsx
+++ b/src/components/date-picker/examples/date-picker-date.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="date"
                     label="date"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-datetime.tsx
+++ b/src/components/date-picker/examples/date-picker-datetime.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="datetime"
                     label="datetime"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-formatted.tsx
+++ b/src/components/date-picker/examples/date-picker-formatted.tsx
@@ -21,7 +21,7 @@ export class DatePickerFormattedExample {
                 type="datetime"
                 label="Localized date"
                 value={this.valueNo}
-                onChange={this.handleChangeNo}
+                onLimelChange={this.handleChangeNo}
             />,
             <limel-example-value value={this.valueNo} />,
             <limel-date-picker
@@ -30,7 +30,7 @@ export class DatePickerFormattedExample {
                 type="datetime"
                 label="Date with custom format"
                 value={this.valueFi}
-                onChange={this.handleChangeFi}
+                onLimelChange={this.handleChangeFi}
             />,
             <limel-example-value value={this.valueFi} />,
         ];

--- a/src/components/date-picker/examples/date-picker-month.tsx
+++ b/src/components/date-picker/examples/date-picker-month.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="month"
                     label="month"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-programmatic-change.tsx
+++ b/src/components/date-picker/examples/date-picker-programmatic-change.tsx
@@ -23,7 +23,7 @@ export class DatePickerExample {
                 type="datetime"
                 label="datetime"
                 value={this.value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-value value={this.value} />,
         ];

--- a/src/components/date-picker/examples/date-picker-quarter.tsx
+++ b/src/components/date-picker/examples/date-picker-quarter.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="quarter"
                     label="quarter"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-time.tsx
+++ b/src/components/date-picker/examples/date-picker-time.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="time"
                     label="time"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-week.tsx
+++ b/src/components/date-picker/examples/date-picker-week.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="week"
                     label="week"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/examples/date-picker-year.tsx
+++ b/src/components/date-picker/examples/date-picker-year.tsx
@@ -18,7 +18,7 @@ export class DatePickerExample {
                     type="year"
                     label="year"
                     value={this.value}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </p>

--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
@@ -66,7 +66,7 @@ export class DatePickerCalendar {
      * Emitted when the date picker value is changed.
      */
     @Event()
-    public change: EventEmitter<Date>;
+    public limelChange: EventEmitter<Date>;
 
     private picker: Picker;
     private flatPickrCreated: boolean = false;
@@ -79,7 +79,7 @@ export class DatePickerCalendar {
                 this.picker = new DateOnlyPicker(
                     this.format,
                     this.language,
-                    this.change
+                    this.limelChange
                 );
                 break;
 
@@ -87,7 +87,7 @@ export class DatePickerCalendar {
                 this.picker = new TimePicker(
                     this.format,
                     this.language,
-                    this.change
+                    this.limelChange
                 );
                 break;
 
@@ -95,7 +95,7 @@ export class DatePickerCalendar {
                 this.picker = new WeekPicker(
                     this.format,
                     this.language,
-                    this.change
+                    this.limelChange
                 );
                 break;
 
@@ -103,7 +103,7 @@ export class DatePickerCalendar {
                 this.picker = new MonthPicker(
                     this.format,
                     this.language,
-                    this.change,
+                    this.limelChange,
                     translate
                 );
                 break;
@@ -112,7 +112,7 @@ export class DatePickerCalendar {
                 this.picker = new QuarterPicker(
                     this.format,
                     this.language,
-                    this.change,
+                    this.limelChange,
                     translate
                 );
                 break;
@@ -120,7 +120,7 @@ export class DatePickerCalendar {
                 this.picker = new YearPicker(
                     this.format,
                     this.language,
-                    this.change,
+                    this.limelChange,
                     translate
                 );
                 break;
@@ -130,7 +130,7 @@ export class DatePickerCalendar {
                 this.picker = new DatetimePicker(
                     this.format,
                     this.language,
-                    this.change
+                    this.limelChange
                 );
                 break;
         }

--- a/src/components/dialog/examples/dialog-action-buttons.tsx
+++ b/src/components/dialog/examples/dialog-action-buttons.tsx
@@ -55,7 +55,7 @@ export class DialogActionButtonsExample {
                         label="It's OK. I'm aware of the consequences of this action."
                         id="confirmation-checkbox"
                         required={true}
-                        onChange={this.confirmed}
+                        onLimelChange={this.confirmed}
                         checked={this.checked}
                     />
                 </div>

--- a/src/components/dialog/examples/dialog-form.tsx
+++ b/src/components/dialog/examples/dialog-form.tsx
@@ -47,7 +47,7 @@ export class DialogFormExample {
                             value={this.name}
                             required={true}
                             invalid={!this.nameValid()}
-                            onChange={this.nameOnChange}
+                            onLimelChange={this.nameOnChange}
                         />
                     </p>
                     <p>
@@ -56,7 +56,7 @@ export class DialogFormExample {
                             value={this.age}
                             required={true}
                             invalid={!this.ageValid()}
-                            onChange={this.ageOnChange}
+                            onLimelChange={this.ageOnChange}
                             type="number"
                         />
                     </p>

--- a/src/components/dialog/examples/dialog-heading.tsx
+++ b/src/components/dialog/examples/dialog-heading.tsx
@@ -81,17 +81,17 @@ export class DialogHeadingExample {
                     required={true}
                     label="Title"
                     value={this.title}
-                    onChange={this.handleTitleChange}
+                    onLimelChange={this.handleTitleChange}
                 />
                 <limel-input-field
                     label="Subtitle"
                     value={this.subtitle}
-                    onChange={this.handleSubtitleChange}
+                    onLimelChange={this.handleSubtitleChange}
                 />
                 <limel-input-field
                     label="Supporting text"
                     value={this.supportingText}
-                    onChange={this.handleSupportingTextChange}
+                    onLimelChange={this.handleSupportingTextChange}
                 />
 
                 <limel-select

--- a/src/components/dialog/examples/dialog-heading.tsx
+++ b/src/components/dialog/examples/dialog-heading.tsx
@@ -99,7 +99,7 @@ export class DialogHeadingExample {
                     options={this.icons}
                     label="Icon"
                     value={this.icon}
-                    onChange={this.handleIconChange}
+                    onLimelChange={this.handleIconChange}
                 />
 
                 <limel-button

--- a/src/components/file/examples/file-accepted-types.tsx
+++ b/src/components/file/examples/file-accepted-types.tsx
@@ -19,7 +19,7 @@ export class FileAcceptedTypesExample {
         return [
             <limel-file
                 label="Attach only images (png, jpeg)"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 required={this.required}
                 value={this.value}
                 accept="image/jpeg,image/png"

--- a/src/components/file/examples/file-composite.tsx
+++ b/src/components/file/examples/file-composite.tsx
@@ -41,7 +41,7 @@ export class FileCompositeExample {
 
     public render() {
         return [
-            <limel-file {...this.props} onChange={this.handleChange} />,
+            <limel-file {...this.props} onLimelChange={this.handleChange} />,
             this.renderForm(),
             <limel-example-event-printer
                 ref={(el) => (this.eventPrinter = el)}

--- a/src/components/file/examples/file-composite.tsx
+++ b/src/components/file/examples/file-composite.tsx
@@ -57,7 +57,7 @@ export class FileCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/file/examples/file-custom-icon.tsx
+++ b/src/components/file/examples/file-custom-icon.tsx
@@ -25,7 +25,7 @@ export class FileCustomIconExample {
         return [
             <limel-file
                 label="Attach a file"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 value={this.value}
             />,
             <limel-example-value value={this.value} />,

--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -25,7 +25,7 @@ export class FileExample {
         return [
             <limel-file
                 label="Attach a file"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 required={this.required}
                 value={this.value}
                 disabled={this.disabled}

--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -35,17 +35,17 @@ export class FileExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -108,10 +108,16 @@ export class File {
     public language: Languages = 'en';
 
     /**
-     * Dispatched when a file is selected/deselected
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<FileInfo>;
+
+    /**
+     * Dispatched when a file is selected/deselected
+     */
+    @Event()
+    private limelChange: EventEmitter<FileInfo>;
 
     /**
      * Dispatched when clicking on a chip
@@ -284,6 +290,7 @@ export class File {
             fileContent: file,
         };
         this.change.emit(limeFile);
+        this.limelChange.emit(limeFile);
         this.chipSet.blur();
         this.mdcTextField.valid = true;
     }
@@ -295,6 +302,7 @@ export class File {
         if (!file) {
             this.fileInput.value = '';
             this.change.emit(file);
+            this.limelChange.emit(file);
             if (this.required) {
                 this.mdcTextField.valid = false;
             }

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -189,7 +189,7 @@ export class File {
                 label={this.label}
                 leadingIcon="upload_to_cloud"
                 language={this.language}
-                onChange={this.handleChipSetChange}
+                onLimelChange={this.handleChipSetChange}
                 onClick={this.handleFileSelection}
                 onInteract={this.handleChipInteract}
                 onKeyDown={this.handleKeyDown}

--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -114,6 +114,7 @@ export class LimeElementsWidgetAdapter extends React.Component {
 
         const newEvents = {
             change: this.props.widgetProps.onChange,
+            limelChange: this.props.widgetProps.onLimelChange,
             blur: this.handleBlur,
             ...events,
         };

--- a/src/components/form/examples/basic-form.tsx
+++ b/src/components/form/examples/basic-form.tsx
@@ -27,7 +27,7 @@ export class FormExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 onValidate={this.handleFormValidate}
                 value={this.formData}
                 schema={schema}

--- a/src/components/form/examples/custom-component-form.tsx
+++ b/src/components/form/examples/custom-component-form.tsx
@@ -46,7 +46,7 @@ export class CustomComponentFormExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 value={this.formData}
                 schema={schema}
             />,

--- a/src/components/form/examples/custom-component-form.tsx
+++ b/src/components/form/examples/custom-component-form.tsx
@@ -46,7 +46,8 @@ export class CustomComponentFormExample {
     public render() {
         return [
             <limel-form
-                onLimelChange={this.handleFormChange}
+                onChange={this.handleChange}
+                onLimelChange={this.handleLimelChange}
                 value={this.formData}
                 schema={schema}
             />,
@@ -54,7 +55,13 @@ export class CustomComponentFormExample {
         ];
     }
 
-    private handleFormChange = (event) => {
+    private handleChange = (event) => {
+        console.log('handleChange', event.detail);
+        this.formData = event.detail;
+    };
+
+    private handleLimelChange = (event) => {
+        console.log('handleLimelChange', event.detail);
         this.formData = event.detail;
     };
 }

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -99,7 +99,7 @@ export class CustomPickerExample implements FormComponent<number> {
                 disabled={this.disabled}
                 readonly={this.readonly}
                 required={this.required}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 searcher={this.search}
                 helperText={this.helperText}
             />

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -44,10 +44,17 @@ export class CustomPickerExample implements FormComponent<number> {
     public helperText?: string;
 
     /**
+     * @deprecated Use `limelChange` instead.
      * Emitted when the value is changed
      */
     @Event()
     public change: EventEmitter<number>;
+
+    /**
+     * Emitted when the value is changed
+     */
+    @Event()
+    public limelChange: EventEmitter<number>;
 
     private heroes: Array<ListItem<number>> = [
         {
@@ -81,6 +88,8 @@ export class CustomPickerExample implements FormComponent<number> {
     ) => {
         event.stopPropagation();
         this.change.emit(event.detail?.value);
+        // When the event below is emitted, the whole form is emptied 😲
+        this.limelChange.emit(event.detail?.value);
     };
 
     private search = async (query: string): Promise<ListItem[]> => {

--- a/src/components/form/examples/custom-error-message-form.tsx
+++ b/src/components/form/examples/custom-error-message-form.tsx
@@ -23,7 +23,7 @@ export class CustomErrorMessageFormExample {
         return [
             <limel-form
                 onValidate={this.handleFormValidate}
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 value={this.formData}
                 schema={schema}
                 transformErrors={this.transformErrors}

--- a/src/components/form/examples/dynamic-form.tsx
+++ b/src/components/form/examples/dynamic-form.tsx
@@ -48,7 +48,7 @@ export class DynamicFormExample {
             <textarea onChange={this.handleTextChange}>{this.text}</textarea>,
             <br />,
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 onValidate={this.handleValidate}
                 value={this.formData}
                 schema={this.schema}

--- a/src/components/form/examples/layout-form.tsx
+++ b/src/components/form/examples/layout-form.tsx
@@ -63,7 +63,7 @@ export class FormLayoutExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 onValidate={this.handleFormValidate}
                 value={this.formData}
                 schema={schema}

--- a/src/components/form/examples/list-form.tsx
+++ b/src/components/form/examples/list-form.tsx
@@ -24,7 +24,7 @@ export class ListFormExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 value={this.formData}
                 schema={schema}
             />,

--- a/src/components/form/examples/nested-form.tsx
+++ b/src/components/form/examples/nested-form.tsx
@@ -16,7 +16,7 @@ export class NestedFormExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 value={this.formData}
                 schema={schema}
             />,

--- a/src/components/form/examples/props-factory-form.tsx
+++ b/src/components/form/examples/props-factory-form.tsx
@@ -24,7 +24,7 @@ export class PropsFactoryFormExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 value={this.formData}
                 schema={schema}
                 propsFactory={this.propsFactory}

--- a/src/components/form/examples/props-factory-picker.tsx
+++ b/src/components/form/examples/props-factory-picker.tsx
@@ -116,7 +116,7 @@ export class PropsFactoryPickerExample implements FormComponent<number> {
                 disabled={this.disabled}
                 readonly={this.readonly}
                 required={this.required}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 searcher={this.search}
             />
         );

--- a/src/components/form/examples/props-factory-picker.tsx
+++ b/src/components/form/examples/props-factory-picker.tsx
@@ -50,10 +50,17 @@ export class PropsFactoryPickerExample implements FormComponent<number> {
     public disabled: boolean;
 
     /**
+     * @deprecated Use `limelChange` instead.
      * Emitted when the value is changed
      */
     @Event()
     public change: EventEmitter<number>;
+
+    /**
+     * Emitted when the value is changed
+     */
+    @Event()
+    public limelChange: EventEmitter<number>;
 
     private heroes: Array<ListItem<number>> = [
         {
@@ -98,6 +105,10 @@ export class PropsFactoryPickerExample implements FormComponent<number> {
     ) => {
         event.stopPropagation();
         this.change.emit(event.detail?.value);
+        // I'm guessing this also doesn't work, just like for
+        // custom-component-picker, but I added it here so we
+        // don't forget about it. /Ads
+        this.limelChange.emit(event.detail?.value);
     };
 
     private search = async (query: string): Promise<ListItem[]> => {

--- a/src/components/form/examples/row-layout.tsx
+++ b/src/components/form/examples/row-layout.tsx
@@ -16,7 +16,7 @@ export class FormRowLayoutExample {
     public render() {
         return [
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 value={this.formData}
                 schema={schema}
             />,

--- a/src/components/form/examples/span-fields.tsx
+++ b/src/components/form/examples/span-fields.tsx
@@ -180,7 +180,7 @@ export class FormLayoutExample {
                 />
             </limel-example-controls>,
             <limel-form
-                onChange={this.handleFormChange}
+                onLimelChange={this.handleFormChange}
                 onValidate={this.handleFormValidate}
                 value={this.formData}
                 schema={this.schema}

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -92,10 +92,16 @@ export class Form {
     public errors: ValidationError;
 
     /**
-     * Emitted when a change is made within the form
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     public change: EventEmitter<object>;
+
+    /**
+     * Emitted when a change is made within the form
+     */
+    @Event()
+    public limelChange: EventEmitter<object>;
 
     /**
      * Emitted when the validity of the form changes, or when
@@ -193,6 +199,7 @@ export class Form {
 
     private handleChange(event: any) {
         this.change.emit(event.formData);
+        this.limelChange.emit(event.formData);
     }
 
     private validateForm(value: object) {

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -171,6 +171,8 @@ export class Form {
                     schema: this.modifiedSchema,
                     formData: this.value,
                     onChange: this.handleChange,
+                    // @ts-ignore
+                    onLimelChange: this.handleLimelChange, // This doesn't seem to do anything /Ads
                     widgets: widgets,
                     liveValidate: true,
                     showErrorList: false,
@@ -199,6 +201,9 @@ export class Form {
 
     private handleChange(event: any) {
         this.change.emit(event.formData);
+    }
+
+    private handleLimelChange(event: any) {
         this.limelChange.emit(event.formData);
     }
 

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -86,8 +86,24 @@ export interface FormComponent<T = any> {
 
     /**
      * The event to emit when the value of the current property has changed
+     * @deprecated Components implementing the FormComponent interface should
+     * add the `limelChange` event alongside the `change` event.
+     * In the next major version of lime-elements, the `limelChange` event will
+     * be made required, and the `change` event will be made optional.
+     * In the next major version after that, the `change` event will be removed.
      */
     change: EventEmitter<T>;
+
+    /**
+     * The event to emit when the value of the current property has changed
+     *
+     * Components implementing the FormComponent interface should add the
+     * `limelChange` event alongside the `change` event.
+     * In the next major version of lime-elements, the `limelChange` event will
+     * be made required, and the `change` event will be made optional.
+     * In the next major version after that, the `change` event will be removed.
+     */
+    limelChange?: EventEmitter<T>;
 }
 
 export interface FormInfo {

--- a/src/components/form/widgets/checkbox.ts
+++ b/src/components/form/widgets/checkbox.ts
@@ -22,6 +22,7 @@ export class Checkbox extends React.Component {
             },
             events: {
                 change: this.handleChange,
+                limelChange: this.handleLimelChange,
             },
         });
     }
@@ -35,5 +36,16 @@ export class Checkbox extends React.Component {
         }
 
         props.onChange(event.detail);
+    }
+
+    private handleLimelChange(event: CustomEvent<boolean>) {
+        const props = this.props;
+        event.stopPropagation();
+
+        if (!props.onLimelChange) {
+            return;
+        }
+
+        props.onLimelChange(event.detail);
     }
 }

--- a/src/components/form/widgets/code-editor.ts
+++ b/src/components/form/widgets/code-editor.ts
@@ -29,6 +29,7 @@ export class CodeEditor extends React.Component {
             },
             events: {
                 change: this.handleChange,
+                limelChange: this.handleLimelChange,
             },
         });
     }
@@ -45,6 +46,24 @@ export class CodeEditor extends React.Component {
             const value = JSON.parse(event.detail);
 
             props.onChange(value);
+            props.onValidate();
+        } catch (e) {
+            props.onValidate('Should be a valid JSON document');
+        }
+    }
+
+    private handleLimelChange(event: CustomEvent<string>) {
+        const props = this.props;
+        event.stopPropagation();
+
+        if (!props.onLimelChange) {
+            return;
+        }
+
+        try {
+            const value = JSON.parse(event.detail);
+
+            props.onLimelChange(value);
             props.onValidate();
         } catch (e) {
             props.onValidate('Should be a valid JSON document');

--- a/src/components/form/widgets/date-picker.ts
+++ b/src/components/form/widgets/date-picker.ts
@@ -23,6 +23,7 @@ export class DatePicker extends React.Component {
             value: this.getValue(),
             events: {
                 change: this.handleChange,
+                limelChange: this.handleLimelChange,
             },
             widgetProps: props,
             extraProps: {
@@ -62,6 +63,31 @@ export class DatePicker extends React.Component {
             formatMapping[props.schema.format]
         );
         props.onChange(dateString);
+    }
+
+    private handleLimelChange(event: CustomEvent<Date>) {
+        const props = this.props;
+        event.stopPropagation();
+
+        if (!props.onLimelChange) {
+            return;
+        }
+
+        if (!event.detail) {
+            props.onLimelChange(null);
+
+            return;
+        }
+
+        const formatMapping = {
+            'date-time': 'YYYY-MM-DDTHH:mm:ssZ',
+            date: 'YYYY-MM-DD',
+            time: 'HH:mm:ss',
+        };
+        const dateString = moment(event.detail).format(
+            formatMapping[props.schema.format]
+        );
+        props.onLimelChange(dateString);
     }
 }
 

--- a/src/components/form/widgets/input-field.ts
+++ b/src/components/form/widgets/input-field.ts
@@ -27,6 +27,7 @@ export class InputField extends React.Component {
             value: props.value,
             events: {
                 change: this.handleChange,
+                limelChange: this.handleLimelChange,
             },
             widgetProps: props,
             extraProps: {
@@ -56,6 +57,27 @@ export class InputField extends React.Component {
         }
 
         props.onChange(value);
+    }
+
+    private handleLimelChange(event: CustomEvent<string>) {
+        event.stopPropagation();
+        const props = this.props;
+        const type = getInputType(props.schema);
+
+        if (!props.onLimelChange) {
+            return;
+        }
+
+        let value: string;
+        if (event.detail || typeof event.detail === 'number') {
+            value = event.detail;
+        } else if (type === 'number') {
+            value = null;
+        } else {
+            value = props.required ? null : '';
+        }
+
+        props.onLimelChange(value);
     }
 }
 

--- a/src/components/form/widgets/select.ts
+++ b/src/components/form/widgets/select.ts
@@ -33,6 +33,7 @@ export class Select extends React.Component {
             value: value,
             events: {
                 change: this.handleChange,
+                limelChange: this.handleLimelChange,
             },
             widgetProps: props,
             extraProps: {
@@ -59,6 +60,24 @@ export class Select extends React.Component {
         }
 
         props.onChange(event.detail.value);
+    }
+
+    private handleLimelChange(event: CustomEvent<Option | Option[]>) {
+        const props = this.props;
+        event.stopPropagation();
+
+        if (!props.onLimelChange) {
+            return;
+        }
+
+        if (isMultiple(event.detail)) {
+            const value = event.detail.map((option) => option.value);
+            props.onChange(value);
+
+            return;
+        }
+
+        props.onLimelChange(event.detail.value);
     }
 }
 

--- a/src/components/form/widgets/slider.ts
+++ b/src/components/form/widgets/slider.ts
@@ -25,6 +25,7 @@ export class Slider extends React.Component {
             value: props.value,
             events: {
                 change: this.handleChange,
+                limelChange: this.handleLimelChange,
             },
             widgetProps: props,
             extraProps: {
@@ -47,6 +48,17 @@ export class Slider extends React.Component {
         }
 
         props.onChange(event.detail);
+    }
+
+    private handleLimelChange(event: CustomEvent<number>) {
+        const props = this.props;
+        event.stopPropagation();
+
+        if (!props.onLimelChange) {
+            return;
+        }
+
+        props.onLimelChange(event.detail);
     }
 }
 

--- a/src/components/form/widgets/types.ts
+++ b/src/components/form/widgets/types.ts
@@ -2,5 +2,6 @@ import { WidgetProps as RjsfWidgetProps } from '@rjsf/core';
 import { LimeJSONSchema } from '../internal.types';
 
 export interface WidgetProps extends RjsfWidgetProps {
+    onLimelChange: (value: any) => void;
     schema: LimeJSONSchema;
 }

--- a/src/components/icon/examples/icon-finder.tsx
+++ b/src/components/icon/examples/icon-finder.tsx
@@ -47,7 +47,7 @@ export class IconFinder {
                 type="input"
                 value={this.value}
                 onChange={this.chipSetOnChange}
-                onInput={this.onInput}
+                onLimelInput={this.onInput}
                 onKeyUp={this.onKeyUp}
                 searchLabel="Type and press enter to search"
                 emptyInputOnBlur={true}

--- a/src/components/icon/examples/icon-finder.tsx
+++ b/src/components/icon/examples/icon-finder.tsx
@@ -46,7 +46,7 @@ export class IconFinder {
                 label="Icon finder"
                 type="input"
                 value={this.value}
-                onChange={this.chipSetOnChange}
+                onLimelChange={this.chipSetOnChange}
                 onLimelInput={this.onInput}
                 onKeyUp={this.onKeyUp}
                 searchLabel="Type and press enter to search"

--- a/src/components/info-tile/examples/info-tile-loading.tsx
+++ b/src/components/info-tile/examples/info-tile-loading.tsx
@@ -47,7 +47,7 @@ export class InfoTileLoadingExample {
                 <limel-checkbox
                     label="Loading"
                     checked={this.loading}
-                    onChange={this.setLoading}
+                    onLimelChange={this.setLoading}
                 />
             </limel-example-controls>,
         ];

--- a/src/components/info-tile/examples/info-tile-loading.tsx
+++ b/src/components/info-tile/examples/info-tile-loading.tsx
@@ -37,7 +37,7 @@ export class InfoTileLoadingExample {
             <limel-info-tile
                 icon="partly_cloudy_rain"
                 label="Partly cloudy with a risk of rain"
-                prefix="temp"
+                limelPrefix="temp"
                 value="23"
                 suffix="°C"
                 link={link}

--- a/src/components/info-tile/examples/info-tile-progress.tsx
+++ b/src/components/info-tile/examples/info-tile-progress.tsx
@@ -50,7 +50,7 @@ export class InfoTileProgressExample {
                     label="Progress value"
                     type="number"
                     value={`${this.progress.value}`}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
             </limel-example-controls>,
         ];

--- a/src/components/info-tile/examples/info-tile-progress.tsx
+++ b/src/components/info-tile/examples/info-tile-progress.tsx
@@ -39,7 +39,7 @@ export class InfoTileProgressExample {
             <limel-info-tile
                 label="Won deals this month"
                 icon="money"
-                prefix="Total value"
+                limelPrefix="Total value"
                 value="70,659"
                 suffix="EUR"
                 link={{ href: '#' }}

--- a/src/components/info-tile/examples/info-tile-styling.tsx
+++ b/src/components/info-tile/examples/info-tile-styling.tsx
@@ -40,7 +40,7 @@ export class InfoTileStylingExample {
                 value={this.value}
                 suffix="kWh"
                 progress={this.progress}
-                prefix="↑"
+                limelPrefix="↑"
             />,
         ];
     }

--- a/src/components/info-tile/examples/info-tile.tsx
+++ b/src/components/info-tile/examples/info-tile.tsx
@@ -41,7 +41,7 @@ export class InfoTileExample {
                 <limel-info-tile
                     icon="partly_cloudy_rain"
                     label="Partly cloudy with a risk of rain"
-                    prefix="temp"
+                    limelPrefix="temp"
                     value="23"
                     suffix="°C"
                     link={link}

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -42,10 +42,16 @@ export class InfoTile {
     public label?: string = null;
 
     /**
-     * A string of text that is visually placed before the value.
+     * @deprecated Use `limelPrefix` instead.
      */
     @Prop({ reflect: true })
     public prefix?: string;
+
+    /**
+     * A string of text that is visually placed before the value.
+     */
+    @Prop({ reflect: true })
+    public limelPrefix?: string;
 
     /**
      * A string of text that is visually placed after the value.
@@ -102,7 +108,7 @@ export class InfoTile {
 
     public render() {
         const extendedAriaLabel =
-            this.checkProps(this?.prefix) +
+            this.checkProps(this?.limelPrefix || this?.prefix) +
             this.value +
             ' ' +
             this.checkProps(this?.suffix) +
@@ -150,8 +156,10 @@ export class InfoTile {
     }
 
     private renderPrefix = () => {
-        if (this.prefix) {
-            return <span class="prefix">{this.prefix}</span>;
+        if (this.limelPrefix || this.prefix) {
+            return (
+                <span class="prefix">{this.limelPrefix || this.prefix}</span>
+            );
         }
     };
 

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -193,7 +193,7 @@ export class InfoTile {
             return (
                 <limel-circular-progress
                     class="progress"
-                    prefix={this.progress.prefix}
+                    limelPrefix={this.progress.prefix}
                     value={this.progress.value}
                     suffix={this.progress.suffix}
                     maxValue={this.progress.maxValue}

--- a/src/components/input-field/examples/input-field-autocomplete.tsx
+++ b/src/components/input-field/examples/input-field-autocomplete.tsx
@@ -52,17 +52,17 @@ export class InputFieldAutocompleteExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/input-field/examples/input-field-autocomplete.tsx
+++ b/src/components/input-field/examples/input-field-autocomplete.tsx
@@ -46,7 +46,7 @@ export class InputFieldAutocompleteExample {
                 invalid={this.invalid}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/components/input-field/examples/input-field-error-icon.tsx
+++ b/src/components/input-field/examples/input-field-error-icon.tsx
@@ -23,7 +23,7 @@ export class InputFieldErrorIconExample {
                 minlength={MIN_LENGTH}
                 helperText="Please enter at least 6 characters!"
                 value={this.valueNative}
-                onChange={this.onChangeNative}
+                onLimelChange={this.onChangeNative}
             />,
             <limel-input-field
                 label="Text Field with consumer validation"
@@ -31,7 +31,7 @@ export class InputFieldErrorIconExample {
                 invalid={this.isInvalid()}
                 helperText="Please enter an email with the domain 'test.com'"
                 value={this.valueConsumer}
-                onChange={this.onChangeConsumer}
+                onLimelChange={this.onChangeConsumer}
             />,
         ];
     }

--- a/src/components/input-field/examples/input-field-focus.tsx
+++ b/src/components/input-field/examples/input-field-focus.tsx
@@ -35,7 +35,7 @@ export class InputFieldFocusExample {
             <limel-input-field
                 label="Set focus on me!"
                 value={this.value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 ref={this.getInputFieldRef}
                 tabindex="0"
             />,

--- a/src/components/input-field/examples/input-field-icon-both.tsx
+++ b/src/components/input-field/examples/input-field-icon-both.tsx
@@ -19,7 +19,7 @@ export class InputFieldIconBothExample {
                 value={this.value}
                 leadingIcon="globe"
                 trailingIcon="external_link"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onAction={this.onAction}
             />
         );

--- a/src/components/input-field/examples/input-field-icon-leading.tsx
+++ b/src/components/input-field/examples/input-field-icon-leading.tsx
@@ -31,7 +31,7 @@ export class InputFieldIconLeadingExample {
                 minlength={MIN_LENGTH}
                 helperText={`Please enter at least ${MIN_LENGTH} characters!`}
                 leadingIcon="map_marker"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/input-field/examples/input-field-icon-trailing.tsx
+++ b/src/components/input-field/examples/input-field-icon-trailing.tsx
@@ -29,7 +29,7 @@ export class InputFieldIconTrailingExample {
                 type="email"
                 value={this.value}
                 trailingIcon="filled_message"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onAction={this.onAction}
             />
         );

--- a/src/components/input-field/examples/input-field-number-prefix.tsx
+++ b/src/components/input-field/examples/input-field-number-prefix.tsx
@@ -16,7 +16,7 @@ export class InputFieldPrefixExample {
         return (
             <limel-input-field
                 label="Price per unit"
-                prefix="$"
+                limelPrefix="$"
                 value={this.value}
                 type="number"
                 onChange={this.handleChange}

--- a/src/components/input-field/examples/input-field-number-prefix.tsx
+++ b/src/components/input-field/examples/input-field-number-prefix.tsx
@@ -19,7 +19,7 @@ export class InputFieldPrefixExample {
                 limelPrefix="$"
                 value={this.value}
                 type="number"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/input-field/examples/input-field-number.tsx
+++ b/src/components/input-field/examples/input-field-number.tsx
@@ -37,7 +37,7 @@ export class InputFieldNumberExample {
                 readonly={this.readonly}
                 invalid={this.invalid}
                 required={this.required}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/components/input-field/examples/input-field-number.tsx
+++ b/src/components/input-field/examples/input-field-number.tsx
@@ -43,22 +43,22 @@ export class InputFieldNumberExample {
                 <limel-checkbox
                     checked={this.formatNumber}
                     label="Format value"
-                    onChange={this.setFormatNumber}
+                    onLimelChange={this.setFormatNumber}
                 />
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/input-field/examples/input-field-pattern.tsx
+++ b/src/components/input-field/examples/input-field-pattern.tsx
@@ -17,7 +17,7 @@ export class InputFieldPatternExample {
                 label="Personal identity number (YYYYMMDD-XXXX)"
                 value={this.value}
                 pattern={'[0-9]{8}[-][0-9]{4}'}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/input-field/examples/input-field-placeholder.tsx
+++ b/src/components/input-field/examples/input-field-placeholder.tsx
@@ -55,7 +55,7 @@ export class InputFieldPlaceholderExample {
                 placeholder="example: 19990101-1234"
                 helperText="Use correct format (12 digits, and a dash after your birth date)"
                 value={this.value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/input-field/examples/input-field-search.tsx
+++ b/src/components/input-field/examples/input-field-search.tsx
@@ -18,7 +18,7 @@ export class InputFieldSearchExample {
                 type="search"
                 leadingIcon="search"
                 value={this.value}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/input-field/examples/input-field-showlink.tsx
+++ b/src/components/input-field/examples/input-field-showlink.tsx
@@ -73,17 +73,17 @@ export class InputFieldShowlinkExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.emailValue} />,

--- a/src/components/input-field/examples/input-field-showlink.tsx
+++ b/src/components/input-field/examples/input-field-showlink.tsx
@@ -35,7 +35,7 @@ export class InputFieldShowlinkExample {
                 required={this.required}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleEmailChange}
+                onLimelChange={this.handleEmailChange}
                 type="email"
                 showLink
             />,
@@ -45,7 +45,7 @@ export class InputFieldShowlinkExample {
                 required={this.required}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleTelChange}
+                onLimelChange={this.handleTelChange}
                 type="tel"
                 showLink
             />,
@@ -55,7 +55,7 @@ export class InputFieldShowlinkExample {
                 required={this.required}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleUrlChange}
+                onLimelChange={this.handleUrlChange}
                 type="url"
                 showLink
             />,
@@ -65,7 +65,7 @@ export class InputFieldShowlinkExample {
                 required={this.required}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleUrlChange}
+                onLimelChange={this.handleUrlChange}
                 type="urlAsText"
                 showLink
             />,

--- a/src/components/input-field/examples/input-field-text-multiple.tsx
+++ b/src/components/input-field/examples/input-field-text-multiple.tsx
@@ -25,13 +25,13 @@ export class InputFieldTextExample {
                     <limel-input-field
                         label="Fields shouldn't be too close!"
                         value={this.firstValue}
-                        onChange={this.firstOnChange}
+                        onLimelChange={this.firstOnChange}
                     />
                     <limel-input-field
                         label="Type something here now to see why…"
                         helperText="See how the label covers the previous field? Now add some distance 👇"
                         value={this.secondValue}
-                        onChange={this.secondOnChange}
+                        onLimelChange={this.secondOnChange}
                     />
                 </section>
                 <limel-checkbox

--- a/src/components/input-field/examples/input-field-text-multiple.tsx
+++ b/src/components/input-field/examples/input-field-text-multiple.tsx
@@ -36,7 +36,7 @@ export class InputFieldTextExample {
                 </section>
                 <limel-checkbox
                     label="Then click this to add distance between fields"
-                    onChange={this.toggleMode}
+                    onLimelChange={this.toggleMode}
                     checked={this.addDistance}
                 />
             </div>

--- a/src/components/input-field/examples/input-field-text-suffix.tsx
+++ b/src/components/input-field/examples/input-field-text-suffix.tsx
@@ -19,7 +19,7 @@ export class InputFieldSuffixExample {
                 suffix="pcs"
                 value={this.value}
                 type="number"
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/input-field/examples/input-field-text.tsx
+++ b/src/components/input-field/examples/input-field-text.tsx
@@ -36,7 +36,7 @@ export class InputFieldTextExample {
                 invalid={this.invalid}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/components/input-field/examples/input-field-text.tsx
+++ b/src/components/input-field/examples/input-field-text.tsx
@@ -42,17 +42,17 @@ export class InputFieldTextExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/input-field/examples/input-field-textarea.tsx
+++ b/src/components/input-field/examples/input-field-textarea.tsx
@@ -37,9 +37,18 @@ export class InputFieldTextareaExample {
                 readonly={this.readonly}
             />,
             <limel-example-controls>
-                <limel-checkbox onChange={this.setDisabled} label="Disabled" />
-                <limel-checkbox onChange={this.setReadonly} label="Readonly" />
-                <limel-checkbox onChange={this.setRequired} label="Required" />
+                <limel-checkbox
+                    onLimelChange={this.setDisabled}
+                    label="Disabled"
+                />
+                <limel-checkbox
+                    onLimelChange={this.setReadonly}
+                    label="Readonly"
+                />
+                <limel-checkbox
+                    onLimelChange={this.setRequired}
+                    label="Required"
+                />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,
         ];

--- a/src/components/input-field/examples/input-field-textarea.tsx
+++ b/src/components/input-field/examples/input-field-textarea.tsx
@@ -32,7 +32,7 @@ export class InputFieldTextareaExample {
                 maxlength={MAX_LENGTH}
                 value={this.value}
                 required={this.required}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 disabled={this.disabled}
                 readonly={this.readonly}
             />,

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -226,10 +226,16 @@ export class InputField {
     public showLink = false;
 
     /**
-     * Emitted when the input value is changed.
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<string>;
+
+    /**
+     * Emitted when the input value is changed.
+     */
+    @Event()
+    private limelChange: EventEmitter<string>;
 
     /**
      * Emitted when `trailingIcon` or `leadingIcon` is set
@@ -897,6 +903,7 @@ export class InputField {
 
     private changeEmitter = (value: string) => {
         this.change.emit(value);
+        this.limelChange.emit(value);
     };
 
     private handleIconClick = () => {

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -104,11 +104,17 @@ export class InputField {
     public helperText: string;
 
     /**
+     * @deprecated Use `limelPrefix` instead.
+     */
+    @Prop({ reflect: true })
+    public prefix: string;
+
+    /**
      * A short piece of text to display before the value inside the input field.
      * Displayed for all types except `textarea`.
      */
     @Prop({ reflect: true })
-    public prefix: string;
+    public limelPrefix: string;
 
     /**
      * A short piece of text to display after the value inside the input field.
@@ -513,11 +519,14 @@ export class InputField {
             'mdc-text-field__affix--prefix': true,
         };
 
-        return <span class={classList}>{this.prefix}</span>;
+        return <span class={classList}>{this.limelPrefix ?? this.prefix}</span>;
     };
 
     private hasPrefix = () => {
-        return this.prefix !== null && this.prefix !== undefined;
+        return (
+            (this.limelPrefix ?? this.prefix) !== null &&
+            (this.limelPrefix ?? this.prefix) !== undefined
+        );
     };
 
     private isInvalid = () => {

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -847,7 +847,7 @@ export class InputField {
 
         return (
             <limel-list
-                onChange={this.handleCompletionChange}
+                onLimelChange={this.handleCompletionChange}
                 onKeyDown={this.handleKeyDownInDropdown}
                 type="selectable"
                 items={filteredCompletions}

--- a/src/components/linear-progress/examples/linear-progress-color.tsx
+++ b/src/components/linear-progress/examples/linear-progress-color.tsx
@@ -36,7 +36,7 @@ export class LinearProgressExampleColor {
                 label="Color"
                 options={this.colors}
                 value={this.color}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
         ];
     }

--- a/src/components/linear-progress/examples/linear-progress.tsx
+++ b/src/components/linear-progress/examples/linear-progress.tsx
@@ -16,7 +16,7 @@ export class LinearProgressExample {
                 label="Value"
                 type="number"
                 value={(this.value * FRACTION).toFixed(0)}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <p>
                 <limel-linear-progress value={this.value} />

--- a/src/components/list/examples/list-action.tsx
+++ b/src/components/list/examples/list-action.tsx
@@ -28,7 +28,12 @@ export class ListActionExample {
     ];
 
     public render() {
-        return <limel-list items={this.items} onSelect={this.onSelectAction} />;
+        return (
+            <limel-list
+                items={this.items}
+                onLimelSelect={this.onSelectAction}
+            />
+        );
     }
 
     private onSelectAction(event: LimelListCustomEvent<ListItem>) {

--- a/src/components/list/examples/list-checkbox-icons.tsx
+++ b/src/components/list/examples/list-checkbox-icons.tsx
@@ -69,7 +69,7 @@ export class ListCheckboxIconsExample {
     public render() {
         return [
             <limel-list
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 items={this.items}
                 type="checkbox"
             />,

--- a/src/components/list/examples/list-checkbox.tsx
+++ b/src/components/list/examples/list-checkbox.tsx
@@ -36,7 +36,7 @@ export class ListCheckboxExample {
     public render() {
         return [
             <limel-list
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 items={this.items}
                 type="checkbox"
             />,

--- a/src/components/list/examples/list-radio-button-icons.tsx
+++ b/src/components/list/examples/list-radio-button-icons.tsx
@@ -69,7 +69,7 @@ export class ListRadioButtonIconsExample {
     public render() {
         return [
             <limel-list
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 items={this.items}
                 type="radio"
             />,

--- a/src/components/list/examples/list-radio-button.tsx
+++ b/src/components/list/examples/list-radio-button.tsx
@@ -36,7 +36,7 @@ export class ListRadioButtonExample {
     public render() {
         return [
             <limel-list
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 items={this.items}
                 type="radio"
             />,

--- a/src/components/list/examples/list-selectable.tsx
+++ b/src/components/list/examples/list-selectable.tsx
@@ -26,7 +26,7 @@ export class SelectableListExample {
     public render() {
         return (
             <limel-list
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 type="selectable"
                 items={this.items}
             />

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -201,10 +201,33 @@ describe('limel-list', () => {
                 const propValue = await limelList.getProperty('type');
                 expect(propValue).toBe('selectable');
             });
-            describe('the `change` event', () => {
+            describe('the `change` event (deprecated)', () => {
                 let spy;
                 beforeEach(async () => {
                     spy = await page.spyOnEvent('change');
+                });
+                describe('when an item is selected', () => {
+                    let item;
+                    beforeEach(async () => {
+                        item = await innerList.find('li');
+                        await item.click();
+                        await page.waitForTimeout(20); // Give the event a chance to bubble.
+                    });
+                    it('is emitted', () => {
+                        expect(spy).toHaveReceivedEventTimes(1);
+                    });
+                    it('passes the selected item as the event details', () => {
+                        expect(spy).toHaveReceivedEventDetail({
+                            ...items[0],
+                            selected: true,
+                        });
+                    });
+                });
+            });
+            describe('the `limelChange` event', () => {
+                let spy;
+                beforeEach(async () => {
+                    spy = await page.spyOnEvent('limelChange');
                 });
                 describe('when an item is selected', () => {
                     let item;

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -101,10 +101,16 @@ export class List {
     private limelChange: EventEmitter<ListItem | ListItem[]>;
 
     /**
-     * Fired when an action has been selected from the action menu of a list item
+     * @deprecated Use `limelSelect` instead.
      */
     @Event()
     protected select: EventEmitter<ListItem | ListItem[]>;
+
+    /**
+     * Fired when an action has been selected from the action menu of a list item
+     */
+    @Event()
+    protected limelSelect: EventEmitter<ListItem | ListItem[]>;
 
     public connectedCallback() {
         this.setup();

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -89,10 +89,16 @@ export class List {
     private selectable: boolean;
 
     /**
-     * Fired when a new value has been selected from the list. Only fired if selectable is set to true
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<ListItem | ListItem[]>;
+
+    /**
+     * Fired when a new value has been selected from the list. Only fired if selectable is set to true
+     */
+    @Event()
+    private limelChange: EventEmitter<ListItem | ListItem[]>;
 
     /**
      * Fired when an action has been selected from the action menu of a list item
@@ -231,10 +237,12 @@ export class List {
 
         if (selectedItem) {
             this.change.emit({ ...selectedItem, selected: false });
+            this.limelChange.emit({ ...selectedItem, selected: false });
         }
 
         if (listItems[index] !== selectedItem) {
             this.change.emit({ ...listItems[index], selected: true });
+            this.limelChange.emit({ ...listItems[index], selected: true });
         }
     };
 
@@ -260,6 +268,7 @@ export class List {
             });
 
         this.change.emit(selectedItems);
+        this.limelChange.emit(selectedItems);
     };
 
     private isListItem = (item: ListItem): boolean => {

--- a/src/components/menu-list/menu-list.e2e.ts
+++ b/src/components/menu-list/menu-list.e2e.ts
@@ -204,10 +204,33 @@ describe('limel-menu-list', () => {
                 const propValue = await limelList.getProperty('type');
                 expect(propValue).toBe('menu');
             });
-            describe('the `select` event', () => {
+            describe('the `select` event (deprecated)', () => {
                 let spy;
                 beforeEach(async () => {
                     spy = await page.spyOnEvent('select');
+                });
+                describe('when an item is selected', () => {
+                    let item;
+                    beforeEach(async () => {
+                        item = await innerList.find('li');
+                        await item.click();
+                        await page.waitForTimeout(20); // Give the event a chance to bubble.
+                    });
+                    it('is emitted', () => {
+                        expect(spy).toHaveReceivedEventTimes(1);
+                    });
+                    it('passes the selected item as the event details but as not selected', () => {
+                        expect(spy).toHaveReceivedEventDetail({
+                            ...items[0],
+                            selected: false,
+                        });
+                    });
+                });
+            });
+            describe('the `limelSelect` event', () => {
+                let spy;
+                beforeEach(async () => {
+                    spy = await page.spyOnEvent('limelSelect');
                 });
                 describe('when an item is selected', () => {
                     let item;

--- a/src/components/menu-list/menu-list.e2e.ts
+++ b/src/components/menu-list/menu-list.e2e.ts
@@ -204,7 +204,7 @@ describe('limel-menu-list', () => {
                 const propValue = await limelList.getProperty('type');
                 expect(propValue).toBe('menu');
             });
-            describe('the `change` event', () => {
+            describe('the `select` event', () => {
                 let spy;
                 beforeEach(async () => {
                     spy = await page.spyOnEvent('select');

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -77,10 +77,16 @@ export class MenuList {
     private mdcMenu: MDCMenu;
 
     /**
-     * Fired when a new value has been selected from the list.
+     * @deprecated Use `limelSelect` instead.
      */
     @Event()
     private select: EventEmitter<MenuItem>;
+
+    /**
+     * Fired when a new value has been selected from the list.
+     */
+    @Event()
+    private limelSelect: EventEmitter<MenuItem>;
 
     public connectedCallback() {
         this.setup();
@@ -178,10 +184,12 @@ export class MenuList {
 
         if (selectedItem) {
             this.select.emit({ ...selectedItem, selected: false });
+            this.limelSelect.emit({ ...selectedItem, selected: false });
         }
 
         if (MenuItems[index] !== selectedItem) {
             this.select.emit({ ...MenuItems[index], selected: false });
+            this.limelSelect.emit({ ...MenuItems[index], selected: false });
         }
     };
 

--- a/src/components/menu/examples/menu-basic-secondary-text.tsx
+++ b/src/components/menu/examples/menu-basic-secondary-text.tsx
@@ -54,7 +54,7 @@ export class MenuBasicExample {
 
     public render() {
         return [
-            <limel-menu items={this.items} onSelect={this.handleSelect}>
+            <limel-menu items={this.items} onLimelSelect={this.handleSelect}>
                 <limel-button label="Menu" slot="trigger" />
             </limel-menu>,
             <limel-example-value

--- a/src/components/menu/examples/menu-basic.tsx
+++ b/src/components/menu/examples/menu-basic.tsx
@@ -27,7 +27,7 @@ export class MenuBasicExample {
 
     public render() {
         return [
-            <limel-menu items={this.items} onSelect={this.handleSelect}>
+            <limel-menu items={this.items} onLimelSelect={this.handleSelect}>
                 <limel-button label="Menu" slot="trigger" />
             </limel-menu>,
             <limel-example-value

--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -68,7 +68,7 @@ export class MenuCompositeExample {
                 badgeIcons={this.props.badgeIcons}
                 open={this.props.open}
                 gridLayout={this.props.gridLayout}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
                 onCancel={this.handleCancel}
             >
                 <limel-button label="Menu" slot="trigger" />

--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -79,7 +79,7 @@ export class MenuCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
             </limel-example-controls>,
             <limel-example-event-printer

--- a/src/components/menu/examples/menu-disabled.tsx
+++ b/src/components/menu/examples/menu-disabled.tsx
@@ -28,7 +28,7 @@ export class MenuDisabledExample {
             <limel-menu
                 items={this.items}
                 disabled={true}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
             >
                 <limel-button label="Menu" slot="trigger" />
             </limel-menu>

--- a/src/components/menu/examples/menu-hotkeys.tsx
+++ b/src/components/menu/examples/menu-hotkeys.tsx
@@ -28,7 +28,7 @@ export class MenuHotkeysExample {
         console.log(this.items);
 
         return [
-            <limel-menu items={this.items} onSelect={this.handleSelect}>
+            <limel-menu items={this.items} onLimelSelect={this.handleSelect}>
                 <limel-button label="Menu" slot="trigger" />
             </limel-menu>,
             <limel-example-value

--- a/src/components/menu/examples/menu-notification.tsx
+++ b/src/components/menu/examples/menu-notification.tsx
@@ -51,7 +51,7 @@ export class MenuNotificationExample {
 
     public render() {
         return (
-            <limel-menu items={this.items} onSelect={this.handleSelect}>
+            <limel-menu items={this.items} onLimelSelect={this.handleSelect}>
                 <limel-icon-button
                     slot="trigger"
                     icon="gender_neutral_user"

--- a/src/components/menu/examples/menu-open-direction.tsx
+++ b/src/components/menu/examples/menu-open-direction.tsx
@@ -70,7 +70,7 @@ export class MenuOpenDirectionExample {
                 label="openDirection"
                 options={this.availableOpenDirections}
                 value={this.selectedOpenDirection}
-                onChange={this.handleNewSelection}
+                onLimelChange={this.handleNewSelection}
             />,
         ];
     }

--- a/src/components/menu/menu.e2e.ts
+++ b/src/components/menu/menu.e2e.ts
@@ -112,9 +112,11 @@ describe('limel-menu', () => {
     });
 
     describe('menu item', () => {
+        let spyForDeprecatedEvent;
         let spy;
         beforeEach(async () => {
-            spy = await page.spyOnEvent('select');
+            spyForDeprecatedEvent = await page.spyOnEvent('select');
+            spy = await page.spyOnEvent('limelSelect');
             limelMenu.setProperty('open', true);
             await page.waitForChanges();
         });
@@ -125,10 +127,16 @@ describe('limel-menu', () => {
                 await list.click();
                 await page.waitForChanges();
             });
-            it('emits the `select` event', () => {
+            it('emits the `select` event (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(1);
+            });
+            it('emits the `limelSelect` event', () => {
                 expect(spy).toHaveReceivedEventTimes(1);
             });
             it('passes the selected item as the event details', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventDetail(
+                    items[0]
+                );
                 expect(spy).toHaveReceivedEventDetail(items[0]);
             });
             it('closes the menu', async () => {

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -77,10 +77,16 @@ export class Menu {
     private cancel: EventEmitter<void>;
 
     /**
-     * Is emitted when a menu item is selected.
+     * @deprecated Use `limelSelect` instead.
      */
     @Event()
     private select: EventEmitter<MenuItem | MenuItem[]>;
+
+    /**
+     * Is emitted when a menu item is selected.
+     */
+    @Event()
+    private limelSelect: EventEmitter<MenuItem | MenuItem[]>;
 
     @Element()
     private host: HTMLLimelMenuElement;
@@ -140,6 +146,7 @@ export class Menu {
                             type="menu"
                             badgeIcons={this.badgeIcons}
                             onSelect={this.handleSelect}
+                            onLimelSelect={this.handleLimelSelect}
                             ref={this.setListElement}
                         />
                     </limel-menu-surface>
@@ -186,7 +193,12 @@ export class Menu {
 
     private handleSelect = (event: CustomEvent<MenuItem>) => {
         event.stopPropagation();
+    };
+
+    private handleLimelSelect = (event: CustomEvent<MenuItem>) => {
+        event.stopPropagation();
         this.select.emit(event.detail);
+        this.limelSelect.emit(event.detail);
         this.open = false;
     };
 

--- a/src/components/picker/examples/picker-composite.tsx
+++ b/src/components/picker/examples/picker-composite.tsx
@@ -75,7 +75,7 @@ export class PickerCompositeExample {
             <limel-picker
                 {...this.props}
                 searcher={this.search}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onInteract={this.handleEvent}
             />,
             this.renderForm(),

--- a/src/components/picker/examples/picker-composite.tsx
+++ b/src/components/picker/examples/picker-composite.tsx
@@ -133,7 +133,7 @@ export class PickerCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/picker/examples/picker-empty-suggestions.tsx
+++ b/src/components/picker/examples/picker-empty-suggestions.tsx
@@ -44,7 +44,7 @@ export class PickerExample {
                 value={this.selectedItem}
                 searcher={this.search}
                 emptyResultMessage="No results"
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItem} />,

--- a/src/components/picker/examples/picker-icons.tsx
+++ b/src/components/picker/examples/picker-icons.tsx
@@ -119,7 +119,7 @@ export class PickerIconsExample {
                 searchLabel={'Search your awesomenaut'}
                 multiple={true}
                 searcher={this.search}
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItems} />,

--- a/src/components/picker/examples/picker-leading-icon-example.tsx
+++ b/src/components/picker/examples/picker-leading-icon-example.tsx
@@ -35,7 +35,7 @@ export class PickerLeadingIconExample {
                 leadingIcon="search"
                 value={this.selectedItem}
                 searcher={this.search}
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <p>

--- a/src/components/picker/examples/picker-multiple.tsx
+++ b/src/components/picker/examples/picker-multiple.tsx
@@ -40,7 +40,7 @@ export class PickerMultipleExample {
                 value={this.selectedItems}
                 multiple={true}
                 searcher={this.search}
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItems} />,

--- a/src/components/picker/examples/picker-single.tsx
+++ b/src/components/picker/examples/picker-single.tsx
@@ -36,7 +36,7 @@ export class PickerSingleExample {
                 label="Favorite awesomenaut"
                 value={this.selectedItem}
                 searcher={this.search}
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItem} />,

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -95,7 +95,7 @@ export class PickerStaticActionsExample {
                 value={this.selectedItem}
                 searchLabel={'Search your awesomenaut'}
                 searcher={this.search}
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
                 onInteract={this.onInteract}
                 onAction={this.onAction}
                 actions={this.actions}

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -108,7 +108,7 @@ export class PickerStaticActionsExample {
                 <limel-select
                     class="is-narrow"
                     label="Action Scroll Behavior"
-                    onChange={this.setBehavior}
+                    onLimelChange={this.setBehavior}
                     value={this.actionScrollBehavior}
                     options={this.actionScrollBehaviors}
                 />
@@ -116,7 +116,7 @@ export class PickerStaticActionsExample {
                 <limel-select
                     class="is-narrow"
                     label="Action Position"
-                    onChange={this.setPosition}
+                    onLimelChange={this.setPosition}
                     value={this.actionPosition}
                     options={this.actionPositions}
                 />

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -373,7 +373,7 @@ export class Picker {
                 }}
                 badgeIcons={true}
                 type={'selectable'}
-                onChange={this.handleActionListChange}
+                onLimelChange={this.handleActionListChange}
                 items={this.actions.map(this.removeUnusedPropertiesOnAction)}
             />,
         ];
@@ -459,7 +459,7 @@ export class Picker {
         return (
             <limel-list
                 badgeIcons={hasIcons && this.badgeIcons}
-                onChange={this.handleListChange}
+                onLimelChange={this.handleListChange}
                 onKeyDown={this.onListKeyDown}
                 type="selectable"
                 items={this.items}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -262,7 +262,7 @@ export class Picker {
                 readonly={this.readonly}
                 required={this.required}
                 searchLabel={this.searchLabel}
-                onInput={this.handleTextInput}
+                onLimelInput={this.handleTextInput}
                 onKeyDown={this.handleInputKeyDown}
                 onChange={this.handleChange}
                 onInteract={this.handleInteract}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -264,7 +264,7 @@ export class Picker {
                 searchLabel={this.searchLabel}
                 onLimelInput={this.handleTextInput}
                 onKeyDown={this.handleInputKeyDown}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 onInteract={this.handleInteract}
                 onStartEdit={this.handleInputFieldFocus}
                 onStopEdit={this.handleStopEditAndBlur}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -159,10 +159,18 @@ export class Picker {
     public badgeIcons: boolean = true;
 
     /**
-     * Fired when a new value has been selected from the picker
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<
+        ListItem<number | string> | Array<ListItem<number | string>>
+    >;
+
+    /**
+     * Fired when a new value has been selected from the picker
+     */
+    @Event()
+    private limelChange: EventEmitter<
         ListItem<number | string> | Array<ListItem<number | string>>
     >;
 
@@ -559,6 +567,7 @@ export class Picker {
             }
 
             this.change.emit(newValue);
+            this.limelChange.emit(newValue);
             this.items = [];
         }
 
@@ -610,6 +619,7 @@ export class Picker {
         }
 
         this.change.emit(newValue);
+        this.limelChange.emit(newValue);
     }
 
     private handleInteract(event: LimelChipSetCustomEvent<Chip>) {

--- a/src/components/progress-flow/examples/progress-flow-basic.tsx
+++ b/src/components/progress-flow/examples/progress-flow-basic.tsx
@@ -39,7 +39,7 @@ export class ProgressFlowBasicExample {
         return [
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 disabled={this.disabled}
                 readonly={this.readonly}
             />,

--- a/src/components/progress-flow/examples/progress-flow-basic.tsx
+++ b/src/components/progress-flow/examples/progress-flow-basic.tsx
@@ -47,12 +47,12 @@ export class ProgressFlowBasicExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
             </limel-example-controls>,
             <limel-example-value

--- a/src/components/progress-flow/examples/progress-flow-colors-css.tsx
+++ b/src/components/progress-flow/examples/progress-flow-colors-css.tsx
@@ -50,7 +50,7 @@ export class ProgressFlowColorsCssExample {
         return (
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/progress-flow/examples/progress-flow-colors.tsx
+++ b/src/components/progress-flow/examples/progress-flow-colors.tsx
@@ -59,7 +59,7 @@ export class ProgressFlowColorsExample {
         return (
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/progress-flow/examples/progress-flow-narrow.tsx
+++ b/src/components/progress-flow/examples/progress-flow-narrow.tsx
@@ -39,7 +39,7 @@ export class ProgressNarrowExample {
         return (
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 class="is-narrow"
             />
         );

--- a/src/components/progress-flow/examples/progress-flow-off-progress-steps.tsx
+++ b/src/components/progress-flow/examples/progress-flow-off-progress-steps.tsx
@@ -65,7 +65,7 @@ export class ProgressFlowOffProgressStepsExample {
         return (
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/progress-flow/examples/progress-flow-with-disabled-step.tsx
+++ b/src/components/progress-flow/examples/progress-flow-with-disabled-step.tsx
@@ -40,7 +40,7 @@ export class ProgressFlowDisabledStepExample {
         return (
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/progress-flow/examples/progress-flow-with-secondary-text.tsx
+++ b/src/components/progress-flow/examples/progress-flow-with-secondary-text.tsx
@@ -35,7 +35,7 @@ export class ProgressFlowSecondaryTextExample {
         return (
             <limel-progress-flow
                 flowItems={this.flowItems}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />
         );
     }

--- a/src/components/progress-flow/progress-flow.e2e.ts
+++ b/src/components/progress-flow/progress-flow.e2e.ts
@@ -161,10 +161,12 @@ describe('limel-progress-flow', () => {
     });
 
     describe('when a flow item is clicked', () => {
+        let spyForDeprecatedEvent: EventSpy;
         let spy: EventSpy;
 
         beforeEach(async () => {
-            spy = await progressFlow.spyOnEvent('change');
+            spyForDeprecatedEvent = await progressFlow.spyOnEvent('change');
+            spy = await progressFlow.spyOnEvent('limelChange');
         });
 
         describe('when the flow item was not already selected', () => {
@@ -178,7 +180,14 @@ describe('limel-progress-flow', () => {
                 await progressFlowItems[0].click();
             });
 
-            it('emits a change event', async () => {
+            it('emits a change event (deprecated)', async () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(1);
+                expect(spyForDeprecatedEvent).toHaveReceivedEventDetail({
+                    text: 'Customer contact',
+                });
+            });
+
+            it('emits a limelChange event', async () => {
                 expect(spy).toHaveReceivedEventTimes(1);
                 expect(spy).toHaveReceivedEventDetail({
                     text: 'Customer contact',
@@ -199,7 +208,11 @@ describe('limel-progress-flow', () => {
                 await progressFlowItems[0].click();
             });
 
-            it('does not emit a change event', () => {
+            it('does not emit a change event (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(0);
+            });
+
+            it('does not emit a limelChange event', () => {
                 expect(spy).toHaveReceivedEventTimes(0);
             });
         });

--- a/src/components/progress-flow/progress-flow.tsx
+++ b/src/components/progress-flow/progress-flow.tsx
@@ -52,10 +52,16 @@ export class ProgressFlow {
     public readonly = false;
 
     /**
-     * Fired when a new value has been selected from the progress flow
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     public change: EventEmitter<FlowItem>;
+
+    /**
+     * Fired when a new value has been selected from the progress flow
+     */
+    @Event()
+    public limelChange: EventEmitter<FlowItem>;
 
     private selectedItemIndex: number;
 
@@ -131,6 +137,7 @@ export class ProgressFlow {
     private handleFlowItemClick = (flowItem: FlowItem) => () => {
         if (!flowItem.selected && !flowItem.disabled && !this.disabled) {
             this.change.emit(flowItem);
+            this.limelChange.emit(flowItem);
         }
     };
 

--- a/src/components/select/examples/select-change-options.tsx
+++ b/src/components/select/examples/select-change-options.tsx
@@ -51,7 +51,7 @@ export class SelectExample {
                 value={this.value}
                 options={this.optionGroups[this.currentOptionGroup]}
                 disabled={this.disabled}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-controls
                 style={{ '--example-controls-max-columns-width': '9rem' }}

--- a/src/components/select/examples/select-dialog.tsx
+++ b/src/components/select/examples/select-dialog.tsx
@@ -67,13 +67,13 @@ export class SelectDialogExample {
                     label="Favorite hero"
                     value={this.heroValue}
                     options={this.heroOptions}
-                    onChange={this.handleHeroChange}
+                    onLimelChange={this.handleHeroChange}
                 />
                 <limel-select
                     label="Loathed villain"
                     value={this.villainValue}
                     options={this.villainOptions}
-                    onChange={this.handleVillainChange}
+                    onLimelChange={this.handleVillainChange}
                 />
                 <limel-icon name="star_wars" />
                 <limel-button

--- a/src/components/select/examples/select-multiple.tsx
+++ b/src/components/select/examples/select-multiple.tsx
@@ -43,17 +43,17 @@ export class SelectMultipleExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/select/examples/select-multiple.tsx
+++ b/src/components/select/examples/select-multiple.tsx
@@ -36,7 +36,7 @@ export class SelectMultipleExample {
                 disabled={this.disabled}
                 readonly={this.readonly}
                 required={this.required}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
                 multiple={true}
             />,
             <limel-example-controls>

--- a/src/components/select/examples/select-narrow.tsx
+++ b/src/components/select/examples/select-narrow.tsx
@@ -64,7 +64,7 @@ export class SelectExample {
                     class="is-narrow"
                     value={this.value}
                     options={this.options}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
             </limel-header>
         );

--- a/src/components/select/examples/select-preselected.tsx
+++ b/src/components/select/examples/select-preselected.tsx
@@ -26,7 +26,7 @@ export class SelectExample {
                     label="Favorite hero"
                     value={this.value}
                     options={this.options}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </section>

--- a/src/components/select/examples/select-with-empty-option.tsx
+++ b/src/components/select/examples/select-with-empty-option.tsx
@@ -36,7 +36,7 @@ export class SelectWithEmptyOptionExample {
                     value={this.value}
                     options={this.options}
                     required={this.required}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-controls>
                     <limel-checkbox

--- a/src/components/select/examples/select-with-empty-option.tsx
+++ b/src/components/select/examples/select-with-empty-option.tsx
@@ -42,7 +42,7 @@ export class SelectWithEmptyOptionExample {
                     <limel-checkbox
                         checked={this.required}
                         label="Required"
-                        onChange={this.setRequired}
+                        onLimelChange={this.setRequired}
                     />
                 </limel-example-controls>
                 <limel-example-value value={this.value} />

--- a/src/components/select/examples/select-with-icons.tsx
+++ b/src/components/select/examples/select-with-icons.tsx
@@ -53,7 +53,7 @@ export class SelectExample {
                     helperText="If you see a lack of diversity, it's our icon-provider's fault"
                     value={this.value}
                     options={this.options}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </section>

--- a/src/components/select/examples/select.tsx
+++ b/src/components/select/examples/select.tsx
@@ -38,7 +38,7 @@ export class SelectExample {
                 readonly={this.readonly}
                 required={this.required}
                 invalid={this.invalid}
-                onChange={this.changeHandler}
+                onLimelChange={this.changeHandler}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/components/select/examples/select.tsx
+++ b/src/components/select/examples/select.tsx
@@ -44,22 +44,22 @@ export class SelectExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
                 <limel-checkbox
                     checked={this.invalid}
                     label="Invalid"
-                    onChange={this.setInvalid}
+                    onLimelChange={this.setInvalid}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/select/select.e2e.ts
+++ b/src/components/select/select.e2e.ts
@@ -317,27 +317,37 @@ describe('limel-select (native)', () => {
         });
 
         describe('when selecting a value', () => {
+            let spyForDeprecatedEvent;
             let spy;
 
             beforeEach(async () => {
-                spy = await page.spyOnEvent('change');
+                spyForDeprecatedEvent = await page.spyOnEvent('change');
+                spy = await page.spyOnEvent('limelChange');
                 const appleOption = await innerSelect.find(
                     'option[value="apple"]'
                 );
                 await appleOption.click();
             });
 
-            it('emits change event', () => {
+            it('emits a change event (deprecated)', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEvent();
+            });
+
+            it('emits a limelChange event', () => {
                 expect(spy).toHaveReceivedEvent();
             });
 
             it('passes the selected option as the event details', () => {
+                expect(spyForDeprecatedEvent).toHaveReceivedEventDetail([
+                    options[0],
+                ]);
                 expect(spy).toHaveReceivedEventDetail([options[0]]);
             });
 
             describe('when selecting another value', () => {
                 beforeEach(async () => {
-                    spy = await page.spyOnEvent('change');
+                    spyForDeprecatedEvent = await page.spyOnEvent('change');
+                    spy = await page.spyOnEvent('limelChange');
                     const appleOption = await innerSelect.find(
                         'option[value="lime"]'
                     );
@@ -345,11 +355,19 @@ describe('limel-select (native)', () => {
                     await appleOption.click();
                 });
 
-                it('emits one change event', () => {
+                it('emits one change event (deprecated)', () => {
+                    expect(spyForDeprecatedEvent).toHaveReceivedEventTimes(1);
+                });
+
+                it('emits one limelChange event', () => {
                     expect(spy).toHaveReceivedEventTimes(1);
                 });
 
                 it('passes the selected option as the event details', () => {
+                    expect(spyForDeprecatedEvent).toHaveReceivedEventDetail([
+                        options[0],
+                        options[1],
+                    ]);
                     expect(spy).toHaveReceivedEventDetail([
                         options[0],
                         options[1],

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -196,7 +196,7 @@ const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
                 <limel-list
                     items={items}
                     type={props.multiple ? 'checkbox' : 'selectable'}
-                    onChange={props.onMenuChange}
+                    onLimelChange={props.onMenuChange}
                 />
             </limel-menu-surface>
         </limel-portal>

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -102,10 +102,16 @@ export class Select {
     public multiple: boolean = false;
 
     /**
-     * Emitted when the value is changed.
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<Option | Option[]>;
+
+    /**
+     * Emitted when the value is changed.
+     */
+    @Event()
+    private limelChange: EventEmitter<Option | Option[]>;
 
     @Element()
     private host: HTMLLimelSelectElement;
@@ -256,6 +262,7 @@ export class Select {
             const listItems: ListItem[] = event.detail;
             const options: Option[] = listItems.map((item) => item.value);
             this.change.emit(options);
+            this.limelChange.emit(options);
 
             return;
         }
@@ -271,6 +278,7 @@ export class Select {
         }
 
         this.change.emit(option);
+        this.limelChange.emit(option);
         this.menuOpen = false;
         this.setTriggerFocus();
     }
@@ -279,6 +287,7 @@ export class Select {
         if (this.emitFirstChangeEvent()) {
             this.hasChanged = true;
             this.change.emit(this.options[0]);
+            this.limelChange.emit(this.options[0]);
         }
 
         this.menuOpen = true;
@@ -322,11 +331,13 @@ export class Select {
 
         if (this.multiple) {
             this.change.emit(options);
+            this.limelChange.emit(options);
 
             return;
         }
 
         this.change.emit(options[0]);
+        this.limelChange.emit(options[0]);
         this.menuOpen = false;
     }
 }

--- a/src/components/select/test/select.test-wrapper.tsx
+++ b/src/components/select/test/select.test-wrapper.tsx
@@ -33,7 +33,7 @@ export class SelectTestWrapper {
                 {...props}
                 label="Favourite Doctor"
                 value={this.value}
-                onChange={this.onChange}
+                onLimelChange={this.onChange}
             />
         );
     }

--- a/src/components/slider/examples/slider-composite.tsx
+++ b/src/components/slider/examples/slider-composite.tsx
@@ -61,7 +61,7 @@ export class SliderCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleFormChange}
+                    onLimelChange={this.handleFormChange}
                 />
             </limel-example-controls>
         );

--- a/src/components/slider/examples/slider-composite.tsx
+++ b/src/components/slider/examples/slider-composite.tsx
@@ -37,7 +37,10 @@ export class SliderCompositeExample {
 
     public render() {
         return [
-            <limel-slider {...this.props} onChange={this.handleSliderChange} />,
+            <limel-slider
+                {...this.props}
+                onLimelChange={this.handleSliderChange}
+            />,
             this.renderForm(),
             <limel-example-event-printer
                 ref={(el) => (this.eventPrinter = el)}

--- a/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
+++ b/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
@@ -39,7 +39,7 @@ export class SliderMultiplierPercentageColorsExample {
                 valuemin={this.minValue}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.changeHandler}
+                onLimelChange={this.changeHandler}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
+++ b/src/components/slider/examples/slider-multiplier-percentage-colors.tsx
@@ -45,12 +45,12 @@ export class SliderMultiplierPercentageColorsExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/slider/examples/slider-multiplier.tsx
+++ b/src/components/slider/examples/slider-multiplier.tsx
@@ -32,7 +32,7 @@ export class SliderMultiplierExample {
                     step={this.step}
                     valuemax={this.maxValue}
                     valuemin={this.minValue}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />
             </section>

--- a/src/components/slider/examples/slider.tsx
+++ b/src/components/slider/examples/slider.tsx
@@ -30,7 +30,7 @@ export class SliderExample {
                 valuemin={this.minValue}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/components/slider/examples/slider.tsx
+++ b/src/components/slider/examples/slider.tsx
@@ -36,12 +36,12 @@ export class SliderExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -92,10 +92,16 @@ export class Slider {
     public step: number;
 
     /**
-     * Emitted when the value has been changed
+     * @deprecated Use `limelChange` instead.
      */
     @Event()
     private change: EventEmitter<number>;
+
+    /**
+     * Emitted when the value has been changed
+     */
+    @Event()
+    private limelChange: EventEmitter<number>;
 
     @Element()
     private rootElement: HTMLLimelSliderElement;
@@ -307,6 +313,7 @@ export class Slider {
         }
 
         this.change.emit(value / this.factor);
+        this.limelChange.emit(value / this.factor);
     };
 
     private multiplyByFactor(value) {

--- a/src/components/snackbar/examples/snackbar-dismissible.tsx
+++ b/src/components/snackbar/examples/snackbar-dismissible.tsx
@@ -43,7 +43,7 @@ export class SnackbarExample {
                 <limel-checkbox
                     label="Dismissible"
                     checked={this.dismissible}
-                    onChange={this.onChange}
+                    onLimelChange={this.onChange}
                 />
             </limel-example-controls>,
             <limel-snackbar

--- a/src/components/spinner/examples/spinner-color.tsx
+++ b/src/components/spinner/examples/spinner-color.tsx
@@ -24,7 +24,7 @@ export class SpinnerColorExample {
                 <limel-checkbox
                     checked={this.limeBranded}
                     label="Lime branded (default design)"
-                    onChange={this.renderBranded}
+                    onLimelChange={this.renderBranded}
                 />
             </limel-example-controls>,
         ];

--- a/src/components/spinner/examples/spinner.tsx
+++ b/src/components/spinner/examples/spinner.tsx
@@ -28,7 +28,7 @@ export class SpinnerExample {
                 <limel-checkbox
                     checked={this.limeBranded}
                     label="Lime branded (default design)"
-                    onChange={this.renderBranded}
+                    onLimelChange={this.renderBranded}
                 />
             </limel-example-controls>,
         ];

--- a/src/components/split-button/examples/split-button-basic.tsx
+++ b/src/components/split-button/examples/split-button-basic.tsx
@@ -31,7 +31,7 @@ export class SplitButtonBasicExample {
                 icon="send"
                 items={this.items}
                 onClick={this.onClick}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
             />
         );
     }

--- a/src/components/split-button/examples/split-button-repeat-default-command.tsx
+++ b/src/components/split-button/examples/split-button-repeat-default-command.tsx
@@ -38,7 +38,7 @@ export class SplitButtonRepeatDefaultCommandExample {
                 primary={true}
                 items={this.items}
                 onClick={this.onClick}
-                onSelect={this.handleSelect}
+                onLimelSelect={this.handleSelect}
             />
         );
     }

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -53,10 +53,16 @@ export class SplitButton {
     public items: Array<MenuItem | ListSeparator> = [];
 
     /**
-     * Is emitted when a menu item is selected.
+     * @deprecated Use `limelSelect` instead.
      */
     @Event()
     public select: EventEmitter<MenuItem>;
+
+    /**
+     * Is emitted when a menu item is selected.
+     */
+    @Event()
+    public limelSelect: EventEmitter<MenuItem>;
 
     render() {
         return (

--- a/src/components/switch/examples/switch.tsx
+++ b/src/components/switch/examples/switch.tsx
@@ -27,17 +27,17 @@ export class SwitchExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.value}
                     label="Selected"
-                    onChange={this.setChecked}
+                    onLimelChange={this.setChecked}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -770,7 +770,7 @@ export class Table {
                 style={{ display: showSelectAll ? 'inline-block' : 'none' }}
             >
                 <limel-checkbox
-                    onChange={this.selectAllOnChange}
+                    onLimelChange={this.selectAllOnChange}
                     disabled={!this.data.length}
                     checked={this.tableSelection?.hasSelection}
                     indeterminate={

--- a/src/components/tooltip/examples/tooltip-composite.tsx
+++ b/src/components/tooltip/examples/tooltip-composite.tsx
@@ -46,7 +46,7 @@ export class TooltipCompositeExample {
                 <limel-form
                     schema={this.schema}
                     value={this.props}
-                    onChange={this.handleChange}
+                    onLimelChange={this.handleChange}
                 />
             </limel-collapsible-section>
         );

--- a/src/design-guidelines/color-system/examples/extended-color-palette.tsx
+++ b/src/design-guidelines/color-system/examples/extended-color-palette.tsx
@@ -45,7 +45,7 @@ export class PaletteExample {
                 </div>
                 <limel-checkbox
                     label="Highlight Lime's brand colors"
-                    onChange={this.toggleMode}
+                    onLimelChange={this.toggleMode}
                     checked={this.brandColors}
                 />
                 <div class="brand-colors-tips">

--- a/src/design-guidelines/color-system/examples/lime-color-palette.tsx
+++ b/src/design-guidelines/color-system/examples/lime-color-palette.tsx
@@ -103,7 +103,7 @@ export class PaletteExample {
                 </div>
                 <limel-checkbox
                     label="Highlight primary brand colors"
-                    onChange={this.toggleMode}
+                    onLimelChange={this.toggleMode}
                     checked={this.primaryColors}
                 />
             </div>

--- a/src/design-guidelines/color-system/examples/primary-color-palette.tsx
+++ b/src/design-guidelines/color-system/examples/primary-color-palette.tsx
@@ -42,7 +42,7 @@ export class PaletteExample {
                 </div>
                 <limel-checkbox
                     label="Highlight Lime's brand colors"
-                    onChange={this.toggleMode}
+                    onLimelChange={this.toggleMode}
                     checked={this.brandColors}
                 />
                 <div class="brand-colors-tips">

--- a/src/design-guidelines/declutter/examples/input-field-text-decluttering-guidelines.tsx
+++ b/src/design-guidelines/declutter/examples/input-field-text-decluttering-guidelines.tsx
@@ -37,7 +37,7 @@ export class InputFieldTextExample {
                 invalid={this.invalid}
                 disabled={this.disabled}
                 readonly={this.readonly}
-                onChange={this.handleChange}
+                onLimelChange={this.handleChange}
             />,
             <limel-example-controls>
                 <limel-checkbox

--- a/src/design-guidelines/declutter/examples/input-field-text-decluttering-guidelines.tsx
+++ b/src/design-guidelines/declutter/examples/input-field-text-decluttering-guidelines.tsx
@@ -43,17 +43,17 @@ export class InputFieldTextExample {
                 <limel-checkbox
                     checked={this.disabled}
                     label="Disabled"
-                    onChange={this.setDisabled}
+                    onLimelChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
-                    onChange={this.setReadonly}
+                    onLimelChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.required}
                     label="Required"
-                    onChange={this.setRequired}
+                    onLimelChange={this.setRequired}
                 />
             </limel-example-controls>,
         ];

--- a/src/design-guidelines/size/examples/size-edge-case.tsx
+++ b/src/design-guidelines/size/examples/size-edge-case.tsx
@@ -30,7 +30,7 @@ export class SizeEdgeCaseExample {
             </div>,
             <limel-checkbox
                 label="Visualize sizes"
-                onChange={this.toggleMode}
+                onLimelChange={this.toggleMode}
                 checked={this.visualizeSizes}
             />,
         ];

--- a/src/design-guidelines/size/examples/size.tsx
+++ b/src/design-guidelines/size/examples/size.tsx
@@ -27,7 +27,7 @@ export class SizeExample {
             </div>,
             <limel-checkbox
                 label="Visualize sizes"
-                onChange={this.toggleMode}
+                onLimelChange={this.toggleMode}
                 checked={this.visualizeSizes}
             />,
         ];

--- a/src/events.md
+++ b/src/events.md
@@ -23,7 +23,7 @@ class MyComponent {
         return [
             <limel-input-field
                 value={this.value}
-                onChange={this.handleChange} />,
+                onLimelChange={this.handleChange} />,
             <limel-button
                 label="Submit"
                 onClick={this.handleClick} />


### PR DESCRIPTION
fix: #2377

Deprecate events that shadow native events (event that have the same name as native events):

- `change`
- `input`
- `select`

New events have been added, where the names have been prefixed.

Also, the property `prefix` is a "reserved public name", so that's also been deprecated and a new property, `limelPrefix` has been added.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
