### PR TITLE
fix(split-button): use the same color for the menu trigger

### DIFF
--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -81,7 +81,10 @@ limel-menu {
     width: 1rem;
 
     &:not(:disabled) {
-        @include is-flat-clickable();
+        @include is-flat-clickable(
+            $color: 'inherit',
+            $color--hovered: 'inherit'
+        );
         @include visualize-keyboard-focus();
         cursor: pointer;
 


### PR DESCRIPTION
the menu trigger has a dark color
![image](https://github.com/Lundalogik/lime-elements/assets/35954987/9ea4e2b5-a88a-496a-bb5f-39837ab7d019)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
