### PR TITLE
fix(file): render dropzone help text better when file picker has a small width

### DIFF
--- a/src/components/chip-set/partial-styles/_file-picker.scss
+++ b/src/components/chip-set/partial-styles/_file-picker.scss
@@ -31,6 +31,7 @@
                 padding: 0 functions.pxToRem(12);
 
                 font-size: functions.pxToRem(13);
+                line-height: 1;
                 color: var(--mdc-theme-text-secondary-on-background);
             }
 
@@ -60,7 +61,7 @@
 }
 
 // below block prevents overlapping of `label` and dropzone tip text
-$max-width-of-dropzone-tip: 58%;
+$max-width-of-dropzone-tip: 50%;
 $max-width-of-label-when-not-readonly: 40%;
 
 :host(.is-file-picker.shows-dropzone) {


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/3645

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
