### PR TITLE
Fade out content that overflow out of the top and bottom edges of a dialog's content

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.scss
+++ b/src/components/breadcrumbs/breadcrumbs.scss
@@ -6,24 +6,18 @@
 */
 
 $padding: 0.5rem;
-$mask: linear-gradient(
-    to right,
-    transparent 0%,
-    black calc(0% + #{$padding}),
-    black calc(100% - #{$padding}),
-    transparent 100%
-);
 
 :host(limel-breadcrumbs) {
-    --limel-breadcrumbs-item-height: 1.5rem; // for internal use
-    --limel-breadcrumbs-gap: 0.75rem; // for internal use
-    --limel-breadcrumbs-gap: 0.75rem; // for internal use
+    --limel-breadcrumbs-item-height: 1.5rem;
+    --limel-breadcrumbs-gap: 0.75rem;
+    --limel-breadcrumbs-gap: 0.75rem;
     --limel-breadcrumbs-item-text-color: var(
         --breadcrumbs-item-text-color,
         rgb(var(--contrast-1500))
-    ); // for internal use
-    -webkit-mask-image: $mask;
-    mask-image: $mask;
+    );
+    @include mixins.fade-out-overflowed-content-on-edges(horizontally);
+    --limel-left-edge-fade-width: #{$padding};
+    --limel-right-edge-fade-width: #{$padding};
 }
 
 ol,

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -1,4 +1,5 @@
 @use '../../style/functions';
+@use '../../style/mixins';
 
 @use '../../style/internal/lime-theme';
 
@@ -16,7 +17,7 @@
  * @prop --dialog-max-width: Max width of the dialog.
  * @prop --dialog-max-height: Max height of the dialog.
  * @prop --dialog-border-radius: Border radius of the dialog corners
- * @prop --dialog-padding-top-bottom: Padding on top and bottom of dialog content. Defaults to `1.5rem`.
+ * @prop --dialog-padding-top-bottom: Padding on top and bottom of dialog content. Affects the height of fade-out effects on top and bottom edges when the content is scrollable and has overflowed out of the content area. Defaults to `1.5rem`. Note that if you use this variable and set it to numbers smaller than 1rem, you will loose the fade-out effects on the edges. If you have set these paddings to `0`, losing the fade out effects should be however fine for your use case! Because in such a case your intention is to handle the `overflow` internally in the component that is displayed in the dialog's content.
  * @prop --dialog-padding-left-right: Padding on the sides of dialog content. Defaults to `1.25rem`.
  */
 
@@ -74,59 +75,23 @@ $responsive-body-padding: 3vw; // 3% of viewport's width
     }
 
     .mdc-dialog__content {
+        --limel-top-edge-fade-height: var(--dialog-padding-top-bottom, 1.5rem);
+        --limel-bottom-edge-fade-height: var(
+            --dialog-padding-top-bottom,
+            1.5rem
+        );
+        @include mixins.fade-out-overflowed-content-on-edges(vertically);
+
         color: var(--mdc-theme-on-surface);
-        padding: var(
-                --dialog-padding-top-bottom,
-                min(1.5rem, $responsive-body-padding)
-            )
-            var(
-                --dialog-padding-left-right,
-                min(1.25rem, $responsive-body-padding)
-            );
+        padding-left: var(
+            --dialog-padding-left-right,
+            min(1.25rem, $responsive-body-padding)
+        );
+        padding-right: var(
+            --dialog-padding-left-right,
+            min(1.25rem, $responsive-body-padding)
+        );
     }
