### PR TITLE
feat(menu): enable having nested menus (sub-menus)

### DIFF
--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -140,6 +140,7 @@ export class MenuListRenderer {
             >
                 {item.icon ? this.renderIcon(this.config, item) : null}
                 {this.renderText(item)}
+                {this.renderSubMenuIcon(item)}
                 {this.renderNotification(item)}
                 {this.twoLines && this.avatarList ? this.renderDivider() : null}
             </li>
@@ -171,6 +172,14 @@ export class MenuListRenderer {
                 </div>
             </div>
         );
+    };
+
+    private renderSubMenuIcon = (item: MenuItem) => {
+        if (!this.hasSubItems(item)) {
+            return;
+        }
+
+        return <limel-icon class="sub-menu-icon" name="-lime-caret-right" />;
     };
 
     private rendertext = (item: ListSeparator) => {
@@ -245,5 +254,9 @@ export class MenuListRenderer {
         }
 
         return <hr class={classes} />;
+    };
+
+    private hasSubItems = (item: MenuItem): boolean => {
+        return Array.isArray(item.items) && item.items.length > 0;
     };
 }

--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -39,3 +39,9 @@
 limel-badge {
     transform: translateX(0.75rem);
 }
+
+.sub-menu-icon {
+    width: 1rem;
+    transform: translateX(0.75rem);
+    flex-shrink: 0;
+}

