### PR TITLE
fix(list): recreate the mdcList on item change

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -144,23 +144,27 @@ export class List {
             return;
         }
 
-        const listItems = this.items.filter(this.isListItem);
+        setTimeout(() => {
+            this.setup();
 
-        if (this.multiple) {
-            this.mdcList.selectedIndex = listItems
-                .filter((item: ListItem) => item.selected)
-                .map((item: ListItem) => listItems.indexOf(item));
-        } else {
-            const selectedIndex = listItems.findIndex(
-                (item: ListItem) => item.selected
-            );
+            const listItems = this.items.filter(this.isListItem);
 
-            if (selectedIndex === -1) {
-                this.mdcList.initializeListType();
+            if (this.multiple) {
+                this.mdcList.selectedIndex = listItems
+                    .filter((item: ListItem) => item.selected)
+                    .map((item: ListItem) => listItems.indexOf(item));
             } else {
-                this.mdcList.selectedIndex = selectedIndex;
+                const selectedIndex = listItems.findIndex(
+                    (item: ListItem) => item.selected
+                );
+
+                if (selectedIndex === -1) {
+                    this.mdcList.initializeListType();
+                } else {
+                    this.mdcList.selectedIndex = selectedIndex;
+                }
             }
-        }
+        }, 0);
     }
 
     private setup = () => {
@@ -170,6 +174,11 @@ export class List {
     };
 
     private setupList = () => {
+        if (this.mdcList) {
+            this.teardown();
+            this.mdcList = null;
+        }
+
         const element = this.element.shadowRoot.querySelector(
             '.mdc-deprecated-list'
         );


### PR DESCRIPTION
See #2482 as reference.
This solves some of the keyboard navigation issues we've had with the limel-list element.

See Kia showing the bug that is fixed here:

https://github.com/Lundalogik/lime-elements/assets/35954987/fa1a6d0d-cc6b-4fdf-8769-c327c2141b01

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
