### PR TITLE
fix(types): export a missing type 'LimeSchemaOptions'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export {
     TableComponent,
     Icon,
     Link,
+    LimeSchemaOptions,
 } from './interface';
 export { ColumnAggregatorType } from './components/table/table.types';


### PR DESCRIPTION
Export the missing type `LimeSchemaOptions`
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
