### PR TITLE
feat(menu-list): add identifier to MenuItem interface

### DIFF
--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -138,6 +138,7 @@ export class MenuListRenderer {
                 role="menuitem"
                 aria-disabled={item.disabled ? 'true' : 'false'}
                 aria-selected={item.selected ? 'true' : 'false'}
+                data-item={item.identifier ? item.identifier : null}
                 data-index={index}
                 data-text={item.text}
                 {...attributes}

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -66,6 +66,11 @@ export interface MenuItem<T = any> {
     text: string;
 
     /**
+     * A value to uniquely identify each item.
+     */
+    identifier?: string;
+
+    /**
      * Additional supporting text to display in the menu item.
      */
     secondaryText?: string;


### PR DESCRIPTION

fix: https://github.com/Lundalogik/crm-feature/issues/3265
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced menu functionality by adding a unique identifier for each item, paving the way for improved element targeting and future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->