### PR TITLE
refactor(icon-button): render tooltip instead of `title` for `label` …

### DIFF
--- a/src/components/icon-button/icon-button.e2e.ts
+++ b/src/components/icon-button/icon-button.e2e.ts
@@ -8,13 +8,12 @@ describe('limel-icon-button', () => {
             page = await createPage(`
                 <limel-icon-button icon="unit-test" label="Add favorite"></limel-icon-button>
             `);
-            mdcIconButton = await page.find('limel-icon-button >>> button');
+            mdcIconButton = await page.find(
+                'limel-icon-button >>> limel-tooltip'
+            );
         });
         it('displays the correct label', () => {
-            expect(mdcIconButton).toEqualAttribute(
-                'aria-label',
-                'Add favorite'
-            );
+            expect(mdcIconButton).toEqualAttribute('label', 'Add favorite');
         });
     });
 });

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -3,6 +3,7 @@ import {
     makeEnterClickable,
     removeEnterClickable,
 } from 'src/util/make-enter-clickable';
+import { createRandomString } from '../../util/random-string';
 
 /**
  * @exampleComponent limel-example-icon-button-basic
@@ -70,6 +71,8 @@ export class IconButton {
 
     public render() {
         const buttonAttributes: { tabindex?: string } = {};
+        const tooltipId = createRandomString();
+
         if (this.host.hasAttribute('tabindex')) {
             buttonAttributes.tabindex = this.host.getAttribute('tabindex');
         }
@@ -77,12 +80,17 @@ export class IconButton {
         return (
             <button
                 disabled={this.disabled}
-                aria-label={this.label}
-                title={this.label}
+                id={tooltipId}
                 {...buttonAttributes}
             >
                 <limel-icon name={this.icon} badge={true} />
+                {this.renderTooltip(tooltipId)}
             </button>
         );
+    }
+    private renderTooltip(tooltipId) {
+        if (this.label) {
+            return <limel-tooltip elementId={tooltipId} label={this.label} />;
+        }
     }
 }


### PR DESCRIPTION
…prop
![Screenshot 2023-10-23 at 16 27 03](https://github.com/Lundalogik/lime-elements/assets/50618208/075371c3-5b03-4267-921e-650bac2fd1b4)
![Screenshot 2023-10-23 at 16 33 01](https://github.com/Lundalogik/lime-elements/assets/50618208/871c1d71-65da-4b88-b4f0-c1c33fead330)



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
