### PR TITLE
feat(dialog): add actions to the heading area

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -32,12 +32,14 @@ import { createRandomString } from '../../util/random-string';
  * @exampleComponent limel-example-dialog
  * @exampleComponent limel-example-dialog-nested-close-events
  * @exampleComponent limel-example-dialog-heading
+ * @exampleComponent limel-example-dialog-heading-actions
  * @exampleComponent limel-example-dialog-form
  * @exampleComponent limel-example-dialog-size
  * @exampleComponent limel-example-dialog-fullscreen
  * @exampleComponent limel-example-dialog-closing-actions
  * @exampleComponent limel-example-dialog-action-buttons
  * @slot - Content to put inside the dialog
+ * @slot header-actions - The dialog header buttons
  * @slot button - The dialog buttons
  */
 @Component({
@@ -243,7 +245,9 @@ export class Dialog {
                     heading={title}
                     subheading={subtitle}
                     supportingText={supportingText}
-                ></limel-header>
+                >
+                    <slot name="header-actions" slot="actions" />
+                </limel-header>
             );
         } else if (typeof this.heading === 'string') {
             return <limel-header heading={this.heading}></limel-header>;

--- a/src/components/dialog/examples/dialog-heading-actions.tsx
+++ b/src/components/dialog/examples/dialog-heading-actions.tsx
@@ -1,0 +1,70 @@
+import { DialogHeading } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Dialog with action inside the heading
+ *
+ * In this example you can also see how available style properties can be used.
+ */
+@Component({
+    tag: 'limel-example-dialog-heading-actions',
+    styleUrl: 'dialog-heading.scss',
+    shadow: true,
+})
+export class DialogHeadingActionsExample {
+    @State()
+    private isOpen = false;
+
+    @State()
+    private title: string = 'Title';
+
+    @State()
+    private subtitle: string = 'Subtitle';
+
+    @State()
+    private supportingText: string;
+
+    public render() {
+        const heading: DialogHeading = {
+            title: this.title,
+            subtitle: this.subtitle,
+            supportingText: this.supportingText,
+            icon: 'info',
+        };
+
+        return [
+            <limel-button
+                primary={true}
+                label="Open"
+                onClick={this.openDialog}
+            />,
+            <limel-dialog
+                open={this.isOpen}
+                onClose={this.closeDialog}
+                heading={heading}
+            >
+                <limel-icon-button
+                    label="Close"
+                    icon="multiply"
+                    slot="header-actions"
+                    onClick={this.closeDialog}
+                ></limel-icon-button>
+                <p>This is a dialog with an action in the header.</p>
+                <limel-button
+                    label="Ok"
+                    primary={true}
+                    onClick={this.closeDialog}
+                    slot="button"
+                />
+            </limel-dialog>,
+        ];
+    }
+
+    private openDialog = () => {
+        this.isOpen = true;
+    };
+
+    private closeDialog = () => {
+        this.isOpen = false;
+    };
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1861

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
