### PR TITLE
refactor(input-field): simplify the logic for rendering the portal

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -802,10 +802,6 @@ export class InputField {
             return;
         }
 
-        return this.renderDropdown();
-    };
-
-    private renderPortal = (content = null) => {
         const dropdownZIndex = getComputedStyle(
             this.limelInputField
         ).getPropertyValue('--dropdown-z-index');
@@ -827,16 +823,10 @@ export class InputField {
                     }}
                     onDismiss={this.handleCloseMenu}
                 >
-                    {content}
+                    {this.renderListResult()}
                 </limel-menu-surface>
             </limel-portal>
         );
-    };
-
-    private renderDropdown = () => {
-        const content = this.renderListResult();
-
-        return this.renderPortal(content);
     };
 
     private renderListResult = () => {


### PR DESCRIPTION
The portal is currently used to show auto-completion suggestions. But the plan is to use it for showing even the helper-line. This change will make the next thing easier.
I believe this change provides a better code organization, and achieves the same functionality
in terms of rendering the autocomplete list with the same conditions and handling the same interactions.
The core structure and logic of rendering the list, controlling its visibility, and handling user interactions remain consistent in both versions.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
