### PR TITLE
fix(picker): don't display clear all button when the suggestions are …

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -269,7 +269,7 @@ export class Picker {
                 onStartEdit={this.handleInputFieldFocus}
                 onStopEdit={this.handleStopEditAndBlur}
                 emptyInputOnBlur={false}
-                clearAllButton={this.multiple}
+                clearAllButton={this.multiple && !this.chipSetEditMode}
                 {...props}
             />,
             this.renderDropdown(),


### PR DESCRIPTION
…being shown

This has two reasons:
1. The button is not functional, because the dropdown should close first for the
user to be actually able to press the clear all button.
2. It causes another bug, where you cannot close the suggestion list if you have clicked on the close all button, while the list was open.

fix https://github.com/Lundalogik/crm-feature/issues/3559


## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
