### PR TITLE
fix(action-bar): do not display tooltip of invisible action buttons

### DIFF
--- a/src/components/action-bar/action-bar-item/action-bar-item.scss
+++ b/src/components/action-bar/action-bar-item/action-bar-item.scss
@@ -9,6 +9,7 @@ limel-action-bar-item {
 
     &:not([is-visible]) {
         opacity: 0;
+        pointer-events: none;
     }
 }
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2510

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
