### PR TITLE
fix(types): export missing types again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 export * from './components';
 
-export { FormComponent, TabPanelComponent, TableComponent } from './interface';
+export {
+    DockMenu,
+    FormComponent,
+    FormInfo,
+    GridLayoutOptions,
+    TabPanelComponent,
+    TableComponent,
+} from './interface';
 export { ColumnAggregatorType } from './components/table/table.types';


### PR DESCRIPTION
A few types accidently got lost when #2522 was merged. This should add them back again



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
