### PR TITLE
fix(schema-field): throw warning instead of error if a custom compone…

### DIFF
--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -34,7 +34,21 @@ const shouldChangeToUndefined = (value, schema): boolean => {
 };
 
 const hasCustomComponent = (schema): boolean => {
-    return Boolean(schema.lime?.component?.name);
+    const name = schema.lime?.component?.name;
+    if (!name) {
+        return false;
+    }
+
+    try {
+        verifyCustomComponentIsDefined(name);
+    } catch {
+        // eslint-disable-next-line no-console
+        console.warn(`Custom component ${name} not defined`);
+
+        return false;
+    }
+
+    return true;
 };
 
 const verifyCustomComponentIsDefined = (elementName): void => {


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#3536

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
