### PR TITLE
Some small cleanups in limel-tooltip

### DIFF
--- a/src/components/tooltip/examples/tooltip-basic.tsx
+++ b/src/components/tooltip/examples/tooltip-basic.tsx
@@ -4,10 +4,10 @@ import { Component, h } from '@stencil/core';
  * Basic example
  */
 @Component({
-    tag: 'limel-example-tooltip',
+    tag: 'limel-example-tooltip-basic',
     shadow: true,
 })
-export class TooltipExample {
+export class TooltipBasicExample {
     public render() {
         return [
             <limel-button icon="search" id="tooltip-example" />,

--- a/src/components/tooltip/tooltip.spec.tsx
+++ b/src/components/tooltip/tooltip.spec.tsx
@@ -1,7 +1,7 @@
 import { h } from '@stencil/core';
 import { SpecPage, newSpecPage } from '@stencil/core/testing';
 import { Portal } from '../portal/portal';
-import { TooltipExample } from './examples/tooltip';
+import { TooltipBasicExample } from './examples/tooltip-basic';
 import { Tooltip } from './tooltip';
 
 let page: SpecPage;
@@ -12,7 +12,7 @@ let anchor: HTMLAnchorElement;
 
 beforeEach(async () => {
     page = await newSpecPage({
-        components: [Tooltip, TooltipExample, Portal],
+        components: [Tooltip, TooltipBasicExample, Portal],
         template: () => {
             return (
                 <div>

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -82,11 +82,11 @@ export class Tooltip {
     @Prop({ reflect: true })
     public maxlength?: number = DEFAULT_MAX_LENGTH;
 
-    @State()
-    private open: boolean;
-
     @Element()
     private host: HTMLLimelTooltipElement;
+
+    @State()
+    private open: boolean;
 
     private portalId: string;
     private tooltipId: string;

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -42,7 +42,7 @@ const DEFAULT_MAX_LENGTH = 50;
  * use that, not a tooltip.
  * - Make sure to use the tooltip on an element that users naturally and
  * effortlessly recognize can be hovered.
- * @exampleComponent limel-example-tooltip
+ * @exampleComponent limel-example-tooltip-basic
  * @exampleComponent limel-example-tooltip-max-character
  * @exampleComponent limel-example-tooltip-composite
  * @private

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop, Element, State } from '@stencil/core';
+import { JSX } from 'react';
 import { createRandomString } from '../../util/random-string';
 
 const DEFAULT_MAX_LENGTH = 50;
@@ -105,7 +106,7 @@ export class Tooltip {
         this.removeListeners();
     }
 
-    public render() {
+    public render(): JSX.Element {
         const tooltipZIndex = getComputedStyle(this.host).getPropertyValue(
             '--tooltip-z-index'
         );


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
