### PR TITLE
fix(picker): be able to clear all items in the picker when clicking 'clear all' button

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -693,10 +693,6 @@ export class Picker {
     }
 
     private handleCloseMenu() {
-        if (this.items.length > 0) {
-            return;
-        }
-
         this.clearInputField();
     }
 


### PR DESCRIPTION
**EDIT:** _Apparently the [original bug](https://github.com/Lundalogik/lime-crm-components/issues/1612) (which this revert would reintroduce) was worse than I had understood. So we shouldn't merge this without also having a fix or workaround for that bug. /Ads_

When we have multiple items in the picker and clicking the Clear all button in the picker not clearing all the items at all. This bug causes freezing of the whole component.

fix Lundalogik/crm-feature#3559


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
