### PR TITLE
fix(code-editor): avoid potential attempt at reading property of undefined

### DIFF
--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -102,7 +102,7 @@ export class CodeEditor {
 
     public disconnectedCallback() {
         this.observer.unobserve(this.host);
-        this.editor.off('change', this.handleChange);
+        this.editor?.off('change', this.handleChange);
         this.editor = null;
 
         this.darkMode.removeEventListener('change', this.handleChangeDarkMode);


### PR DESCRIPTION
I got this error when I navigated fairly quickly between pages in Lime CRM Admin.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
