### PR TITLE
Deprecate `iconColor`, `iconBackgroundColor` etc, in favour of using the `Icon` interface

### DIFF
--- a/src/components/action-bar/action-bar-item/action-bar-item.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-item.tsx
@@ -12,6 +12,7 @@ import {
     makeEnterClickable,
     removeEnterClickable,
 } from 'src/util/make-enter-clickable';
+import { getIconColor, getIconName } from '../../icon/get-icon-props';
 
 /**
  * @private
@@ -55,6 +56,10 @@ export class ActionBarButton {
 
     public componentWillLoad() {
         makeEnterClickable(this.host);
+    }
+
+    public componentDidLoad() {
+        this.triggerIconColorWarning();
     }
 
     public disconnectedCallback() {
@@ -105,11 +110,14 @@ export class ActionBarButton {
         }
 
         if ('icon' in this.item) {
+            const name = getIconName(this.item.icon);
+            const color = getIconColor(this.item.icon, this.item.iconColor);
+
             return (
                 <limel-icon
-                    name={this.item.icon}
+                    name={name}
                     style={{
-                        '--action-bar-item-icon-color': `${this.item.iconColor}`,
+                        '--action-bar-item-icon-color': `${color}`,
                     }}
                 />
             );
@@ -145,6 +153,15 @@ export class ActionBarButton {
                     elementId={this.tooltipId}
                     label={this.item.commandText}
                 />
+            );
+        }
+    }
+
+    private triggerIconColorWarning() {
+        if (this.isItem(this.item) && this.item.iconColor) {
+            /* eslint-disable-next-line no-console */
+            console.warn(
+                "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`."
             );
         }
     }

--- a/src/components/action-bar/action-bar.types.ts
+++ b/src/components/action-bar/action-bar.types.ts
@@ -1,4 +1,4 @@
-import { MenuItem } from '../../interface';
+import { Icon, MenuItem } from '../../interface';
 
 /**
  * Renders the button in the action bar without their labels.
@@ -8,7 +8,7 @@ export type ActionBarItem = ActionBarItemOnlyIcon | ActionBarItemWithLabel;
 
 interface ActionBarItemOnlyIcon extends MenuItem {
     iconOnly: true;
-    icon: string;
+    icon: string | Icon;
 }
 
 interface ActionBarItemWithLabel extends MenuItem {

--- a/src/components/action-bar/examples/action-bar-colors.tsx
+++ b/src/components/action-bar/examples/action-bar-colors.tsx
@@ -4,7 +4,7 @@ import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 /**
  * Using colors
  *
- * You can specify colors for single actions, by setting `iconColor`.
+ * You can specify colors for single actions, by setting `color` on the `icon`.
  *
  * :::note
  * Make sure not to overuse colors!
@@ -22,9 +22,11 @@ export class ActionBarColorsExample {
     private actionBarItems: Array<ActionBarItem | ListSeparator> = [
         {
             text: 'Record',
-            icon: 'dot_circle',
+            icon: {
+                name: 'dot_circle',
+                color: 'rgb(var(--color-red-default))',
+            },
             iconOnly: true,
-            iconColor: 'rgb(var(--color-red-default))',
         },
         {
             text: 'Stop',

--- a/src/components/action-bar/examples/action-bar-floating.tsx
+++ b/src/components/action-bar/examples/action-bar-floating.tsx
@@ -48,13 +48,17 @@ export class ActionBarFloatingExample {
         },
         {
             text: 'Park',
-            icon: 'circled_pause',
-            iconColor: 'rgb(var(--color-orange-default))',
+            icon: {
+                name: 'circled_pause',
+                color: 'rgb(var(--color-orange-default))',
+            },
         },
         {
             text: 'Close',
-            icon: 'do_not_disturb',
-            iconColor: 'rgb(var(--color-red-default))',
+            icon: {
+                name: 'do_not_disturb',
+                color: 'rgb(var(--color-red-default))',
+            },
         },
     ];
 

--- a/src/components/action-bar/examples/action-bar-in-list.tsx
+++ b/src/components/action-bar/examples/action-bar-in-list.tsx
@@ -11,8 +11,10 @@ export class ActionBarInListExample {
     private actionBarItems: Array<ActionBarItem | ListSeparator> = [
         {
             text: 'Mark as Done',
-            icon: 'checkmark',
-            iconColor: 'rgb(var(--color-sky-default))',
+            icon: {
+                name: 'checkmark',
+                color: 'rgb(var(--color-sky-default))',
+            },
             iconOnly: true,
         },
         {
@@ -28,8 +30,10 @@ export class ActionBarInListExample {
         },
         {
             text: 'Call',
-            icon: 'phone',
-            iconColor: 'rgb(var(--color-green-default))',
+            icon: {
+                name: 'phone',
+                color: 'rgb(var(--color-green-default))',
+            },
             iconOnly: true,
         },
     ];

--- a/src/components/action-bar/examples/action-bar-styling.tsx
+++ b/src/components/action-bar/examples/action-bar-styling.tsx
@@ -9,7 +9,7 @@ import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
  *
  * :::note
  * The `--action-bar-item-icon-color` affects all icons.
- * However, the `iconColor` specified on individual items
+ * However, the `color` specified for `icon` for individual items
  * will override that.
  * :::
  */
@@ -36,8 +36,10 @@ export class ActionBarStylingExample {
         { separator: true },
         {
             text: 'Delete',
-            icon: 'trash',
-            iconColor: 'rgb(var(--color-red-default))',
+            icon: {
+                name: 'trash',
+                color: 'rgb(var(--color-red-default))',
+            },
         },
     ];
 

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -12,6 +12,7 @@ import {
     removeEnterClickable,
 } from '../../util/make-enter-clickable';
 import { createRandomString } from '../../util/random-string';
+import { getIconColor, getIconName } from '../icon/get-icon-props';
 
 /**
  * A Breadcrumb consists of a list of distinct "places" that a user has gone through,
@@ -154,16 +155,19 @@ export class Breadcrumbs {
     };
 
     private renderIcon = (item: BreadcrumbsItem) => {
-        if (!item.icon?.name) {
+        const name = getIconName(item.icon);
+        const color = getIconColor(item.icon);
+
+        if (!name) {
             return;
         }
 
         return (
             <limel-icon
                 style={{
-                    color: `${item.icon.color}`,
+                    color: `${color}`,
                 }}
-                name={item.icon.name}
+                name={name}
             />
         );
     };

--- a/src/components/breadcrumbs/breadcrumbs.types.ts
+++ b/src/components/breadcrumbs/breadcrumbs.types.ts
@@ -9,7 +9,7 @@ export interface BreadcrumbsItem {
     /**
      * Icon of the step.
      */
