### PR TITLE
fix(input-field): handle completions changing after component is loaded

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -328,6 +328,11 @@ export class InputField {
         }
     }
 
+    @Watch('completions')
+    protected completionsWatcher() {
+        this.mapCompletions();
+    }
+
     private initialize = () => {
         const element =
             this.limelInputField.shadowRoot.querySelector('.mdc-text-field');
@@ -337,12 +342,16 @@ export class InputField {
 
         this.mdcTextField = new MDCTextField(element);
 
-        this.completionsList = [...this.completions].map((item) => {
-            return { text: item };
-        });
+        this.mapCompletions();
 
         window.addEventListener('resize', this.layout, { passive: true });
         this.limelInputField.addEventListener('focus', this.setFocus);
+    };
+
+    private mapCompletions = () => {
+        this.completionsList = [...this.completions].map((item) => {
+            return { text: item };
+        });
     };
 
     private setFocus = () => {


### PR DESCRIPTION
To test this, you can go to the _Input Field with Completions_ example in the docs, inspect the component, and make sure you select the `limel-input-field` element. Then go to the console and run `$0.completions = ['hej', 'svejs']`. Then focus the input field, and the completions should have updated.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
