### PR TITLE
fix(menu): show empty result when no search hits

### DIFF
--- a/src/components/menu/examples/menu-searchable.tsx
+++ b/src/components/menu/examples/menu-searchable.tsx
@@ -38,6 +38,7 @@ export class MenuSubItemsExample {
                 items={this.items}
                 searcher={this.handleSearch}
                 onSelect={this.handleSelect}
+                emptyResultMessage="No items found"
             >
                 <limel-button label="Menu" slot="trigger" />
             </limel-menu>,

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -409,7 +409,7 @@ export class Menu {
     private renderMenuList = () => {
         let items = this.visibleItems;
 
-        if (this.searchResults?.length) {
+        if (Array.isArray(this.searchResults) && this.searchValue) {
             items = this.searchResults;
         }
 


### PR DESCRIPTION
Fixes #2660 

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