-    icon?: Omit<Icon, 'backgroundColor'>;
+    icon?: string | Omit<Icon, 'backgroundColor'>;
 
     /**
      * If set to `icon-only`, the `text` will be rendered as a tooltip

--- a/src/components/breadcrumbs/examples/breadcrumbs-icon-only.tsx
+++ b/src/components/breadcrumbs/examples/breadcrumbs-icon-only.tsx
@@ -29,20 +29,20 @@ export class BreadcrumbsIconsExample {
         {
             text: 'Home',
             type: 'icon-only',
-            icon: { name: 'smart_home' },
+            icon: 'smart_home',
         },
         {
             text: 'Products',
-            icon: { name: 'shop' },
+            icon: 'shop',
         },
         {
             text: 'Phones',
-            icon: { name: 'iphone_x' },
+            icon: 'iphone_x',
         },
         {
             text: 'Accessories',
             type: 'icon-only',
-            icon: { name: 'headphones' },
+            icon: 'headphones',
         },
     ];
 

--- a/src/components/breadcrumbs/examples/breadcrumbs-styling.tsx
+++ b/src/components/breadcrumbs/examples/breadcrumbs-styling.tsx
@@ -24,11 +24,11 @@ export class BreadcrumbsStylingExample {
         },
         {
             text: 'Products',
-            icon: { name: 'menu' },
+            icon: 'menu',
         },
         {
             text: 'Phones',
-            icon: { name: 'iphone_x' },
+            icon: 'iphone_x',
         },
         {
             text: 'Accessories',

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -20,6 +20,12 @@ import { handleKeyboardEvent } from './chip-set-input-helpers';
 import translate from '../../global/translations';
 import { getHref, getTarget } from '../../util/link-helper';
 import { isEqual } from 'lodash-es';
+import {
+    getIconBackgroundColor,
+    getIconColor,
+    getIconName,
+    getIconTitle,
+} from '../icon/get-icon-props';
 
 const SELECTED_CHIP_CLASS = 'mdc-chip--selected';
 const INPUT_FIELD_TABINDEX = 1;
@@ -262,6 +268,8 @@ export class ChipSet {
     }
 
     public componentDidLoad() {
+        this.triggerIconColorWarning(this.value);
+
         if (this.type === 'input') {
             this.mdcTextField = new MDCTextField(
                 this.host.shadowRoot.querySelector('.mdc-text-field')
@@ -700,23 +708,30 @@ export class ChipSet {
     }
 
     private renderChipIcon(chip: Chip) {
+        const name = getIconName(chip.icon);
+        const color = getIconColor(chip.icon, chip.iconFillColor);
+        const backgroundColor = getIconBackgroundColor(
+            chip.icon,
+            chip.iconBackgroundColor
+        );
+        const title = getIconTitle(chip.icon, chip.iconTitle);
         const style = {};
-        if (chip.iconFillColor) {
-            style['--icon-color'] = chip.iconFillColor;
+        if (color) {
+            style['--icon-color'] = color;
         }
 
-        if (chip.iconBackgroundColor) {
-            style['--icon-background-color'] = chip.iconBackgroundColor;
+        if (backgroundColor) {
+            style['--icon-background-color'] = backgroundColor;
         }
 
         return (
             <limel-icon
                 class="mdc-chip__icon mdc-chip__icon--leading"
-                name={chip.icon}
+                name={name}
                 style={style}
                 size="small"
                 badge={true}
-                title={chip.iconTitle}
+                title={title}
             />
         );
     }
@@ -804,5 +819,21 @@ export class ChipSet {
         }
 
         return <limel-badge label={chip.badge} />;
+    }
+
+    private triggerIconColorWarning(value: Chip[]) {
+        for (const chip of value) {
+            if (
+                chip.icon &&
+                (chip.iconFillColor ||
+                    chip.iconBackgroundColor ||
+                    chip.iconTitle)
+            ) {
+                /* eslint-disable-next-line no-console */
+                console.warn(
+                    "The `iconFillColor`, `iconBackgroundColor`, and `iconTitle` props are deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name', `iconBackgroundColor: 'color-name', and `iconTitle: 'title'`, write `icon { name: 'icon-name', color: 'color-name', backgroundColor: 'color-name', title: 'title' }`."
+                );
+            }
+        }
     }
 }

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -1,3 +1,5 @@
+import { Icon } from '../../interface';
+
 export interface Chip<T = any> {
     /**
      * ID of the chip. Must be unique.
@@ -12,20 +14,47 @@ export interface Chip<T = any> {
     /**
      * Name of the icon to use. Not valid for `filter`.
      */
-    icon?: string;
+    icon?: string | Icon;
 
     /**
      * Color of the icon. Overrides `--icon-color`.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
+     * ```
      */
     iconFillColor?: string;
 
     /**
      * `title` attribute of the icon
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    title: string,
+     * },
+     * ```
      */
     iconTitle?: string;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    backgroundColor: string,
+     * },
+     * ```
      */
     iconBackgroundColor?: string;
 

--- a/src/components/chip-set/examples/chip-icon-colors.tsx
+++ b/src/components/chip-set/examples/chip-icon-colors.tsx
@@ -23,21 +23,27 @@ export class ChipIconColorExample {
                     {
                         id: 2,
                         text: 'Elephant',
-                        icon: 'elephant',
-                        iconFillColor: 'rgb(var(--color-magenta-default))',
+                        icon: {
+                            name: 'elephant',
+                            color: 'rgb(var(--color-magenta-default))',
+                        },
                     },
                     {
                         id: 3,
                         text: 'Caterpillar',
-                        icon: 'caterpillar',
-                        iconBackgroundColor: 'rgb(var(--color-orange-default))',
+                        icon: {
+                            name: 'caterpillar',
+                            backgroundColor: 'rgb(var(--color-orange-default))',
+                        },
                     },
                     {
                         id: 4,
                         text: 'Fish',
-                        icon: 'fish',
-                        iconFillColor: 'rgb(var(--color-yellow-light))',
-                        iconBackgroundColor: 'rgb(var(--color-indigo-darker))',
+                        icon: {
+                            name: 'fish',
+                            color: 'rgb(var(--color-yellow-light))',
+                            backgroundColor: 'rgb(var(--color-indigo-darker))',
+                        },
                     },
                 ]}
             />,

--- a/src/components/dock/examples/my-custom-menu-with-notifications.tsx
+++ b/src/components/dock/examples/my-custom-menu-with-notifications.tsx
@@ -10,8 +10,10 @@ export class MyCustomMenuWithNotifications {
     private items: Array<ListItem<number>> = [
         {
             text: 'Preferences',
-            icon: 'horizontal_settings_mixer',
-            iconColor: 'rgb(var(--color-blue-default)',
+            icon: {
+                name: 'horizontal_settings_mixer',
+                color: 'rgb(var(--color-blue-default)',
+            },
             primaryComponent: {
                 name: 'limel-badge',
                 props: {
@@ -24,8 +26,10 @@ export class MyCustomMenuWithNotifications {
         },
         {
             text: "What's new",
-            icon: 'new',
-            iconColor: 'rgb(var(--color-orange-default)',
+            icon: {
+                name: 'new',
+                color: 'rgb(var(--color-orange-default)',
+            },
             primaryComponent: {
                 name: 'limel-badge',
                 props: {
@@ -38,8 +42,10 @@ export class MyCustomMenuWithNotifications {
         },
         {
             text: 'Sign out',
-            icon: 'shutdown',
-            iconColor: 'rgb(var(--color-red-default))',
+            icon: {
+                name: 'shutdown',
+                color: 'rgb(var(--color-red-default))',
+            },
         },
     ];
 

--- a/src/components/dock/examples/my-custom-menu.tsx
+++ b/src/components/dock/examples/my-custom-menu.tsx
@@ -9,38 +9,52 @@ export class MyCustomMenu {
     private items: Array<ListItem<number>> = [
         {
             text: 'Companies',
-            icon: 'organization',
-            iconColor: 'rgb(var(--color-blue-default)',
+            icon: {
+                name: 'organization',
+                color: 'rgb(var(--color-blue-default)',
+            },
         },
         {
             text: 'Deals',
-            icon: 'money',
-            iconColor: 'rgb(var(--color-green-default))',
+            icon: {
+                name: 'money',
+                color: 'rgb(var(--color-green-default))',
+            },
         },
         {
             text: 'Agreements',
-            icon: 'handshake',
-            iconColor: 'rgb(var(--color-pink-default))',
+            icon: {
+                name: 'handshake',
+                color: 'rgb(var(--color-pink-default))',
+            },
         },
         {
             text: 'Todos',
-            icon: 'today',
-            iconColor: 'rgb(var(--color-teal-default))',
+            icon: {
+                name: 'today',
+                color: 'rgb(var(--color-teal-default))',
+            },
         },
         {
             text: 'History',
-            icon: 'comments',
-            iconColor: 'rgb(var(--color-grey-light))',
+            icon: {
+                name: 'comments',
+                color: 'rgb(var(--color-grey-light))',
+            },
         },
         {
             text: 'Coworkers',
-            icon: 'gender_neutral_user',
-            iconColor: 'rgb(var(--color-orange-light))',
+            icon: {
+                name: 'gender_neutral_user',
+                color: 'rgb(var(--color-orange-light))',
+            },
         },
         {
             text: 'Persons',
-            icon: 'user_group_man_man',
-            iconColor: 'rgb(var(--color-yellow-dark)',
+            icon: {
+                name: 'user_group_man_man',
+                color: 'rgb(var(--color-yellow-dark)',
+            },
         },
     ];
 

--- a/src/components/file/file-metadata.ts
+++ b/src/components/file/file-metadata.ts
@@ -2,10 +2,17 @@ import { FileInfo } from '../../interface';
 import { getIconForFile } from './icons';
 import { getIconFillColorForFile } from './icon-fill-colors';
 import { getIconBackgroundColorForFile } from './icon-background-colors';
+import {
+    getIconBackgroundColor,
+    getIconColor,
+    getIconName,
+} from '../icon/get-icon-props';
 
 export function getFileIcon(file: FileInfo) {
-    if (file?.icon) {
-        return file.icon;
+    const name = getIconName(file.icon);
+
+    if (name) {
+        return name;
     }
 
     const extension = getExtension(file);
@@ -17,8 +24,10 @@ export function getFileIcon(file: FileInfo) {
 }
 
 export function getFileColor(file: FileInfo) {
-    if (file?.iconColor) {
-        return file.iconColor;
+    const color = getIconColor(file.icon, file.iconColor);
+
+    if (color) {
+        return color;
     }
 
     const extension = getExtension(file);
@@ -30,8 +39,13 @@ export function getFileColor(file: FileInfo) {
 }
 
 export function getFileBackgroundColor(file: FileInfo) {
-    if (file?.iconBackgroundColor) {
-        return file.iconBackgroundColor;
+    const backgroundColor = getIconBackgroundColor(
+        file.icon,
+        file.iconBackgroundColor
+    );
+
+    if (backgroundColor) {
+        return backgroundColor;
     }
 
     const extension = getExtension(file);
@@ -43,8 +57,10 @@ export function getFileBackgroundColor(file: FileInfo) {
 }
 
 export function getFileExtensionTitle(file: FileInfo) {
-    if (file?.icon) {
-        return file.icon;
+    const name = getIconName(file.icon);
+
+    if (name) {
+        return name;
     }
 
     return getExtension(file);

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -240,11 +240,13 @@ export class File {
                 ...DEFAULT_FILE_CHIP,
                 text: this.value.filename,
                 id: this.value.id,
-                icon: getFileIcon(this.value),
-                iconFillColor: getFileColor(this.value),
-                iconBackgroundColor: getFileBackgroundColor(this.value),
+                icon: {
+                    name: getFileIcon(this.value),
+                    title: getFileExtensionTitle(this.value),
+                    color: getFileColor(this.value),
+                    backgroundColor: getFileBackgroundColor(this.value),
+                },
                 href: this.value.href,
-                iconTitle: getFileExtensionTitle(this.value),
             },
         ];
     }

--- a/src/components/file/file.types.ts
+++ b/src/components/file/file.types.ts
@@ -1,3 +1,5 @@
+import { Icon } from '../../interface';
+
 export interface FileInfo {
     /**
      * ID of the file. Must be unique.
@@ -37,15 +39,31 @@ export interface FileInfo {
     /**
      * Name of the icon to use.
      */
-    icon?: string;
+    icon?: string | Icon;
 
     /**
      * Icon color. Overrides `--icon-color`.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
      */
     iconColor?: string;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    backgroundColor: string,
+     * },
      */
     iconBackgroundColor?: string;
 

--- a/src/components/form/examples/custom-component-picker.tsx
+++ b/src/components/form/examples/custom-component-picker.tsx
@@ -56,26 +56,34 @@ export class CustomPickerExample implements FormComponent<number> {
         {
             text: 'Superman',
             value: 1001,
-            icon: 'superman',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'superman',
+                color: 'var(--lime-deep-red)',
+            },
         },
         {
             text: 'Squirrel Girl',
             value: 1002,
-            icon: 'squirrel',
-            iconColor: 'var(--lime-orange)',
+            icon: {
+                name: 'squirrel',
+                color: 'var(--lime-orange)',
+            },
         },
         {
             text: 'Captain America',
             value: 1003,
-            icon: 'captain_america',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'captain_america',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             text: 'Black Widow',
             value: 1004,
-            icon: 'spider',
-            iconColor: 'var(--lime-dark-grey)',
+            icon: {
+                name: 'spider',
+                color: 'var(--lime-dark-grey)',
+            },
         },
     ];
 

--- a/src/components/form/examples/props-factory-picker.tsx
+++ b/src/components/form/examples/props-factory-picker.tsx
@@ -62,26 +62,34 @@ export class PropsFactoryPickerExample implements FormComponent<number> {
         {
             text: 'Superman',
             value: 1001,
-            icon: 'superman',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'superman',
+                color: 'var(--lime-deep-red)',
+            },
         },
         {
             text: 'Squirrel Girl',
             value: 1002,
-            icon: 'squirrel',
-            iconColor: 'var(--lime-orange)',
+            icon: {
+                name: 'squirrel',
+                color: 'var(--lime-orange)',
+            },
         },
         {
             text: 'Captain America',
             value: 1003,
-            icon: 'captain_america',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'captain_america',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             text: 'Black Widow',
             value: 1004,
-            icon: 'spider',
-            iconColor: 'var(--lime-dark-grey)',
+            icon: {
+                name: 'spider',
+                color: 'var(--lime-dark-grey)',
+            },
         },
     ];
 

--- a/src/components/icon/get-icon-props.ts
+++ b/src/components/icon/get-icon-props.ts
@@ -1,0 +1,117 @@
+import { Icon } from '../../interface';
+
+/**
+ * Get the icon name.
+ * This helps in setting the right icon, both if the consumer only types `icon: string`,
+ * and if they use the `Icon` interface for writing the icon name.
+ * @param {string | Icon | undefined} icon - The icon to retrieve the name from.
+ * @returns {string | undefined} The icon name or the provided string, or `undefined` if `icon` is falsy.
+ */
+export function getIconName(
+    icon: string | Icon | undefined
+): string | undefined {
+    if (typeof icon === 'object' && 'name' in icon) {
+        return icon.name;
+    }
+
+    if (typeof icon === 'string') {
+        return icon;
+    }
+
+    return undefined;
+}
+
+/**
+ * Get the icon color.
+ * This is added because the old way of specifying `iconColor`
+ * deprecated in our components. So consumers should now use the new
+ * `Icon` interface instead. But our components must still support the
+ * old way of writing `iconColor: string`.
+ * @param {string | Icon | undefined} icon - The icon to retrieve the color from.
+ * @param {string | undefined} [iconColor] - The color to use when the deprecated `iconColor` is used.
+ * @returns {string | undefined} The icon color or the provided color string, or `undefined` if `iconColor` is falsy.
+ */
+export function getIconColor(
+    icon: string | Icon | undefined,
+    iconColor?: string | undefined
+): string | undefined {
+    if (typeof icon === 'object' && 'color' in icon) {
+        return icon.color;
+    }
+
+    if (typeof icon === 'string') {
+        return iconColor;
+    }
+
+    return undefined;
+}
+
+/**
+ * Get the icon color.
+ * This is added because the old way of specifying `iconFillColor` is
+ * deprecated in our components. So consumers should now use the new
+ * `Icon` interface instead. But our components must still support the
+ * old way of writing `iconFillColor: string`.
+ * @param {string | Icon} icon - The icon to retrieve the color from.
+ * @param {string | undefined} [iconFillColor] - The color to use when `iconFillColor` is used.
+ * @returns {string | undefined} The icon color or the provided color string, or `undefined` if `iconColor` is falsy.
+ */
+export function getIconFillColor(
+    icon: string | Icon | undefined,
+    iconFillColor?: string | undefined
+): string {
+    if (typeof icon === 'object' && 'color' in icon) {
+        return icon.color;
+    }
+
+    if (typeof icon === 'string') {
+        return iconFillColor;
+    }
+
+    return undefined;
+}
+
+/**
+ * Get the icon background color.
+ * This function is used to retrieve the background color associated with an icon,
+ * whether provided as a string or using the `Icon` interface.
+ * @param {string | Icon | undefined} icon - The icon to retrieve the background color from.
+ * @param {string | undefined} [iconBackgroundColor] - The background color to use when provided explicitly.
+ * @returns {string | undefined} The icon background color or the provided background color string, or `undefined` if `iconBackgroundColor` is falsy.
+ */
+export function getIconBackgroundColor(
+    icon: string | Icon | undefined,
+    iconBackgroundColor?: string | undefined
+): string | undefined {
+    if (typeof icon === 'object' && 'backgroundColor' in icon) {
+        return icon.backgroundColor;
+    }
+
+    if (typeof icon === 'string') {
+        return iconBackgroundColor;
+    }
+
+    return undefined;
+}
+
+/**
+ * Get the icon title.
+ * This function is used to retrieve the title associated with an icon, whether provided as a string or using the `Icon` interface.
+ * @param {string | Icon | undefined} icon - The icon to retrieve the title from.
+ * @param {string | undefined} [iconTitle] - The title to use when provided explicitly.
+ * @returns {string | undefined} The icon title or the provided title string, or `undefined` if `iconTitle` is falsy.
+ */
+export function getIconTitle(
+    icon: string | Icon | undefined,
+    iconTitle?: string | undefined
+): string | undefined {
+    if (typeof icon === 'object' && 'title' in icon) {
+        return icon.title;
+    }
+
+    if (typeof icon === 'string') {
+        return iconTitle;
+    }
+
+    return undefined;
+}

--- a/src/components/list/examples/list-badge-icons.tsx
+++ b/src/components/list/examples/list-badge-icons.tsx
@@ -21,29 +21,37 @@ export class BadgeIconsListExample {
             text: 'Smash Up!',
             secondaryText: '2-4 players',
             value: 2,
-            icon: 'alien',
-            iconColor: 'rgb(var(--color-lime-light))',
+            icon: {
+                name: 'alien',
+                color: 'rgb(var(--color-lime-light))',
+            },
         },
         {
             text: 'Pandemic',
             secondaryText: '2-4 players',
             value: 3,
-            icon: 'virus',
-            iconColor: 'rgb(var(--color-red-light))',
+            icon: {
+                name: 'virus',
+                color: 'rgb(var(--color-red-light))',
+            },
         },
         {
             text: 'Catan',
             secondaryText: '3-4 players',
             value: 4,
-            icon: 'wheat',
-            iconColor: 'rgb(var(--color-amber-default))',
+            icon: {
+                name: 'wheat',
+                color: 'rgb(var(--color-amber-default))',
+            },
         },
         {
             text: 'Ticket to Ride',
             secondaryText: '2-5 players',
             value: 5,
-            icon: 'steam_engine',
-            iconColor: 'rgb(var(--color-glaucous-default))',
+            icon: {
+                name: 'steam_engine',
+                color: 'rgb(var(--color-glaucous-default))',
+            },
         },
     ];
 

--- a/src/components/list/examples/list-checkbox-icons.tsx
+++ b/src/components/list/examples/list-checkbox-icons.tsx
@@ -15,45 +15,57 @@ export class ListCheckboxIconsExample {
             text: 'Pikachu',
             value: 1,
             selected: true,
-            icon: 'pokemon',
-            iconColor: 'var(--lime-yellow)',
+            icon: {
+                name: 'pokemon',
+                color: 'var(--lime-yellow)',
+            },
         },
         {
             text: 'Charmander',
             value: 2,
             selected: false,
             disabled: true,
-            icon: 'fire_element',
-            iconColor: 'var(--lime-red)',
+            icon: {
+                name: 'fire_element',
+                color: 'var(--lime-red)',
+            },
         },
         {
             text: 'Super Mario',
             value: 3,
             selected: false,
-            icon: 'super_mario',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'super_mario',
+                color: 'var(--lime-deep-red)',
+            },
         },
         {
             text: 'Yoshi',
             value: 4,
             selected: false,
             disabled: true,
-            icon: 'easter_egg',
-            iconColor: 'var(--lime-green)',
+            icon: {
+                name: 'easter_egg',
+                color: 'var(--lime-green)',
+            },
         },
         {
             text: 'Minion',
             value: 6,
             selected: true,
-            icon: 'minion_1',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'minion_1',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             text: 'Pokéball',
             value: 5,
             selected: false,
-            icon: 'pokeball',
-            iconColor: 'var(--lime-magenta)',
+            icon: {
+                name: 'pokeball',
+                color: 'var(--lime-magenta)',
+            },
         },
     ];
 

--- a/src/components/list/examples/list-grid.tsx
+++ b/src/components/list/examples/list-grid.tsx
@@ -26,26 +26,34 @@ export class ListGridExample {
         {
             text: 'Smash Up!',
             value: 2,
-            icon: 'alien',
-            iconColor: 'rgb(var(--color-lime-light))',
+            icon: {
+                name: 'alien',
+                color: 'rgb(var(--color-lime-light))',
+            },
         },
         {
             text: 'Pandemic',
             value: 3,
-            icon: 'virus',
-            iconColor: 'rgb(var(--color-red-light))',
+            icon: {
+                name: 'virus',
+                color: 'rgb(var(--color-red-light))',
+            },
         },
         {
             text: 'Catan',
             value: 4,
-            icon: 'wheat',
-            iconColor: 'rgb(var(--color-amber-default))',
+            icon: {
+                name: 'wheat',
+                color: 'rgb(var(--color-amber-default))',
+            },
         },
         {
             text: 'Ticket to Ride',
             value: 5,
-            icon: 'steam_engine',
-            iconColor: 'rgb(var(--color-glaucous-default))',
+            icon: {
+                name: 'steam_engine',
+                color: 'rgb(var(--color-glaucous-default))',
+            },
         },
     ];
 

--- a/src/components/list/examples/list-radio-button-icons.tsx
+++ b/src/components/list/examples/list-radio-button-icons.tsx
@@ -15,45 +15,57 @@ export class ListRadioButtonIconsExample {
             text: 'Pikachu',
             value: 1,
             selected: false,
-            icon: 'pokemon',
-            iconColor: 'var(--lime-yellow)',
+            icon: {
+                name: 'pokemon',
+                color: 'var(--lime-yellow)',
+            },
         },
         {
             text: 'Charmander',
             value: 2,
             selected: false,
             disabled: true,
-            icon: 'fire_element',
-            iconColor: 'var(--lime-red)',
+            icon: {
+                name: 'fire_element',
+                color: 'var(--lime-red)',
+            },
         },
         {
             text: 'Super Mario',
             value: 3,
             selected: false,
-            icon: 'super_mario',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'super_mario',
+                color: 'var(--lime-deep-red)',
+            },
         },
         {
             text: 'Yoshi',
             value: 4,
             selected: false,
             disabled: true,
-            icon: 'easter_egg',
-            iconColor: 'var(--lime-green)',
+            icon: {
+                name: 'easter_egg',
+                color: 'var(--lime-green)',
+            },
         },
         {
             text: 'Minion',
             value: 6,
             selected: true,
-            icon: 'minion_1',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'minion_1',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             text: 'Pokéball',
             value: 5,
             selected: false,
-            icon: 'pokeball',
-            iconColor: 'var(--lime-magenta)',
+            icon: {
+                name: 'pokeball',
+                color: 'var(--lime-magenta)',
+            },
         },
     ];
 

--- a/src/components/list/list-item.types.ts
+++ b/src/components/list/list-item.types.ts
@@ -1,4 +1,4 @@
-import { MenuItem } from '../../interface';
+import { MenuItem, Icon } from '../../interface';
 
 export interface ListItem<T = any> {
     /**
@@ -19,10 +19,19 @@ export interface ListItem<T = any> {
     /**
      * Name of the icon to use.
      */
-    icon?: string;
+    icon?: string | Icon;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
+     * ```
      */
     iconColor?: string;
 

