### PR TITLE
Fix/cascading menu list keyboard navigation

### DIFF
--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -4,10 +4,8 @@ import {
     MenuItem,
     MenuListType,
 } from '../../interface';
-import { MDCList, MDCListActionEvent } from '@material/list';
 import { MDCMenu, MDCMenuItemEvent } from '@material/menu';
 import { MDCRipple } from '@material/ripple';
-import { strings as listStrings } from '@material/list/constants';
 import { strings as menuStrings } from '@material/menu/constants';
 import {
     Component,
@@ -21,7 +19,6 @@ import {
 import { MenuListRenderer } from './menu-list-renderer';
 import { MenuListRendererConfig } from './menu-list-renderer-config';
 
-const { ACTION_EVENT } = listStrings;
 const { SELECTED_EVENT } = menuStrings;
 
 /**
@@ -73,7 +70,6 @@ export class MenuList {
 
     private config: MenuListRendererConfig;
     private MenuListRenderer = new MenuListRenderer();
-    private mdcList: MDCList;
     private mdcMenu: MDCMenu;
 
     /**
@@ -112,17 +108,7 @@ export class MenuList {
     }
 
     @Watch('items')
-    protected itemsChanged() {
-        if (!this.mdcList) {
-            return;
-        }
-
-        const MenuItems = this.items.filter(this.isMenuItem);
-
-        this.mdcList.selectedIndex = MenuItems.findIndex(
-            (item: MenuItem) => item.selected
-        );
-    }
+    protected itemsChanged() {}
 
     private setup = () => {
         this.setupMenu();
@@ -151,15 +137,8 @@ export class MenuList {
     };
 
     private teardown = () => {
-        this.mdcList?.unlisten(ACTION_EVENT, this.handleAction);
-        this.mdcList?.destroy();
-
         this.mdcMenu?.unlisten(SELECTED_EVENT, this.handleMenuSelect);
         this.mdcMenu?.destroy();
-    };
-
-    private handleAction = (event: MDCListActionEvent) => {
-        this.handleSingleSelect(event.detail.index);
     };
 
     private handleMenuSelect = (event: MDCMenuItemEvent) => {

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -108,7 +108,11 @@ export class MenuList {
     }
 
     @Watch('items')
-    protected itemsChanged() {}
+    protected itemsChanged() {
+        setTimeout(() => {
+            this.setup();
+        }, 0);
+    }
 
     private setup = () => {
         this.setupMenu();
@@ -116,6 +120,11 @@ export class MenuList {
     };
 
     private setupMenu = () => {
+        if (this.mdcMenu) {
+            this.teardown();
+            this.mdcMenu = null;
+        }
+
         const element = this.element.shadowRoot.querySelector('.mdc-menu');
         if (!element) {
             return;


### PR DESCRIPTION
The keyboard navigation doesn't work when we change the items in the menu, in the cascading menu PR.
This because the MDCMenu.items isn't in sync with what is actually rendered from the `this.items`.

We couldn't find a way to "force" a refresh, so we tried re-creating it which seems to fix our issues.

Here you can see how it doesn't work in [PR#2473](https://github.com/Lundalogik/lime-elements/pull/2473), and how it does work in [This PR#2482](https://github.com/Lundalogik/lime-elements/pull/2482)


https://github.com/Lundalogik/lime-elements/assets/1814702/b91b08ed-3de9-47ce-836a-f4edccec2931


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
