### PR TITLE
chore(packages): upgrade Kompendium from 0.12.3 to 0.12.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "jest-cli": "^27.5.1",
         "jsonlint-mod": "^1.7.6",
         "jsx-dom": "^8.0.7",
-        "kompendium": "^0.12.3",
+        "kompendium": "^0.12.5",
         "lodash-es": "^4.17.21",
         "material-components-web": "^13.0.0",
         "moment": "^2.29.4",
@@ -7440,9 +7440,9 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.3.tgz",
-      "integrity": "sha512-u1D8F55EHSgRRMo948TuP0U399JgSAfRoasvUJ6MXOri5Z8kxYPXSX9Cu6yuvIxyAkYnU6zB01ztr+2kmfb4ag==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.5.tgz",
+      "integrity": "sha512-W9LTUQr2YwVBJ1WMF8m+kS+vXQQfJbyMLyfjN0ao3lR4PFi2Tjps84pcnQORW0uHt3GqyeK+FuA13AZ+KY7ghQ==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.3.1",
@@ -16589,9 +16589,9 @@
       "dev": true
     },
     "kompendium": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.3.tgz",
-      "integrity": "sha512-u1D8F55EHSgRRMo948TuP0U399JgSAfRoasvUJ6MXOri5Z8kxYPXSX9Cu6yuvIxyAkYnU6zB01ztr+2kmfb4ag==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-0.12.5.tgz",
+      "integrity": "sha512-W9LTUQr2YwVBJ1WMF8m+kS+vXQQfJbyMLyfjN0ao3lR4PFi2Tjps84pcnQORW0uHt3GqyeK+FuA13AZ+KY7ghQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "jest-cli": "^27.5.1",
     "jsonlint-mod": "^1.7.6",
     "jsx-dom": "^8.0.7",
-    "kompendium": "^0.12.3",
+    "kompendium": "^0.12.5",
     "lodash-es": "^4.17.21",
     "material-components-web": "^13.0.0",
     "moment": "^2.29.4",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
