### PR TITLE
fix(menu): be able to use ListSeparator in search result

### DIFF
--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -114,9 +114,11 @@ export interface MenuItem<T = any> {
  * a promise that will eventually be resolved with an array of `MenuItem`:s.
  * @param {string} query A search query. What the user has written
  * in the input field of a limel-menu.
- * @returns {Promise<MenuItem[]>} The search result.
+ * @returns {Promise<Array<MenuItem | ListSeparator>>} The search result.
  */
-export type MenuSearcher = (query: string) => Promise<MenuItem[]>;
+export type MenuSearcher = (
+    query: string
+) => Promise<Array<MenuItem | ListSeparator>>;
 
 /**
  * A loader function that takes a `MenuItem` as an argument, and returns


### PR DESCRIPTION
A very small typing issue, where we missed that the search results of the `MenuSearcher` type could contains `ListSeparators`

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
