### PR TITLE
fix(checkbox): create a unique id for the helper text & use it by `aria` attributes

### DIFF
--- a/src/components/checkbox/checkbox.template.tsx
+++ b/src/components/checkbox/checkbox.template.tsx
@@ -11,6 +11,7 @@ interface CheckboxTemplateProps {
     onChange?: (event: Event) => void;
     label?: string;
     helperText?: string;
+    helperTextId?: string;
 }
 
 export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = (
@@ -41,6 +42,8 @@ export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = (
                     disabled={props.disabled || props.readonly}
                     required={props.required}
                     onChange={props.onChange}
+                    aria-controls={props.helperTextId}
+                    aria-describedby={props.helperTextId}
                     {...inputProps}
                 />
                 <div class="mdc-checkbox__background">
@@ -67,14 +70,25 @@ export const CheckboxTemplate: FunctionalComponent<CheckboxTemplateProps> = (
                 {props.label}
             </label>
         </div>,
-        <HelperText text={props.helperText} />,
+        <HelperText
+            text={props.helperText}
+            helperTextId={props.helperTextId}
+        />,
     ];
 };
 
-const HelperText: FunctionalComponent<{ text: string }> = (props) => {
+const HelperText: FunctionalComponent<{
+    helperTextId: string;
+    text: string;
+}> = (props) => {
     if (typeof props.text !== 'string') {
         return;
     }
 
-    return <limel-helper-line helperText={props.text.trim()} />;
+    return (
+        <limel-helper-line
+            helperText={props.text.trim()}
+            helperTextId={props.helperTextId}
+        />
+    );
 };

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -83,6 +83,7 @@ export class Checkbox {
     private formField: MDCFormField;
     private mdcCheckbox: MDCCheckbox;
     private id: string = createRandomString();
+    private helperTextId: string = createRandomString();
 
     @Watch('checked')
     protected handleCheckedChange(newValue: boolean) {
@@ -126,6 +127,7 @@ export class Checkbox {
                 disabled={this.disabled || this.readonly}
                 label={this.label}
                 helperText={this.helperText}
+                helperTextId={this.helperTextId}
                 checked={this.checked || this.indeterminate}
                 indeterminate={this.indeterminate}
                 required={this.required}


### PR DESCRIPTION
The `aria-controls` and `aria-describedby` are using these IDs to give clues to assistive technologies.
In the former implementation, we were lacking ids
for the helper text elements.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
