### PR TITLE
fix(color-picker): enable opening the color palette using the `Enter`…

### DIFF
--- a/src/components/color-picker/color-picker-palette.scss
+++ b/src/components/color-picker/color-picker-palette.scss
@@ -1,4 +1,5 @@
 @use '../../design-guidelines/color-system/examples/extended-color-palette';
+@use '../../style/mixins';
 @import './color-picker';
 
 :host {
@@ -30,6 +31,11 @@
 }
 
 .swatch:not(.hue) {
+    border: none;
+    aspect-ratio: 1;
+
+    @include mixins.visualize-keyboard-focus();
+
     // We could use the `@include mixins.is-flat-clickable();` mixin
     // But its `background-color` arguments would interfere with the
     // styles here. So we just copy/pasted the useful parts of the mixin here

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -74,11 +74,10 @@ export class Palette implements FormComponent {
         };
 
         return (
-            <div
+            <button
                 class={classList}
                 onClick={this.handleClick(color, brightness)}
-                tabindex="0"
-            ></div>
+            />
         );
     };
 

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -12,6 +12,17 @@
     grid-template-columns: auto 1fr;
 }
 
+.picker-trigger {
+    all: unset;
+    border-radius: 0.5rem;
+    @include mixins.is-elevated-clickable();
+    @include mixins.visualize-keyboard-focus();
+
+    &:after {
+        box-shadow: 0 0 0 0.25rem rgb(var(--contrast-100)) inset;
+    }
+}
+
 .chosen-color-preview,
 .picker-trigger {
     box-sizing: border-box;
@@ -37,15 +48,6 @@
     &:after {
         background: var(--background);
         z-index: 1;
-    }
-}
-
-.picker-trigger {
-    border-radius: 0.5rem;
-    @include mixins.is-elevated-clickable();
-
-    &:after {
-        box-shadow: 0 0 0 0.25rem rgb(var(--contrast-100)) inset;
     }
 }
 

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -44,7 +44,7 @@ test('the component renders all colors in the palette', () => {
         brightnesses.forEach((brightness) => {
             const swatchElement = getSwatchElement(color, brightness);
             expect(swatchElement).toEqualHtml(`
-                <div class="--color-${color}-${brightness} swatch" tabindex="0"></div>
+                <button class="--color-${color}-${brightness} swatch"></button>
             `);
         });
     });

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -28,7 +28,7 @@ test('the component renders', () => {
             <mock:shadow-root>
                     <div class="color-picker">
                         <limel-popover opendirection="bottom-start">
-                            <div class="picker-trigger" id="tooltip-button" role="button" slot="trigger" tabindex="0"></div>
+                            <button class="picker-trigger" id="tooltip-button" role="button" slot="trigger"></button>
                             <limel-color-picker-palette label="Hair color">
                                 <mock:shadow-root></mock:shadow-root>
                             </limel-color-picker-palette>

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -122,12 +122,11 @@ export class ColorPicker implements FormComponent {
         const background = this.value ? { '--background': this.value } : {};
 
         return (
-            <div
+            <button
                 class="picker-trigger"
                 slot="trigger"
                 style={background}
                 role="button"
-                tabindex="0"
                 onClick={this.openPopover}
                 id="tooltip-button"
             />


### PR DESCRIPTION
… key



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
