### PR TITLE
fix(popover): prevent large content to overflow the component's surface

### DIFF
--- a/src/components/popover-surface/popover-surface.scss
+++ b/src/components/popover-surface/popover-surface.scss
@@ -15,6 +15,8 @@
 
 .limel-popover-surface {
     flex: 1;
+    min-width: 0;
+    min-height: 0;
     border-radius: var(--popover-border-radius, functions.pxToRem(12));
     box-shadow: var(--shadow-depth-16);
 


### PR DESCRIPTION
Having large elements inside the popover surface would result in too wide or too tall popovers. Basically the content went beyond the `width` which was defined by `--popover-surface-width`.

fix: https://github.com/Lundalogik/crm-feature/issues/3623

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
