### PR TITLE
feat(column sorting): set default sort direction to descending

### DIFF
--- a/src/components/table/columns.ts
+++ b/src/components/table/columns.ts
@@ -24,6 +24,7 @@ export class ColumnDefinitionFactory {
             field: column.field,
             hozAlign: column.horizontalAlign,
             headerSort: column.headerSort,
+            headerSortStartingDir: 'desc',
         };
 
         if (column.headerComponent) {

--- a/src/components/table/table.e2e.ts
+++ b/src/components/table/table.e2e.ts
@@ -81,20 +81,20 @@ describe('limel-table', () => {
             headerA.click();
             await page.waitForChanges();
             rowData = await getFirstRowContent();
-            expect(rowData[0]).toEqual('1');
+            expect(rowData[0]).toEqual('2');
             headerA.click();
             await page.waitForChanges();
             rowData = await getFirstRowContent();
-            expect(rowData[0]).toEqual('2');
+            expect(rowData[0]).toEqual('1');
 
             headerB.click();
             await page.waitForChanges();
             rowData = await getFirstRowContent();
-            expect(rowData[1]).toEqual('ascending');
+            expect(rowData[1]).toEqual('descending');
             headerB.click();
             await page.waitForChanges();
             rowData = await getFirstRowContent();
-            expect(rowData[1]).toEqual('descending');
+            expect(rowData[1]).toEqual('ascending');
         });
     });
 


### PR DESCRIPTION
This sets the default sorting direction, when clicking on the tabulator in the table view, to descending. 

Fixes https://github.com/Lundalogik/crm-feature/issues/3655