### PR TITLE
Header improvements

### DIFF
--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -58,20 +58,20 @@
 
 .heading {
     color: var(--header-heading-color, rgb(var(--contrast-1100)));
-    font-size: functions.pxToRem(17);
+    font-size: functions.pxToRem(16);
     font-weight: 500;
 }
 
 .subheading {
     color: var(--header-subheading-color, rgb(var(--contrast-900)));
-    font-size: functions.pxToRem(14);
+    font-size: functions.pxToRem(13);
     font-weight: 400;
 }
 
 .subheading__supporting-text {
     color: var(--header-supporting-text-color, var(--header-subheading-color));
     span {
-        margin: 0 0.25rem;
+        margin: 0 0.125rem;
     }
 }
 

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -71,8 +71,7 @@
 .subheading__supporting-text {
     color: var(--header-supporting-text-color, var(--header-subheading-color));
     span {
-        margin: 0 functions.pxToRem(8);
-        font-weight: bold;
+        margin: 0 0.25rem;
     }
 }
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -119,7 +119,7 @@ export class Header {
         }
 
         return (
-            <span class="information__headings__subheading__supporting-text">
+            <span class="subheading__supporting-text">
                 <span>·</span> {this.supportingText}
             </span>
         );

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -83,6 +83,13 @@ export class Header {
     @Prop()
     public supportingText: string;
 
+    /**
+     * The visual divider that separates the `subheading` and the `supportingText`.
+     * It must be a single character such as `-` or `,`.
+     */
+    @Prop()
+    public subheadingDivider: string = '·';
+
     public render() {
         return [
             <div class="information">
@@ -120,7 +127,8 @@ export class Header {
 
         return (
             <span class="subheading__supporting-text">
-                <span>·</span> {this.supportingText}
+                <span>{this.subheadingDivider}</span>
+                {this.supportingText}
             </span>
         );
     }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
