### PR TITLE
fix(slider): prevent helper line to occupy screen space when hidden

### DIFF
--- a/src/components/slider/partial-styles/_helper-text.scss
+++ b/src/components/slider/partial-styles/_helper-text.scss
@@ -1,12 +1,10 @@
 limel-helper-line {
-    opacity: 0;
     order: 3;
 }
 
-:host(:focus),
-:host(:focus-visible),
-:host(:focus-within) {
+:host(limel-slider:hover),
+:host(limel-slider:focus-within) {
     limel-helper-line {
-        opacity: 1;
+        will-change: grid-template-rows;
     }
 }

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -109,6 +109,9 @@ export class Slider {
     @State()
     private percentageClass: string;
 
+    @State()
+    private isFocused: boolean = false;
+
     private mdcSlider: MDCSlider;
     private labelId: string;
     private helperTextId: string;
@@ -123,6 +126,9 @@ export class Slider {
         this.initialize();
         this.observer = new ResizeObserver(this.resizeObserverCallback);
         this.observer.observe(this.rootElement);
+
+        this.rootElement.addEventListener('focus', this.handleFocus);
+        this.rootElement.addEventListener('blur', this.handleBlur);
     }
 
     public componentWillLoad() {
@@ -247,10 +253,21 @@ export class Slider {
 
         return (
             <limel-helper-line
+                class={{
+                    hide: !this.isFocused,
+                }}
                 helperText={this.helperText}
                 helperTextId={this.helperTextId}
             />
         );
+    };
+
+    private handleFocus = () => {
+        this.isFocused = true;
+    };
+
+    private handleBlur = () => {
+        this.isFocused = false;
     };
 
     private initialize = () => {


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
