### PR TITLE
refactor(icon-button): generate `tooltipId` only once

### DIFF
--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -62,6 +62,8 @@ export class IconButton {
         this.initialize();
     }
 
+    private tooltipId = createRandomString();
+
     private initialize() {
         const element = this.host.shadowRoot.querySelector('.mdc-icon-button');
         if (!element) {
@@ -71,7 +73,6 @@ export class IconButton {
 
     public render() {
         const buttonAttributes: { tabindex?: string } = {};
-        const tooltipId = createRandomString();
 
         if (this.host.hasAttribute('tabindex')) {
             buttonAttributes.tabindex = this.host.getAttribute('tabindex');
@@ -80,11 +81,11 @@ export class IconButton {
         return (
             <button
                 disabled={this.disabled}
-                id={tooltipId}
+                id={this.tooltipId}
                 {...buttonAttributes}
             >
                 <limel-icon name={this.icon} badge={true} />
-                {this.renderTooltip(tooltipId)}
+                {this.renderTooltip(this.tooltipId)}
             </button>
         );
     }


### PR DESCRIPTION
Generating a new id on every render is problematic. Better to do it only once when the component is created.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
