### PR TITLE
fix(types): some exported types were exported as `any`

### DIFF
--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -8,7 +8,8 @@ import {
     EventEmitter,
     Watch,
 } from '@stencil/core';
-import { Languages, ListItem } from '@limetech/lime-elements';
+import { ListItem } from '../list/list-item.types';
+import { Languages } from '../../interface';
 import translate from '../../global/translations';
 import { detectExtension } from './extension-mapping';
 import { Fullscreen } from './fullscreen';

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -14,7 +14,7 @@ import { zipObject, isFunction } from 'lodash-es';
 import {
     LimelBreadcrumbsCustomEvent,
     LimelInputFieldCustomEvent,
-} from '@limetech/lime-elements';
+} from '../../components';
 
 import { BreadcrumbsItem } from '../breadcrumbs/breadcrumbs.types';
 import { ListSeparator } from '../list/list-item.types';


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
