### PR TITLE
only render portal when the element is actually needed to be displayed

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -802,6 +802,13 @@ export class InputField {
             return;
         }
 
+        const filteredCompletions: ListItem[] = this.filterCompletions(
+            this.value
+        );
+        if (!filteredCompletions || filteredCompletions.length === 0) {
+            return null;
+        }
+
         const dropdownZIndex = getComputedStyle(
             this.limelInputField
         ).getPropertyValue('--dropdown-z-index');
@@ -830,19 +837,12 @@ export class InputField {
     };
 
     private renderListResult = () => {
-        const filteredCompletions: ListItem[] = this.filterCompletions(
-            this.value
-        );
-        if (!filteredCompletions || filteredCompletions.length === 0) {
-            return null;
-        }
-
         return (
             <limel-list
                 onChange={this.handleCompletionChange}
                 onKeyDown={this.handleKeyDownInDropdown}
                 type="selectable"
-                items={filteredCompletions}
+                items={this.filterCompletions(this.value)}
             />
         );
     };

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -117,55 +117,64 @@ export class Menu {
     }
 
     public render() {
+        return (
+            <div class="mdc-menu-surface--anchor" onClick={this.onTriggerClick}>
+                <slot ref={this.setTriggerRef} name="trigger" />
+                {this.renderNotificationBadge()}
+                {this.renderPortal()}
+            </div>
+        );
+    }
+
+    private renderPortal = () => {
+        if (!this.open) {
+            return;
+        }
+
         const cssProperties = this.getCssProperties();
         const dropdownZIndex = getComputedStyle(this.host).getPropertyValue(
             '--dropdown-z-index'
         );
-
         const menuSurfaceWidth = this.getMenuSurfaceWidth(
             cssProperties['--menu-surface-width']
         );
 
         return (
-            <div class="mdc-menu-surface--anchor" onClick={this.onTriggerClick}>
-                <slot ref={this.setTriggerRef} name="trigger" />
-                {this.renderNotificationBadge()}
-                <limel-portal
-                    visible={this.open}
-                    containerId={this.portalId}
-                    openDirection={this.openDirection}
-                    position="absolute"
-                    containerStyle={{ 'z-index': dropdownZIndex }}
+            <limel-portal
+                visible={this.open}
+                containerId={this.portalId}
+                openDirection={this.openDirection}
+                position="absolute"
+                containerStyle={{ 'z-index': dropdownZIndex }}
+            >
+                <limel-menu-surface
+                    open={this.open}
+                    onDismiss={this.onClose}
+                    style={{
+                        ...cssProperties,
+                        '--mdc-menu-min-width': menuSurfaceWidth,
+                        '--limel-menu-surface-display': 'flex',
+                        '--limel-menu-surface-flex-direction': 'column',
+                    }}
+                    class={{
+                        'has-grid-layout': this.gridLayout,
+                    }}
                 >
-                    <limel-menu-surface
-                        open={this.open}
-                        onDismiss={this.onClose}
-                        style={{
-                            ...cssProperties,
-                            '--mdc-menu-min-width': menuSurfaceWidth,
-                            '--limel-menu-surface-display': 'flex',
-                            '--limel-menu-surface-flex-direction': 'column',
-                        }}
+                    <limel-menu-list
                         class={{
-                            'has-grid-layout': this.gridLayout,
+                            'has-grid-layout has-interactive-items':
+                                this.gridLayout,
                         }}
-                    >
-                        <limel-menu-list
-                            class={{
-                                'has-grid-layout has-interactive-items':
-                                    this.gridLayout,
-                            }}
-                            items={this.items}
-                            type="menu"
-                            badgeIcons={this.badgeIcons}
-                            onSelect={this.handleSelect}
-                            ref={this.setListElement}
-                        />
-                    </limel-menu-surface>
-                </limel-portal>
-            </div>
+                        items={this.items}
+                        type="menu"
+                        badgeIcons={this.badgeIcons}
+                        onSelect={this.handleSelect}
+                        ref={this.setListElement}
+                    />
+                </limel-menu-surface>
+            </limel-portal>
         );
-    }
+    };
 
     public componentDidRender() {
         const slotElement = this.host.shadowRoot.querySelector('slot');

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -173,6 +173,10 @@ const SelectDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
 };
 
 const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
+    if (!props.isOpen) {
+        return;
+    }
+
     const items = createMenuItems(props.options, props.value, props.required);
 
     return (


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/3703
fix https://github.com/Lundalogik/lime-elements/issues/2583

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
