### PR TITLE
fix(select): don't render empty icons

### DIFF
--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -258,6 +258,15 @@ function createMenuItems(
         const name = getIconName(option.icon);
         const color = getIconColor(option.icon, option.iconColor);
 
+        if (!name) {
+            return {
+                text: text,
+                selected: selected,
+                disabled: disabled,
+                value: option,
+            };
+        }
+
         return {
             text: text,
             selected: selected,


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2618

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
