### PR TITLE
Icon button: remove dependency of MDC

### DIFF
--- a/src/components/icon-button/icon-button.e2e.ts
+++ b/src/components/icon-button/icon-button.e2e.ts
@@ -8,9 +8,7 @@ describe('limel-icon-button', () => {
             page = await createPage(`
                 <limel-icon-button icon="unit-test" label="Add favorite"></limel-icon-button>
             `);
-            mdcIconButton = await page.find(
-                'limel-icon-button >>> .mdc-icon-button'
-            );
+            mdcIconButton = await page.find('limel-icon-button >>> button');
         });
         it('displays the correct label', () => {
             expect(mdcIconButton).toEqualAttribute(

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -1,11 +1,8 @@
 @use '../../style/mixins';
-@use '../../style/functions';
 
 /**
  * @prop --icon-background-color: Background color of the button.
  */
-
-$height-of-limel-button: functions.pxToRem(36);
 
 :host([hidden]) {
     display: none;
@@ -25,9 +22,9 @@ button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    height: $height-of-limel-button;
-    width: $height-of-limel-button;
 
+    height: 2.25rem;
+    width: 2.25rem;
     border-radius: 50%;
 
     :host([elevated]) & {
@@ -42,5 +39,5 @@ button {
 }
 
 limel-icon {
-    width: functions.pxToRem(20);
+    width: 1.25rem;
 }

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -1,6 +1,5 @@
 @use '../../style/mixins';
 @use '../../style/functions';
-@use '@material/icon-button/styles';
 
 /**
  * @prop --icon-background-color: Background color of the button.
@@ -16,17 +15,19 @@ $height-of-limel-button: functions.pxToRem(36);
     pointer-events: none;
 }
 
-.mdc-icon-button {
+button {
+    all: unset;
     @include mixins.is-flat-clickable(
         $background-color: var(--icon-background-color, transparent)
     );
+    @include mixins.visualize-keyboard-focus;
+
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    box-sizing: border-box;
     height: $height-of-limel-button;
     width: $height-of-limel-button;
-    padding: functions.pxToRem(2);
+
     border-radius: 50%;
 
     :host([elevated]) & {
@@ -38,16 +39,8 @@ $height-of-limel-button: functions.pxToRem(36);
     &:disabled {
         color: var(--mdc-theme-text-disabled-on-background);
     }
-
-    &:focus-visible {
-        // only when non-pointer input is being used,
-        // e.g. tabbed into using keyboard
-        box-shadow: var(--shadow-depth-8-focused);
-        border-radius: 50%;
-    }
 }
 
 limel-icon {
     width: functions.pxToRem(20);
-    height: functions.pxToRem(20);
 }

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -76,7 +76,6 @@ export class IconButton {
 
         return (
             <button
-                class="mdc-icon-button"
                 disabled={this.disabled}
                 aria-label={this.label}
                 title={this.label}


### PR DESCRIPTION
This component is very minimal and simple, and we are completely overwriting MDC styles with our own styles. 
We don't use MDC ripple effect, and nothing else from the MDC. 
There is no need for us to be dependent on MDC here anymore.


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
