### PR TITLE
Avoid rendering the component unless the value is a number

### DIFF
--- a/src/components/linear-progress/linear-progress.tsx
+++ b/src/components/linear-progress/linear-progress.tsx
@@ -56,6 +56,10 @@ export class LinearProgress {
     }
 
     public render() {
+        if (!this.isFinite(this.value)) {
+            return;
+        }
+
         const classList = {
             'mdc-linear-progress': true,
             'mdc-linear-progress--indeterminate': this.indeterminate,
@@ -85,10 +89,14 @@ export class LinearProgress {
 
     @Watch('value')
     protected watchValue(newValue) {
-        if (!this.mdcLinearProgress) {
+        if (!this.mdcLinearProgress || !this.isFinite(newValue)) {
             return;
         }
 
         this.mdcLinearProgress.progress = newValue;
+    }
+
+    private isFinite(value: unknown) {
+        return Number.isFinite(value);
     }
 }

--- a/src/components/linear-progress/linear-progress.tsx
+++ b/src/components/linear-progress/linear-progress.tsx
@@ -15,13 +15,13 @@ export class LinearProgress {
     /**
      * The value of the progress bar. Should be between `0` and `1`.
      */
-    @Prop()
+    @Prop({ reflect: true })
     public value: number = 0;
 
     /**
      * Puts the progress bar in an indeterminate state
      */
-    @Prop()
+    @Prop({ reflect: true })
     public indeterminate: boolean = false;
 
     @Element()


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/3585

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
