### PR TITLE
Avoid future cases of broken type exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,6 +121,14 @@ module.exports = {
                 markers: ['/'],
             },
         ],
+        'no-restricted-imports': [
+            'error',
+            {
+                name: '@limetech/lime-elements',
+                message:
+                    'Production code should not import from `@limetech/lime-elements`. Please import from a relative path instead.',
+            },
+        ],
     },
     overrides: [
         {
@@ -185,6 +193,7 @@ module.exports = {
                     { name: ['test', 'only'], message: "don't focus tests" },
                     { name: 'ftest', message: "don't focus tests" },
                 ],
+                'no-restricted-imports': 'off',
             },
         },
     ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -128,6 +128,16 @@ module.exports = {
                 message:
                     'Production code should not import from `@limetech/lime-elements`. Please import from a relative path instead.',
             },
+            {
+                name: 'lodash',
+                message:
+                    'Import from lodash-es instead. This will reduce the bundle size.',
+            },
+            {
+                name: 'underscore',
+                message:
+                    'This project uses lodash instead of underscore. Please import from lodash-es instead. This will reduce the bundle size.',
+            },
         ],
     },
     overrides: [
@@ -193,7 +203,19 @@ module.exports = {
                     { name: ['test', 'only'], message: "don't focus tests" },
                     { name: 'ftest', message: "don't focus tests" },
                 ],
-                'no-restricted-imports': 'off',
+                'no-restricted-imports': [
+                    'error',
+                    {
+                        name: 'lodash',
+                        message:
+                            'Import from lodash-es instead. This will reduce the bundle size.',
+                    },
+                    {
+                        name: 'underscore',
+                        message:
+                            'This project uses lodash instead of underscore. Please import from lodash-es instead. This will reduce the bundle size.',
+                    },
+                ],
             },
         },
     ],

--- a/src/components/form/examples/form-with-help.tsx
+++ b/src/components/form/examples/form-with-help.tsx
@@ -33,7 +33,7 @@ import { schema } from './help-form-schema';
  * in the place of the helper text.
  * :::
  *
- * @link help-form-schema.ts
+ * @sourceFile help-form-schema.ts
  */
 @Component({
     tag: 'limel-example-form-with-help',

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -1,4 +1,4 @@
-import { Components } from '../../components';
+import { Help } from '../help/help.types';
 import { EventEmitter } from '@stencil/core';
 
 export interface ValidationStatus {
@@ -167,7 +167,7 @@ export interface LimeSchemaOptions {
      */
     disabled?: boolean;
 
-    help?: string | Components.LimelHelp;
+    help?: string | Help;
 }
 
 /**

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -1,4 +1,4 @@
-import { Components } from '@limetech/lime-elements';
+import { Components } from '../../components';
 import { EventEmitter } from '@stencil/core';
 
 export interface ValidationStatus {

--- a/src/components/form/widgets/input-field.ts
+++ b/src/components/form/widgets/input-field.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InputType } from '@limetech/lime-elements';
+import { InputType } from '../../input-field/input-field.types';
 import { isIntegerType, isNumberType } from '../schema';
 import { WidgetProps } from './types';
 import { LimeElementsWidgetAdapter } from '../adapters';

--- a/src/components/help/examples/help-read-more.tsx
+++ b/src/components/help/examples/help-read-more.tsx
@@ -10,7 +10,7 @@ import { helpAndDocumentation, link } from './help-and-documentation';
  * of the popover after the content, does not scroll away with the content,
  * and it will be styled in a consistent way.
  *
- * @link help-and-documentation.ts
+ * @sourceFile help-and-documentation.ts
  */
 
 @Component({

--- a/src/components/help/help.tsx
+++ b/src/components/help/help.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, State } from '@stencil/core';
 import { OpenDirection } from '../menu/menu.types';
 import { Link } from '../../interface';
+import { Help as HelpInterface } from './help.types';
 
 /**
  * A good design is self-explanatory! However, sometimes concepts are
@@ -28,35 +29,27 @@ import { Link } from '../../interface';
     shadow: true,
     styleUrl: 'help.scss',
 })
-export class Help {
+export class Help implements HelpInterface {
     /**
-     * The markdown content that will be displayed in the popover.
+     * @inheritdoc
      */
     @Prop()
     public value: string;
 
     /**
-     * Visualizes the trigger element. Defaults to: **?**
-     * :::important
-     * Be consistent across the product if you want to change it to a custom character.
-     * All instances of the help component should have the same trigger visualization.
-     * :::
+     * @inheritdoc
      */
     @Prop()
     public trigger: string = '?';
 
     /**
-     * If supplied, it will render a "Read more" link at the bottom of the content.
-     * Even though you can add a link anywhere in the content, it is recommended to
-     * use the read more link. Because it will always be displayed at the bottom
-     * of the popover after the content, does not scroll away with the content,
-     * and it will be styled in a consistent way.
+     * @inheritdoc
      */
     @Prop()
     public readMoreLink?: Link;
 
     /**
-     * Decides the popover's location in relation to the trigger.
+     * @inheritdoc
      */
     @Prop({ reflect: true })
     public openDirection: OpenDirection = 'top-start';

--- a/src/components/help/help.types.ts
+++ b/src/components/help/help.types.ts
@@ -1,0 +1,32 @@
+import { OpenDirection } from '../menu/menu.types';
+import { Link } from '../../interface';
+
+export interface Help {
+    /**
+     * Decides the popover's location in relation to the trigger.
+     */
+    openDirection: OpenDirection;
+
+    /**
+     * If supplied, it will render a "Read more" link at the bottom of the content.
+     * Even though you can add a link anywhere in the content, it is recommended to
+     * use the read more link. Because it will always be displayed at the bottom
+     * of the popover after the content, does not scroll away with the content,
+     * and it will be styled in a consistent way.
+     */
+    readMoreLink?: Link;
+
+    /**
+     * Visualizes the trigger element. Defaults to: **?**
+     * :::important
+     * Be consistent across the product if you want to change it to a custom character.
+     * All instances of the help component should have the same trigger visualization.
+     * :::
+     */
+    trigger: string;
+
+    /**
+     * The markdown content that will be displayed in the popover.
+     */
+    value: string;
+}


### PR DESCRIPTION
Fixes problem mentioned in [this Slack message](https://lime-technologies.slack.com/archives/C1K6TN9BK/p1705587480128879).

> Ok, I found out that some types exported from Lime Elements are broken again :disappointed: I fixed them a while back, but now some of them were just exported as any again, leading to a lot of confusion and loss of type hints. It happens if anything is imported from @limetech/lime-elements from within lime elements itself, so please keep this in mind and do not do it! :smile:  (it's ok to import from @limetech/lime-elements in the examples, and this is actually how we should do it in there). Here's a PR to fix it, we maybe could investigate if it's possible to check for this kind of error automatically since it's hard to discover manually and I just did it by accident now after a lot of debugging :smile:
https://github.com/Lundalogik/lime-elements/pull/2726

The first commit fixes the problem mentioned above. The second commit bans importing from `lodash` and `underscore`, with an instruction to import from `lodash-es` instead.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
