### PR TITLE
feat(button-like-components): add helper function for enter clicking

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,4 +1,8 @@
-import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { Component, h, Prop, State, Watch, Element } from '@stencil/core';
+import {
+    makeEnterClickable,
+    removeEnterClickable,
+} from '../../util/makeEnterClickable';
 
 /**
  * @exampleComponent limel-example-button-basic
@@ -66,7 +70,18 @@ export class Button {
     @State()
     private justLoaded = false;
 
+    @Element()
+    private host: HTMLElement;
+
     private justLoadedTimeout?: number;
+
+    public componentWillLoad() {
+        makeEnterClickable(this.host);
+    }
+
+    public disconnectedCallback() {
+        removeEnterClickable(this.host);
+    }
 
     public render() {
         return (

--- a/src/util/makeEnterClickable.ts
+++ b/src/util/makeEnterClickable.ts
@@ -1,0 +1,73 @@
+import { forceUpdate } from '@stencil/core';
+
+const eventHandlers: WeakMap<HTMLElement, CallBacks> = new WeakMap();
+
+export function makeEnterClickable(element: HTMLElement) {
+    if (eventHandlers.has(element)) {
+        return;
+    }
+
+    let isActive = false;
+    let hasJustReleasedEnter = true;
+
+    const keydownHandler = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' && !isActive) {
+            isActive = true;
+
+            forceUpdate(element);
+        }
+    };
+
+    const keyupHandler = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' && isActive) {
+            isActive = false;
+            hasJustReleasedEnter = true;
+
+            forceUpdate(element);
+        }
+    };
+
+    const clickHandler = (event: MouseEvent) => {
+        if (!isActive) {
+            return;
+        }
+
+        if (hasJustReleasedEnter) {
+            hasJustReleasedEnter = false;
+
+            return;
+        }
+
+        event.stopImmediatePropagation();
+    };
+
+    eventHandlers.set(element, {
+        keydownHandler: keydownHandler,
+        keyupHandler: keyupHandler,
+        clickHandler: clickHandler,
+    });
+
+    element.addEventListener('keydown', keydownHandler);
+    element.addEventListener('keyup', keyupHandler);
+    element.addEventListener('click', clickHandler, true);
+}
+
+export function removeEnterClickable(element: HTMLElement) {
+    const callBacks: CallBacks = eventHandlers.get(element);
+
+    if (!callBacks || !eventHandlers.has(element)) {
+        return;
+    }
+
+    element.removeEventListener('keydown', callBacks.keydownHandler);
+    element.removeEventListener('keyup', callBacks.keyupHandler);
+    element.removeEventListener('click', callBacks.clickHandler, true);
+
+    eventHandlers.delete(element);
+}
+
+interface CallBacks {
+    keydownHandler: (arg: KeyboardEvent) => void;
+    keyupHandler: (arg: KeyboardEvent) => void;
+    clickHandler: (arg: MouseEvent) => void;
+}


### PR DESCRIPTION
Added helper function that you would put in componentWillLoad that adds the event listeners needed to make buttons clickable with enter.

We add it to limel-buttons to make testing easy (this will probably conflict with another similar issue, and we need to fix this conflict before merge).

Fixes Lundalogik/crm-feature#3518

## How to test this PR:
I tested it by throwing in a timeout in `componentWillLoad` that calls the add/remove event. I suggest trying something similar, calling them in different orders, maybe repeatedly, and see if it breaks.

The docs have a really good playground for the limel-button to test this functionality.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
