### PR TITLE
Make non-empty and optional fields with errors invalid

### DIFF
--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -31,13 +31,6 @@ export class LimeElementsWidgetAdapter extends React.Component {
         super(props);
 
         this.handleBlur = this.handleBlur.bind(this);
-        this.initState();
-    }
-
-    private initState() {
-        if (this.hasValue()) {
-            this.state.modified = true;
-        }
     }
 
     private hasValue() {
@@ -71,11 +64,7 @@ export class LimeElementsWidgetAdapter extends React.Component {
         const { modified } = this.state;
         const { rawErrors } = this.props.widgetProps;
 
-        if (!modified) {
-            return false;
-        }
-
-        return !!rawErrors;
+        return !!rawErrors && (modified || this.hasValue());
     }
 
     private isRequired() {

--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -64,7 +64,9 @@ export class LimeElementsWidgetAdapter extends React.Component {
         const { modified } = this.state;
         const { rawErrors } = this.props.widgetProps;
 
-        return !!rawErrors && (modified || this.hasValue());
+        return (
+            !!rawErrors && (modified || this.hasValue() || !this.isRequired())
+        );
     }
 
     private isRequired() {

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -108,13 +108,6 @@ export class SchemaField extends React.Component<FieldProps> {
         this.handleChange = this.handleChange.bind(this);
         this.handleCustomComponentChange =
             this.handleCustomComponentChange.bind(this);
-        this.initState();
-    }
-
-    private initState() {
-        if (this.hasValue()) {
-            this.state.modified = true;
-        }
     }
 
     private hasValue() {
@@ -144,11 +137,7 @@ export class SchemaField extends React.Component<FieldProps> {
         const { modified } = this.state;
         const { errorSchema } = this.props;
 
-        if (!modified) {
-            return false;
-        }
-
-        return !isEmpty(errorSchema);
+        return (modified || this.hasValue()) && !isEmpty(errorSchema);
     }
 
     private isRequired() {

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -137,7 +137,10 @@ export class SchemaField extends React.Component<FieldProps> {
         const { modified } = this.state;
         const { errorSchema } = this.props;
 
-        return (modified || this.hasValue()) && !isEmpty(errorSchema);
+        return (
+            (modified || this.hasValue() || !this.isRequired()) &&
+            !isEmpty(errorSchema)
+        );
     }
 
     private isRequired() {


### PR DESCRIPTION
This makes sure fields that have a value and an error are rendered as invalid.

Also, empty fields that are not required are always rendered as invalid when they have errors.

Fixes: Lundalogik/crm-feature#3478

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
