### PR TITLE
Feat/limel menu cascading items

### DIFF
--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -1,6 +1,7 @@
 import { ListSeparator, MenuItem } from '../../interface';
 import { h } from '@stencil/core';
 import { MenuListRendererConfig } from './menu-list-renderer-config';
+import { isFunction } from 'lodash-es';
 
 export class MenuListRenderer {
     private defaultConfig: MenuListRendererConfig = {
@@ -139,6 +140,7 @@ export class MenuListRenderer {
             >
                 {item.icon ? this.renderIcon(this.config, item) : null}
                 {this.renderText(item)}
+                {this.renderSubMenuIcon(item)}
                 {this.renderNotification(item)}
                 {this.twoLines && this.avatarList ? this.renderDivider() : null}
             </li>
@@ -170,6 +172,14 @@ export class MenuListRenderer {
                 </div>
             </div>
         );
+    };
+
+    private renderSubMenuIcon = (item: MenuItem) => {
+        if (!this.hasSubItems(item)) {
+            return;
+        }
+
+        return <limel-icon class="sub-menu-icon" name="-lime-caret-right" />;
     };
 
     private rendertext = (item: ListSeparator) => {
@@ -241,5 +251,12 @@ export class MenuListRenderer {
         }
 
         return <hr class={classes} />;
+    };
+
+    private hasSubItems = (item: MenuItem): boolean => {
+        return (
+            (Array.isArray(item.items) && item.items.length > 0) ||
+            isFunction(item.items)
+        );
     };
 }

--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -39,3 +39,9 @@
 limel-badge {
     transform: translateX(0.75rem);
 }
+
+.sub-menu-icon {
+    width: 1rem;
+    transform: translateX(0.75rem);
+    flex-shrink: 0;
+}

--- a/src/components/menu/examples/item-constants.ts
+++ b/src/components/menu/examples/item-constants.ts
@@ -1,0 +1,53 @@
+import { MenuItem } from '../menu.types';
+
+export const CascadingMenuItems: MenuItem[] = [
+    {
+        text: 'Format',
+        items: [
+            {
+                text: 'Bold',
+                icon: 'bold',
+            },
+            {
+                text: 'Italic',
+                icon: 'italic',
+            },
+            {
+                text: 'Bullets and numbering',
+                icon: 'bulleted_list',
+                items: [
+                    {
+                        text: 'Numbered list',
+                        icon: 'numbered_list',
+                    },
+                    {
+                        text: 'Bullet list',
+                        icon: 'bulleted_list',
+                    },
+                    {
+                        text: 'Checklist',
+                        icon: 'todo_list',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        text: 'Edit',
+        items: [
+            {
+                text: 'Copy',
+                icon: 'copy',
+            },
+            {
+                text: 'Cut',
+                icon: 'cut',
+            },
+            { separator: true },
+            {
+                text: 'Paste',
+                icon: 'paste',
+            },
+        ],
+    },
+];

--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -55,9 +55,10 @@ export class MenuCompositeExample {
             },
         };
 
-        delete this.schema.properties.label;
         delete this.schema.properties.selectedMenuItem;
+        delete this.schema.properties.searcher;
         delete this.schema.properties.loadSubItems;
+        delete this.schema.properties.surfaceWidth;
     }
 
     public render() {

--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -1,3 +1,4 @@
+import { Components } from '@limetech/lime-elements';
 import { Component, h, Prop, State } from '@stencil/core';
 
 /**
@@ -40,7 +41,7 @@ export class MenuCompositeExample {
         open: false,
         openDirection: 'right',
         gridLayout: false,
-    };
+    } as Components.LimelMenu;
 
     private eventPrinter: HTMLLimelExampleEventPrinterElement;
 
@@ -55,6 +56,8 @@ export class MenuCompositeExample {
         };
 
         delete this.schema.properties.label;
+        delete this.schema.properties.selectedMenuItem;
+        delete this.schema.properties.loadSubItems;
     }
 
     public render() {
@@ -62,9 +65,10 @@ export class MenuCompositeExample {
 
         return [
             <limel-menu
-                items={this.props.items as any}
+                loading={this.props.loading}
+                items={this.props.items}
                 disabled={this.props.disabled}
-                openDirection={this.props.openDirection as any}
+                openDirection={this.props.openDirection}
                 badgeIcons={this.props.badgeIcons}
                 open={this.props.open}
                 gridLayout={this.props.gridLayout}

--- a/src/components/menu/examples/menu-open-sub-menu-programatically.scss
+++ b/src/components/menu/examples/menu-open-sub-menu-programatically.scss
@@ -1,0 +1,9 @@
+:host(limel-example-menu-open-sub-menu-programatically) {
+    display: flex;
+    flex-direction: column;
+}
+
+.menu-container {
+    display: flex;
+    gap: 2rem;
+}

--- a/src/components/menu/examples/menu-open-sub-menu-programatically.tsx
+++ b/src/components/menu/examples/menu-open-sub-menu-programatically.tsx
@@ -1,0 +1,113 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h, Host } from '@stencil/core';
+import { CascadingMenuItems } from './item-constants';
+
+/**
+ * Opening sub-menus programatically
+ *
+ * It is possible to open any sub-menu in the menu-hierarchy.
+ * This is done by using the parentItem property of the MenuItem class.
+ * @link item-constants.ts
+ */
+@Component({
+    tag: 'limel-example-menu-open-sub-menu-programatically',
+    shadow: true,
+    styleUrl: 'menu-open-sub-menu-programatically.scss',
+})
+export class MenuOpenSubMenuProgramaticallyExample {
+    private readonly rootItems: Array<MenuItem | ListSeparator> =
+        CascadingMenuItems;
+
+    @State()
+    private items: Array<MenuItem | ListSeparator> = this.rootItems;
+
+    @State()
+    private lastSelectedItem: string;
+
+    @State()
+    private selectedMenuItem: MenuItem;
+
+    @State()
+    private openMenu: boolean = false;
+
+    public render() {
+        return (
+            <Host>
+                {this.renderMenu()}
+                <limel-example-value
+                    label="Last selected item"
+                    value={this.lastSelectedItem}
+                />
+            </Host>
+        );
+    }
+
+    private renderMenu() {
+        return (
+            <div class="menu-container">
+                <limel-menu
+                    items={this.items}
+                    open={this.openMenu}
+                    selectedMenuItem={this.selectedMenuItem}
+                    onSelect={this.handleSelect}
+                    onNavigateMenu={async (
+                        event: LimelMenuCustomEvent<MenuItem>
+                    ) => {
+                        if (!event.detail) {
+                            this.items = this.rootItems;
+                        }
+                    }}
+                    onCancel={() => {
+                        this.items = this.rootItems;
+                        this.openMenu = false;
+                    }}
+                >
+                    <limel-button label="Menu" slot="trigger" />
+                </limel-menu>
+                <limel-button
+                    label="Shortcut to Lists"
+                    primary={true}
+                    onClick={this.buttonClick}
+                />
+            </div>
+        );
+    }
+
+    private buttonClick = () => {
+        const selectedItem: MenuItem = {
+            text: 'Lists',
+            parentItem: this.rootItems[0] as MenuItem,
+        };
+        const selectedItems: MenuItem[] = [
+            {
+                text: 'Numbered list',
+                icon: 'numbered_list',
+                parentItem: selectedItem,
+            },
+            {
+                text: 'Bullet list',
+                icon: 'bulleted_list',
+                parentItem: selectedItem,
+            },
+            {
+                text: 'Checklist',
+                icon: 'todo_list',
+                parentItem: selectedItem,
+            },
+        ];
+        this.selectedMenuItem = selectedItem;
+        this.items = selectedItems;
+        this.openMenu = true;
+    };
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.selectedMenuItem = null;
+        this.items = this.rootItems;
+        this.lastSelectedItem = event.detail.text;
+        this.openMenu = false;
+    };
+}

--- a/src/components/menu/examples/menu-searchable.tsx
+++ b/src/components/menu/examples/menu-searchable.tsx
@@ -1,0 +1,58 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+import { SearchMenuItems } from './subitems-search';
+import { CascadingMenuItems } from './item-constants';
+
+/**
+ * Searchable items
+ * @link subitems-search.ts
+ * @link item-constants.ts
+ */
+@Component({
+    tag: 'limel-example-menu-searchable',
+    shadow: true,
+})
+export class MenuSubItemsExample {
+    private items: Array<MenuItem | ListSeparator> = [
+        ...CascadingMenuItems,
+        {
+            text: 'Long sub list',
+            items: Array.from(Array(50), (_value, index) => {
+                return {
+                    text: `Item ${index + 1}`,
+                };
+            }),
+        },
+    ];
+
+    @State()
+    private lastSelectedItem: MenuItem;
+
+    public render() {
+        return [
+            <limel-menu
+                items={this.items}
+                searcher={this.handleSearch}
+                onSelect={this.handleSelect}
+            >
+                <limel-button label="Menu" slot="trigger" />
+            </limel-menu>,
+            <limel-example-value
+                label="Last selected item"
+                value={this.lastSelectedItem?.text ?? ''}
+            />,
+        ];
+    }
+
+    private handleSearch = async (queryString: string) => {
+        return SearchMenuItems(queryString, this.items);
+    };
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.lastSelectedItem = event.detail;
+    };
+}

--- a/src/components/menu/examples/menu-sub-menu-lazy-loading.tsx
+++ b/src/components/menu/examples/menu-sub-menu-lazy-loading.tsx
@@ -1,0 +1,81 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+
+const NETWORK_DELAY = 1000;
+/**
+ * Lazy loading infinite amount of sub-menu.
+ */
+@Component({
+    tag: 'limel-example-menu-sub-menu-lazy-loading',
+    shadow: true,
+})
+export class MenuSubMenuLazyLoadingExample {
+    private items: Array<MenuItem | ListSeparator> = [];
+
+    @State()
+    private lastSelectedItem: string;
+
+    public componentWillLoad() {
+        this.items = [
+            {
+                text: 'Item 1',
+                items: this.handleLoadSubItems,
+            },
+            {
+                text: 'Item 2',
+                items: this.handleLoadSubItems,
+            },
+            {
+                text: 'Item 3',
+                items: this.handleLoadSubItems,
+            },
+            {
+                text: 'Item 4',
+                items: this.handleLoadSubItems,
+            },
+            {
+                text: 'Item 5',
+                items: this.handleLoadSubItems,
+            },
+        ];
+    }
+
+    public render() {
+        return [
+            <limel-menu items={this.items} onSelect={this.handleSelect}>
+                <limel-button label="Menu" slot="trigger" />
+            </limel-menu>,
+            <limel-example-value
+                label="Last selected item"
+                value={this.lastSelectedItem}
+            />,
+        ];
+    }
+
+    private handleLoadSubItems = async (
+        item: MenuItem
+    ): Promise<MenuItem[]> => {
+        return new Promise<MenuItem[]>((resolve) => {
+            // Simulate some network delay
+            setTimeout(() => {
+                const subItems = [];
+                for (let i = 1; i < 6; i++) {
+                    subItems.push({
+                        text: `${item.text}.${i}`,
+                        items: this.handleLoadSubItems,
+                    });
+                }
+
+                resolve(subItems);
+            }, NETWORK_DELAY);
+        });
+    };
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.lastSelectedItem = event.detail.text;
+    };
+}

--- a/src/components/menu/examples/menu-sub-menu.tsx
+++ b/src/components/menu/examples/menu-sub-menu.tsx
@@ -1,0 +1,73 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+import { CascadingMenuItems } from './item-constants';
+
+/**
+ * Sub-menus
+ * To have an enhanced navigation and provide a better organization of items,
+ * you can incorporate sub-menus within the menu structure;
+ * and create a so called "Cascading menu".
+ * These sub-menus provide users with an efficient way to access a
+ * wide range of choices without overwhelming them with clutter or complexity.
+ *
+ * The main menu, often called the parent menu,
+ * typically consists of top-level options that represent primary categories or options.
+ * Sub-menus, on the other hand, are secondary or menus that are nested
+ * beneath these primary options.
+ *
+ * Some of the benefits of creating tree-structure for the menus are:
+ * - **Organized Information:** Sub-menus enable a clear and organized presentation of content,
+ * making it easier for users to find what they're looking for within a specific category.
+ * - **Space Efficiency:** They save screen space by concealing secondary options until needed,
+ * reducing visual clutter and making the interface cleaner and more user-friendly.
+ * - **Scalability:** Sub-menus can accommodate a large number of choices or features
+ * within a single parent menu, making them suitable for complex applications or websites.
+ * - **Logical Hierarchy:** By structuring information hierarchically,
+ * sub-menus help users understand the relationships between various
+ * options and navigate through the interface more intuitively.
+ *
+ * Our cascading menus are designed to be mobile-friendly.
+ * This means that sub-menus are opend within the same menu surface,
+ * instead of the classic way of sticking out on the side, as a secondary menu.
+ * Thanks to a breadcrumbs component on the top, the users can easily navigate back
+ * and forward within the menu structure.
+ *
+ * :::tip
+ * It is also very easy to navigate the nested menu structure using the keyboard.
+ * Using the <kbd>↓</kbd> & <kbd>↑</kbd> keys, the user can naturally
+ * navigate within the presented menu.
+ * Pressing the <kbd>→</kbd> key on a menu item that has sub-menu opens a nested menu;
+ * and pressing the <kbd>←</kbd> key takes the user back to the previous/parent menu.
+ * :::
+ * @link item-constants.ts
+ */
+@Component({
+    tag: 'limel-example-menu-sub-menus',
+    shadow: true,
+})
+export class MenuSubMenusExample {
+    private items: Array<MenuItem | ListSeparator> = CascadingMenuItems;
+
+    @State()
+    private lastSelectedItem: string;
+
+    public render() {
+        return [
+            <limel-menu items={this.items} onSelect={this.handleSelect}>
+                <limel-button label="Menu" slot="trigger" />
+            </limel-menu>,
+            <limel-example-value
+                label="Last selected item"
+                value={this.lastSelectedItem}
+            />,
+        ];
+    }
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.lastSelectedItem = event.detail.text;
+    };
+}

