### PR TITLE
Fix exported types

### DIFF
--- a/src/components/action-bar/action-bar-item/action-bar-item.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-item.tsx
@@ -6,9 +6,8 @@ import {
     h,
     Prop,
 } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
+import { ActionBarItem, ListSeparator } from '../../../interface';
 import { createRandomString } from '../../../util/random-string';
-import { ListSeparator } from 'src/interface';
 import {
     makeEnterClickable,
     removeEnterClickable,

--- a/src/components/action-bar/action-bar-item/action-bar-overflow-menu.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-overflow-menu.tsx
@@ -1,11 +1,11 @@
 import { Component, Prop, h, Event, EventEmitter } from '@stencil/core';
 import {
-    MenuItem,
-    LimelMenuCustomEvent,
-    ListSeparator,
     ActionBarItem,
+    ListSeparator,
+    MenuItem,
     OpenDirection,
-} from '@limetech/lime-elements';
+} from '../../../interface';
+import { LimelMenuCustomEvent } from 'src/components';
 
 /**
  * @private

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -8,9 +8,12 @@ import {
     State,
     Element,
 } from '@stencil/core';
-import { ActionBarItem } from './action-bar.types';
-import { MenuItem, OpenDirection } from '../menu/menu.types';
-import { ListSeparator } from '../list/list-item.types';
+import {
+    ActionBarItem,
+    MenuItem,
+    OpenDirection,
+    ListSeparator,
+} from '../../interface';
 import { isItem } from './isItem';
 
 /**

--- a/src/components/action-bar/action-bar.types.ts
+++ b/src/components/action-bar/action-bar.types.ts
@@ -1,4 +1,4 @@
-import { MenuItem } from '../menu/menu.types';
+import { MenuItem } from '../../interface';
 
 /**
  * Renders the button in the action bar without their labels.

--- a/src/components/action-bar/examples/action-bar-colors.tsx
+++ b/src/components/action-bar/examples/action-bar-colors.tsx
@@ -1,6 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
-import { ListSeparator } from 'src/interface';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 /**
  * Using colors

--- a/src/components/action-bar/examples/action-bar-floating.tsx
+++ b/src/components/action-bar/examples/action-bar-floating.tsx
@@ -1,6 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
-import { ListSeparator } from 'src/interface';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 /**
  * Floating Example

--- a/src/components/action-bar/examples/action-bar-in-list.tsx
+++ b/src/components/action-bar/examples/action-bar-in-list.tsx
@@ -1,6 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
-import { ListSeparator } from 'src/interface';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 @Component({
     tag: 'limel-example-action-bar-in-list',

--- a/src/components/action-bar/examples/action-bar-overflow-menu.tsx
+++ b/src/components/action-bar/examples/action-bar-overflow-menu.tsx
@@ -1,6 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
-import { ListSeparator } from 'src/interface';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 /**
  * Overflow menu

--- a/src/components/action-bar/examples/action-bar-styling.tsx
+++ b/src/components/action-bar/examples/action-bar-styling.tsx
@@ -1,6 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
-import { ListSeparator } from 'src/interface';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 /**
  * Styling

--- a/src/components/action-bar/examples/action-bar.tsx
+++ b/src/components/action-bar/examples/action-bar.tsx
@@ -1,6 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ActionBarItem } from '../action-bar.types';
-import { ListSeparator } from 'src/interface';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 /**
  * Basic Example

--- a/src/components/action-bar/isItem.ts
+++ b/src/components/action-bar/isItem.ts
@@ -1,5 +1,4 @@
-import { ListSeparator } from '../list/list-item.types';
-import { ActionBarItem } from './action-bar.types';
+import { ActionBarItem, ListSeparator } from '../../interface';
 
 export function isItem(
     item: ActionBarItem | ListSeparator

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -6,7 +6,7 @@ import {
     EventEmitter,
     Prop,
 } from '@stencil/core';
-import { BreadcrumbsItem } from './breadcrumbs.types';
+import { BreadcrumbsItem } from '../../interface';
 import {
     makeEnterClickable,
     removeEnterClickable,

--- a/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -1,5 +1,4 @@
-import { Link } from '@limetech/lime-elements';
-import { Icon } from 'src/global/shared-types/icon.types';
+import { Icon, Link } from '../../interface';
 
 export interface BreadcrumbsItem {
     /**

--- a/src/components/breadcrumbs/examples/breadcrumbs-divider.tsx
+++ b/src/components/breadcrumbs/examples/breadcrumbs-divider.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { BreadcrumbsItem } from '../breadcrumbs.types';
+import { BreadcrumbsItem } from '@limetech/lime-elements';
 
 /**
  * Changing the divider

--- a/src/components/breadcrumbs/examples/breadcrumbs-icon-only.tsx
+++ b/src/components/breadcrumbs/examples/breadcrumbs-icon-only.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { BreadcrumbsItem } from '../breadcrumbs.types';
+import { BreadcrumbsItem } from '@limetech/lime-elements';
 
 /**
  * Using icons

--- a/src/components/breadcrumbs/examples/breadcrumbs-links.tsx
+++ b/src/components/breadcrumbs/examples/breadcrumbs-links.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { BreadcrumbsItem } from '../breadcrumbs.types';
+import { BreadcrumbsItem } from '@limetech/lime-elements';
 
 /**
  * Items as hyperlinks

--- a/src/components/breadcrumbs/examples/breadcrumbs-styling.tsx
+++ b/src/components/breadcrumbs/examples/breadcrumbs-styling.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { BreadcrumbsItem } from '../breadcrumbs.types';
+import { BreadcrumbsItem } from '@limetech/lime-elements';
 
 /**
  * Styling

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -7,7 +7,7 @@ import {
     State,
     Watch,
 } from '@stencil/core';
-import { Button } from '../button/button.types';
+import { Button } from '../../interface';
 import { createRandomString } from '../../util/random-string';
 
 /**

--- a/src/components/button-group/examples/button-group-composite.tsx
+++ b/src/components/button-group/examples/button-group-composite.tsx
@@ -1,6 +1,5 @@
 import { Component, h, Prop, State } from '@stencil/core';
-import { Button } from '../../button/button.types';
-import { LimelButtonGroupCustomEvent } from '@limetech/lime-elements';
+import { Button, LimelButtonGroupCustomEvent } from '@limetech/lime-elements';
 
 /**
  * Composite

--- a/src/components/callout/callout.tsx
+++ b/src/components/callout/callout.tsx
@@ -1,7 +1,6 @@
 import { Component, h, Prop } from '@stencil/core';
-import { CalloutType } from './callout.types';
+import { CalloutType, Languages } from '../../interface';
 import { getHeading, getIcon } from './callout.helpers';
-import { Languages } from '@limetech/lime-elements';
 
 /**
  * Callouts—also known as Admonitions—are useful for including supportive or

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -1,4 +1,4 @@
-import { Chip, Languages } from '@limetech/lime-elements';
+import { Chip, Languages } from '../../interface';
 import {
     MDCChipInteractionEvent,
     MDCChipSelectionEvent,

--- a/src/components/chip-set/examples/chip-set-composite.tsx
+++ b/src/components/chip-set/examples/chip-set-composite.tsx
@@ -1,6 +1,5 @@
 import { Component, h, Prop, State } from '@stencil/core';
-import { Languages } from '../../date-picker/date.types';
-import { Chip } from '../chip.types';
+import { Chip, Languages } from '@limetech/lime-elements';
 
 /**
  * Composite

--- a/src/components/circular-progress/circular-progress.tsx
+++ b/src/components/circular-progress/circular-progress.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
-import { CircularProgressSize } from './circular-progress.types';
+import { CircularProgressSize } from '../../interface';
 import { abbreviate } from '../badge/format';
 
 const PERCENT = 100;

--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -8,7 +8,7 @@ import {
     State,
     Watch,
 } from '@stencil/core';
-import { ColorScheme, Language } from './code-editor.types';
+import { ColorScheme, Language } from '../../interface';
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/selection/active-line';

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { FormComponent } from '../form/form.types';
+import { FormComponent } from '../../interface';
 import { brightnesses, colors, getColorName, getCssColor } from './swatches';
 
 /**

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable multiline-ternary */
 import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
