### PR TITLE
Dematerialize `limel-button`, remove its dependency on MDC

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -19,18 +19,17 @@ button {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.375rem;
+    gap: 0.125rem;
 
     border: none;
     border-radius: 0.4rem;
-    min-width: functions.pxToRem(36);
     padding: {
         top: 0;
-        right: var(--button-padding-right, #{functions.pxToRem(12)});
+        right: var(--button-padding-right, 0.5rem);
         bottom: 0;
-        left: var(--button-padding-left, #{functions.pxToRem(12)});
+        left: var(--button-padding-left, 0.5rem);
     }
-    height: 100%;
+
     min-height: functions.pxToRem(36);
     width: 100%;
 
@@ -72,11 +71,6 @@ button {
 .icon {
     width: 1.25rem;
     flex-shrink: 0;
-    margin-left: functions.pxToRem(-4);
-
-    &.no-label {
-        margin-right: functions.pxToRem(-10);
-    }
 }
 
 .label {
@@ -85,6 +79,7 @@ button {
     font-weight: 500;
     letter-spacing: functions.pxToRem(1);
     opacity: 1;
+    padding: 0 0.25rem;
 }
 
 limel-spinner {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -30,7 +30,7 @@ button {
         left: var(--button-padding-left, 0.5rem);
     }
 
-    min-height: functions.pxToRem(36);
+    min-height: 2.25rem;
     width: 100%;
 
     &:disabled {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -83,8 +83,6 @@ button {
 }
 
 limel-spinner {
-    opacity: 0;
-    display: none;
     position: absolute;
 }
 
@@ -119,7 +117,6 @@ svg {
     }
     limel-spinner {
         opacity: 1;
-        display: block;
     }
 }
 
@@ -132,10 +129,6 @@ svg {
     svg {
         opacity: 1;
     }
-    limel-spinner {
-        display: block;
-        animation: fade-out-spinner 0.3s ease;
-    }
 }
 
 .just-failed {
@@ -146,17 +139,6 @@ svg {
 .outlined {
     border: 1px solid;
     border-color: var(--mdc-theme-primary);
-}
-
-@keyframes fade-out-spinner {
-    0% {
-        opacity: 1;
-        transform: scale(1);
-    }
-    100% {
-        opacity: 0;
-        transform: scale(1.5);
-    }
 }
 
 @keyframes shake {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -34,6 +34,12 @@ button {
     min-height: functions.pxToRem(36);
     width: 100%;
 
+    &:disabled {
+        &.outlined {
+            border-color: rgba(var(--contrast-1700), 0.2);
+        }
+    }
+
     &:not(:disabled) {
         @include mixins.visualize-keyboard-focus;
         @include mixins.is-elevated-clickable();
@@ -61,91 +67,85 @@ button {
             background-color: rgba(var(--contrast-1600), 0.1);
         }
     }
+}
 
-    &:disabled {
-        &.outlined {
-            border-color: rgba(var(--contrast-1700), 0.2);
-        }
+.icon {
+    width: 1.25rem;
+    flex-shrink: 0;
+    margin-left: functions.pxToRem(-4);
+
+    &.no-label {
+        margin-right: functions.pxToRem(-10);
     }
+}
 
-    .icon {
-        width: 1.25rem;
-        flex-shrink: 0;
-        margin-left: functions.pxToRem(-4);
+.label {
+    font-family: Roboto, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: functions.pxToRem(1);
+    opacity: 1;
+}
 
-        &.no-label {
-            margin-right: functions.pxToRem(-10);
-        }
+limel-spinner {
+    opacity: 0;
+    display: none;
+    position: absolute;
+}
+
+limel-icon {
+    vertical-align: top;
+}
+
+svg {
+    height: functions.pxToRem(30);
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: functions.pxToRem(30);
+
+    line {
+        stroke: rgb(var(--color-white));
+        stroke-width: 2;
     }
+}
 
+limel-icon,
+.label,
+limel-spinner,
+svg {
+    transition: opacity 300ms ease-in-out;
+}
+
+.loading {
+    limel-icon,
     .label {
-        font-family: Roboto, sans-serif;
-        font-size: 0.875rem;
-        font-weight: 500;
-        letter-spacing: functions.pxToRem(1);
+        opacity: 0;
+    }
+    limel-spinner {
+        opacity: 1;
+        display: block;
+    }
+}
+
+.just-loaded,
+.just-failed {
+    limel-icon,
+    .label {
+        opacity: 0;
+    }
+    svg {
         opacity: 1;
     }
-
     limel-spinner {
-        opacity: 0;
-        display: none;
-        position: absolute;
+        display: block;
+        animation: fade-out-spinner 0.3s ease;
     }
+}
 
-    limel-icon {
-        vertical-align: top;
-    }
-
-    svg {
-        height: functions.pxToRem(30);
-        opacity: 0;
-        pointer-events: none;
-        position: absolute;
-        width: functions.pxToRem(30);
-
-        line {
-            stroke: rgb(var(--color-white));
-            stroke-width: 2;
-        }
-    }
-
-    limel-icon,
-    .label,
-    limel-spinner,
-    svg {
-        transition: opacity 300ms ease-in-out;
-    }
-
-    &.loading {
-        limel-icon,
-        .label {
-            opacity: 0;
-        }
-        limel-spinner {
-            opacity: 1;
-            display: block;
-        }
-    }
-
-    &.just-loaded,
-    &.just-failed {
-        limel-icon,
-        .label {
-            opacity: 0;
-        }
-        svg {
-            opacity: 1;
-        }
-        limel-spinner {
-            display: block;
-            animation: fade-out-spinner 0.3s ease;
-        }
-    }
-
-    &.just-failed {
-        background-color: var(--lime-error-text-color) !important;
-        animation: shake 0.82s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-    }
+.just-failed {
+    background-color: var(--lime-error-text-color) !important;
+    animation: shake 0.82s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
 }
 
 .outlined {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -3,9 +3,6 @@
 
 @use '../../style/internal/lime-theme';
 
-@use '@material/button/styles';
-@use '@material/button';
-
 :host {
     display: inline-block;
 }
@@ -19,63 +16,73 @@
 }
 
 button {
-    &.mdc-button {
-        min-width: functions.pxToRem(36);
-        padding: {
-            top: 0;
-            right: var(--button-padding-right, #{functions.pxToRem(12)});
-            bottom: 0;
-            left: var(--button-padding-left, #{functions.pxToRem(12)});
-        }
-        height: 100%;
-        min-height: functions.pxToRem(36);
-        width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
 
+    border: none;
+    border-radius: 0.4rem;
+    min-width: functions.pxToRem(36);
+    padding: {
+        top: 0;
+        right: var(--button-padding-right, #{functions.pxToRem(12)});
+        bottom: 0;
+        left: var(--button-padding-left, #{functions.pxToRem(12)});
+    }
+    height: 100%;
+    min-height: functions.pxToRem(36);
+    width: 100%;
+
+    &:not(:disabled) {
+        @include mixins.visualize-keyboard-focus;
+        @include mixins.is-elevated-clickable();
+    }
+
+    :host(limel-button[primary]) & {
         &:not(:disabled) {
-            @include mixins.visualize-keyboard-focus;
-            @include mixins.is-elevated-clickable();
+            color: var(--mdc-theme-on-primary, rgb(var(--color-white)));
+            background-color: var(
+                --mdc-theme-primary,
+                rgb(var(--color-teal-default))
+            );
         }
-
-        :host(limel-button[primary]) & {
-            &:not(:disabled) {
-                color: var(--mdc-theme-on-primary, rgb(var(--color-white)));
-                background-color: var(
-                    --mdc-theme-primary,
-                    rgb(var(--color-teal-default))
-                );
-            }
-            &:disabled {
-                background-color: rgba(var(--contrast-1700), 0.15);
-            }
-        }
-
-        :host(limel-button:not([primary])) & {
-            &:not(:disabled) {
-                color: var(--mdc-theme-primary, rgb(var(--color-teal-default)));
-            }
-            &:disabled {
-                color: rgba(var(--contrast-1600), 0.37);
-                background-color: rgba(var(--contrast-1600), 0.1);
-            }
-        }
-
         &:disabled {
-            &.mdc-button--outlined {
-                border-color: rgba(var(--contrast-1700), 0.2);
-            }
+            background-color: rgba(var(--contrast-1700), 0.15);
         }
+    }
 
-        .mdc-button__icon {
-            flex-shrink: 0;
-            margin-left: functions.pxToRem(-4);
+    :host(limel-button:not([primary])) & {
+        &:not(:disabled) {
+            color: var(--mdc-theme-primary, rgb(var(--color-teal-default)));
+        }
+        &:disabled {
+            color: rgba(var(--contrast-1600), 0.37);
+            background-color: rgba(var(--contrast-1600), 0.1);
+        }
+    }
 
-            &.no-label {
-                margin-right: functions.pxToRem(-4);
-            }
+    &:disabled {
+        &.outlined {
+            border-color: rgba(var(--contrast-1700), 0.2);
+        }
+    }
+
+    .icon {
+        width: 1.25rem;
+        flex-shrink: 0;
+        margin-left: functions.pxToRem(-4);
+
+        &.no-label {
+            margin-right: functions.pxToRem(-10);
         }
     }
 
     .label {
+        font-family: Roboto, sans-serif;
+        font-size: 0.875rem;
+        font-weight: 500;
+        letter-spacing: functions.pxToRem(1);
         opacity: 1;
     }
 
@@ -141,8 +148,9 @@ button {
     }
 }
 
-.mdc-button--outlined {
-    @include button.outline-color(primary);
+.outlined {
+    border: 1px solid;
+    border-color: var(--mdc-theme-primary);
 }
 
 @keyframes fade-out-spinner {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -96,7 +96,7 @@ export class Button {
             >
                 {this.renderIcon()}
                 {this.renderLabel()}
-                <limel-spinner limeBranded={false} />
+                {this.renderSpinner()}
                 <svg viewBox="0 0 30 30">{this.renderLoadingIcons()}</svg>
             </button>
         );
@@ -144,5 +144,13 @@ export class Button {
         }
 
         return <span class="label">{this.label}</span>;
+    }
+
+    private renderSpinner() {
+        if (!this.loading) {
+            return;
+        }
+
+        return <limel-spinner limeBranded={false} />;
     }
 }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -119,14 +119,14 @@ export class Button {
     private renderLoadingIcons() {
         if (this.loadingFailed) {
             return [
-                <line x1="9" y1="9" x2="21" y2="21"></line>,
-                <line x1="21" y1="9" x2="9" y2="21"></line>,
+                <line x1="9" y1="9" x2="21" y2="21" />,
+                <line x1="21" y1="9" x2="9" y2="21" />,
             ];
         }
 
         return [
-            <line x1="8" y1="14" x2="15" y2="20"></line>,
-            <line x1="23" y1="9" x2="14" y2="20"></line>,
+            <line x1="8" y1="14" x2="15" y2="20" />,
+            <line x1="23" y1="9" x2="14" y2="20" />,
         ];
     }
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -95,7 +95,7 @@ export class Button {
                 disabled={this.disabled || this.loading}
             >
                 {this.renderIcon()}
-                <span class="label">{this.label}</span>
+                {this.renderLabel()}
                 <limel-spinner limeBranded={false} />
                 <svg viewBox="0 0 30 30">{this.renderLoadingIcons()}</svg>
             </button>
@@ -130,18 +130,19 @@ export class Button {
         ];
     }
 
-    private renderIcon(): HTMLElement {
+    private renderIcon() {
         if (!this.icon) {
             return;
         }
 
-        let withoutLabelClass = '';
+        return <limel-icon class="icon" name={this.icon} />;
+    }
+
+    private renderLabel() {
         if (!this.label) {
-            withoutLabelClass = 'no-label';
+            return;
         }
 
-        return (
-            <limel-icon class={`icon ${withoutLabelClass}`} name={this.icon} />
-        );
+        return <span class="label">{this.label}</span>;
     }
 }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -87,16 +87,15 @@ export class Button {
         return (
             <button
                 class={{
-                    'mdc-button': true,
                     loading: this.loading,
                     'just-loaded': this.justLoaded && !this.loadingFailed,
                     'just-failed': this.justLoaded && this.loadingFailed,
-                    'mdc-button--outlined': this.outlined,
+                    outlined: this.outlined,
                 }}
                 disabled={this.disabled || this.loading}
             >
                 {this.renderIcon()}
-                <span class="label mdc-button__label">{this.label}</span>
+                <span class="label">{this.label}</span>
                 <limel-spinner limeBranded={false} />
                 <svg viewBox="0 0 30 30">{this.renderLoadingIcons()}</svg>
             </button>
@@ -142,9 +141,7 @@ export class Button {
         }
 
         return (
-            <i class={`mdc-button__icon ${withoutLabelClass}`}>
-                <limel-icon name={this.icon} />
-            </i>
+            <limel-icon class={`icon ${withoutLabelClass}`} name={this.icon} />
         );
     }
 }

--- a/src/components/button/partial-styles/_has-reduced-presence.scss
+++ b/src/components/button/partial-styles/_has-reduced-presence.scss
@@ -36,7 +36,7 @@ $speed-of-reducing-presence: 0.3s;
             limel-icon,
             limel-spinner,
             svg,
-            .mdc-button__icon {
+            .icon {
                 transition: all $speed-of-reducing-presence ease;
                 transition-delay: $speed-of-reducing-presence;
 


### PR DESCRIPTION
`limel-button` includes an internal `button` element. There is no reason to depend on MDC, merely to get a bunch of styles.  We don't get any specific functionality from MDC as far as I can say. Everything else is handled basically inside the component already.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
