### PR TITLE
fix(input-field): apply the user's locale when formatting numbers

### DIFF
--- a/src/components/config/config.tsx
+++ b/src/components/config/config.tsx
@@ -13,7 +13,7 @@ export class Config {
      * Global configuration for Lime Elements
      */
     @Prop()
-    public config: object;
+    public config: Partial<typeof globalConfig>;
 
     public componentDidLoad() {
         this.setGlobalConfig();

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -29,6 +29,7 @@ import { getHref, getTarget } from '../../util/link-helper';
 import { JSXBase } from '@stencil/core/internal';
 import { createRandomString } from '../../util/random-string';
 import { LimelListCustomEvent } from 'src/components';
+import config from '../../global/config';
 
 interface LinkProperties {
     href: string;
@@ -216,6 +217,12 @@ export class InputField {
      */
     @Prop({ reflect: true })
     public showLink = false;
+
+    /**
+     * The locale to use for formatting numbers.
+     */
+    @Prop({ reflect: true })
+    public locale: string = config.defaultLocale;
 
     /**
      * Emitted when the input value is changed.
@@ -708,7 +715,7 @@ export class InputField {
 
         let renderValue = this.value;
         if (this.formatNumber && this.value) {
-            renderValue = new Intl.NumberFormat(navigator.language).format(
+            renderValue = new Intl.NumberFormat(this.locale).format(
                 Number(this.value)
             );
         }

--- a/src/global/config.ts
+++ b/src/global/config.ts
@@ -1,5 +1,6 @@
 export class Config {
     public iconPath = '';
+    public defaultLocale = navigator.language;
     public featureSwitches: any = getFeatureSwitches(localStorage);
 }
 


### PR DESCRIPTION
The property "locale" specifies the user's locale and/or preferences in which numbers should be formatted. This affect the formatting of integers and decimals

fix Lundalogik/crm-feature#3673



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