--- a/src/components/list/list-renderer.tsx
+++ b/src/components/list/list-renderer.tsx
@@ -3,6 +3,7 @@ import { h } from '@stencil/core';
 import { CheckboxTemplate } from '../checkbox/checkbox.template';
 import { ListRendererConfig } from './list-renderer-config';
 import { RadioButtonTemplate } from './radio-button/radio-button.template';
+import { getIconColor, getIconName } from '../icon/get-icon-props';
 
 export class ListRenderer {
     private defaultConfig: ListRendererConfig = {
@@ -214,11 +215,14 @@ export class ListRenderer {
      */
     private renderIcon = (config: ListRendererConfig, item: ListItem) => {
         const style: any = {};
-        if (item.iconColor) {
+        const name = getIconName(item.icon);
+        const color = getIconColor(item.icon, item.iconColor);
+
+        if (color) {
             if (config.badgeIcons) {
-                style['--icon-background-color'] = item.iconColor;
+                style['--icon-background-color'] = color;
             } else {
-                style.color = item.iconColor;
+                style.color = color;
             }
         }
 
@@ -226,7 +230,7 @@ export class ListRenderer {
             <limel-icon
                 badge={config.badgeIcons}
                 class="mdc-deprecated-list-item__graphic"
-                name={item.icon}
+                name={name}
                 style={style}
                 size={config.iconSize}
             />

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -107,6 +107,7 @@ export class List {
 
     public componentDidLoad() {
         this.setup();
+        this.triggerIconColorWarning();
     }
 
     public render() {
@@ -271,4 +272,13 @@ export class List {
     private isListItem = (item: ListItem): boolean => {
         return !('separator' in item);
     };
+
+    private triggerIconColorWarning() {
+        if (this.items.some((item) => 'iconColor' in item)) {
+            /* eslint-disable-next-line no-console */
+            console.warn(
+                "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`."
+            );
+        }
+    }
 }

--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -1,6 +1,7 @@
 import { ListSeparator, MenuItem } from '../../interface';
 import { h } from '@stencil/core';
 import { MenuListRendererConfig } from './menu-list-renderer-config';
+import { getIconColor, getIconName } from '../icon/get-icon-props';
 
 export class MenuListRenderer {
     private defaultConfig: MenuListRendererConfig = {
@@ -206,11 +207,14 @@ export class MenuListRenderer {
      */
     private renderIcon = (config: MenuListRendererConfig, item: MenuItem) => {
         const style: any = {};
-        if (item.iconColor) {
+        const name = getIconName(item.icon);
+        const color = getIconColor(item.icon, item.iconColor);
+
+        if (color) {
             if (config.badgeIcons) {
-                style['--icon-background-color'] = item.iconColor;
+                style['--icon-background-color'] = color;
             } else {
-                style.color = item.iconColor;
+                style.color = color;
             }
         }
 
@@ -218,7 +222,7 @@ export class MenuListRenderer {
             <limel-icon
                 badge={config.badgeIcons}
                 class="mdc-deprecated-list-item__graphic"
-                name={item.icon}
+                name={name}
                 style={style}
                 size={config.iconSize}
             />

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -88,6 +88,7 @@ export class MenuList {
 
     public componentDidLoad() {
         this.setup();
+        this.triggerIconColorWarning();
     }
 
     public render() {
@@ -176,4 +177,13 @@ export class MenuList {
     private isMenuItem = (item: MenuItem): boolean => {
         return !('separator' in item);
     };
+
+    private triggerIconColorWarning() {
+        if (this.items.some((item) => 'iconColor' in item)) {
+            /* eslint-disable-next-line no-console */
+            console.warn(
+                "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`."
+            );
+        }
+    }
 }

--- a/src/components/menu/examples/menu-badge-icons.tsx
+++ b/src/components/menu/examples/menu-badge-icons.tsx
@@ -12,15 +12,25 @@ export class MenuBadgeIconsExample {
     private items: Array<MenuItem | ListSeparator> = [
         {
             text: 'Copy',
-            icon: 'copy',
-            iconColor: 'rgb(var(--color-lime-light))',
+            icon: {
+                name: 'copy',
+                color: 'rgb(var(--color-lime-light))',
+            },
         },
-        { text: 'Cut', icon: 'cut', iconColor: 'rgb(var(--color-red-light))' },
+        {
+            text: 'Cut',
+            icon: {
+                name: 'cut',
+                color: 'rgb(var(--color-red-light))',
+            },
+        },
         { separator: true },
         {
             text: 'Paste',
-            icon: 'paste',
-            iconColor: 'rgb(var(--color-amber-default))',
+            icon: {
+                name: 'paste',
+                color: 'rgb(var(--color-amber-default))',
+            },
         },
     ];
 

--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -21,20 +21,26 @@ export class MenuCompositeExample {
         items: [
             {
                 text: 'Copy',
-                icon: 'copy',
-                iconColor: 'rgb(var(--color-lime-light))',
+                icon: {
+                    name: 'copy',
+                    color: 'rgb(var(--color-lime-light))',
+                },
             },
             {
                 text: 'Cut',
-                icon: 'cut',
-                iconColor: 'rgb(var(--color-red-light))',
+                icon: {
+                    name: 'cut',
+                    color: 'rgb(var(--color-red-light))',
+                },
             },
             { separator: true },
             {
                 text: 'Paste',
                 disabled: true,
-                icon: 'paste',
-                iconColor: 'rgb(var(--color-amber-default))',
+                icon: {
+                    name: 'paste',
+                    color: 'rgb(var(--color-amber-default))',
+                },
             },
         ],
         open: false,

--- a/src/components/menu/examples/menu-grid.tsx
+++ b/src/components/menu/examples/menu-grid.tsx
@@ -38,39 +38,53 @@ export class MenuGridExample {
     private items: Array<MenuItem | ListSeparator> = [
         {
             text: 'Companies',
-            icon: 'organization',
-            iconColor: 'rgb(var(--color-blue-default)',
+            icon: {
+                name: 'organization',
+                color: 'rgb(var(--color-blue-default)',
+            },
         },
         {
             text: 'Deals',
-            icon: 'money',
-            iconColor: 'rgb(var(--color-green-default))',
+            icon: {
+                name: 'money',
+                color: 'rgb(var(--color-green-default))',
+            },
         },
         {
             text: 'Agreements',
-            icon: 'handshake',
-            iconColor: 'rgb(var(--color-pink-default))',
+            icon: {
+                name: 'handshake',
+                color: 'rgb(var(--color-pink-default))',
+            },
         },
         {
             text: 'Todos',
-            icon: 'today',
-            iconColor: 'rgb(var(--color-teal-default))',
+            icon: {
+                name: 'today',
+                color: 'rgb(var(--color-teal-default))',
+            },
         },
         {
             text: 'History',
-            icon: 'comments',
-            iconColor: 'rgb(var(--color-grey-light))',
+            icon: {
+                name: 'comments',
+                color: 'rgb(var(--color-grey-light))',
+            },
         },
         { separator: true },
         {
             text: 'Coworkers',
-            icon: 'gender_neutral_user',
-            iconColor: 'rgb(var(--color-orange-light))',
+            icon: {
+                name: 'gender_neutral_user',
+                color: 'rgb(var(--color-orange-light))',
+            },
         },
         {
             text: 'Persons',
-            icon: 'user_group_man_man',
-            iconColor: 'rgb(var(--color-yellow-dark)',
+            icon: {
+                name: 'user_group_man_man',
+                color: 'rgb(var(--color-yellow-dark)',
+            },
         },
     ];
 

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,3 +1,5 @@
+import { Icon } from '../../interface';
+
 export type OpenDirection =
     | 'left-start'
     | 'left'
@@ -54,10 +56,19 @@ export interface MenuItem<T = any> {
     /**
      * Name of the icon to use.
      */
-    icon?: string;
+    icon?: string | Icon;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
+     * ```
      */
     iconColor?: string;
 

--- a/src/components/picker/examples/picker-icons.tsx
+++ b/src/components/picker/examples/picker-icons.tsx
@@ -18,96 +18,122 @@ export class PickerIconsExample {
             secondaryText:
                 'Anchor Hook, Anchor Drop, Ink Spray, Ink Propulsion',
             value: 1,
-            icon: 'octopus',
-            iconColor: 'var(--lime-red)',
+            icon: {
+                name: 'octopus',
+                color: 'var(--lime-red)',
+            },
         },
         {
             text: 'Ayla',
             secondaryText: 'Evil Eye, Rage, Chain Whack, Hop Skip',
             value: 2,
-            icon: 'visible',
-            iconColor: 'var(--lime-magenta)',
+            icon: {
+                name: 'visible',
+                color: 'var(--lime-magenta)',
+            },
         },
         {
             text: 'Clunk',
             secondaryText: 'Vacuum Bite, Explode, Missiles, Jet Boost',
             value: 3,
-            icon: 'robot_3',
-            iconColor: 'var(--lime-dark-blue)',
+            icon: {
+                name: 'robot_3',
+                color: 'var(--lime-dark-blue)',
+            },
         },
         {
             text: 'Coco',
             secondaryText: 'Ball Lightning, Blaze, Shock, Ollie',
             value: 4,
-            icon: 'surfing',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'surfing',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             text: 'Derpl',
             secondaryText: 'Grid Trap, Siege Mode, Cat Shot, Booster Rocket',
             value: 5,
-            icon: 'cat',
-            iconColor: 'var(--lime-green)',
+            icon: {
+                name: 'cat',
+                color: 'var(--lime-green)',
+            },
         },
         {
             text: 'Froggy G',
             secondaryText:
                 'Splash Dash, Tornado Move, Bolt .45 Fish-gun, Frog Jump',
             value: 6,
-            icon: 'frog',
-            iconColor: 'var(--lime-turquoise)',
+            icon: {
+                name: 'frog',
+                color: 'var(--lime-turquoise)',
+            },
         },
         {
             text: 'Gnaw',
             secondaryText: 'Acid Spit, Grow Weedling, Bite, Skroggle Jump',
             value: 7,
-            icon: 'dog',
-            iconColor: 'var(--lime-orange)',
+            icon: {
+                name: 'dog',
+                color: 'var(--lime-orange)',
+            },
         },
         {
             text: 'Lonestar',
             secondaryText:
                 'Dynamite Throw, Summon Hyper Bull, Blaster, Double Jump',
             value: 8,
-            icon: 'sheriff',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'sheriff',
+                color: 'var(--lime-deep-red)',
+            },
         },
         {
             text: 'Leon',
             secondaryText: 'Tounge Snatch, Cloaking Skin, Slash, Reptile Jump',
             value: 9,
-            icon: 'croissant',
-            iconColor: 'var(--lime-yellow)',
+            icon: {
+                name: 'croissant',
+                color: 'var(--lime-yellow)',
+            },
         },
         {
             text: 'Raelynn',
             secondaryText:
                 'Timerift, Snipe, Protoblaster, Six Million Solar Human Jump',
             value: 10,
-            icon: 'sniper_rifle',
-            iconColor: 'var(--lime-dark-grey)',
+            icon: {
+                name: 'sniper_rifle',
+                color: 'var(--lime-dark-grey)',
+            },
         },
         {
             text: 'Skølldir',
             secondaryText: 'Mighty Throw, Earthquake, Bash, Explosive Fart',
             value: 11,
-            icon: 'beer',
-            iconColor: 'var(--lime-orange)',
+            icon: {
+                name: 'beer',
+                color: 'var(--lime-orange)',
+            },
         },
         {
             text: 'Voltar',
             secondaryText:
                 'Suicide Drones, Healbot, Techno Synaptic Wave, Hover',
             value: 12,
-            icon: 'brain',
-            iconColor: 'var(--lime-magenta)',
+            icon: {
+                name: 'brain',
+                color: 'var(--lime-magenta)',
+            },
         },
         {
             text: 'Yuri',
             secondaryText: 'Mine Deploying, Time Warp, Laser, Jet Pack',
             value: 13,
-            icon: 'year_of_monkey',
-            iconColor: 'var(--lime-light-grey)',
+            icon: {
+                name: 'year_of_monkey',
+                color: 'var(--lime-light-grey)',
+            },
         },
     ];
 

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -46,14 +46,18 @@ export class PickerStaticActionsExample {
     private actions: Array<ListItem<Action>> = [
         {
             text: 'Add a dog',
-            icon: 'dog',
-            iconColor: 'rgb(var(--color-orange-default))',
+            icon: {
+                name: 'dog',
+                color: 'rgb(var(--color-orange-default))',
+            },
             value: { id: 'dog' },
         },
         {
             text: 'Add a cat',
-            icon: 'cat',
-            iconColor: 'rgb(var(--color-green-default))',
+            icon: {
+                name: 'cat',
+                color: 'rgb(var(--color-green-default))',
+            },
             value: { id: 'cat' },
         },
     ];

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../util/keycodes';
 import { createRandomString } from '../../util/random-string';
 import { LimelChipSetCustomEvent, LimelListCustomEvent } from 'src/components';
+import { getIconFillColor, getIconName } from '../icon/get-icon-props';
 
 const SEARCH_DEBOUNCE = 500;
 const CHIP_SET_TAG_NAME = 'limel-chip-set';
@@ -320,12 +321,15 @@ export class Picker {
     }
 
     private createChip(listItem: ListItem): Chip {
+        const name = getIconName(listItem.icon);
+        const color = getIconFillColor(listItem.icon, listItem.iconColor);
+
         return {
             id: `${listItem.value}`,
             text: listItem.text,
             removable: true,
-            icon: listItem.icon,
-            iconFillColor: listItem.iconColor,
+            icon: name,
+            iconFillColor: color,
             value: listItem,
         };
     }

--- a/src/components/progress-flow/examples/progress-flow-colors.tsx
+++ b/src/components/progress-flow/examples/progress-flow-colors.tsx
@@ -27,31 +27,39 @@ export class ProgressFlowColorsExample {
             text: 'Magenta step',
             selectedColor: 'rgb(var(--color-magenta-default)',
             passedColor: 'rgb(var(--color-green-light))',
-            icon: 'roller_brush',
-            iconColor: 'rgb(var(--color-magenta-default)',
+            icon: {
+                name: 'roller_brush',
+                color: 'rgb(var(--color-magenta-default)',
+            },
         },
         {
             value: 'purple',
             text: 'Purple step',
             selectedColor: 'rgb(var(--color-purple-default))',
             passedColor: 'rgb(var(--color-green-default))',
-            icon: 'brush',
-            iconColor: 'rgb(var(--color-purple-default))',
+            icon: {
+                name: 'brush',
+                color: 'rgb(var(--color-purple-default))',
+            },
         },
         {
             value: 'organge',
             text: 'Blue step',
             selectedColor: 'rgb(var(--color-blue-default))',
             passedColor: 'rgb(var(--color-green-dark))',
-            icon: 'paint_brush',
-            iconColor: 'rgb(var(--color-blue-default))',
+            icon: {
+                name: 'paint_brush',
+                color: 'rgb(var(--color-blue-default))',
+            },
         },
         {
             value: 'red',
             text: 'Green step',
             selectedColor: 'rgb(var(--color-green-darker))',
-            icon: 'cosmetic_brush',
-            iconColor: 'rgb(var(--color-green-darker))',
+            icon: {
+                name: 'cosmetic_brush',
+                color: 'rgb(var(--color-green-darker))',
+            },
         },
     ];
 

--- a/src/components/progress-flow/examples/progress-flow-off-progress-steps.tsx
+++ b/src/components/progress-flow/examples/progress-flow-off-progress-steps.tsx
@@ -48,16 +48,20 @@ export class ProgressFlowOffProgressStepsExample {
             text: 'Rejected',
             isOffProgress: true,
             selectedColor: 'rgb(var(--color-red-dark))',
-            icon: 'do_not_disturb',
-            iconColor: 'rgb(var(--color-red-dark))',
+            icon: {
+                name: 'do_not_disturb',
+                color: 'rgb(var(--color-red-dark))',
+            },
         },
         {
             value: 'onhold',
             text: 'On hold',
             isOffProgress: true,
             selectedColor: 'rgb(var(--color-coral-default))',
-            icon: 'circled_pause',
-            iconColor: 'rgb(var(--color-coral-default))',
+            icon: {
+                name: 'circled_pause',
+                color: 'rgb(var(--color-coral-default))',
+            },
         },
     ];
 

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.tsx
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.tsx
@@ -7,6 +7,7 @@ import {
     Prop,
 } from '@stencil/core';
 import { FlowItem } from '../../../interface';
+import { getIconName } from 'src/components/icon/get-icon-props';
 
 /**
  * @private
@@ -100,7 +101,9 @@ export class ProgressFlowItem {
             return;
         }
 
-        return <limel-icon name={this.item.icon} size="small" class="icon" />;
+        const name = getIconName(this.item.icon);
+
+        return <limel-icon name={name} size="small" class="icon" />;
     }
 
     private renderDivider() {

--- a/src/components/progress-flow/progress-flow.tsx
+++ b/src/components/progress-flow/progress-flow.tsx
@@ -7,6 +7,7 @@ import {
     Prop,
 } from '@stencil/core';
 import { FlowItem } from '../../interface';
+import { getIconColor } from '../icon/get-icon-props';
 
 /**
  * @exampleComponent limel-example-progress-flow-basic
@@ -61,6 +62,10 @@ export class ProgressFlow {
 
     public componentDidRender() {
         this.scrollToSelectedItem();
+    }
+
+    public componentDidLoad() {
+        this.triggerIconColorWarning();
     }
 
     public render() {
@@ -135,7 +140,9 @@ export class ProgressFlow {
     };
 
     private getItemStyle(flowItem: FlowItem) {
+        const color = getIconColor(flowItem.icon, flowItem.iconColor);
         const style: any = {};
+
         if (flowItem?.selectedColor) {
             style['--progress-flow-step-background-color--selected'] =
                 flowItem.selectedColor;
@@ -146,8 +153,8 @@ export class ProgressFlow {
                 flowItem.passedColor;
         }
 
-        if (flowItem?.iconColor) {
-            style['--progress-flow-icon-color--inactive'] = flowItem.iconColor;
+        if (color) {
+            style['--progress-flow-icon-color--inactive'] = color;
         }
 
         return style;
@@ -174,5 +181,16 @@ export class ProgressFlow {
 
     private getElementForSelectedItem(): HTMLLimelProgressFlowItemElement {
         return this.element.shadowRoot.querySelector('.flow-item.selected');
+    }
+
+    private triggerIconColorWarning() {
+        for (const flowItem of this.flowItems) {
+            if (flowItem.iconColor) {
+                /* eslint-disable-next-line no-console */
+                console.warn(
+                    "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`."
+                );
+            }
+        }
     }
 }

--- a/src/components/progress-flow/progress-flow.types.ts
+++ b/src/components/progress-flow/progress-flow.types.ts
@@ -20,6 +20,15 @@ export interface FlowItem extends ListItem {
     /**
      * Fill color of the icon on the step,
      * when it is neither selected nor passed.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
+     * ```
      */
     iconColor?: string;
 }

--- a/src/components/select/examples/select-with-icons.tsx
+++ b/src/components/select/examples/select-with-icons.tsx
@@ -15,33 +15,43 @@ export class SelectExample {
         {
             text: 'Batman',
             value: 'bat',
-            icon: 'batman_old',
-            iconColor: 'rgb(var(--color-black))',
+            icon: {
+                name: 'batman_old',
+                color: 'rgb(var(--color-black))',
+            },
         },
         {
             text: 'Iron Man',
             value: 'iron',
             disabled: true,
-            icon: 'iron_man',
-            iconColor: 'rgb(var(--color-coral-default))',
+            icon: {
+                name: 'iron_man',
+                color: 'rgb(var(--color-coral-default))',
+            },
         },
         {
             text: 'Spider-Man',
             value: 'spider',
-            icon: 'spiderman_head',
-            iconColor: 'rgb(var(--color-red-default))',
+            icon: {
+                name: 'spiderman_head',
+                color: 'rgb(var(--color-red-default))',
+            },
         },
         {
             text: 'Superman',
             value: 'super',
-            icon: 'superman',
-            iconColor: 'rgb(var(--color-blue-default))',
+            icon: {
+                name: 'superman',
+                color: 'rgb(var(--color-blue-default))',
+            },
         },
         {
             text: 'Wonder Woman',
             value: 'wonder',
-            icon: 'wonder_woman',
-            iconColor: 'rgb(var(--color-yellow-darker))',
+            icon: {
+                name: 'wonder_woman',
+                color: 'rgb(var(--color-yellow-darker))',
+            },
         },
     ];
 

--- a/src/components/select/option.types.ts
+++ b/src/components/select/option.types.ts
@@ -1,3 +1,4 @@
+import { Icon } from '../../interface';
 /**
  * Describes an option for limel-select.
  */
@@ -29,10 +30,19 @@ export interface Option<T extends string = string> {
     /**
      * Displays an icon beside the name of the option.
      */
-    icon?: string;
+    icon?: string | Icon;
 
     /**
      * Adds a color to the icon.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
+     * ```
      */
     iconColor?: string;
 }

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -1,6 +1,7 @@
 import { ListItem, Option } from '../../interface';
 import { FunctionalComponent, h } from '@stencil/core';
 import { isMultiple } from '../../util/multiple';
+import { getIconColor, getIconName } from '../icon/get-icon-props';
 
 interface SelectTemplateProps {
     disabled?: boolean;
@@ -254,14 +255,18 @@ function createMenuItems(
     return options.filter(menuOptionFilter).map((option) => {
         const selected = isSelected(option, value);
         const { text, disabled } = option;
+        const name = getIconName(option.icon);
+        const color = getIconColor(option.icon, option.iconColor);
 
         return {
             text: text,
             selected: selected,
             disabled: disabled,
             value: option,
-            icon: option.icon,
-            iconColor: option.iconColor,
+            icon: {
+                name: name,
+                color: color,
+            },
         };
     });
 }
@@ -305,17 +310,30 @@ function getSelectedIcon(value: any) {
         return '';
     }
 
+    const name = getIconName(value.icon);
+    const color = getIconColor(value.icon, value.iconColor);
     const style: any = {};
-    if (value.iconColor) {
-        style.color = value.iconColor;
+    if (color) {
+        style.color = color;
     }
 
     return (
         <limel-icon
             class="limel-select__selected-option__icon"
-            name={value.icon}
+            name={name}
             size="medium"
             style={style}
         />
     );
+}
+
+export function triggerIconColorWarning(options: Option[]) {
+    options.forEach((option) => {
+        if (option.iconColor) {
+            /* eslint-disable-next-line no-console */
+            console.warn(
+                "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`."
+            );
+        }
+    });
 }

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../util/keycodes';
 import { isMultiple } from '../../util/multiple';
 import { createRandomString } from '../../util/random-string';
-import { SelectTemplate } from './select.template';
+import { SelectTemplate, triggerIconColorWarning } from './select.template';
 
 /**
  * @exampleComponent limel-example-select
@@ -147,6 +147,7 @@ export class Select {
 
     public componentDidLoad() {
         this.initialize();
+        triggerIconColorWarning(this.options);
     }
 
     private initialize() {

--- a/src/components/tab-bar/examples/tab-bar-with-dynamic-tab-width.tsx
+++ b/src/components/tab-bar/examples/tab-bar-with-dynamic-tab-width.tsx
@@ -20,21 +20,27 @@ export class TabBarExample {
         {
             id: 1,
             text: 'Cats',
-            icon: 'black_cat',
+            icon: {
+                name: 'black_cat',
+                color: 'var(--lime-dark-grey)',
+            },
             active: true,
-            iconColor: 'var(--lime-dark-grey)',
         },
         {
             id: 2,
             text: 'Dogs',
-            icon: 'dog',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'dog',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             id: 3,
             text: 'Birds',
-            icon: 'bird',
-            iconColor: 'var(--lime-red)',
+            icon: {
+                name: 'bird',
+                color: 'var(--lime-red)',
+            },
         },
     ];
 

--- a/src/components/tab-bar/examples/tab-bar-with-equal-tab-width.tsx
+++ b/src/components/tab-bar/examples/tab-bar-with-equal-tab-width.tsx
@@ -20,21 +20,27 @@ export class TabBarExample {
         {
             id: 1,
             text: 'Cats',
-            icon: 'black_cat',
+            icon: {
+                name: 'black_cat',
+                color: 'var(--lime-dark-grey)',
+            },
             active: true,
-            iconColor: 'var(--lime-dark-grey)',
         },
         {
             id: 2,
             text: 'Dogs',
-            icon: 'dog',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'dog',
+                color: 'var(--lime-blue)',
+            },
         },
         {
             id: 3,
             text: 'Birds',
-            icon: 'bird',
-            iconColor: 'var(--lime-red)',
+            icon: {
+                name: 'bird',
+                color: 'var(--lime-red)',
+            },
         },
     ];
 

--- a/src/components/tab-bar/examples/tab-bar.tsx
+++ b/src/components/tab-bar/examples/tab-bar.tsx
@@ -14,50 +14,64 @@ export class TabBarExample {
         {
             id: 1,
             text: 'Joker',
-            icon: 'joker',
+            icon: {
+                name: 'joker',
+                color: 'var(--lime-green)',
+            },
             active: true,
-            iconColor: 'var(--lime-green)',
         },
         {
             id: 2,
             text: 'Parasite',
-            icon: 'insect',
-            iconColor: 'var(--lime-magenta)',
+            icon: {
+                name: 'insect',
+                color: 'var(--lime-magenta)',
+            },
             badge: 999,
         },
         {
             id: 3,
             text: 'Harriet',
-            icon: 'administrator_female',
-            iconColor: 'var(--lime-orange)',
+            icon: {
+                name: 'administrator_female',
+                color: 'var(--lime-orange)',
+            },
             badge: 99940,
         },
         {
             id: 4,
             text: 'Bombshell',
-            icon: 'surprised',
-            iconColor: 'var(--lime-blue)',
+            icon: {
+                name: 'surprised',
+                color: 'var(--lime-blue)',
+            },
             badge: 999990,
         },
         {
             id: 5,
             text: 'Judy',
-            icon: 'female',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'female',
+                color: 'var(--lime-deep-red)',
+            },
             badge: 940000,
         },
         {
             id: 6,
             text: 'Friends',
-            icon: 'friends',
-            iconColor: 'var(--lime-yellow)',
+            icon: {
+                name: 'friends',
+                color: 'var(--lime-yellow)',
+            },
             badge: 1290000,
         },
         {
             id: 7,
             text: 'Little Women',
-            icon: 'female',
-            iconColor: 'var(--lime-deep-red)',
+            icon: {
+                name: 'female',
+                color: 'var(--lime-deep-red)',
+            },
             badge: 4,
         },
         {

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -14,6 +14,7 @@ import { strings } from '@material/tab-bar/constants';
 import { Tab } from '../../interface';
 import { isEqual, difference } from 'lodash-es';
 import { setActiveTab } from './tabs';
+import { getIconColor, getIconName } from '../icon/get-icon-props';
 
 const { TAB_ACTIVATED_EVENT } = strings;
 const SCROLL_DISTANCE_ON_CLICK_PX = 150;
@@ -84,6 +85,7 @@ export class TabBar {
 
     public componentDidLoad() {
         this.setup();
+        this.triggerIconColorWarning();
     }
 
     public componentDidUpdate() {
@@ -259,16 +261,18 @@ export class TabBar {
             return;
         }
 
+        const name = getIconName(tab.icon);
+        const color = getIconColor(tab.icon, tab.iconColor);
         const style = { color: '' };
 
-        if (tab.iconColor) {
-            style.color = tab.iconColor;
+        if (color) {
+            style.color = color;
         }
 
         return (
             <limel-icon
                 class="mdc-tab__icon"
-                name={tab.icon}
+                name={name}
                 style={style}
                 size="small"
                 aria-hidden="true"
@@ -303,5 +307,14 @@ export class TabBar {
                 <span class="mdc-tab__ripple" />
             </button>
         );
+    }
+
+    private triggerIconColorWarning() {
+        if (this.tabs.some((tab) => tab.iconColor)) {
+            /* eslint-disable-next-line no-console */
+            console.warn(
+                "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`."
+            );
+        }
     }
 }

--- a/src/components/tab-bar/tab.types.ts
+++ b/src/components/tab-bar/tab.types.ts
@@ -1,3 +1,5 @@
+import { Icon } from '../../interface';
+
 export interface Tab {
     /**
      * Id of the tab. Must be unique.
@@ -12,7 +14,7 @@ export interface Tab {
     /**
      * Name of the icon to use.
      */
-    icon?: string;
+    icon?: string | Icon;
 
     /**
      * True if the tab should be selected.
@@ -21,6 +23,15 @@ export interface Tab {
 
     /**
      * Color of the icon.
+     * @deprecated This property is deprecated and will be removed soon!
+     *
+     * Use the new `Icon` interface instead and write:
+     * ```
+     * icon {
+     *    name: string,
+     *    color: string,
+     * },
+     * ```
      */
     iconColor?: string;
 

--- a/src/components/tab-panel/examples/tab-panel-content.tsx
+++ b/src/components/tab-panel/examples/tab-panel-content.tsx
@@ -41,7 +41,7 @@ export class TabPanelContentExample implements TabPanelComponent {
         }
 
         const style = {
-            backgroundColor: this.tab.iconColor,
+            backgroundColor: this.tab.icon.color,
             color: 'white',
         };
 
@@ -51,7 +51,7 @@ export class TabPanelContentExample implements TabPanelComponent {
                     <limel-icon
                         badge={true}
                         size="large"
-                        name={this.tab.icon}
+                        name={this.tab.icon.name}
                         style={style}
                     />
                     <p>

--- a/src/components/tab-panel/examples/tab-panel.tsx
+++ b/src/components/tab-panel/examples/tab-panel.tsx
@@ -22,21 +22,27 @@ export class TabPanelExample {
         {
             id: 'joker',
             text: 'Joker',
-            icon: 'joker',
+            icon: {
+                name: 'joker',
+                color: 'var(--lime-green)',
+            },
             active: true,
-            iconColor: 'var(--lime-green)',
         },
         {
             id: 'parasite',
             text: 'Parasite',
-            icon: 'insect',
-            iconColor: 'var(--lime-magenta)',
+            icon: {
+                name: 'insect',
+                color: 'var(--lime-magenta)',
+            },
         },
         {
             id: 'harriet',
             text: 'Harriet',
-            icon: 'administrator_female',
-            iconColor: 'var(--lime-orange)',
+            icon: {
+                name: 'administrator_female',
+                color: 'var(--lime-orange)',
+            },
         },
     ];
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2505

💡 Don't get scared of the number of files changed in this PR. Most of the files are the updated examples that now use the new `Icon` interface. The logic of deprecating the old props works exactly the same for all components. Once you see and understand one of them, you will have an easy time understanding the rest of them.

### Which components are updated:
This is the list of component that are affected:

- [x] menu
- [x] list
- [x] action bar
- [x] chipset
- [x] select
- [x] progress flow
- [x] picker
- [x] tab bar
- [x] file





# How to test this PR?

`iconColor`, `iconFillColor`, `iconBackgroundColor` and `iconTitle` props are deprecated now in different components. But they should still work if they are used.

The old way may look like this:
```tsx
icon: 'name',
iconFillColor: 'black',
iconBackgroundColor: 'white',
iconTitle: 'title',
```
And the new way looks like this:
```tsx
icon: {
	name: 'name',
    color: 'black',
    backgroundColor: 'white',
    title: 'title',
},
```

⚠️ Keep in mind that the old way still work, but the combination of the old and new will not work! So for example a config like below wouldn't work and the `iconColor` would not get applied:
```tsx
icon: {
	name: 'name',
},
iconColor: 'color'
```

An easy test is to link this to the web client (where all the configs in crm-components are still old) and see if each component still show the colors as expected. 

Otherwise, a manual test is to change back the "examples" in Lime Elements docs to what they were before and make sure that each component renders the colors as expected.


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
