### PR TITLE
fix(limel-picker): don't show an empty icon if no icon is provided

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -321,14 +321,14 @@ export class Picker {
     }
 
     private createChip(listItem: ListItem): Chip {
+        const name = getIconName(listItem.icon);
+        const color = getIconFillColor(listItem.icon, listItem.iconColor);
+
         return {
             id: `${listItem.value}`,
             text: listItem.text,
             removable: true,
-            icon: {
-                name: getIconName(listItem.icon),
-                color: getIconFillColor(listItem.icon, listItem.iconColor),
-            },
+            icon: name ? { name: name, color: color } : undefined,
             value: listItem,
         };
     }


### PR DESCRIPTION
Fix: https://github.com/Lundalogik/lime-elements/issues/2749
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
