### PR TITLE
feat(icon-button): override default browser behavior on clicking enter

### DIFF
--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -1,4 +1,8 @@
 import { Component, Element, h, Prop } from '@stencil/core';
+import {
+    makeEnterClickable,
+    removeEnterClickable,
+} from 'src/util/makeEnterClickable';
 
 /**
  * @exampleComponent limel-example-icon-button-basic
@@ -43,6 +47,14 @@ export class IconButton {
 
     public connectedCallback() {
         this.initialize();
+    }
+
+    public componentWillLoad() {
+        makeEnterClickable(this.host);
+    }
+
+    public disconnectedCallback() {
+        removeEnterClickable(this.host);
     }
 
     public componentDidLoad() {


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#2544

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
