### PR TITLE
Feat chip

### DIFF
--- a/src/components/chip/chip.e2e.ts
+++ b/src/components/chip/chip.e2e.ts
@@ -1,0 +1,57 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('limel-chip', () => {
+    let page;
+
+    beforeEach(async () => {
+        page = await newE2EPage();
+    });
+
+    it('renders with the correct text', async () => {
+        await page.setContent('<limel-chip text="Test chip"></limel-chip>');
+        await page.waitForChanges();
+
+        const element = await page.find('limel-chip >>> .chip');
+        expect(element.textContent).toEqual('Test chip');
+    });
+
+    it('renders as a link when the link prop is provided', async () => {
+        await page.setContent(
+            '<limel-chip text="Test chip" link="{ href: \'https://example.com\' }"></limel-chip>',
+        );
+
+        const element = await page.find('limel-chip');
+        element.setProperty('link', { href: 'https://example.com' });
+
+        await page.waitForChanges();
+
+        expect(element)
+            .toEqualHtml(`<limel-chip class="hydrated" language="en" link="{ href: 'https://example.com' }" text="Test chip">
+        <mock:shadow-root>
+          <a class="chip" href="https://example.com" tabindex="0">
+            <span class="text">
+              Test chip
+            </span>
+          </a>
+        </mock:shadow-root>
+      </limel-chip>`);
+    });
+
+    it('renders with a badge when the badge prop is provided', async () => {
+        await page.setContent(
+            '<limel-chip text="Test chip" badge="5"></limel-chip>',
+        );
+
+        const element = await page.find('limel-chip >>> limel-badge');
+        expect(element.getAttribute('label')).toEqual('5');
+    });
+
+    it('renders with a remove button when the removable prop is true', async () => {
+        await page.setContent(
+            '<limel-chip text="Test chip" removable></limel-chip>',
+        );
+
+        const element = await page.find('limel-chip >>> .remove-button');
+        expect(element).not.toBeNull();
+    });
+});

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -1,0 +1,183 @@
+@use '../../style/mixins';
+
+/**
+* @prop --chip-max-width: Maximum width of the chip. Defaults to `10rem`. Keep in mind that the chips should not appear too big.
+*/
+
+:host(limel-chip) {
+    --limel-chip-height: 1.75rem;
+    --limel-chip-gap: 0.5rem;
+    isolation: isolate;
+    display: inline-flex;
+    align-items: center;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+.chip {
+    all: unset;
+    position: relative;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+
+    max-width: var(--chip-max-width, 10rem);
+    height: var(--limel-chip-height);
+
+    border-radius: var(--limel-chip-height);
+    font-size: 0.875rem;
+    padding: 0 0.125rem;
+
+    &:has(limel-icon) {
+        .text {
+            padding-left: 0.25rem;
+        }
+    }
+
+    &:not([disabled]) {
+        @include mixins.visualize-keyboard-focus;
+        @include mixins.is-elevated-inset-clickable;
+    }
+
+    &:has(limel-badge) {
+        padding-right: 0.375rem;
+
+        .text {
+            padding-right: 0;
+        }
+    }
+
+    &:has(+ .remove-button:hover) {
+        box-shadow: var(--shadow-depth-8-error);
+    }
+}
+
+:host(limel-chip[disabled]) {
+    .chip {
+        // Similar to `limel-button[disabled]`
+        color: rgba(var(--contrast-1600), 0.37);
+        background-color: rgba(var(--contrast-1600), 0.1);
+        box-shadow: none;
+    }
+}
+
+:host(limel-chip[readonly]) {
+    .chip {
+        box-shadow: 0 0 0 1px rgba(var(--contrast-800), 0.5);
+    }
+}
+
+:host(limel-chip[selected]) {
+    .chip {
+        box-shadow: var(--button-shadow-inset);
+
+        &:focus-visible {
+            box-shadow: var(--button-shadow-inset),
+                var(--shadow-depth-8-focused);
+        }
+
+        &:active {
+            box-shadow: var(--button-shadow-inset-pressed);
+        }
+    }
+    .text {
+        color: var(--mdc-theme-primary);
+    }
+}
+
+:host(limel-chip[removable]) {
+    .chip:not([disabled]) {
+        padding-right: calc(var(--limel-chip-height) + 0.125rem);
+
+        .text {
+            padding-right: 0;
+        }
+    }
+}
+
+:host(limel-chip[type='filter']) {
+    .chip {
+        border-top-left-radius: 0.5rem;
+        border-bottom-left-radius: 0.5rem;
+
+        &:after {
+            content: '';
+            transition:
+                background-color 0.4s ease 0.2s,
+                box-shadow 0.6s ease 0.2s;
+            box-sizing: border-box;
+            position: absolute;
+            bottom: 0.125rem;
+            left: 0.125rem;
+            width: 0.5rem;
+            height: 0.5rem;
+            border-radius: 50%;
+            background-color: rgb(var(--contrast-800), 0.8);
+            box-shadow: 0 0 0 1px rgb(var(--color-white)) inset;
+        }
+    }
+}
+
+:host(limel-chip[type='filter'][selected]) {
+    .chip {
+        &:after {
+            background-color: rgb(var(--color-green-default));
+            box-shadow:
+                0 0 0.375rem 0 rgb(var(--color-green-light)),
+                0 0 0 1px rgb(var(--color-white)) inset;
+        }
+    }
+}
+
+limel-icon {
+    flex-shrink: 0;
+    width: calc(var(--limel-chip-height) - 0.25rem);
+    height: calc(var(--limel-chip-height) - 0.25rem);
+    padding: 0.0625rem;
+}
+
+limel-badge {
+    pointer-events: none;
+}
+
+.text {
+    @include mixins.truncate-text;
+    line-height: 1.2;
+    padding: 0 0.5rem;
+}
+
+.trailing-button {
+    all: unset;
+    @include mixins.is-flat-clickable(
+        $color--hovered: rgb(var(--color-red-dark))
+    );
+
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    margin-left: calc(var(--limel-chip-height) * -1 + 0.125rem);
+    margin-right: 0.125rem;
+    width: calc(var(--limel-chip-height) - 0.25rem);
+    height: calc(var(--limel-chip-height) - 0.25rem);
+
+    border-radius: 50%;
+
+    svg {
+        transition:
+            color 0.2s ease,
+            transform 0.2s ease;
+        width: 1.25rem;
+    }
+
+    &:hover {
+        svg {
+            transform: scale(0.8);
+        }
+    }
+}

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -1,0 +1,280 @@
+import {
+    Component,
+    Element,
+    Event,
+    EventEmitter,
+    h,
+    Host,
+    Prop,
+} from '@stencil/core';
+import { Icon, Languages, Link } from '../../interface';
+import { getIconName } from '../icon/get-icon-props';
+import {
+    makeEnterClickable,
+    removeEnterClickable,
+} from '../../util/make-enter-clickable';
+import translate from '../../global/translations';
+import {
+    BACKSPACE,
+    BACKSPACE_KEY_CODE,
+    DELETE,
+    DELETE_KEY_CODE,
+} from '../../util/keycodes';
+import { Chip as OldChipInterface } from '../chip-set/chip.types';
+
+interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
+    badge?: string | number;
+}
+
+/**
+ * Chips and buttons are both interactive elements in UI design,
+ * but they serve different purposes and are used in different contexts.
+ *
+ * :::warning
+ * Do not use the chip component carelessly, as an alternative for
+ * [`limel-button`](#/component/limel-button/) in the UI design!
+ *
+ * **Buttons:**
+ * Buttons are used to trigger actions. They are typically used to
+ * submit forms, open dialogs, initiate a process, or perform any action
+ * that changes the state of the application.
+ * Buttons' labels usually contain action words, in other words, the labels is
+ * a _verb in imperative mood_ such as "Submit" or "Delete".
+ * Buttons are placed in areas where it's clear they will initiate
+ * an action when clicked.
+ *
+ * **Chips:**
+ * Chips however are elements which may look like buttons, but they are
+ * representing choices, filters, or tags, in a small block
+ * or clearly bundled into a group. Chips are rarely used alone in the
+ * user interface.
+ * They are often used in a so called "chip-set", or placed together in
+ * a section of the UI, where the user can expect more than one chip to be present.
+ *
+ * For example, a chip may represent a filter in a filter bar, or a tag in a tag list,
+ * or an item in a shopping list.
+ * Clicking a chip can also trigger an action, for example toggling a filter ON or OFF,
+ * or opening a page with all posts tagged with the tag represented by the chip,
+ * or navigating to a page with more information about the item in the shopping list.
+ * :::
+ *
+ * @private
+ * @exampleComponent limel-example-chip-button
+ * @exampleComponent limel-example-chip-link
+ * @exampleComponent limel-example-chip-icon-colors
+ * @exampleComponent limel-example-chip-badge
+ * @exampleComponent limel-example-chip-filter
+ * @exampleComponent limel-example-chip-removable
+ * @exampleComponent limel-example-chip-aria-role
+ */
+@Component({
+    tag: 'limel-chip',
+    shadow: true,
+    styleUrl: 'chip.scss',
+})
+export class Chip implements ChipInterface {
+    /**
+     * Defines the language for translations.
+     * Will translate the translatable strings on the components.
+     */
+    @Prop({ reflect: true })
+    public language: Languages = 'en';
+
+    /**
+     * Label displayed on the chip
+     */
+    @Prop({ reflect: true })
+    public text: string;
+
+    /**
+     * Icon of the chip.
+     */
+    @Prop()
+    public icon: string | Icon;
+
+    /**
+     * If supplied, the chip will become a clickable link.
+     */
+    @Prop()
+    public link?: Omit<Link, 'text'>;
+
+    /**
+     * The value of the badge, displayed on the chip.
+     */
+    @Prop({ reflect: true })
+    public badge?: string | number;
+
+    /**
+     * Set to `true` to disable the chip.
+     */
+    @Prop({ reflect: true })
+    public disabled = false;
+
+    /**
+     * Set to `true` to render the chip as a static UI element.
+     * Useful when the parent component has a `readonly` state.
+     */
+    @Prop({ reflect: true })
+    public readonly = false;
+
+    /**
+     * Set to `true` to visualize the chip in a "selected" state.
+     * This is typically used when the chip is used in a chip-set
+     * along with other chips.
+     */
+    @Prop({ reflect: true })
+    public selected = false;
+
+    /**
+     * Set to `true` to render a remove button on the chip.
+     */
+    @Prop({ reflect: true })
+    public removable = false;
+
+    /**
+     * Set to `filter` to render the chip with a distinct style
+     * suitable for visualizing filters.
+     */
+    @Prop({ reflect: true })
+    public type: 'filter';
+
+    /**
+     * Fired when clicking on the remove button of a `removable` chip.
+     */
+    @Event()
+    public remove: EventEmitter<void>;
+
+    @Element()
+    private host: HTMLLimelChipElement;
+
+    public componentWillLoad() {
+        makeEnterClickable(this.host);
+    }
+
+    public disconnectedCallback() {
+        removeEnterClickable(this.host);
+    }
+
+    public render() {
+        return (
+            <Host onClick={this.filterClickWhenDisabled}>
+                {this.link ? this.renderAsLink() : this.renderAsButton()}
+            </Host>
+        );
+    }
+
+    private renderAsButton = () => {
+        return [
+            <button
+                class="chip"
+                role="button"
+                disabled={this.disabled || this.readonly}
+                onKeyDown={this.handleDeleteKeyDown}
+            >
+                {this.renderIcon()}
+                {this.renderLabel()}
+                {this.renderBadge()}
+            </button>,
+            this.renderRemoveButton(),
+        ];
+    };
+
+    private renderAsLink = () => {
+        return [
+            <a
+                class="chip"
+                href={this.link.href}
+                title={this.link.title}
+                target={this.link.target}
+                aria-disabled={this.disabled || this.readonly}
+                tabindex={this.disabled || this.readonly ? -1 : 0}
+                onKeyDown={this.handleDeleteKeyDown}
+            >
+                {this.renderIcon()}
+                {this.renderLabel()}
+                {this.renderBadge()}
+            </a>,
+            this.renderRemoveButton(),
+        ];
+    };
+
+    private renderLabel = () => {
+        return <span class="text">{this.text}</span>;
+    };
+
+    private renderIcon() {
+        const icon = getIconName(this.icon);
+
+        if (!icon) {
+            return;
+        }
+
+        return (
+            <limel-icon
+                badge={true}
+                name={icon}
+                style={{
+                    color: `${(this.icon as Icon)?.color}`,
+                    'background-color': `${
+                        (this.icon as Icon)?.backgroundColor
+                    }`,
+                }}
+            />
+        );
+    }
+
+    private renderBadge() {
+        if (!this.badge) {
+            return;
+        }
+
+        return <limel-badge label={this.badge} />;
+    }
+
+    private renderRemoveButton() {
+        if (!this.removable || this.readonly || this.disabled) {
+            return;
+        }
+
+        const svgData =
+            '<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="currentColor" stroke-width="2" d="m8 8 16 16M24 8 8 24"/></svg>';
+
+        return (
+            <button
+                class="trailing-button remove-button"
+                tabIndex={-1}
+                aria-label={this.removeChipLabel}
+                innerHTML={svgData}
+                onClick={this.handleRemoveClick}
+            />
+        );
+    }
+
+    private filterClickWhenDisabled = (e) => {
+        if (this.disabled || this.readonly) {
+            e.preventDefault();
+        }
+    };
+
+    private handleRemoveClick = (event: MouseEvent | KeyboardEvent) => {
+        event.stopPropagation();
+        this.remove.emit();
+    };
+
+    private handleDeleteKeyDown = (event: KeyboardEvent) => {
+        if (!this.removable) {
+            return;
+        }
+
+        const keys = [DELETE, BACKSPACE];
+        const keycodes = [DELETE_KEY_CODE, BACKSPACE_KEY_CODE];
+
+        if (keys.includes(event.key) || keycodes.includes(event.keyCode)) {
+            this.handleRemoveClick(event);
+        }
+    };
+
+    private removeChipLabel = (): string => {
+        return translate.get('chip-set.remove-chip', this.language);
+    };
+}

