### PR TITLE
Feat/menu custom width dropdown

### DIFF
--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -2,6 +2,11 @@
 @use '@material/elevation';
 @use '@material/menu';
 
+/**
+* @prop --limel-menu-surface-display: defines whether the surface is treated as a block, flex or grid. It affects layout used to display its children. Defaults to `block`.
+* @prop --limel-menu-surface-flex-direction: defines the direction of menu-surface layout.
+*/
+
 :host(limel-menu-surface) {
     display: block;
     max-height: inherit;
@@ -11,6 +16,8 @@
 @include menu.core-styles;
 
 .mdc-menu-surface {
+    display: var(--limel-menu-surface-display, block);
+    flex-direction: var(--limel-menu-surface-flex-direction, row);
     max-height: inherit;
     position: relative;
     --mdc-menu-max-width: var(

--- a/src/components/menu/examples/menu-surface-width.scss
+++ b/src/components/menu/examples/menu-surface-width.scss
@@ -1,0 +1,33 @@
+:host(limel-example-menu-surface-width) {
+    box-sizing: border-box;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.is-resizable {
+    position: relative;
+    resize: horizontal;
+    overflow: auto;
+    width: clamp(10rem, 30rem, 100%);
+
+    padding: 0.5rem 0.5rem 3rem 0.5rem;
+    border: 1px solid rgb(var(--contrast-500));
+
+    &::after {
+        content: 'Resize me ⤵';
+        font-size: 0.75rem;
+        position: absolute;
+        right: 0.25rem;
+        bottom: 0.25rem;
+    }
+}
+
+limel-menu {
+    width: 100%;
+}
+
+.highlight-limel-menu {
+    box-sizing: border-box;
+    border: 1px dashed rgb(var(--color-orange-light));
+}

--- a/src/components/menu/examples/menu-surface-width.tsx
+++ b/src/components/menu/examples/menu-surface-width.tsx
@@ -1,0 +1,107 @@
+import {
+    MenuItem,
+    ListSeparator,
+    SurfaceWidth,
+    Option,
+    LimelSelectCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+
+interface SurfaceWidthOption extends Option<SurfaceWidth> {
+    buttonLabel: string;
+}
+
+/**
+ * Size of the menu drop-down surface
+ *
+ * Any element in the UI can be configured to open a menu.
+ * By default, the dropdown that opens up after the menu trigger is clicked
+ * inherits its width from the items that are inside the dropdown menu.
+ *
+ * However, for some designs, you may want the width of the menu dropdown
+ * to be exactly as wide as the width of its trigger element, or
+ * as wide as `limel-menu` element itself. This is easily achieved using the
+ * `surfaceWidth` prop. Read more on `SurfaceWidth`.
+ *
+ * :::tip
+ * In this example, `limel-menu` is highlighted with a dashed border,
+ * to make it easier to see its width.
+ * :::
+ * :::note
+ * The `--menu-surface-width` Overrides the width defined by `surfaceWidth`!
+ * :::
+ */
+@Component({
+    tag: 'limel-example-menu-surface-width',
+    styleUrl: 'menu-surface-width.scss',
+    shadow: true,
+})
+export class MenuSurfaceWidthExample {
+    private items: Array<MenuItem | ListSeparator> = [
+        {
+            text: 'Small text',
+        },
+        {
+            text: 'Very very wide text',
+        },
+    ];
+
+    private availableSurfaceWidths: SurfaceWidthOption[] = [];
+
+    @State()
+    private selectedSurfaceWidth: SurfaceWidthOption;
+
+    constructor() {
+        this.availableSurfaceWidths = [
+            {
+                text: 'inherit-from-items',
+                value: 'inherit-from-items',
+                buttonLabel: 'Width based on menu items (default)',
+            },
+            {
+                text: 'inherit-from-menu',
+                value: 'inherit-from-menu',
+                buttonLabel: 'Width based on limel-menu',
+            },
+            {
+                text: 'inherit-from-trigger',
+                value: 'inherit-from-trigger',
+                buttonLabel: 'Width based on trigger element',
+            },
+        ] as SurfaceWidthOption[];
+
+        this.selectedSurfaceWidth = this.availableSurfaceWidths.find(
+            (v) => v.value === 'inherit-from-items'
+        );
+    }
+
+    public render() {
+        return [
+            <div class="is-resizable">
+                <limel-menu
+                    class="highlight-limel-menu"
+                    items={this.items}
+                    surfaceWidth={this.selectedSurfaceWidth?.value}
+                >
+                    <limel-button
+                        slot="trigger"
+                        label={this.selectedSurfaceWidth?.buttonLabel}
+                    />
+                </limel-menu>
+            </div>,
+            <limel-select
+                class="is-narrow"
+                label="surfaceWidth"
+                options={this.availableSurfaceWidths}
+                value={this.selectedSurfaceWidth}
+                onChange={this.handleNewSelection}
+            />,
+        ];
+    }
+
+    private handleNewSelection = (
+        event: LimelSelectCustomEvent<SurfaceWidthOption>
+    ) => {
+        this.selectedSurfaceWidth = event.detail;
+    };
+}

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -4,7 +4,7 @@
 
 /**
  * @prop --dropdown-z-index: `z-index` of the dropdown menu.
- * @prop --menu-surface-width: Width of the menu surface.
+ * @prop --menu-surface-width: Width of the menu surface. Overrides the width defined by `surfaceWidth`.
  * @prop --list-grid-item-max-width: Maximum width of items in the menu list when `gridLayout={true}`. Defaults to `10rem`.
  * @prop --list-grid-item-min-width: Minimum width of items in the menu list when `gridLayout={true}`. Defaults to `7.5rem`.
  * @prop --list-grid-gap: Distance between the items in the menu list when `gridLayout={true}`. Defaults to `0.75rem`.

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -12,6 +12,24 @@ export type OpenDirection =
     | 'bottom'
     | 'bottom-end';
 
+/**
+ * Any element in the UI can be configured to open a menu.
+ * By default width of menu's dropdown is based on the items in the dropdown.
+ * However, size of the dropdown menu that opens can be controlled
+ * based on design requirements.
+ * - `inherit-from-items`: This is the default layout in which the widest item
+ * in the menu list sets the width of the dropdown menu.
+ * - `inherit-from-trigger`: Width of the dropdown menu will as wide as the
+ * width of the element that triggers the menu.
+ * - `inherit-from-menu`: Width of the dropdown menu will be as wide as the
+ * width of the `limel-menu` element itself. Useful when a menu surface needs
+ * to be opened programmatically, without a visible UI element.
+ */
+export type SurfaceWidth =
+    | 'inherit-from-items'
+    | 'inherit-from-trigger'
+    | 'inherit-from-menu';
+
 export interface MenuItem<T = any> {
     /**
      * The additional supporting text is used for shortcut commands and displayed in the menu item.


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