-import { FormComponent } from '../form/form.types';
+import { FormComponent } from '../../interface';
 
 /**
  * This component enables you to select a swatch from out color palette, simply

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -10,7 +10,7 @@ import {
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
 import { isAndroidDevice, isIOSDevice } from '../../util/device';
-import { DateType, InputType, Languages } from '@limetech/lime-elements';
+import { DateType, InputType, Languages } from '../../interface';
 import { DateFormatter } from './dateFormatter';
 import { MDCTextField } from '@material/textfield';
 

--- a/src/components/date-picker/dateFormatter.ts
+++ b/src/components/date-picker/dateFormatter.ts
@@ -6,7 +6,7 @@ import 'moment/locale/nb';
 import 'moment/locale/nl';
 import 'moment/locale/sv';
 import moment from 'moment/moment';
-import { DateType } from './date.types';
+import { DateType } from '../../interface';
 
 export class DateFormatter {
     private language: string;

--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
@@ -1,5 +1,5 @@
 import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
-import { DateType, Languages } from '@limetech/lime-elements';
+import { DateType, Languages } from '../../../interface';
 import translate from '../../../global/translations';
 import { DatePicker as DateOnlyPicker } from '../pickers/DatePicker';
 import { DatetimePicker } from '../pickers/DatetimePicker';

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -1,4 +1,4 @@
-import { DialogHeading, ClosingActions } from '@limetech/lime-elements';
+import { DialogHeading, ClosingActions } from '../../interface';
 import { MDCDialog } from '@material/dialog';
 import {
     Component,

--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -7,7 +7,7 @@ import {
     State,
     Watch,
 } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '../../../interface';
 import { createRandomString } from '../../../util/random-string';
 
 /**

--- a/src/components/dock/dock.tsx
+++ b/src/components/dock/dock.tsx
@@ -7,7 +7,7 @@ import {
     Prop,
     State,
 } from '@stencil/core';
-import { DockItem } from './dock.types';
+import { DockItem } from '../../interface';
 
 const DEFAULT_MOBILE_BREAKPOINT = 700;
 

--- a/src/components/dock/examples/dock-basic.tsx
+++ b/src/components/dock/examples/dock-basic.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '@limetech/lime-elements';
 
 /**
  * Basic Example

--- a/src/components/dock/examples/dock-colors-css.tsx
+++ b/src/components/dock/examples/dock-colors-css.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '@limetech/lime-elements';
 
 /**
  * Using CSS color variables for theming the Dock

--- a/src/components/dock/examples/dock-custom-component.tsx
+++ b/src/components/dock/examples/dock-custom-component.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '@limetech/lime-elements';
 
 /**
  * Displaying a custom component after Dock item is clicked

--- a/src/components/dock/examples/dock-expanded.tsx
+++ b/src/components/dock/examples/dock-expanded.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '@limetech/lime-elements';
 
 /**
  * Basic Example expanded

--- a/src/components/dock/examples/dock-mobile.tsx
+++ b/src/components/dock/examples/dock-mobile.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '@limetech/lime-elements';
 
 /**
  * Setting a horizontal layout for mobile devices.

--- a/src/components/dock/examples/dock-notification.tsx
+++ b/src/components/dock/examples/dock-notification.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { DockItem } from '../dock.types';
+import { DockItem } from '@limetech/lime-elements';
 
 /**
  * Displaying a notification badge

--- a/src/components/file/file-metadata.ts
+++ b/src/components/file/file-metadata.ts
@@ -1,4 +1,4 @@
-import { FileInfo } from '@limetech/lime-elements';
+import { FileInfo } from '../../interface';
 import { getIconForFile } from './icons';
 import { getIconFillColorForFile } from './icon-fill-colors';
 import { getIconBackgroundColorForFile } from './icon-background-colors';

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -1,5 +1,5 @@
 import translate from '../../global/translations';
-import { Chip, FileInfo, Languages } from '@limetech/lime-elements';
+import { Chip, FileInfo, Languages } from '../../interface';
 import { MDCTextField } from '@material/textfield';
 import {
     Component,

--- a/src/components/flex-container/flex-container.tsx
+++ b/src/components/flex-container/flex-container.tsx
@@ -2,7 +2,7 @@ import {
     FlexContainerAlign,
     FlexContainerDirection,
     FlexContainerJustify,
-} from '@limetech/lime-elements';
+} from '../../interface';
 import { Component, h, Prop } from '@stencil/core';
 
 /**

--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { WidgetProps } from '../widgets/types';
 import { LimeElementsAdapter } from './base-adapter';
 import { capitalize } from 'lodash-es';
-import { LimeSchemaOptions } from '../form.types';
+import { LimeSchemaOptions } from '../../../interface';
 
 interface WidgetAdapterProps {
     name: string;

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -1,6 +1,9 @@
 import { Component, h, Prop, EventEmitter, Event } from '@stencil/core';
-import { FormComponent, LimelPickerCustomEvent } from '@limetech/lime-elements';
-import { ListItem } from '../../list/list-item.types';
+import {
+    FormComponent,
+    LimelPickerCustomEvent,
+    ListItem,
+} from '@limetech/lime-elements';
 
 @Component({
     tag: 'limel-example-custom-picker',

--- a/src/components/form/examples/props-factory-picker.tsx
+++ b/src/components/form/examples/props-factory-picker.tsx
@@ -1,6 +1,9 @@
 import { Component, h, Prop, EventEmitter, Event } from '@stencil/core';
-import { FormComponent, LimelPickerCustomEvent } from '@limetech/lime-elements';
-import { ListItem } from '../../list/list-item.types';
+import {
+    FormComponent,
+    LimelPickerCustomEvent,
+    ListItem,
+} from '@limetech/lime-elements';
 
 @Component({
     tag: 'limel-example-props-factory-picker',

--- a/src/components/form/examples/server-errors.tsx
+++ b/src/components/form/examples/server-errors.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { ValidationError } from '../form.types';
+import { ValidationError } from '@limetech/lime-elements';
 import { schema } from './list-schema';
 
 /**

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import JSONSchemaForm, { AjvError } from '@rjsf/core';
 import retargetEvents from 'react-shadow-dom-retarget-events';
-import { FormError, ValidationError, ValidationStatus } from './form.types';
+import { FormError, ValidationError, ValidationStatus } from '../../interface';
 import {
     ArrayFieldTemplate,
     FieldTemplate,

--- a/src/components/form/internal.types.ts
+++ b/src/components/form/internal.types.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from 'json-schema';
-import { LimeSchemaOptions } from './form.types';
+import { LimeSchemaOptions } from '../../interface';
 
 export interface LimeJSONSchema extends JSONSchema7 {
     lime?: LimeSchemaOptions;

--- a/src/components/form/templates/array-field-collapsible-item.ts
+++ b/src/components/form/templates/array-field-collapsible-item.ts
@@ -1,4 +1,4 @@
-import { Action } from '@limetech/lime-elements';
+import { Action } from '../../collapsible-section/action';
 import React from 'react';
 import { findTitle } from './common';
 import { ArrayFieldItem, Runnable } from './types';

--- a/src/components/form/templates/field.ts
+++ b/src/components/form/templates/field.ts
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from 'react';
-import { GridLayoutOptions } from '../form.types';
+import { GridLayoutOptions } from '../../../interface';
 import { isObjectType } from '../schema';
 
 export const FieldTemplate = (props) => {

--- a/src/components/form/templates/grid-layout.ts
+++ b/src/components/form/templates/grid-layout.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormLayoutOptions, GridLayoutOptions } from '../form.types';
+import { FormLayoutOptions, GridLayoutOptions } from '../../../interface';
 
 const MAX_COLUMNS = 5;
 const MAX_COLUMN_WIDTH = 15;

--- a/src/components/form/widgets/select.ts
+++ b/src/components/form/widgets/select.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Option } from '../../select/option.types';
+import { Option } from '../../../interface';
 import { isMultiple } from '../../../util/multiple';
 import { LimeElementsWidgetAdapter } from '../adapters';
 import { WidgetProps } from './types';

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Prop, Watch } from '@stencil/core';
 import config from '../../global/config';
 import iconCache from '../../global/icon-cache/factory';
-import { IconSize } from './icon.types';
+import { IconSize } from '../../interface';
 
 /**
  * The recommended icon library for use with Lime Elements is the Windows 10 set

--- a/src/components/info-tile/examples/info-tile-progress.tsx
+++ b/src/components/info-tile/examples/info-tile-progress.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { InfoTileProgress } from '../info-tile.types';
+import { InfoTileProgress } from '@limetech/lime-elements';
 
 /**
  * Displaying a progress bar

--- a/src/components/info-tile/examples/info-tile-styling.tsx
+++ b/src/components/info-tile/examples/info-tile-styling.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { InfoTileProgress } from '../info-tile.types';
+import { InfoTileProgress } from '@limetech/lime-elements';
 
 /**
  * How to style the Info tile

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -1,6 +1,5 @@
 import { Component, Prop, h } from '@stencil/core';
-import { InfoTileProgress } from './info-tile.types';
-import { Link } from '@limetech/lime-elements';
+import { InfoTileProgress, Link } from '../../interface';
 
 /**
  * This component can be used on places such as a start page or a dashboard.

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -24,11 +24,11 @@ import {
     TAB,
     TAB_KEY_CODE,
 } from '../../util/keycodes';
-import { InputType } from './input-field.types';
-import { LimelListCustomEvent, ListItem } from '@limetech/lime-elements';
+import { InputType, ListItem } from '../../interface';
 import { getHref, getTarget } from '../../util/link-helper';
 import { JSXBase } from '@stencil/core/internal';
 import { createRandomString } from '../../util/random-string';
+import { LimelListCustomEvent } from 'src/components';
 
 interface LinkProperties {
     href: string;

--- a/src/components/list/list-item.types.ts
+++ b/src/components/list/list-item.types.ts
@@ -1,4 +1,4 @@
-import { MenuItem } from '../menu/menu.types';
+import { MenuItem } from '../../interface';
 
 export interface ListItem<T = any> {
     /**

--- a/src/components/list/list-renderer-config.ts
+++ b/src/components/list/list-renderer-config.ts
@@ -1,4 +1,4 @@
-import { IconSize, ListType } from '@limetech/lime-elements';
+import { IconSize, ListType } from '../../interface';
 
 export interface ListRendererConfig {
     isOpen?: boolean;

--- a/src/components/list/list-renderer.tsx
+++ b/src/components/list/list-renderer.tsx
@@ -1,4 +1,4 @@
-import { ListItem, ListSeparator, MenuItem } from '@limetech/lime-elements';
+import { ListItem, ListSeparator, MenuItem } from '../../interface';
 import { h } from '@stencil/core';
 import { CheckboxTemplate } from '../checkbox/checkbox.template';
 import { ListRendererConfig } from './list-renderer-config';

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -1,9 +1,4 @@
-import {
-    IconSize,
-    ListItem,
-    ListSeparator,
-    ListType,
-} from '@limetech/lime-elements';
+import { IconSize, ListItem, ListSeparator, ListType } from '../../interface';
 import { MDCList, MDCListActionEvent } from '@material/list';
 import { strings as listStrings } from '@material/list/constants';
 import {

--- a/src/components/menu-list/menu-list-renderer-config.ts
+++ b/src/components/menu-list/menu-list-renderer-config.ts
@@ -1,4 +1,4 @@
-import { IconSize, MenuListType } from '@limetech/lime-elements';
+import { IconSize, MenuListType } from '../../interface';
 
 export interface MenuListRendererConfig {
     isOpen?: boolean;

--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -1,4 +1,4 @@
-import { ListSeparator, MenuItem } from '@limetech/lime-elements';
+import { ListSeparator, MenuItem } from '../../interface';
 import { h } from '@stencil/core';
 import { MenuListRendererConfig } from './menu-list-renderer-config';
 

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -1,9 +1,9 @@
 import {
     IconSize,
-    MenuItem,
     ListSeparator,
+    MenuItem,
     MenuListType,
-} from '@limetech/lime-elements';
+} from '../../interface';
 import { MDCList, MDCListActionEvent } from '@material/list';
 import { MDCMenu, MDCMenuItemEvent } from '@material/menu';
 import { MDCRipple } from '@material/ripple';

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -9,11 +9,7 @@ import {
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
 import { zipObject } from 'lodash-es';
-import {
-    ListSeparator,
-    MenuItem,
-    OpenDirection,
-} from '@limetech/lime-elements';
+import { ListSeparator, MenuItem, OpenDirection } from '../../interface';
 
 /**
  * @slot trigger - Element to use as a trigger for the menu.

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -1,12 +1,13 @@
 import {
     Action,
+    ActionPosition,
+    ActionScrollBehavior,
     LimelPickerCustomEvent,
     LimelSelectCustomEvent,
     ListItem,
     Option,
 } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { ActionScrollBehavior, ActionPosition } from '../actions.types';
 
 /**
  * With static actions

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -1,11 +1,11 @@
 import {
     Action,
+    ActionPosition,
+    ActionScrollBehavior,
     Chip,
-    LimelChipSetCustomEvent,
-    LimelListCustomEvent,
     ListItem,
     Searcher,
-} from '@limetech/lime-elements';
+} from '../../interface';
 import {
     Component,
     Element,
@@ -31,7 +31,7 @@ import {
     TAB_KEY_CODE,
 } from '../../util/keycodes';
 import { createRandomString } from '../../util/random-string';
-import { ActionScrollBehavior, ActionPosition } from './actions.types';
+import { LimelChipSetCustomEvent, LimelListCustomEvent } from 'src/components';
 
 const SEARCH_DEBOUNCE = 500;
 const CHIP_SET_TAG_NAME = 'limel-chip-set';

--- a/src/components/picker/searcher.types.ts
+++ b/src/components/picker/searcher.types.ts
@@ -1,4 +1,4 @@
-import { ListItem } from '../list/list-item.types';
+import { ListItem } from '../../interface';
 
 /**
  * A search function that takes a search-string as an argument, and returns

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -11,7 +11,7 @@ import { createRandomString } from '../../util/random-string';
 import { zipObject } from 'lodash-es';
 import { portalContains } from '../portal/contains';
 import { ESCAPE } from '../../util/keycodes';
-import { OpenDirection } from '../menu/menu.types';
+import { OpenDirection } from '../../interface';
 
 /**
  * A popover is an impermanent layer that is displayed on top of other content

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Prop, Watch } from '@stencil/core';
-import { OpenDirection } from '../menu/menu.types';
+import { OpenDirection } from '../../interface';
 import {
     createPopper,
     Instance,

--- a/src/components/progress-flow/examples/progress-flow-basic.tsx
+++ b/src/components/progress-flow/examples/progress-flow-basic.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Basic Example

--- a/src/components/progress-flow/examples/progress-flow-colors-css.tsx
+++ b/src/components/progress-flow/examples/progress-flow-colors-css.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Customizing colors further, using CSS

--- a/src/components/progress-flow/examples/progress-flow-colors.tsx
+++ b/src/components/progress-flow/examples/progress-flow-colors.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Using colors

--- a/src/components/progress-flow/examples/progress-flow-narrow.tsx
+++ b/src/components/progress-flow/examples/progress-flow-narrow.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Compact layout

--- a/src/components/progress-flow/examples/progress-flow-off-progress-steps.tsx
+++ b/src/components/progress-flow/examples/progress-flow-off-progress-steps.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Example with off-progress steps

--- a/src/components/progress-flow/examples/progress-flow-with-disabled-step.tsx
+++ b/src/components/progress-flow/examples/progress-flow-with-disabled-step.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Disabled steps

--- a/src/components/progress-flow/examples/progress-flow-with-secondary-text.tsx
+++ b/src/components/progress-flow/examples/progress-flow-with-secondary-text.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '@limetech/lime-elements';
 
 /**
  * Example with secondary text

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.tsx
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.tsx
@@ -6,7 +6,7 @@ import {
     h,
     Prop,
 } from '@stencil/core';
-import { FlowItem } from '../progress-flow.types';
+import { FlowItem } from '../../../interface';
 
 /**
  * @private

--- a/src/components/progress-flow/progress-flow.tsx
+++ b/src/components/progress-flow/progress-flow.tsx
@@ -6,7 +6,7 @@ import {
     h,
     Prop,
 } from '@stencil/core';
-import { FlowItem } from './progress-flow.types';
+import { FlowItem } from '../../interface';
 
 /**
  * @exampleComponent limel-example-progress-flow-basic

--- a/src/components/progress-flow/progress-flow.types.ts
+++ b/src/components/progress-flow/progress-flow.types.ts
@@ -1,4 +1,4 @@
-import { ListItem } from '../list/list-item.types';
+import { ListItem } from '../../interface';
 
 export interface FlowItem extends ListItem {
     /**

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -1,4 +1,4 @@
-import { ListItem, Option } from '@limetech/lime-elements';
+import { ListItem, Option } from '../../interface';
 import { FunctionalComponent, h } from '@stencil/core';
 import { isMultiple } from '../../util/multiple';
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1,4 +1,4 @@
-import { ListItem, Option } from '@limetech/lime-elements';
+import { ListItem, Option } from '../../interface';
 import { MDCFloatingLabel } from '@material/floating-label';
 import { MDCSelectHelperText } from '@material/select/helper-text';
 import {

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h } from '@stencil/core';
-import { Link } from '@limetech/lime-elements';
+import { Link } from '../../interface';
 
 /**
  * This component can be used on places such as a start page or a dashboard.

--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -1,4 +1,4 @@
-import { Languages } from '@limetech/lime-elements';
+import { Languages } from '../../interface';
 import { MDCSnackbar, MDCSnackbarCloseEvent } from '@material/snackbar';
 import {
     Component,

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -1,4 +1,4 @@
-import { SpinnerSize } from '@limetech/lime-elements';
+import { SpinnerSize } from '../../interface';
 import { Component, Prop, h } from '@stencil/core';
 
 /**

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -1,5 +1,5 @@
 import { Component, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
-import { ListSeparator, MenuItem } from '@limetech/lime-elements';
+import { ListSeparator, MenuItem } from '../../interface';
 
 /**
  * A split button is a button with two components:

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@stencil/core';
 import { MDCTabBar, MDCTabBarActivatedEvent } from '@material/tab-bar';
 import { strings } from '@material/tab-bar/constants';
-import { Tab } from './tab.types';
+import { Tab } from '../../interface';
 import { isEqual, difference } from 'lodash-es';
 import { setActiveTab } from './tabs';
 

--- a/src/components/tab-bar/tabs.ts
+++ b/src/components/tab-bar/tabs.ts
@@ -1,4 +1,4 @@
-import { Tab } from './tab.types';
+import { Tab } from '../../interface';
 
 /**
  * Set a tabs `active` state to true in a list of tabs. The previous tab with

--- a/src/components/tab-panel/tab-panel.tsx
+++ b/src/components/tab-panel/tab-panel.tsx
@@ -8,7 +8,7 @@ import {
     Host,
     Watch,
 } from '@stencil/core';
-import { Tab } from '../tab-bar/tab.types';
+import { Tab } from '../../interface';
 import { dispatchResizeEvent } from '../../util/dispatch-resize-event';
 
 /**

--- a/src/components/tab-panel/tab-panel.types.ts
+++ b/src/components/tab-panel/tab-panel.types.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '@stencil/core';
-import { Tab } from '../tab-bar/tab.types';
+import { Tab } from '../../interface';
 
 /**
  * Interface for components rendered inside a `limel-tab-panel`

--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -1,4 +1,8 @@
-import { Column, ColumnSorter, ColumnAggregatorFunction } from './table.types';
+import {
+    Column,
+    ColumnSorter,
+    ColumnAggregatorFunction,
+} from '../../interface';
 import Tabulator from 'tabulator-tables';
 import { escape } from 'html-escaper';
 import { ElementPool } from './element-pool';

--- a/src/components/table/examples/header-menu.tsx
+++ b/src/components/table/examples/header-menu.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
-import { ListItem } from '../../list/list-item.types';
+import { ListItem } from '@limetech/lime-elements';
 
 @Component({
     tag: 'limel-example-header-menu',

--- a/src/components/table/examples/table-activate-row.tsx
+++ b/src/components/table/examples/table-activate-row.tsx
@@ -1,6 +1,5 @@
-import { LimelTableCustomEvent } from '@limetech/lime-elements';
+import { Column, LimelTableCustomEvent } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
 import { persons, Person } from './persons';
 
 /**

--- a/src/components/table/examples/table-custom-components.tsx
+++ b/src/components/table/examples/table-custom-components.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 

--- a/src/components/table/examples/table-default-sorted.tsx
+++ b/src/components/table/examples/table-default-sorted.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column, ColumnSorter } from '../table.types';
+import { Column, ColumnSorter } from '@limetech/lime-elements';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 

--- a/src/components/table/examples/table-header-menu.tsx
+++ b/src/components/table/examples/table-header-menu.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { persons, Person } from './persons';
 
 /**

--- a/src/components/table/examples/table-layout-default.tsx
+++ b/src/components/table/examples/table-layout-default.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { invoices, Invoice } from './invoices';
 
 /**

--- a/src/components/table/examples/table-layout-lowDensity.tsx
+++ b/src/components/table/examples/table-layout-lowDensity.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { invoices, Invoice } from './invoices';
 
 /**

--- a/src/components/table/examples/table-layout-stretchColumns.tsx
+++ b/src/components/table/examples/table-layout-stretchColumns.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { invoices, Invoice } from './invoices';
 
 /**

--- a/src/components/table/examples/table-layout-stretchLastColumn.tsx
+++ b/src/components/table/examples/table-layout-stretchLastColumn.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { invoices, Invoice } from './invoices';
 
 /**

--- a/src/components/table/examples/table-local.tsx
+++ b/src/components/table/examples/table-local.tsx
@@ -1,5 +1,9 @@
 import { Component, h, State } from '@stencil/core';
-import { Column, ColumnSorter, ColumnAggregatorType } from '../table.types';
+import {
+    Column,
+    ColumnSorter,
+    ColumnAggregatorType,
+} from '@limetech/lime-elements';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 

--- a/src/components/table/examples/table-low-clickable-rows.tsx
+++ b/src/components/table/examples/table-low-clickable-rows.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 
 /**
  * Visualizing clickable rows better

--- a/src/components/table/examples/table-movable-columns.tsx
+++ b/src/components/table/examples/table-movable-columns.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 

--- a/src/components/table/examples/table-remote.tsx
+++ b/src/components/table/examples/table-remote.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column, TableParams, ColumnSorter } from '../table.types';
+import { Column, TableParams, ColumnSorter } from '@limetech/lime-elements';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 

--- a/src/components/table/examples/table-selectable-rows.tsx
+++ b/src/components/table/examples/table-selectable-rows.tsx
@@ -1,6 +1,9 @@
-import { LimelTableCustomEvent } from '@limetech/lime-elements';
+import {
+    Column,
+    ColumnAggregate,
+    LimelTableCustomEvent,
+} from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
-import { Column, ColumnAggregate } from '../table.types';
 import { persons, Person } from './persons';
 
 /**

--- a/src/components/table/examples/table-sorting-disabled.tsx
+++ b/src/components/table/examples/table-sorting-disabled.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { invoices, Invoice } from './invoices';
 
 /**

--- a/src/components/table/examples/table.tsx
+++ b/src/components/table/examples/table.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { Column } from '../table.types';
+import { Column } from '@limetech/lime-elements';
 import { Person, persons } from './persons';
 
 /**

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -14,7 +14,7 @@ import {
     TableParams,
     ColumnSorter,
     ColumnAggregate,
-} from './table.types';
+} from '../../interface';
 import { ColumnDefinitionFactory, createColumnSorter } from './columns';
 import { isEqual, has } from 'lodash-es';
 import { ElementPool } from './element-pool';

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop, Element, State } from '@stencil/core';
 import { JSX } from 'react';
 import { createRandomString } from '../../util/random-string';
-import { OpenDirection } from '../menu/menu.types';
+import { OpenDirection } from '../../interface';
 
 const DEFAULT_MAX_LENGTH = 50;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from './components';
-export * from './interface';
+
+export { FormComponent, TabPanelComponent, TableComponent } from './interface';
+export { ColumnAggregatorType } from './components/table/table.types';

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -1,19 +1,32 @@
-// Components interfaces
+export * from './components/action-bar/action-bar.types';
+export * from './components/breadcrumbs/breadcrumbs.types';
 export * from './components/button/button.types';
+export * from './components/callout/callout.types';
+export * from './components/chip-set/chip.types';
+export * from './components/circular-progress/circular-progress.types';
+export * from './components/code-editor/code-editor.types';
 export * from './components/collapsible-section/action';
+export * from './components/date-picker/date.types';
+export * from './components/dialog/dialog.types';
+export * from './components/dock/dock.types';
+export * from './components/file/file.types';
+export * from './components/flex-container/flex-container.types';
 export * from './components/form/form.types';
 export * from './components/icon/icon.types';
+export * from './components/info-tile/info-tile.types';
 export * from './components/input-field/input-field.types';
-export {
-    ListSeparator,
-    ListComponent,
-} from './components/list/list-item.types';
-export { OpenDirection } from './components/menu/menu.types';
+export * from './components/list/list-item.types';
+export * from './components/list/list.types';
+export * from './components/menu/menu.types';
+export * from './components/menu-list/menu-list.types';
+export * from './components/picker/actions.types';
+export * from './components/picker/searcher.types';
 export * from './components/progress-flow/progress-flow.types';
+export * from './components/select/option.types';
+export * from './components/select/option.types';
+export * from './components/spinner/spinner.types';
+export * from './components/tab-bar/tab.types';
 export * from './components/tab-panel/tab-panel.types';
 export * from './components/table/table.types';
-export * from './components/dock/dock.types';
-export * from './components/action-bar/action-bar.types';
-export * from './components/info-tile/info-tile.types';
-export * from './components/callout/callout.types';
-export * from './components/breadcrumbs/breadcrumbs.types';
+export * from './global/shared-types/link.types';
+export * from './global/shared-types/icon.types';


### PR DESCRIPTION
A lot of the exported types did not work, probably since #2370 was merged. The types could be imported by consumers, but many interfaces had lost all type information, basically converting the types to `any`. It appears if types are not imported using relative paths in our source files, the types in `components.d.ts` are generated incorrectly.

Also, the examples should import all types from the public package, otherwise it will be confusing for consumers that are reading the documentation.

I will investigate if we can create some kind of lint rule that will prevent us from making this mistake again in the future.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
