### PR TITLE
feat(code-editor): add jinja2 language mode type

### DIFF
--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -11,6 +11,7 @@ import {
 import { ColorScheme, Language } from '../../interface';
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/javascript/javascript';
+import 'codemirror/mode/jinja2/jinja2';
 import 'codemirror/addon/selection/active-line';
 import 'codemirror/addon/edit/matchbrackets';
 import 'codemirror/addon/lint/lint';

--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -21,8 +21,6 @@ import 'codemirror/addon/fold/brace-fold';
 import jslint from 'jsonlint-mod';
 
 /**
- * Currently this component support syntax highlighting for `javascript`,
- * `json` and `typescript` formats.
  * @exampleComponent limel-example-code-editor
  * @exampleComponent limel-example-code-editor-readonly-with-line-numbers
  * @exampleComponent limel-example-code-editor-fold-lint

--- a/src/components/code-editor/code-editor.types.ts
+++ b/src/components/code-editor/code-editor.types.ts
@@ -1,3 +1,3 @@
-export type Language = 'javascript' | 'json' | 'typescript';
+export type Language = 'javascript' | 'jinja2' | 'json' | 'typescript';
 
 export type ColorScheme = 'dark' | 'light' | 'auto';


### PR DESCRIPTION
fix: Lundalogik/lime-crm-components#1846

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