--- a/src/components/menu/examples/item-constants.ts
+++ b/src/components/menu/examples/item-constants.ts
@@ -1,0 +1,53 @@
+import { MenuItem } from '../menu.types';
+
+export const CascadingMenuItems: MenuItem[] = [
+    {
+        text: 'Format',
+        items: [
+            {
+                text: 'Bold',
+                icon: 'bold',
+            },
+            {
+                text: 'Italic',
+                icon: 'italic',
+            },
+            {
+                text: 'Bullets and numbering',
+                icon: 'bulleted_list',
+                items: [
+                    {
+                        text: 'Numbered list',
+                        icon: 'numbered_list',
+                    },
+                    {
+                        text: 'Bullet list',
+                        icon: 'bulleted_list',
+                    },
+                    {
+                        text: 'Checklist',
+                        icon: 'todo_list',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        text: 'Edit',
+        items: [
+            {
+                text: 'Copy',
+                icon: 'copy',
+            },
+            {
+                text: 'Cut',
+                icon: 'cut',
+            },
+            { separator: true },
+            {
+                text: 'Paste',
+                icon: 'paste',
+            },
+        ],
+    },
+];

--- a/src/components/menu/examples/menu-composite.tsx
+++ b/src/components/menu/examples/menu-composite.tsx
@@ -1,3 +1,4 @@
+import { Components } from '@limetech/lime-elements';
 import { Component, h, Prop, State } from '@stencil/core';
 
 /**
@@ -46,7 +47,7 @@ export class MenuCompositeExample {
         open: false,
         openDirection: 'right',
         gridLayout: false,
-    };
+    } as Components.LimelMenu;
 
     private eventPrinter: HTMLLimelExampleEventPrinterElement;
 
@@ -61,6 +62,9 @@ export class MenuCompositeExample {
         };
 
         delete this.schema.properties.label;
+        delete this.schema.properties.currentSubMenu;
+        delete this.schema.properties.loadSubItems;
+        delete this.schema.properties.surfaceWidth;
     }
 
     public render() {
@@ -68,9 +72,9 @@ export class MenuCompositeExample {
 
         return [
             <limel-menu
-                items={this.props.items as any}
+                items={this.props.items}
                 disabled={this.props.disabled}
-                openDirection={this.props.openDirection as any}
+                openDirection={this.props.openDirection}
                 badgeIcons={this.props.badgeIcons}
                 open={this.props.open}
                 gridLayout={this.props.gridLayout}

--- a/src/components/menu/examples/menu-open-sub-menu-programmatically.scss
+++ b/src/components/menu/examples/menu-open-sub-menu-programmatically.scss
@@ -1,0 +1,9 @@
+:host(limel-example-menu-open-sub-menu-programmatically) {
+    display: flex;
+    flex-direction: column;
+}
+
+.menu-container {
+    display: flex;
+    gap: 2rem;
+}

--- a/src/components/menu/examples/menu-open-sub-menu-programmatically.tsx
+++ b/src/components/menu/examples/menu-open-sub-menu-programmatically.tsx
@@ -86,15 +86,15 @@ export class MenuOpenSubMenuProgrammaticallyExample {
             (i) => i.text === 'Format'
         ) as MenuItem;
 
-        const menuToOpen = formatMenuItem.items.find(
-            (i) => i.text === 'Bullets and numbering'
-        ) as MenuItem;
+        const menuToOpen = (
+            formatMenuItem.items as Array<MenuItem | ListSeparator>
+        ).find((i) => i.text === 'Bullets and numbering') as MenuItem;
 
         this.currentSubMenu = {
             ...menuToOpen,
             parentItem: formatMenuItem,
         };
-        this.items = menuToOpen.items;
+        this.items = menuToOpen.items as Array<MenuItem | ListSeparator>;
         this.openMenu = true;
     };
 

--- a/src/components/menu/examples/menu-open-sub-menu-programmatically.tsx
+++ b/src/components/menu/examples/menu-open-sub-menu-programmatically.tsx
@@ -1,0 +1,107 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h, Host } from '@stencil/core';
+import { CascadingMenuItems } from './item-constants';
+
+/**
+ * Opening sub-menus programmatically
+ *
+ * **This example is currently not in use because it's an experimental feature**
+ *
+ * It is possible to open any sub-menu in the menu-hierarchy.
+ * This is done by using the parentItem property of the MenuItem class.
+ * @link item-constants.ts
+ */
+@Component({
+    tag: 'limel-example-menu-open-sub-menu-programmatically',
+    shadow: true,
+    styleUrl: 'menu-open-sub-menu-programmatically.scss',
+})
+export class MenuOpenSubMenuProgrammaticallyExample {
+    private readonly rootItems: Array<MenuItem | ListSeparator> =
+        CascadingMenuItems;
+
+    @State()
+    private items: Array<MenuItem | ListSeparator> = this.rootItems;
+
+    @State()
+    private lastSelectedItem: string;
+
+    @State()
+    private currentSubMenu: MenuItem;
+
+    @State()
+    private openMenu: boolean = false;
+
+    public render() {
+        return (
+            <Host>
+                {this.renderMenu()}
+                <limel-example-value
+                    label="Last selected item"
+                    value={this.lastSelectedItem}
+                />
+            </Host>
+        );
+    }
+
+    private renderMenu() {
+        return (
+            <div class="menu-container">
+                <limel-menu
+                    items={this.items}
+                    open={this.openMenu}
+                    currentSubMenu={this.currentSubMenu}
+                    onSelect={this.handleSelect}
+                    onNavigateMenu={this.handleNavigateMenu}
+                    onCancel={this.handleMenuCancel}
+                >
+                    <limel-button label="Menu" slot="trigger" />
+                </limel-menu>
+                <limel-button
+                    label='Shortcut to "Bullets and numbering"'
+                    primary={true}
+                    onClick={this.buttonClick}
+                />
+            </div>
+        );
+    }
+
+    private handleNavigateMenu = (event: LimelMenuCustomEvent<MenuItem>) => {
+        if (!event.detail) {
+            this.items = this.rootItems;
+        }
+    };
+
+    private handleMenuCancel = () => {
+        this.items = this.rootItems;
+        this.openMenu = false;
+    };
+
+    private buttonClick = () => {
+        const formatMenuItem = this.rootItems.find(
+            (i) => i.text === 'Format'
+        ) as MenuItem;
+
+        const menuToOpen = formatMenuItem.items.find(
+            (i) => i.text === 'Bullets and numbering'
+        ) as MenuItem;
+
+        this.currentSubMenu = {
+            ...menuToOpen,
+            parentItem: formatMenuItem,
+        };
+        this.items = menuToOpen.items;
+        this.openMenu = true;
+    };
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.currentSubMenu = null;
+        this.items = this.rootItems;
+        this.lastSelectedItem = event.detail.text;
+        this.openMenu = false;
+    };
+}

--- a/src/components/menu/examples/menu-sub-menu.tsx
+++ b/src/components/menu/examples/menu-sub-menu.tsx
@@ -1,0 +1,74 @@
+import {
+    MenuItem,
+    ListSeparator,
+    LimelMenuCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+import { CascadingMenuItems } from './item-constants';
+
+/**
+ * Sub-menus
+ * To have an enhanced navigation and provide a better organization of items,
+ * you can incorporate sub-menus within the menu structure;
+ * and create a so called "Cascading menu".
+ * These sub-menus provide the user with an efficient way to access a
+ * wide range of choices without overwhelming them with clutter or complexity.
+ *
+ * The main menu, often called the parent menu,
+ * typically consists of top-level options that represent primary categories or options.
+ * Sub-menus, on the other hand, are secondary or menus that are nested
+ * beneath these primary options.
+ *
+ * Some of the benefits of creating tree-structure for the menus are:
+ * - **Organized Information:** Sub-menus enable a clear and organized presentation of content,
+ * making it easier for the user to find what they're looking for within a specific category.
+ * - **Space Efficiency:** They save screen space by concealing secondary options until needed,
+ * reducing visual clutter and making the interface cleaner and more user-friendly.
+ * - **Scalability:** Sub-menus can accommodate a large number of choices or features
+ * within a single parent menu, making them suitable for complex applications or websites.
+ * - **Logical Hierarchy:** By structuring information hierarchically,
+ * sub-menus help the user understand the relationships between various
+ * options and navigate through the interface more intuitively.
+ *
+ * Our cascading menus are designed to be mobile-friendly.
+ * This means that sub-menus are opened within the same menu surface,
+ * instead of the classic way of sticking out on the side, as a secondary menu.
+ * Thanks to a breadcrumbs component on the top, the user can easily navigate back
+ * and forth within the menu structure.
+ *
+ * :::tip
+ * It is also very easy to navigate the nested menu structure using the keyboard.
+ *
+ * - Using the <kbd>↓</kbd> & <kbd>↑</kbd> keys, the user can naturally
+ * navigate within the presented menu,
+ * - pressing the <kbd>→</kbd> key on a menu item that has sub-menu opens a nested menu,
+ * - and pressing the <kbd>←</kbd> key takes the user back to the previous/parent menu.
+ * :::
+ * @link item-constants.ts
+ */
+@Component({
+    tag: 'limel-example-menu-sub-menus',
+    shadow: true,
+})
+export class MenuSubMenusExample {
+    private items: Array<MenuItem | ListSeparator> = CascadingMenuItems;
+
+    @State()
+    private lastSelectedItem: string;
+
+    public render() {
+        return [
+            <limel-menu items={this.items} onSelect={this.handleSelect}>
+                <limel-button label="Menu" slot="trigger" />
+            </limel-menu>,
+            <limel-example-value
+                label="Last selected item"
+                value={this.lastSelectedItem}
+            />,
+        ];
+    }
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.lastSelectedItem = event.detail.text;
+    };
+}

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -89,7 +89,7 @@ export class Menu {
      * Is emitted when a menu item is selected.
      */
     @Event()
-    private select: EventEmitter<MenuItem | MenuItem[]>;
+    private select: EventEmitter<MenuItem>;
 
     @Element()
     private host: HTMLLimelMenuElement;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -83,13 +83,13 @@ export class Menu {
      * Is emitted when the menu is cancelled.
      */
     @Event()
-    private cancel: EventEmitter<void>;
+    public cancel: EventEmitter<void>;
 
     /**
      * Is emitted when a menu item is selected.
      */
     @Event()
-    private select: EventEmitter<MenuItem>;
+    public select: EventEmitter<MenuItem>;
 
     @Element()
     private host: HTMLLimelMenuElement;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -95,7 +95,6 @@ export class Menu {
     private host: HTMLLimelMenuElement;
 
     private list: HTMLLimelMenuListElement;
-
     private portalId: string;
     private triggerElement: HTMLSlotElement;
 
@@ -103,17 +102,9 @@ export class Menu {
         this.portalId = createRandomString();
     }
 
-    @Watch('open')
-    protected openWatcher() {
-        if (!this.open) {
-            return;
-        }
-
-        const observer = new IntersectionObserver(() => {
-            observer.unobserve(this.list);
-            this.focusMenuItem();
-        });
-        observer.observe(this.list);
+    public componentDidRender() {
+        const slotElement = this.host.shadowRoot.querySelector('slot');
+        slotElement.assignedElements().forEach(this.setTriggerAttributes);
     }
 
     public render() {
@@ -167,9 +158,17 @@ export class Menu {
         );
     }
 
-    public componentDidRender() {
-        const slotElement = this.host.shadowRoot.querySelector('slot');
-        slotElement.assignedElements().forEach(this.setTriggerAttributes);
+    @Watch('open')
+    protected openWatcher() {
+        if (!this.open) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(() => {
+            observer.unobserve(this.list);
+            this.focusMenuItem();
+        });
+        observer.observe(this.list);
     }
 
     private setTriggerAttributes = (element: HTMLElement) => {

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -91,7 +91,7 @@ export interface MenuItem<T = any> {
      * A way of defining a sub-menu for an item.
      * Set it to an array of `MenuItem`s
      */
-    items?: Array<MenuItem<T> | ListSeparator>;
+    items?: Array<MenuItem<T> | ListSeparator> | MenuLoader;
 
     /**
      * :::warning Internal Use Only
@@ -104,3 +104,15 @@ export interface MenuItem<T = any> {
      */
     parentItem?: MenuItem;
 }
+
+/**
+ * A loader function that takes a `MenuItem` as an argument, and returns
+ * a promise that will eventually be resolved with an array of `MenuItem`:s,
+ * that is the sub-menu of the given item.
+ * @param {MenuItem} item The parent item to load the sub-menu for.
+ * @returns {Promise<MenuItem[]>} The sub-menu's items of the given item
+ * @internal
+ */
+export type MenuLoader = (
+    item: MenuItem
+) => Promise<Array<MenuItem | ListSeparator>>;

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,4 +1,4 @@
-import { Icon } from '../../interface';
+import { Icon, ListSeparator } from '../../interface';
 
 export type OpenDirection =
     | 'left-start'
@@ -86,4 +86,21 @@ export interface MenuItem<T = any> {
      * Value of the menu item.
      */
     value?: T;
+
+    /**
+     * A way of defining a sub-menu for an item.
+     * Set it to an array of `MenuItem`s
+     */
+    items?: Array<MenuItem<T> | ListSeparator>;
+
+    /**
+     * :::warning Internal Use Only
+     * This property is for internal use only. We need it for now, but want to
+     * find a better implementation of the functionality it currently enables.
+     * If and when we do so, this property will be removed without prior
+     * notice. If you use it, your code _will_ break in the future.
+     * :::
+     * @internal
+     */
+    parentItem?: MenuItem;
 }


### PR DESCRIPTION
This is one of three PRs that are connected and extracted from #2574 
They are chained in 3 branches and is best reviewed in this order:

1. https://github.com/Lundalogik/lime-elements/pull/2576 **This PR**
2. https://github.com/Lundalogik/lime-elements/pull/2577
3. https://github.com/Lundalogik/lime-elements/pull/2578



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
