### PR TITLE
fix: add support for `m-files://` links

### DIFF
--- a/src/util/link-helper.ts
+++ b/src/util/link-helper.ts
@@ -33,7 +33,16 @@ function isValid(href: string) {
 }
 
 function hasKnownProtocol(input: string) {
-    const knownProtocols = ['ftp', 'ftps', 'https', 'http'];
+    const knownProtocols = [
+        'ftp',
+        'ftps',
+        'https',
+        'http',
+
+        // m-files is a protocol used by the M-Files desktop app or something.
+        // It's not a web protocol, but it allows open M-Files links in their app.
+        'm-files',
+    ];
 
     return knownProtocols.some((knownProtocol) => {
         return input.indexOf(knownProtocol + '://') === 0;


### PR DESCRIPTION
As requested by @EdvinLP in [Open Hours](https://teams.microsoft.com/l/message/19:8eb8d446f40d4696ba03bee0d3b47a56@thread.tacv2/1700479963932?tenantId=15f5bb21-07a4-42c6-ada2-08965bd62081&groupId=2f699c45-fe12-4487-81ae-829eb08a675a&parentMessageId=1700479963932&teamName=Lime%20CRM&channelName=Dev%20Open%20Hours%20(Tues%20and%20Thurs%2010.00%20-%2011.00)&createdTime=1700479963932) (internal link)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
