### PR TITLE
chore(markdown): enable resetting table styles, for Lime CRM's internal use

### DIFF
--- a/src/components/markdown/partial-styles/_tables.scss
+++ b/src/components/markdown/partial-styles/_tables.scss
@@ -1,49 +1,59 @@
-table {
-    table-layout: auto;
-    min-width: 100%;
-    border-collapse: collapse;
-    border-spacing: 0;
-    background: transparent;
-    margin: 0.75rem 0;
+// Why wrapping the table styles in 👇 a `:not()` pseudo-class like below?
+:host(limel-markdown:not(.no-table-styles)) {
+    // Because in Lime CRM, the markdown component is sometimes
+    // used to render the HTML content of an email. Since emails
+    // can have lots of nested tables, the UI will be rendered
+    // horribly with below styles. In such cases, we just want to
+    // default to the user agent stylesheet for tables.
+    // This is for internal use in Lime CRM, which is why there is
+    // no public documentation for this.
+    table {
+        table-layout: auto;
+        min-width: 100%;
+        border-collapse: collapse;
+        border-spacing: 0;
+        background: transparent;
+        margin: 0.75rem 0;
 
-    border: 1px solid rgb(var(--contrast-400));
-}
-
-th,
-td {
-    text-align: left;
-    vertical-align: top;
-    transition: background-color 0.2s ease;
-    font-size: 0.875rem; // 14px
-}
-
-td {
-    padding: 0.5rem 0.375rem 0.75rem 0.375rem;
-}
-
-tr {
-    th {
-        background-color: rgb(var(--contrast-400));
-        padding: 0.25rem 0.375rem;
-        font-weight: normal;
-
-        &:only-child {
-            text-align: center;
-        }
+        border: 1px solid rgb(var(--contrast-400));
     }
-}
 
-tbody {
+    th,
+    td {
+        text-align: left;
+        vertical-align: top;
+        transition: background-color 0.2s ease;
+        font-size: 0.875rem; // 14px
+    }
+
+    td {
+        padding: 0.5rem 0.375rem 0.75rem 0.375rem;
+    }
+
     tr {
-        &:nth-child(odd) {
-            td {
-                background-color: rgb(var(--contrast-200));
+        th {
+            background-color: rgb(var(--contrast-400));
+            padding: 0.25rem 0.375rem;
+            font-weight: normal;
+
+            &:only-child {
+                text-align: center;
             }
         }
+    }
 
-        &:hover {
-            td {
-                background-color: rgb(var(--contrast-300));
+    tbody {
+        tr {
+            &:nth-child(odd) {
+                td {
+                    background-color: rgb(var(--contrast-200));
+                }
+            }
+
+            &:hover {
+                td {
+                    background-color: rgb(var(--contrast-300));
+                }
             }
         }
     }


### PR DESCRIPTION
In Lime CRM, the markdown component is sometimes used to render the HTML content of an email. Since emails can have lots of nested tables, the UI will be rendered horribly with below styles. In such cases, we just want to default to the user agent stylesheet for tables.

This is for internal use in Lime CRM, which is why there is no public documentation for this. Requested by @TommyLindh2 

### How to test this PR?
Add paste the content of this example in the Composite Example of `limel-markdown`.
👇 
[test.txt](https://github.com/Lundalogik/lime-elements/files/13949937/test.txt)

⚠️ Below data is fake

### **How it looks in HTML in the browser**

![image](https://github.com/Lundalogik/lime-elements/assets/1814702/97bdd858-a716-4cd1-a1d8-63b0e2a395bc)


### **How it looks in our Markdown**

![image](https://github.com/Lundalogik/lime-elements/assets/1814702/bbd5f182-2f24-4401-92b9-7fd7cfef9131)


### **When I comment out the table styling**
It looks like this

![image](https://github.com/Lundalogik/lime-elements/assets/1814702/8d03047c-9181-464e-94db-d58a44532b80)


The content of the mail can you see here:

[test.txt](https://github.com/Lundalogik/lime-elements/files/13949937/test.txt)



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
