### PR TITLE
feat(markdown): add a `private` feature for truncating `p` elements

### DIFF
--- a/src/components/markdown/partial-styles/_body-text.scss
+++ b/src/components/markdown/partial-styles/_body-text.scss
@@ -1,3 +1,13 @@
+:host(limel-markdown.truncate-paragraphs) {
+    // This is not a public feature.
+    // We use it only in CRM, in limebb-feed header.
+    p {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+}
+
 p,
 a,
 li {


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/3765

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
