### PR TITLE
fix(file-viewer): use fileType to create a URL for the file

### DIFF
--- a/src/components/file-viewer/file-viewer.e2e.ts
+++ b/src/components/file-viewer/file-viewer.e2e.ts
@@ -47,7 +47,7 @@ describe('limel-file-viewer', () => {
             contentElement = await page.find('limel-file-viewer>>>iframe');
         });
         it('displays the pdf using the iframe element', () => {
-            expect(contentElement.getAttribute('src')).toEqualText('file.pdf');
+            expect(contentElement.getAttribute('src')).toContain('blob:');
         });
         it('does not show button controls', async () => {
             const buttons = await page.find('limel-file-viewer>>>div.buttons');

--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -153,7 +153,7 @@ export class FileViewer {
 
     public async componentWillLoad() {
         this.fileType = detectExtension(this.filename, this.url);
-        await this.createURL(this.url);
+        await this.createURL(this.fileType);
     }
 
     public render() {


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
