### PR TITLE
feat(chip-set): enable consumers to make it `invalid`

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -92,6 +92,13 @@ export class ChipSet {
     public readonly: boolean = false;
 
     /**
+     * Set to `true` to indicate that the current value of the input field is
+     * invalid.
+     */
+    @Prop({ reflect: true })
+    public invalid = false;
+
+    /**
      * For chip-sets of type `input`. Value to use for the `type` attribute on the
      * input field inside the chip-set.
      */
@@ -466,6 +473,15 @@ export class ChipSet {
     }
 
     private isInvalid() {
+        if (this.readonly) {
+            // A readonly field can never be invalid.
+            return false;
+        }
+
+        if (this.invalid) {
+            return true;
+        }
+
         if (!this.required) {
             return false;
         }

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -26,6 +26,9 @@ export class ChipSetInputExample {
     private readonly: boolean = false;
 
     @State()
+    private invalid: boolean = false;
+
+    @State()
     private disabled: boolean = false;
 
     @State()
@@ -59,6 +62,7 @@ export class ChipSetInputExample {
                 value={this.value}
                 required={this.required}
                 readonly={this.readonly}
+                invalid={this.invalid}
                 disabled={this.disabled}
                 leadingIcon={this.hasLeadingIcon ? 'search' : null}
                 maxItems={this.maxItems}
@@ -97,6 +101,11 @@ export class ChipSetInputExample {
                     label="Required"
                     onChange={this.setRequired}
                     checked={this.required}
+                />
+                <limel-checkbox
+                    label="Invalid"
+                    onChange={this.setInvalid}
+                    checked={this.invalid}
                 />
                 <limel-checkbox
                     label={'Leading icon'}
@@ -162,6 +171,10 @@ export class ChipSetInputExample {
 
     private setRequired = (event: CustomEvent<boolean>) => {
         this.required = event.detail;
+    };
+
+    private setInvalid = (event: CustomEvent<boolean>) => {
+        this.invalid = event.detail;
     };
 
     private setEmptyInputOnBlur = (event: CustomEvent<boolean>) => {

--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -21,6 +21,9 @@ export class FileExample {
     @State()
     private readonly = false;
 
+    @State()
+    private invalid = false;
+
     public render() {
         return [
             <limel-file
@@ -30,6 +33,7 @@ export class FileExample {
                 value={this.value}
                 disabled={this.disabled}
                 readonly={this.readonly}
+                invalid={this.invalid}
             />,
             <limel-example-controls>
                 <limel-checkbox
@@ -46,6 +50,11 @@ export class FileExample {
                     checked={this.required}
                     label="Required"
                     onChange={this.setRequired}
+                />
+                <limel-checkbox
+                    checked={this.invalid}
+                    label="Invalid"
+                    onChange={this.setInvalid}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,
@@ -70,5 +79,10 @@ export class FileExample {
     private setReadonly = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.readonly = !!event.detail;
+    };
+
+    private setInvalid = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.invalid = event.detail;
     };
 }

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -96,6 +96,13 @@ export class File {
     public readonly: boolean = false;
 
     /**
+     * Set to `true` to indicate that the current value of the chosen file is
+     * invalid.
+     */
+    @Prop({ reflect: true })
+    public invalid = false;
+
+    /**
      * The [accepted file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers)
      */
     @Prop({ reflect: true })
@@ -186,6 +193,7 @@ export class File {
                 }}
                 disabled={this.disabled}
                 readonly={this.readonly}
+                invalid={this.invalid}
                 label={this.label}
                 leadingIcon="upload_to_cloud"
                 language={this.language}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -101,6 +101,13 @@ export class Picker {
     public required: boolean = false;
 
     /**
+     * Set to `true` to indicate that the current value of the input field is
+     * invalid.
+     */
+    @Prop({ reflect: true })
+    public invalid = false;
+
+    /**
      * Currently selected value or values
      */
     @Prop()
@@ -252,6 +259,7 @@ export class Picker {
                 leadingIcon={this.leadingIcon}
                 value={this.chips}
                 disabled={this.disabled}
+                invalid={this.invalid}
                 delimiter={this.renderDelimiter()}
                 readonly={this.readonly}
                 required={this.required}


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