--- a/src/components/menu/examples/subitems-search.ts
+++ b/src/components/menu/examples/subitems-search.ts
@@ -1,0 +1,44 @@
+import { MenuItem, ListSeparator } from '@limetech/lime-elements';
+
+export function SearchMenuItems(
+    searchValue: string,
+    menuItems: Array<MenuItem | ListSeparator>
+): MenuItem[] {
+    if (!searchValue) {
+        return [];
+    }
+
+    searchValue = searchValue?.toLowerCase();
+    const flattenedItems = flattenMenuItems(menuItems);
+
+    return flattenedItems.filter(
+        (i) =>
+            !('separator' in i) && i.text?.toLowerCase().includes(searchValue)
+    );
+}
+
+function flattenMenuItems(
+    menuItems: Array<MenuItem | ListSeparator>
+): MenuItem[] {
+    const flattenedItems: MenuItem[] = [];
+
+    function flatten(menuItem: MenuItem) {
+        flattenedItems.push(menuItem);
+
+        if (Array.isArray(menuItem.items)) {
+            for (const subItem of menuItem.items) {
+                if (!('separator' in subItem)) {
+                    flatten(subItem as MenuItem);
+                }
+            }
+        }
+    }
+
+    for (const menuItem of menuItems) {
+        if (!('separator' in menuItem)) {
+            flatten(menuItem as MenuItem);
+        }
+    }
+
+    return flattenedItems;
+}

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import {
     Component,
     Event,
@@ -6,15 +7,31 @@ import {
     Prop,
     Element,
     Watch,
+    State,
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
-import { zipObject } from 'lodash-es';
+import { zipObject, isFunction } from 'lodash-es';
+import { LimelBreadcrumbsCustomEvent } from '@limetech/lime-elements';
+
+import { BreadcrumbsItem } from '../breadcrumbs/breadcrumbs.types';
+import { ListSeparator } from '../list/list-item.types';
 import {
-    ListSeparator,
-    MenuItem,
     OpenDirection,
+    MenuItem,
+    MenuLoader,
     SurfaceWidth,
-} from '../../interface';
+} from './menu.types';
+
+import {
+    ARROW_LEFT,
+    ARROW_LEFT_KEY_CODE,
+    ARROW_RIGHT,
+    ARROW_RIGHT_KEY_CODE,
+} from '../../util/keycodes';
+
+interface MenuCrumbItem extends BreadcrumbsItem {
+    menuItem: MenuItem;
+}
 
 /**
  * @slot trigger - Element to use as a trigger for the menu.
@@ -29,6 +46,9 @@ import {
  * @exampleComponent limel-example-menu-hotkeys
  * @exampleComponent limel-example-menu-secondary-text
  * @exampleComponent limel-example-menu-notification
+ * @exampleComponent limel-example-menu-sub-menus
+ * @exampleComponent limel-example-menu-open-sub-menu-programatically
+ * @exampleComponent limel-example-menu-sub-menu-lazy-loading
  * @exampleComponent limel-example-menu-composite
  */
 @Component({
@@ -80,6 +100,20 @@ export class Menu {
     public gridLayout = false;
 
     /**
+     * Making it possible for a consumer to tell the component that it's waiting for something.
+     * For example loading items/root items.
+     */
+    @Prop()
+    public loading: boolean;
+
+    /**
+     * Making it possible for the consumer so explicitly tell the component
+     * what has been selected in the menu.
+     */
+    @Prop({ mutable: true })
+    public selectedMenuItem: MenuItem;
+
+    /**
      * Is emitted when the menu is cancelled.
      */
     @Event()
@@ -89,35 +123,82 @@ export class Menu {
      * Is emitted when a menu item is selected.
      */
     @Event()
-    private select: EventEmitter<MenuItem | MenuItem[]>;
+    public select: EventEmitter<MenuItem>;
+
+    /**
+     * Is emitted when a menu item with a sub-menu is selected.
+     */
+    @Event()
+    public navigateMenu: EventEmitter<MenuItem>;
 
     @Element()
     private host: HTMLLimelMenuElement;
+
+    /**
+     * True while loading a sub-menu.
+     */
+    @State()
+    private loadingSubItems: boolean;
+
+    /**
+     * The current items in the menu list
+     */
+    @State()
+    private currentItems: Array<MenuItem | ListSeparator> = null;
 
     private list: HTMLLimelMenuListElement;
 
     private portalId: string;
     private triggerElement: HTMLSlotElement;
 
+    private get visibleItems(): Array<MenuItem | ListSeparator> {
+        if (Array.isArray(this.currentItems)) {
+            return this.currentItems;
+        }
+
+        return this.items;
+    }
+
     constructor() {
         this.portalId = createRandomString();
+    }
+
+    @Watch('items')
+    protected itemsWatcher() {
+        this.currentItems = null;
+
+        this.setFocus();
+    }
+
+    @Watch('currentItems')
+    protected currentItemsWatcher() {
+        this.setFocus();
     }
 
     @Watch('open')
     protected openWatcher() {
         if (!this.open) {
+            this.currentItems = null;
+
             return;
         }
 
-        const observer = new IntersectionObserver(() => {
-            observer.unobserve(this.list);
-            this.focusMenuItem();
-        });
-        observer.observe(this.list);
+        this.setFocus();
     }
+
+    private setFocus = () => {
+        setTimeout(() => {
+            const observer = new IntersectionObserver(() => {
+                observer.unobserve(this.list);
+                this.focusMenuItem();
+            });
+            observer.observe(this.list);
+        }, 0);
+    };
 
     public render() {
         const cssProperties = this.getCssProperties();
+
         const dropdownZIndex = getComputedStyle(this.host).getPropertyValue(
             '--dropdown-z-index'
         );
@@ -150,17 +231,9 @@ export class Menu {
                             'has-grid-layout': this.gridLayout,
                         }}
                     >
-                        <limel-menu-list
-                            class={{
-                                'has-grid-layout has-interactive-items':
-                                    this.gridLayout,
-                            }}
-                            items={this.items}
-                            type="menu"
-                            badgeIcons={this.badgeIcons}
-                            onSelect={this.handleSelect}
-                            ref={this.setListElement}
-                        />
+                        {this.renderBreadcrumb()}
+                        {this.renderLoader()}
+                        {this.renderMenuList()}
                     </limel-menu-surface>
                 </limel-portal>
             </div>
@@ -171,6 +244,175 @@ export class Menu {
         const slotElement = this.host.shadowRoot.querySelector('slot');
         slotElement.assignedElements().forEach(this.setTriggerAttributes);
     }
+
+    private renderLoader = () => {
+        if (!this.loadingSubItems && !this.loading) {
+            return;
+        }
+
+        const cssProperties = this.getCssProperties();
+
+        return (
+            <div
+                style={{
+                    width: cssProperties['--menu-surface-width'],
+                    display: 'flex',
+                    'align-items': 'center',
+                    'justify-content': 'center',
+                    padding: '0.5rem 0',
+                }}
+            >
+                <limel-spinner size="mini" limeBranded={false} />
+            </div>
+        );
+    };
+
+    private renderBreadcrumb = () => {
+        if (!this.selectedMenuItem) {
+            return;
+        }
+
+        const breadCrumbItems: MenuCrumbItem[] = [];
+        let currentItem = this.selectedMenuItem;
+        while (currentItem) {
+            breadCrumbItems.unshift({
+                text: currentItem.text,
+                icon: {
+                    name: currentItem.icon,
+                    color: currentItem.iconColor,
+                },
+                menuItem: currentItem,
+            });
+            currentItem = currentItem.parentItem;
+        }
+
+        if (!breadCrumbItems.length) {
+            return;
+        }
+
+        return (
+            <limel-breadcrumbs
+                style={{
+                    'border-bottom': 'solid 1px rgb(var(--contrast-500))',
+                    'flex-shrink': '0',
+                }}
+                onSelect={(
+                    event: LimelBreadcrumbsCustomEvent<MenuCrumbItem>
+                ) => {
+                    if (!event.detail.menuItem) {
+                        this.currentItems = null;
+                        this.selectedMenuItem = null;
+                        this.navigateMenu.emit(null);
+
+                        return;
+                    }
+
+                    this.handleSelect(event.detail.menuItem);
+                }}
+                items={[
+                    {
+                        text: '',
+                        icon: {
+                            name: 'home',
+                        },
+                        type: 'icon-only',
+                    },
+                    ...breadCrumbItems,
+                ]}
+            />
+        );
+    };
+
+    private renderMenuList = () => {
+        let items = this.visibleItems;
+        if (this.loadingSubItems || this.loading) {
+            items = [];
+        }
+
+        return (
+            <limel-menu-list
+                tabindex="1"
+                style={{
+                    'overflow-y': 'auto',
+                    'flex-grow': '1',
+                }}
+                class={{
+                    'has-grid-layout has-interactive-items': this.gridLayout,
+                }}
+                items={items}
+                type="menu"
+                badgeIcons={this.badgeIcons}
+                onSelect={this.onSelect}
+                ref={this.setListElement}
+                onKeyDown={this.handleMenuKeyDown}
+            />
+        );
+    };
+
+    /**
+     * Key handler for the menu list
+     * Can go forward/back with righ/left arrow keys
+     * @param {KeyboardEvent} event event
+     * @returns {void}
+     */
+    private handleMenuKeyDown = (event: KeyboardEvent) => {
+        const isLeft =
+            event.key === ARROW_LEFT || event.keyCode === ARROW_LEFT_KEY_CODE;
+
+        const isRight =
+            event.key === ARROW_RIGHT || event.keyCode === ARROW_RIGHT_KEY_CODE;
+
+        if (!isLeft && !isRight) {
+            return;
+        }
+
+        if (!this.gridLayout) {
+            const currentItem = this.getCurrentItem();
+
+            event.stopPropagation();
+            event.preventDefault();
+            if (isRight) {
+                this.goForward(currentItem);
+            } else if (isLeft) {
+                this.goBack(currentItem);
+            }
+        }
+    };
+
+    private getCurrentItem = (): MenuItem => {
+        const activeItem = this.list?.shadowRoot?.querySelector(
+            '[role="menuitem"][tabindex="0"]'
+        );
+        const attrIndex = activeItem?.attributes?.getNamedItem('data-index');
+        const dataIndex = parseInt(attrIndex?.value || '0', 10);
+
+        return this.visibleItems[dataIndex] as MenuItem;
+    };
+
+    private goForward = (currentItem: MenuItem) => {
+        this.handleSelect(currentItem, false);
+    };
+
+    private goBack = (currentItem: MenuItem) => {
+        const parentItem = currentItem?.parentItem;
+        if (!parentItem) {
+            // Already in the root of the menu
+            return;
+        }
+
+        const grandParent = parentItem.parentItem;
+        if (!grandParent) {
+            // Is only one step down, go to the root of the menu.
+            // No need to load a sub-menu.
+            this.selectedMenuItem = null;
+            this.currentItems = null;
+            this.navigateMenu.emit(null);
+
+            return;
+        }
+
+        this.handleSelect(grandParent);
+    };
 
     private setTriggerAttributes = (element: HTMLElement) => {
         const attributes = {
@@ -192,6 +434,7 @@ export class Menu {
     private onClose = () => {
         this.cancel.emit();
         this.open = false;
+        this.selectedMenuItem = null;
     };
 
     private onTriggerClick = (event: MouseEvent) => {
@@ -203,10 +446,50 @@ export class Menu {
         this.open = !this.open;
     };
 
-    private handleSelect = (event: CustomEvent<MenuItem>) => {
-        event.stopPropagation();
-        this.select.emit(event.detail);
+    private handleSelect = async (
+        menuItem: MenuItem,
+        selectOnEmptyChildren: boolean = true
+    ) => {
+        if (Array.isArray(menuItem?.items) && menuItem.items.length > 0) {
+            this.selectedMenuItem = menuItem;
+            this.navigateMenu.emit(menuItem);
+            this.currentItems = menuItem.items.map((item) => ({
+                ...item,
+                parentItem: menuItem,
+            }));
+
+            return;
+        } else if (isFunction(menuItem?.items)) {
+            const menuLoader = menuItem.items as MenuLoader;
+            this.loadingSubItems = true;
+            const subItems = await menuLoader(menuItem);
+            this.loadingSubItems = false;
+
+            if (subItems?.length) {
+                this.selectedMenuItem = menuItem;
+                this.navigateMenu.emit(menuItem);
+                this.currentItems = subItems.map((item) => ({
+                    ...item,
+                    parentItem: menuItem,
+                }));
+
+                return;
+            }
+        }
+
+        if (!selectOnEmptyChildren) {
+            return;
+        }
+
+        this.currentItems = null;
+        this.select.emit(menuItem);
         this.open = false;
+        this.selectedMenuItem = null;
+    };
+
+    private onSelect = (event: CustomEvent<MenuItem>) => {
+        event.stopPropagation();
+        this.handleSelect(event.detail);
     };
 
     private getCssProperties() {
@@ -233,10 +516,14 @@ export class Menu {
     };
 
     private focusMenuItem = () => {
+        if (!this.list) {
+            return;
+        }
+
         const activeElement = this.list.shadowRoot.activeElement as HTMLElement;
         activeElement?.blur();
 
-        const MenuItems = this.items.filter(this.isMenuItem);
+        const MenuItems = this.visibleItems.filter(this.isMenuItem);
         const selectedIndex = Math.max(
             MenuItems.findIndex((item) => item.selected),
             0

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,3 +1,5 @@
+import { ListSeparator } from '../../interface';
+
 export type OpenDirection =
     | 'left-start'
     | 'left'
@@ -75,4 +77,30 @@ export interface MenuItem<T = any> {
      * Value of the menu item.
      */
     value?: T;
+
+    /**
+     * A way of defining a sub-menu for an item.
+     * Either set it to an array of `MenuItem`s
+     * Or use Lazy loading by setting it to a function of type `MenuLoader`
+     * If it's undefined/null it will be considered an item without a sub-menu
+     */
+    items?: Array<MenuItem<T> | ListSeparator> | MenuLoader;
+
+    /**
+     * What parent the item has.
+     * It's used to render the breadcrumbs history
+     * Mostly handled by the menu itself
+     */
+    parentItem?: MenuItem<T>;
 }
+
+/**
+ * A loader function that takes a `MenuItem` as an argument, and returns
+ * a promise that will eventually be resolved with an array of `MenuItem`:s,
+ * that is the sub-menu of the given item.
+ * @param {MenuItem} item The parent item to load the sub-menu for.
+ * @returns {Promise<MenuItem[]>} The sub-menu's items of the given item
+ */
+export type MenuLoader = (
+    item: MenuItem
+) => Promise<Array<MenuItem | ListSeparator>>;

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -95,6 +95,15 @@ export interface MenuItem<T = any> {
 }
 
 /**
+ * A search function that takes a search-string as an argument, and returns
+ * a promise that will eventually be resolved with an array of `MenuItem`:s.
+ * @param {string} query A search query. What the user has written
+ * in the input field of a limel-menu.
+ * @returns {Promise<MenuItem[]>} The search result.
+ */
+export type MenuSearcher = (query: string) => Promise<MenuItem[]>;
+
+/**
  * A loader function that takes a `MenuItem` as an argument, and returns
  * a promise that will eventually be resolved with an array of `MenuItem`:s,
  * that is the sub-menu of the given item.


### PR DESCRIPTION
Reviews of the public API/Interfaces have been done in a separate [PR#2473 ](https://github.com/Lundalogik/lime-elements/pull/2473)

In this PR we have two different features separated by two commits:
- Searchable items
- Enable Sub items


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
