### PR TITLE
fix(action-bar): improve accessibility, using ARIA roles

### DIFF
--- a/src/components/action-bar/action-bar.spec.tsx
+++ b/src/components/action-bar/action-bar.spec.tsx
@@ -52,14 +52,14 @@ describe('action-bar', () => {
 
     it('renders', () => {
         expect(page.root).toEqualHtml(`
-            <limel-action-bar>
+            <limel-action-bar role="grid">
                 <mock:shadow-root>
-                    <div class=items>
-                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
-                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
-                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
-                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
-                        <limel-action-bar-item isvisible=""></limel-action-bar-item>
+                    <div class=items role="rowgroup">
+                        <limel-action-bar-item isvisible="" role="gridcell"></limel-action-bar-item>
+                        <limel-action-bar-item isvisible="" role="gridcell"></limel-action-bar-item>
+                        <limel-action-bar-item isvisible="" role="gridcell"></limel-action-bar-item>
+                        <limel-action-bar-item isvisible="" role="gridcell"></limel-action-bar-item>
+                        <limel-action-bar-item isvisible="" role="gridcell"></limel-action-bar-item>
                     </div>
                 </mock:shadow-root>
             </limel-action-bar>

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -112,8 +112,9 @@ export class ActionBar {
                     'is-full-width': this.layout === 'fullWidth',
                     'is-floating': this.layout === 'floating',
                 }}
+                role="grid"
             >
-                <div class="items">
+                <div class="items" role="rowgroup">
                     {this.actions.map(this.renderActionBarItem)}
                 </div>
                 {this.renderOverflowMenu(overflowActions)}
@@ -143,6 +144,7 @@ export class ActionBar {
                 item={item}
                 onSelect={this.handleSelect}
                 isVisible={this.isVisible(index)}
+                role="gridcell"
             />
         );
     };
@@ -157,6 +159,7 @@ export class ActionBar {
                 openDirection={this.openDirection}
                 items={items}
                 onSelect={this.handleSelect}
+                role="gridcell"
             />
         );
     };


### PR DESCRIPTION
Screen reader users will have a better experience, understanding the structure of the component better, when ARIA roles explain the relationship of the buttons and their containers (the action bar).

fix https://github.com/Lundalogik/lime-elements/issues/2702

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
