### PR TITLE
Continue enabling `Icon` interface in other components

### DIFF
--- a/src/components/dialog/dialog.types.ts
+++ b/src/components/dialog/dialog.types.ts
@@ -1,8 +1,9 @@
+import { Icon } from '../../interface';
 export interface DialogHeading {
     title: string;
     subtitle?: string;
     supportingText?: string;
-    icon: string;
+    icon: string | Icon;
 }
 
 export interface ClosingActions {

--- a/src/components/dialog/examples/dialog-heading-actions.tsx
+++ b/src/components/dialog/examples/dialog-heading-actions.tsx
@@ -48,7 +48,7 @@ export class DialogHeadingActionsExample {
                     icon="multiply"
                     slot="header-actions"
                     onClick={this.closeDialog}
-                ></limel-icon-button>
+                />
                 <p>This is a dialog with an action in the header.</p>
                 <limel-button
                     label="Ok"

--- a/src/components/dialog/examples/dialog-heading.scss
+++ b/src/components/dialog/examples/dialog-heading.scss
@@ -9,21 +9,15 @@
 
     limel-dialog {
         &.company {
-            --dialog-heading-icon-background-color: rgb(
-                var(--color-sky-default)
-            );
+            --dialog-heading-icon-color: rgb(var(--color-sky-default));
         }
 
         &.person {
-            --dialog-heading-icon-background-color: rgb(
-                var(--color-orange-default)
-            );
+            --dialog-heading-icon-color: rgb(var(--color-orange-default));
         }
 
         &.deal {
-            --dialog-heading-icon-background-color: rgb(
-                var(--color-green-default)
-            );
+            --dialog-heading-icon-color: rgb(var(--color-green-default));
         }
 
         &.todo {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,6 @@
 import { Component, h, Prop } from '@stencil/core';
+import { Icon } from '../../interface';
+import { getIconName } from '../icon/get-icon-props';
 
 /**
  * A header is the top most visual element in a component, page, card, or a view.
@@ -60,7 +62,7 @@ export class Header {
      * Icon to display
      */
     @Prop()
-    public icon: string;
+    public icon: string | Icon;
 
     /**
      * Title to display
@@ -105,7 +107,9 @@ export class Header {
             return;
         }
 
-        return <limel-icon class="icon" badge={true} name={this.icon} />;
+        const icon = getIconName(this.icon);
+
+        return <limel-icon class="icon" badge={true} name={icon} />;
     }
 
     private renderSupportingText() {


### PR DESCRIPTION
related to https://github.com/Lundalogik/crm-feature/issues/3818

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
