### PR TITLE
feat(table): add variable for `padding-bottom`

### DIFF
--- a/src/components/table/partial-styles/tabulator-custom-styles.scss
+++ b/src/components/table/partial-styles/tabulator-custom-styles.scss
@@ -159,11 +159,8 @@
     }
 
     .has-aggregation {
-        .tabulator-tableHolder {
-            margin-bottom: functions.pxToRem(
-                24
-            ); // makes sure aggregations row doesn't cover the last table row, and horizontal scroll bar is shown on windows
-        }
+        --limel-table-height-of-aggregations-row: 1.5rem;
+        // makes sure aggregations row doesn't cover the last table row, and horizontal scroll bar is shown on windows
     }
 
     .select-all {

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -5,6 +5,7 @@
 
 /*
 * @prop --table-max-column-width: defines a maximum width for columns using standard size units, to prevent the table from growing too wide. Set to `auto` if you do not need this limitation. Defaults to `40rem`.
+* @prop --table-scrollable-area-padding-bottom: Allows adding extra space at the bottom of the scrollable area of the table. This space will be added between the last row and the aggregations row (if present), or the bottom edge of the table. Defaults to `0`.
 */
 
 $width-of-sorter-arrow: 0.5rem;
@@ -50,6 +51,10 @@ $table--limel-table--row-selector: 1;
         color: var(--table-text-color);
     }
     .tabulator-tableHolder {
+        padding-bottom: calc(
+            var(--table-scrollable-area-padding-bottom, 0rem) +
+                var(--limel-table-height-of-aggregations-row, 0rem)
+        );
         .tabulator-table {
             color: var(--table-text-color);
             background-color: transparent;


### PR DESCRIPTION
In a certain use cases the scrollable area
of a table may need an extra `padding-bottom`.
For example, when another element with a `fixed` or `absolute` `position` is overlayed on the table.

fix https://github.com/Lundalogik/crm-feature/issues/3636

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
