### PR TITLE
Position tooltip relative to target element instead of relative to limel-tooltip element

### DIFF
--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -86,6 +86,13 @@ export class Portal {
     @Prop({ reflect: true })
     public visible = false;
 
+    /**
+     * The element that the content should be positioned relative to.
+     * Defaults to the limel-portal element.
+     */
+    @Prop()
+    public anchor?: HTMLElement = null;
+
     @Element()
     private host: HTMLLimelPortalElement;
 
@@ -252,7 +259,11 @@ export class Portal {
     private createPopper() {
         const config = this.createPopperConfig();
 
-        this.popperInstance = createPopper(this.host, this.container, config);
+        this.popperInstance = createPopper(
+            this.anchor || this.host,
+            this.container,
+            config
+        );
     }
 
     private destroyPopper() {

--- a/src/components/tooltip/examples/tooltip-max-character.scss
+++ b/src/components/tooltip/examples/tooltip-max-character.scss
@@ -1,7 +1,5 @@
 :host(limel-example-tooltip-max-character) {
     display: flex;
-    flex-direction: column;
-    align-content: flex-start;
-    column-gap: 1rem;
-    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: space-between;
 }

--- a/src/components/tooltip/examples/tooltip-max-character.tsx
+++ b/src/components/tooltip/examples/tooltip-max-character.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
 
 /**
- * Using 'maxlength' property
+ * Using `maxlength` property
  * To present an easy to read content, the tooltip's maximum text
  * length is set to 50 characters, including spaces.
  * When this threshold is reached, content will be rendered with line breaks.
@@ -21,20 +21,20 @@ export class TooltipExample {
     public render() {
         return [
             <limel-icon-button icon="info" id="tooltip1" />,
+            <limel-icon-button icon="info" id="tooltip2" />,
+            <limel-icon-button icon="info" id="tooltip3" />,
             <limel-tooltip
                 label="Short text"
                 helperLabel="less than 25ch"
                 elementId="tooltip1"
                 maxlength={25}
             />,
-            <limel-icon-button icon="info" id="tooltip2" />,
             <limel-tooltip
                 label="Long text"
                 helperLabel="The total amount of characters is more than 25"
                 elementId="tooltip2"
                 maxlength={25}
             />,
-            <limel-icon-button icon="info" id="tooltip3" />,
             <limel-tooltip
                 label="Very long text"
                 helperLabel="The total amount of characters is more than default max character length, which is 50ch. Note that there is no max character length specified here."

--- a/src/components/tooltip/tooltip-content.scss
+++ b/src/components/tooltip/tooltip-content.scss
@@ -1,4 +1,4 @@
-:host {
+:host(limel-tooltip-content) {
     animation: display-tooltip 0.2s ease;
     display: flex;
 

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -2,6 +2,14 @@
  * @prop --tooltip-z-index: z-index of the tooltip.
  */
 
-.trigger-anchor {
-    position: relative;
+:host(limel-tooltip) {
+    // Absolutely positioning ensures that this invisible element
+    // does not occupy visible space in the UI.
+    // Without this, `limel-tooltip` could in many cases
+    // mess up the layout, where it is used.
+    // For example, inside a `grid` or `flex` section,
+    // every instance of the tooltip would take some space,
+    // creating gaps and empty holes.
+    position: absolute;
+    pointer-events: none;
 }

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -20,8 +20,9 @@ const DEFAULT_MAX_LENGTH = 50;
  *
  * :::note
  * In order to display the tooltip, the tooltip element and its trigger element
- * must be within the same document or document fragment.
- * A good practice is to just place them next to each other like below:
+ * must be within the same document or document fragment (the same shadowRoot).
+ * Often, it's easiest to just place them next to each other like in the example
+ * below, but if you need to, you can place them differently.
  *
  * ```html
  * <limel-button icon="search" id="tooltip-example" />
@@ -123,6 +124,7 @@ export class Tooltip {
                         'z-index': tooltipZIndex,
                         'pointer-events': 'none',
                     }}
+                    anchor={this.ownerElement}
                 >
                     <limel-tooltip-content
                         label={this.label}

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -46,7 +46,6 @@ const DEFAULT_MAX_LENGTH = 50;
  * @exampleComponent limel-example-tooltip-basic
  * @exampleComponent limel-example-tooltip-max-character
  * @exampleComponent limel-example-tooltip-composite
- * @private
  */
 @Component({
     tag: 'limel-tooltip',

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -91,6 +91,7 @@ export class Tooltip {
     private portalId: string;
     private tooltipId: string;
     private showTooltipTimeoutHandle: number;
+    private ownerElement: HTMLElement;
 
     public constructor() {
         this.portalId = createRandomString();
@@ -98,6 +99,7 @@ export class Tooltip {
     }
 
     public connectedCallback() {
+        this.ownerElement = this.getOwnerElement();
         this.setOwnerAriaLabel();
         this.addListeners();
     }
@@ -136,22 +138,19 @@ export class Tooltip {
     }
 
     private setOwnerAriaLabel() {
-        const owner = this.getOwnerElement();
-        owner?.setAttribute('aria-describedby', this.tooltipId);
+        this.ownerElement?.setAttribute('aria-describedby', this.tooltipId);
     }
 
     private addListeners() {
-        const owner = this.getOwnerElement();
-        owner?.addEventListener('mouseover', this.showTooltip);
-        owner?.addEventListener('mouseout', this.hideTooltip);
-        owner?.addEventListener('click', this.hideTooltip);
+        this.ownerElement?.addEventListener('mouseover', this.showTooltip);
+        this.ownerElement?.addEventListener('mouseout', this.hideTooltip);
+        this.ownerElement?.addEventListener('click', this.hideTooltip);
     }
 
     private removeListeners() {
-        const owner = this.getOwnerElement();
-        owner?.removeEventListener('mouseover', this.showTooltip);
-        owner?.removeEventListener('mouseout', this.hideTooltip);
-        owner?.removeEventListener('click', this.hideTooltip);
+        this.ownerElement?.removeEventListener('mouseover', this.showTooltip);
+        this.ownerElement?.removeEventListener('mouseout', this.hideTooltip);
+        this.ownerElement?.removeEventListener('click', this.hideTooltip);
     }
 
     private showTooltip = () => {

--- a/src/design-guidelines/declutter/declutter.md
+++ b/src/design-guidelines/declutter/declutter.md
@@ -32,8 +32,6 @@ Instead of this 👇, we can use that 👆 again. / Kia
 
 However, sometimes such design decisions depend on the context and it is only you who are designing the UI that can judge. Examples of these follow below.
 
-<!--
-NOTE: this should be uncommented when we make `limel-tooltip` a public component.
 ### Tooltips
 Tooltips are also helpful components in creating a clean UI, by hiding away supplemental
 but disposable pieces of information.
@@ -42,7 +40,6 @@ Users may need such information only once (usually for the first time they
 use a UI) or occasionally. Therefore instead of constantly showing them
 in the user interface, a tooltip can be used to hide them away and display them once needed.
 <limel-example-tooltip-declutter></limel-example-tooltip-declutter>
--->
 
 ### Buttons
 Buttons are particularly strong elements in the UI, since they are meant to perform important actions. Thus, an effective way of reducing clutter is to hide buttons that aren't useful at the moment. This most commonly applies to disabled buttons.


### PR DESCRIPTION
fix: #1408
fix: https://github.com/Lundalogik/crm-feature/issues/2590

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
