### PR TITLE
docs(markdown): add composite example

### DIFF
--- a/src/components/markdown/examples/markdown-composite.scss
+++ b/src/components/markdown/examples/markdown-composite.scss
@@ -1,0 +1,21 @@
+:host(limel-example-markdown-composite) {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    limel-input-field {
+        height: 10rem;
+    }
+
+    fieldset {
+        padding-block: 1rem;
+        padding-inline: 1rem;
+        margin-inline: 0;
+        border: 0.125rem dashed rgb(var(--contrast-700));
+
+        legend {
+            color: rgb(var(--contrast-1000));
+            text-align: center;
+        }
+    }
+}

--- a/src/components/markdown/examples/markdown-composite.tsx
+++ b/src/components/markdown/examples/markdown-composite.tsx
@@ -1,0 +1,37 @@
+import { LimelInputFieldCustomEvent } from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+
+/**
+ * Composite example
+ * Test your markdown code and see what you get in return in real-time.
+ */
+@Component({
+    tag: 'limel-example-markdown-composite',
+    styleUrl: 'markdown-composite.scss',
+    shadow: true,
+})
+export class MarkdownRenderContentExample {
+    @State()
+    private markdown = '# Hello, world!\n\nThis is **markdown**!';
+
+    public render() {
+        return [
+            <limel-input-field
+                label="Markdown to render"
+                type="textarea"
+                value={this.markdown}
+                onChange={this.handleMarkdownChange}
+            />,
+            <fieldset>
+                <legend>Rendered markdown</legend>
+                <limel-markdown value={this.markdown} />
+            </fieldset>,
+        ];
+    }
+
+    private handleMarkdownChange = (
+        event: LimelInputFieldCustomEvent<string>,
+    ) => {
+        this.markdown = event.detail;
+    };
+}

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -16,6 +16,7 @@ import { markdownToHTML } from './markdown-parser';
  * @exampleComponent limel-example-markdown-html
  * @exampleComponent limel-example-markdown-blockquotes
  * @exampleComponent limel-example-markdown-horizontal-rule
+ * @exampleComponent limel-example-markdown-composite
  */
 @Component({
     tag: 'limel-markdown',


### PR DESCRIPTION
This is an example I have locally to test out how a specific markdown/HTML will be rendered in Lime CRM. We have custom styling which make it render in another way than a regular markdown.

So this example makes very much sense to have so that we can test content out directly in the docs.


https://github.com/Lundalogik/lime-elements/assets/1814702/9030f83f-f074-4efc-bcd9-395dd4a72762



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
