### PR TITLE
feat(action-bar-icon-interface): make `icon` field required when `iconOnly` is true

### DIFF
--- a/src/components/action-bar/action-bar.types.ts
+++ b/src/components/action-bar/action-bar.types.ts
@@ -1,9 +1,16 @@
 import { MenuItem } from '../menu/menu.types';
 
-export interface ActionBarItem extends MenuItem {
-    /**
-     * Renders the button in the action bar without their labels.
-     * Does not affect the items that are overflown into the overflow menu.
-     */
-    iconOnly?: boolean;
+/**
+ * Renders the button in the action bar without their labels.
+ * Does not affect the items that are overflown into the overflow menu.
+ */
+export type ActionBarItem = ActionBarItemOnlyIcon | ActionBarItemWithLabel;
+
+interface ActionBarItemOnlyIcon extends MenuItem {
+    iconOnly: true;
+    icon: string;
+}
+
+interface ActionBarItemWithLabel extends MenuItem {
+    iconOnly?: false;
 }


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#3452

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
