### PR TITLE
feat(action-bar): make `ActionBarItem` generic

### DIFF
--- a/src/components/action-bar/action-bar.types.ts
+++ b/src/components/action-bar/action-bar.types.ts
@@ -4,13 +4,15 @@ import { Icon, MenuItem } from '../../interface';
  * Renders the button in the action bar without their labels.
  * Does not affect the items that are overflown into the overflow menu.
  */
-export type ActionBarItem = ActionBarItemOnlyIcon | ActionBarItemWithLabel;
+export type ActionBarItem<T = any> =
+    | ActionBarItemOnlyIcon<T>
+    | ActionBarItemWithLabel<T>;
 
-interface ActionBarItemOnlyIcon extends MenuItem {
+interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
     iconOnly: true;
     icon: string | Icon;
 }
 
-interface ActionBarItemWithLabel extends MenuItem {
+interface ActionBarItemWithLabel<T> extends MenuItem<T> {
     iconOnly?: false;
 }


### PR DESCRIPTION
`ActionBarItem` inherits from `MenuItem` which is generic, so `ActionBarItem` should be too



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
