### PR TITLE
fix(slider): use a unique id for the helper text & use it by `aria-controls`

### DIFF
--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -104,6 +104,7 @@ export class Slider {
 
     private mdcSlider: MDCSlider;
     private labelId: string;
+    private helperTextId: string;
 
     @State()
     private percentageClass: string;
@@ -112,6 +113,7 @@ export class Slider {
         this.inputHandler = this.inputHandler.bind(this);
         this.getContainerClassList = this.getContainerClassList.bind(this);
         this.labelId = createRandomString();
+        this.helperTextId = createRandomString();
     }
 
     public connectedCallback() {
@@ -231,6 +233,7 @@ export class Slider {
                         value={this.multiplyByFactor(this.value)}
                         name="volume"
                         aria-labelledby={this.labelId}
+                        aria-controls={this.helperTextId}
                         {...inputProps}
                     />
                     <div class="mdc-slider__track">
@@ -263,7 +266,12 @@ export class Slider {
             return;
         }
 
-        return <limel-helper-line helperText={this.helperText} />;
+        return (
+            <limel-helper-line
+                helperText={this.helperText}
+                helperTextId={this.helperTextId}
+            />
+        );
     }
 
     @Watch('disabled')

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -11,6 +11,8 @@ import {
     Watch,
 } from '@stencil/core';
 import { getPercentageClass } from './getPercentageClass';
+import { createRandomString } from '../../util/random-string';
+
 /**
  * @exampleComponent limel-example-slider
  * @exampleComponent limel-example-slider-multiplier
@@ -101,6 +103,7 @@ export class Slider {
     private rootElement: HTMLLimelSliderElement;
 
     private mdcSlider: MDCSlider;
+    private labelId: string;
 
     @State()
     private percentageClass: string;
@@ -108,6 +111,7 @@ export class Slider {
     public constructor() {
         this.inputHandler = this.inputHandler.bind(this);
         this.getContainerClassList = this.getContainerClassList.bind(this);
+        this.labelId = createRandomString();
     }
 
     public connectedCallback() {
@@ -196,7 +200,10 @@ export class Slider {
 
         return (
             <Host class={this.getContainerClassList()}>
-                <label class="slider__label mdc-floating-label mdc-floating-label--float-above">
+                <label
+                    class="slider__label mdc-floating-label mdc-floating-label--float-above"
+                    id={this.labelId}
+                >
                     {this.label}
                 </label>
                 <div class="slider__content-range-container">
@@ -223,7 +230,7 @@ export class Slider {
                         max={this.multiplyByFactor(this.valuemax)}
                         value={this.multiplyByFactor(this.value)}
                         name="volume"
-                        aria-label="Discrete slider demo"
+                        aria-labelledby={this.labelId}
                         {...inputProps}
                     />
                     <div class="mdc-slider__track">


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
