### PR TITLE
File viewer lazy load

### DIFF
--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -243,7 +243,6 @@ export class FileViewer {
                 src={
                     this.getOfficeViewerUrl() + this.fileUrl + '&embedded=true'
                 }
-                frameborder="0"
                 loading="lazy"
             />,
         ];

--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -200,14 +200,14 @@ export class FileViewer {
             <div class="action-menu-for-pdf-files">
                 {this.renderActionMenu()}
             </div>,
-            <iframe src={this.fileUrl} />,
+            <iframe src={this.fileUrl} loading="lazy" />,
         ];
     };
 
     private renderImage = () => {
         return [
             this.renderButtons(),
-            <img src={this.fileUrl} alt={this.alt} />,
+            <img src={this.fileUrl} alt={this.alt} loading="lazy" />,
         ];
     };
 
@@ -244,6 +244,7 @@ export class FileViewer {
                     this.getOfficeViewerUrl() + this.fileUrl + '&embedded=true'
                 }
                 frameborder="0"
+                loading="lazy"
             />,
         ];
     };


### PR DESCRIPTION
> The [loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading) attribute on an [<img>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) element (or the [loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#loading) attribute on an [<iframe>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)) can be used to instruct the browser to defer loading of images/iframes that are off-screen until the user scrolls near them.
> 
> ```html
> <img src="image.jpg" alt="..." loading="lazy" />
> <iframe src="video-player.html" title="..." loading="lazy"></iframe>
> ```
> The load event fires when the eagerly-loaded content has all been loaded; at that time, it's entirely possible (or even likely) that there may be lazily-loaded images that are within the [visual viewport](https://developer.mozilla.org/en-US/docs/Glossary/Visual_Viewport) that haven't yet loaded.

Read more:https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
