### PR TITLE
testing what happens when a dialog is inside another dialog

### DIFF
--- a/src/components/dialog/examples/dialog.tsx
+++ b/src/components/dialog/examples/dialog.tsx
@@ -17,6 +17,15 @@ export class DialogExample {
             />,
             <limel-dialog open={this.isOpen} onClose={this.closeDialog}>
                 <p>This is a simple alert-dialog.</p>
+                <limel-dialog open={this.isOpen} onClose={this.closeDialog}>
+                    <p>This is a dialog, inside another dialog!</p>
+                    <limel-button
+                        label="Oh no..."
+                        onClick={this.closeDialog}
+                        slot="button"
+                    />
+                </limel-dialog>
+                ,
                 <limel-button
                     label="Ok"
                     onClick={this.closeDialog}


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
