### PR TITLE
fix(menu): prevent long menus to overflow out of the screen

### DIFF
--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -2,15 +2,16 @@
 @use '@material/elevation';
 @use '@material/menu';
 
-:host {
+:host(limel-menu-surface) {
     display: block;
+    max-height: inherit;
 }
 
 @include menu-surface.core-styles;
 @include menu.core-styles;
 
 .mdc-menu-surface {
-    max-height: 100%;
+    max-height: inherit;
     position: relative;
     --mdc-menu-max-width: var(
         --menu-surface-width,


### PR DESCRIPTION
Last items of menus with many items could
be rendered outside of the screen, preventing
the user from reaching them by scrolling.
This was specially problematic for menus which
have a static placement in the UI.

fix: https://github.com/Lundalogik/lime-elements/issues/2477

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
