### PR TITLE
Markdown code

### DIFF
--- a/src/components/markdown/examples/markdown-code.tsx
+++ b/src/components/markdown/examples/markdown-code.tsx
@@ -12,7 +12,7 @@ alert(a);
 ~~~
 
 Even if the language is indicated, we can only render
-the code blocks without syntax highlighting.
+the <code>code</code> blocks without syntax highlighting.
 `;
 
 /**

--- a/src/components/markdown/partial-styles/_pre-code.scss
+++ b/src/components/markdown/partial-styles/_pre-code.scss
@@ -2,8 +2,10 @@
 @use '../../../style/functions.scss';
 
 code {
-    font-size: 0.875rem;
     @include mixins.font-family(monospace);
+    font-size: functions.pxToRem(13);
+    letter-spacing: functions.pxToRem(-0.2);
+    color: rgb(var(--contrast-1300));
 
     -moz-tab-size: 4;
     -o-tab-size: 4;
@@ -15,20 +17,16 @@ code {
     hyphens: none;
 
     display: inline-block;
-    border-radius: functions.pxToRem(3);
-    padding: functions.pxToRem(1) functions.pxToRem(5);
-    color: rgb(var(--contrast-1300));
+    border-radius: 0.25rem;
+    padding: functions.pxToRem(0.5) 0.25rem;
+
     background-color: rgb(var(--contrast-600));
 }
 
 pre > code {
     display: block;
-    border-radius: 0.5rem;
     margin: 0.5rem 0;
-    padding: 1rem;
+    padding: 0.5rem 0.75rem;
     overflow: auto;
     white-space: pre-wrap;
-
-    color: rgb(var(--contrast-800));
-    background-color: rgb(var(--contrast-1600));
 }

--- a/src/components/markdown/partial-styles/_pre-code.scss
+++ b/src/components/markdown/partial-styles/_pre-code.scss
@@ -1,8 +1,9 @@
+@use '../../../style/mixins.scss';
 @use '../../../style/functions.scss';
 
 code {
-    font-family: 'Source Code Pro', monospace;
     font-size: 0.875rem;
+    @include mixins.font-family(monospace);
 
     -moz-tab-size: 4;
     -o-tab-size: 4;


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2649

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