--- a/src/components/chip/examples/chip-aria-role.tsx
+++ b/src/components/chip/examples/chip-aria-role.tsx
@@ -1,0 +1,57 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Correct usage of ARIA roles
+ *
+ * Chips represent choices, filters, or tags, organized in a block or bundled into a group.
+ * While sighted users see the visually bundled group of chips in a well-designed UI,
+ * screen reader users only hear the chip text, one at a time.
+ * This can make it difficult for users of assistive technologies to understand
+ * the context of the chip.
+ *
+ * To provide an accessible experience, it's important to place the chips in
+ * a semantically correct structure, such as a list or a table,
+ * or properly use ARIA roles on the chip and its container.
+ *
+ * In this example, we demonstrate how to use ARIA roles to improve accessibility for chips.
+ * However, it's recommended to read up on the subject to fully understand the
+ * implications of ARIA roles.
+ *
+ * For more information on ARIA roles, refer to the
+ * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles).
+ */
+@Component({
+    tag: 'limel-example-chip-aria-role',
+    shadow: true,
+    styleUrl: 'limel-example-chip-aria-role.scss',
+})
+export class ChipAriaRoleExample {
+    public render() {
+        return (
+            <div role="grid" aria-label="Filter bar" aria-colcount="3">
+                <div role="rowgroup">
+                    <div role="row">
+                        <limel-chip
+                            role="gridcell"
+                            aria-colindex="1"
+                            text="Age > 20"
+                            removable={true}
+                        />
+                        <limel-chip
+                            role="gridcell"
+                            aria-colindex="2"
+                            text="Gender = Female"
+                            removable={true}
+                        />
+                        <limel-chip
+                            role="gridcell"
+                            aria-colindex="3"
+                            text="Income > $3000 / mo."
+                            removable={true}
+                        />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/components/chip/examples/chip-badge.scss
+++ b/src/components/chip/examples/chip-badge.scss
@@ -1,0 +1,5 @@
+:host {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}

--- a/src/components/chip/examples/chip-badge.tsx
+++ b/src/components/chip/examples/chip-badge.tsx
@@ -1,0 +1,19 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Chip with a badge
+ * Chips can display a badge with a number or a short text.
+ */
+@Component({
+    tag: 'limel-example-chip-badge',
+    shadow: true,
+    styleUrl: 'chip-badge.scss',
+})
+export class ChipBadgeExample {
+    public render() {
+        return [
+            <limel-chip text="Batman" icon="batman_old" badge={2005} />,
+            <limel-chip text="Batman" icon="batman_new" badge="NEW" />,
+        ];
+    }
+}

--- a/src/components/chip/examples/chip-button.tsx
+++ b/src/components/chip/examples/chip-button.tsx
@@ -1,0 +1,74 @@
+import { Component, State, h } from '@stencil/core';
+
+/**
+ * Chip as button
+ * Typically, a chip is used to trigger an action or act as an input element.
+ * This is why the component generates a `<button>` element in the DOM to give
+ * a more semantically correct clues to assistive technologies.
+ *
+ * To trigger these actions, you will only need to handle the `onClick`
+ * event on the component.
+ */
+@Component({
+    tag: 'limel-example-chip-button',
+    shadow: true,
+})
+export class ChipButtonExample {
+    @State()
+    private disabled: boolean = false;
+
+    @State()
+    private selected: boolean = false;
+
+    @State()
+    private readonly: boolean = false;
+
+    public render() {
+        return [
+            <limel-chip
+                text="FunnyCats"
+                icon="hashtag"
+                onClick={this.onClick}
+                disabled={this.disabled}
+                selected={this.selected}
+                readonly={this.readonly}
+            />,
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Disabled"
+                    onChange={this.setDisabled}
+                />
+                <limel-checkbox
+                    checked={this.readonly}
+                    label="Readonly"
+                    onChange={this.setReadonly}
+                />
+                <limel-checkbox
+                    checked={this.selected}
+                    label="Selected"
+                    onChange={this.setSelected}
+                />
+            </limel-example-controls>,
+        ];
+    }
+
+    private onClick() {
+        console.log('Chip is clicked.');
+    }
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private setSelected = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.selected = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
+    };
+}

--- a/src/components/chip/examples/chip-filter.tsx
+++ b/src/components/chip/examples/chip-filter.tsx
@@ -1,0 +1,61 @@
+import { Component, State, h } from '@stencil/core';
+
+/**
+ * Chip as filter
+ * Chips are great candidates to visualize active filters.
+ * However, as chips are used for other purposes as well,
+ * we need to make sure that the user understands that the chip is a filter,
+ * just by the look of it.
+ *
+ * By setting the `type` to `filter`, the chip will be rendered with a distinct style
+ * suitable for visualizing filters.
+ *
+ * :::note
+ * In this mode, clicking on the chip should also toggle its `selected` state.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-filter',
+    shadow: true,
+    styleUrl: 'chip-badge.scss',
+})
+export class ChipFilterExample {
+    @State()
+    private selected: { [id: string]: boolean } = {};
+
+    public render() {
+        return [
+            <limel-chip
+                id="1"
+                text="photos"
+                icon="image_file"
+                type="filter"
+                onClick={() => this.handleClick('1')}
+                selected={this.selected['1']}
+            />,
+            <limel-chip
+                id="2"
+                text="videos"
+                icon="video_file"
+                type="filter"
+                onClick={() => this.handleClick('2')}
+                selected={this.selected['2']}
+            />,
+            <limel-chip
+                id="2"
+                text="audios"
+                icon="audio_file"
+                type="filter"
+                onClick={() => this.handleClick('3')}
+                selected={this.selected['3']}
+            />,
+        ];
+    }
+
+    private handleClick = (id: string) => {
+        this.selected = {
+            ...this.selected,
+            [id]: !this.selected[id],
+        };
+    };
+}

--- a/src/components/chip/examples/chip-icon-color.tsx
+++ b/src/components/chip/examples/chip-icon-color.tsx
@@ -1,0 +1,21 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Icon color
+ * Using the `Icon` interface, you can specify colors for the icon.
+ */
+@Component({
+    tag: 'limel-example-chip-icon-colors',
+    shadow: true,
+})
+export class ChipIconColorsExample {
+    public render() {
+        const icon = {
+            name: 'filled_star',
+            color: 'rgb(var(--color-yellow-default))',
+            backgroundColor: 'rgb(var(--color-blue-dark))',
+        };
+
+        return <limel-chip text="Golden star" icon={icon} />;
+    }
+}

--- a/src/components/chip/examples/chip-link.tsx
+++ b/src/components/chip/examples/chip-link.tsx
@@ -1,0 +1,34 @@
+import { Component, h } from '@stencil/core';
+import { Link } from '@limetech/lime-elements';
+
+/**
+ * Chip as hyperlink
+ * For accessibility and usability alike, if clicking on a chip should
+ * result in any kind of navigation, it is preferable to use a link,
+ * rather than a button.
+ *
+ * That way, the user can choose to, for example, open the link in a new tab.
+ * For this reason, we suggest always providing a Link with
+ * the URL representing the target state of the navigation.
+ */
+@Component({
+    tag: 'limel-example-chip-link',
+    shadow: true,
+})
+export class ChipLinkExample {
+    link: Link = {
+        href: 'https://github.com',
+        title: 'Open Github',
+        target: '_blank',
+    };
+
+    public render() {
+        return (
+            <limel-chip
+                text="Github"
+                icon="github_copyrighted"
+                link={this.link}
+            />
+        );
+    }
+}

--- a/src/components/chip/examples/chip-remove.tsx
+++ b/src/components/chip/examples/chip-remove.tsx
@@ -1,0 +1,43 @@
+import { Component, State, h } from '@stencil/core';
+
+/**
+ * Removable chips
+ * Chips can display a remove button,
+ * when their `removable` prop is set to `true`.
+ *
+ * This is typically used when the chip is used in a chip-set,
+ * where each chip visualizes a chosen option.
+ *
+ * :::tip
+ * When the chip is focused using the keyboard, the user can press
+ * the <kbd>Delete</kbd> or <kbd>Backspace</kbd> keys to
+ * trigger the same remove `event`.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-removable',
+    shadow: true,
+})
+export class ChipRemoveExample {
+    @State()
+    private removeButtonClicked: boolean = false;
+
+    public render() {
+        return [
+            <limel-chip
+                text="My filter"
+                badge={123}
+                removable={true}
+                onRemove={this.handleRemove}
+            />,
+            <limel-example-value
+                label="Remove"
+                value={this.removeButtonClicked}
+            />,
+        ];
+    }
+
+    private handleRemove = () => {
+        this.removeButtonClicked = true;
+    };
+}

--- a/src/components/chip/examples/limel-example-chip-aria-role.scss
+++ b/src/components/chip/examples/limel-example-chip-aria-role.scss
@@ -1,0 +1,5 @@
+div[role='row'] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/2539

💡  **A Note to the reviewer:**
Each commit can practically become a new PR. I /we can make new PRs if you want to have an easier time for reviewing. I just did everything in one round, because based on previous experience of adding new components from scratch, it's way easier to add all the features you intend to add, all at once. This way, while work is in progress, you will just add fixups to previous commits where needed, instead of adding new `fix` or `refactor` commits several times after the first commit is merged. This way, the code becomes much cleaner.

⚠️ The ultimate goal of this PR is to create a component that can be replaced with the internal complexities of `limel-chip-set`. When reviewing, also cast an eye on `limel-chip-set` to be able to judge whether this component is good enough for that purpose, or whether changes are needed.

⏭️ **What's next**
It's good to know what's coming. I'll later make new PRs, implementing new features in this component.
1. Adding possibility of having a custom menu on the chip. This will enable us to create a more decent ui in `limec-relation-picker` instead of the crazy hack that we are doing:  
    <img width="313" alt="image" src="https://github.com/Lundalogik/lime-elements/assets/35954987/d95db2ab-9e02-4da4-b2cb-2dccf8679624">
    If there is an action menu && `removable={true}`, the `X` button will be one of the choices of the ellipsis menu `⋮` instead of being constantly displayed on the chip.
2. I might also add a `loading` state (which renders a spinner) on the chip, in another PR.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
