### PR TITLE
fix(switch): improve understanding of `readonly` & `disabled` states

### DIFF
--- a/src/components/switch/partial-styles/_readonly.scss
+++ b/src/components/switch/partial-styles/_readonly.scss
@@ -2,13 +2,17 @@
     &.lime-switch--readonly {
         --mdc-switch-disabled-selected-track-color: var(--mdc-theme-primary);
         --mdc-switch-disabled-unselected-track-color: rgb(
-            var(--color-red-default)
+            var(--color-red-default),
+            0.6
         );
         --mdc-switch-handle-surface-color: transparent;
-        --mdc-switch-disabled-selected-handle-color: transparent;
-        --mdc-switch-disabled-unselected-handle-color: transparent;
+        --mdc-switch-disabled-selected-handle-color: var(--mdc-theme-primary);
+        --mdc-switch-disabled-unselected-handle-color: rgb(
+            var(--color-red-default),
+            0.8
+        );
 
-        --mdc-switch-disabled-track-opacity: 1;
+        --mdc-switch-disabled-track-opacity: 0.6;
 
         + label.disabled {
             cursor: default;

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -66,7 +66,7 @@ $scale-factor: 0.8;
     --mdc-switch-selected-hover-track-color: var(--mdc-theme-primary);
 
     --mdc-switch-handle-elevation: var(--button-shadow-normal);
-    --mdc-switch-disabled-track-opacity: 0.4;
+    --mdc-switch-disabled-track-opacity: 0.3;
 }
 
 .mdc-switch {


### PR DESCRIPTION
make the component look more like a switch in `readonly` & `disabled` states

Fix: https://github.com/Lundalogik/crm-feature/issues/3312

Before:
![Screenshot 2023-07-21 at 15 00 34](https://github.com/Lundalogik/lime-elements/assets/50618208/86ab8f26-9c3b-4ddd-8796-27dd6d08e7c6)

After:

![Screenshot 2023-07-21 at 16 05 24](https://github.com/Lundalogik/lime-elements/assets/50618208/e9f60b58-f9d7-4ef0-8c6c-2f8594214fd3)



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
