### PR TITLE
chore(mixins): add a mixin for visualising open dropdown states

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -15,6 +15,8 @@
     pointer-events: none;
 }
 
+@include mixins.visualize-aria-expanded('button');
+
 button {
     display: flex;
     align-items: center;

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -12,6 +12,8 @@
     pointer-events: none;
 }
 
+@include mixins.visualize-aria-expanded('button');
+
 button {
     all: unset;
     @include mixins.is-flat-clickable(

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -129,6 +129,11 @@
                     transform: rotate(-180deg);
                 }
             }
+
+            &[aria-expanded]:not([aria-expanded='false']),
+            &[aria-expanded='true'] {
+                box-shadow: var(--button-shadow-inset-pressed);
+            }
         }
     }
 

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -18,6 +18,19 @@
     }
 }
 
+/**
+* This can be used on a trigger element that opens a dropdown menu or a popover.
+*/
+
+@mixin visualize-aria-expanded($trigger-element) {
+    :host([aria-expanded='true']),
+    :host([aria-expanded]:not([aria-expanded='false'])) {
+        #{$trigger-element} {
+            box-shadow: var(--button-shadow-inset-pressed) !important;
+        }
+    }
+}
+
 @mixin in($media) {
     // ⛔️ As long as we don't have a script that generates a
     // `.css` files automatically, we cannot use this mixin.


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/2894

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
