### PR TITLE
feat(tooltip): add `openDirection` prop

### DIFF
--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -181,6 +181,7 @@ export class DockButton {
                     elementId={this.tooltipId}
                     label={this.item.label}
                     helperLabel={this.item.helperLabel}
+                    openDirection={this.getOpenDirection()}
                 />
             );
         }
@@ -190,6 +191,7 @@ export class DockButton {
                 <limel-tooltip
                     elementId={this.tooltipId}
                     label={this.item.helperLabel}
+                    openDirection={this.getOpenDirection()}
                 />
             );
         }
@@ -199,5 +201,13 @@ export class DockButton {
         if (this.customComponentElement?.shadowRoot?.delegatesFocus) {
             this.customComponentElement?.focus();
         }
+    };
+
+    private getOpenDirection = () => {
+        if (this.useMobileLayout) {
+            return 'top';
+        }
+
+        return 'right';
     };
 }

--- a/src/components/tooltip/tooltip.spec.tsx
+++ b/src/components/tooltip/tooltip.spec.tsx
@@ -45,10 +45,11 @@ test('the component renders', () => {
             element-id="tooltip-test"
             label="Description"
             maxlength="50"
+            open-direction="top"
         >
             <mock:shadow-root>
                 <div class="trigger-anchor">
-                    <limel-portal container-id="${containerId}" open-direction="bottom-start" position="absolute">
+                    <limel-portal container-id="${containerId}" open-direction="top" position="absolute">
                         <mock:shadow-root>
                             <slot></slot>
                         </mock:shadow-root>

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, Element, State } from '@stencil/core';
 import { JSX } from 'react';
 import { createRandomString } from '../../util/random-string';
+import { OpenDirection } from '../menu/menu.types';
 
 const DEFAULT_MAX_LENGTH = 50;
 
@@ -82,6 +83,12 @@ export class Tooltip {
     @Prop({ reflect: true })
     public maxlength?: number = DEFAULT_MAX_LENGTH;
 
+    /**
+     * Decides the tooltip's location in relation to its trigger.
+     */
+    @Prop({ reflect: true })
+    public openDirection: OpenDirection = 'top';
+
     @Element()
     private host: HTMLLimelTooltipElement;
 
@@ -116,7 +123,7 @@ export class Tooltip {
         return (
             <div class="trigger-anchor">
                 <limel-portal
-                    openDirection="bottom-start"
+                    openDirection={this.openDirection}
                     visible={this.open}
                     containerId={this.portalId}
                     containerStyle={{


### PR DESCRIPTION
Enables consumers to decide where to visually
render the tooltip, in relation to its trigger element.

fix https://github.com/Lundalogik/lime-elements/issues/2446

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
