### PR TITLE
docs(list): update description of `change` event to match current functionality

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -89,7 +89,8 @@ export class List {
     private selectable: boolean;
 
     /**
-     * Fired when a new value has been selected from the list. Only fired if selectable is set to true
+     * Fired when a new value has been selected from the list.
+     * Only fired if `type` is set to `selectable`, `radio` or `checkbox`.
      */
     @Event()
     private change: EventEmitter<ListItem | ListItem[]>;


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