-}
-
-.scrollbox {
-    --dialog-background-color-transparent: rgba(var(--contrast-100), 0);
-    --dialog-scroll-shadow-color: rgba(var(--color-black), 0.2);
-    --dialog-scroll-shadow-color-transparent: rgba(var(--color-black), 0);
-
-    // Credit to the ever fantastic Lea Verou!
-    // http://lea.verou.me/2012/04/background-attachment-local/
-
-    /* prettier-ignore */
-    background:
-        /* Shadow covers */
-        linear-gradient(
-            var(--dialog-background-color) 30%,
-            var(--dialog-background-color-transparent)
-        ),
-        linear-gradient(
-            var(--dialog-background-color-transparent),
-            var(--dialog-background-color) 70%
-        )
-        0 100%,
-
-        /* Shadows */
-        radial-gradient(
-            farthest-side at 50% 0,
-            var(--dialog-scroll-shadow-color),
-            var(--dialog-scroll-shadow-color-transparent)
-        ),
-        radial-gradient(
-            farthest-side at 50% 100%,
-            var(--dialog-scroll-shadow-color),
-            var(--dialog-scroll-shadow-color-transparent)
-        )
-        0 100%;
-
-    background-repeat: no-repeat;
-    background-color: var(--dialog-background-color);
-    background-size: 100% functions.pxToRem(40), 100% functions.pxToRem(40),
-        100% functions.pxToRem(14), 100% functions.pxToRem(14);
-
-    /* Opera doesn't support this in the shorthand */
-    background-attachment: local, local, scroll, scroll;
 }
 
 #initialFocusElement {

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -164,7 +164,7 @@ export class Dialog {
                         <input type="text" id="initialFocusElement" />
                         {this.renderHeading()}
                         <div
-                            class="mdc-dialog__content scrollbox"
+                            class="mdc-dialog__content"
                             id={'limel-dialog-content-' + this.id}
                         >
                             <slot />

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -184,3 +184,64 @@
     white-space: nowrap;
     text-overflow: ellipsis;
 }
+
+/**
+ * This mixin will mask out the content that is close to
+ * the edges of a scrollable area.
+ * - If the scrollable content has `overflow-y`, use `vertically`
+ * as an argument for `$direction`.
+ - If the scrollable content has `overflow-x`, use `horizontally`
+ * as an argument for `$direction`.
+ *
+ * For the visual effect to work smoothly, we need to make sure that
+ * the size of the fade-out edge effect is the same as the
+ * internal paddings of the scrollable area. Otherwise, content of a
+ * scrollable area that does not have a padding will fade out before
+ * any scrolling has been done.
+ * This is why this mixin already adds paddings, which automatically
+ * default to the size of the fade-out effect.
+ * This size defaults to `1rem`, but to override the size use
+ * `--limel-top-edge-fade-height` & `--limel-bottom-edge-fade-height`
+ * when `vertically` argument is set, and use
+ * `--limel-left-edge-fade-width` & `--limel-right-edge-fade-width`
+ * when `horizontally` argument is set.
+ * Of course you can also programmatically increase and decrease the
+ * size of these variables for each edge, based on the amount of
+ * scrolling that has been done by the user. In this case, make sure
+ * to add a custom padding where the mixin is used, to override
+ * the paddings that are automatically added by the mixin in the
+ * compiled CSS code.
+ */
+@mixin fade-out-overflowed-content-on-edges($direction) {
+    @if $direction == vertically {
+        --limel-overflow-mask-vertical: linear-gradient(
+            to bottom,
+            transparent 0%,
+            black calc(0% + var(--limel-top-edge-fade-height, 1rem)),
+            black calc(100% - var(--limel-bottom-edge-fade-height, 1rem)),
+            transparent 100%
+        );
+
+        -webkit-mask-image: var(--limel-overflow-mask-vertical);
+        mask-image: var(--limel-overflow-mask-vertical);
+
+        padding-top: var(--limel-top-edge-fade-height, 1rem);
+        padding-bottom: var(--limel-bottom-edge-fade-height, 1rem);
+    } @else if $direction == horizontally {
+        --limel-overflow-mask-horizontal: linear-gradient(
+            to right,
+            transparent 0%,
+            black calc(0% + var(--limel-left-edge-fade-width, 1rem)),
+            black calc(100% - var(--limel-right-edge-fade-width, 1rem)),
+            transparent 100%
+        );
+
+        -webkit-mask-image: var(--limel-overflow-mask-horizontal);
+        mask-image: var(--limel-overflow-mask-horizontal);
+
+        padding-left: var(--limel-left-edge-fade-width, 1rem);
+        padding-right: var(--limel-right-edge-fade-width, 1rem);
+    } @else {
+        @error "Please specify the direction #{$direction}!";
+    }
+}


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/1998

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
