### PR TITLE
perf(breadcrumbs): fix minor memory leak in limel-breadcrumbs

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -71,9 +71,6 @@ export class Breadcrumbs {
     @Element()
     private host: HTMLLimelBreadcrumbsElement;
 
-    private button: HTMLButtonElement;
-    private anchor: HTMLAnchorElement;
-
     public render() {
         return (
             <ol
@@ -92,7 +89,7 @@ export class Breadcrumbs {
     }
 
     public disconnectedCallback() {
-        this.removeEnterClickable();
+        removeEnterClickable(this.host);
     }
 
     private renderSteps = () => {
@@ -195,9 +192,4 @@ export class Breadcrumbs {
         event.stopPropagation();
         this.select.emit(item);
     };
-
-    private removeEnterClickable() {
-        const element = this.button ?? this.anchor;
-        removeEnterClickable(element);
-    }
 }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
