### PR TITLE
fix(checkbox): make color of icons in `readonly` more dark

### DIFF
--- a/src/components/checkbox/partial-styles/_readonly.scss
+++ b/src/components/checkbox/partial-styles/_readonly.scss
@@ -2,7 +2,7 @@
     opacity: 1;
     --mdc-ripple-press-opacity: 1;
     --mdc-checkbox-disabled-color: rgb(var(--contrast-1000));
-    --mdc-checkbox-ink-color: rgb(var(--color-white));
+    --mdc-checkbox-ink-color: var(--mdc-theme-on-primary);
 
     .mdc-checkbox__background {
         border-radius: 50%;
@@ -20,7 +20,7 @@
 
             &:after {
                 content: '–';
-                color: rgb(var(--color-white));
+                color: var(--mdc-theme-on-primary);
                 font-size: 1.25rem;
                 position: absolute;
             }


### PR DESCRIPTION
To sync the styles with `readonly` switch.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
