### PR TITLE
fix(input-field): prevent helper line to occupy screen space when hidden 

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -38,14 +38,13 @@
             margin-top: functions.pxToRem(8);
             margin-bottom: 0;
         }
+    }
+}
 
-        &.has-helper-line {
-            // TODO: remove this when helper-line is displayed in portal
-            --heightOfHelperText: 0.9375rem;
-            height: calc(
-                var(--textarea-height, 100%) - var(--heightOfHelperText)
-            );
-        }
+:host(limel-input-field:hover),
+:host(limel-input-field:focus-within) {
+    limel-helper-line {
+        will-change: grid-template-rows;
     }
 }
 
@@ -110,11 +109,6 @@
 }
 
 :not(.mdc-text-field--focused):not(.mdc-text-field--invalid) {
-    + limel-helper-line {
-        // TODO: remove when helper-line is displayed in portal
-        opacity: 0;
-    }
-
     .mdc-text-field__input[type='number'] {
         color: transparent;
         -webkit-text-fill-color: transparent;

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -381,8 +381,6 @@ export class InputField {
 
         if (this.type === 'textarea') {
             classList['mdc-text-field--textarea'] = true;
-            classList['has-helper-line'] =
-                !!this.helperText || !!this.maxlength;
         } else {
             classList['mdc-text-field--with-leading-icon'] = !!this.leadingIcon;
             classList['mdc-text-field--with-trailing-icon'] =
@@ -478,8 +476,13 @@ export class InputField {
             return;
         }
 
+        const hideHelperLine = !(this.isFocused || this.isInvalid());
+
         return (
             <limel-helper-line
+                class={{
+                    hide: hideHelperLine,
+                }}
                 helperTextId={this.helperTextId}
                 helperText={this.helperText}
                 length={length}


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
