### PR TITLE
fix(icon): do not crash if icon is `null`

### DIFF
--- a/src/components/icon/get-icon-props.spec.ts
+++ b/src/components/icon/get-icon-props.spec.ts
@@ -1,0 +1,219 @@
+import {
+    getIconBackgroundColor,
+    getIconColor,
+    getIconFillColor,
+    getIconName,
+    getIconTitle,
+} from './get-icon-props';
+import { Icon } from '../../global/shared-types/icon.types';
+
+describe('getIconName', () => {
+    it('returns the correct icon name when icon is a string', () => {
+        const icon: string | Icon = 'test-icon';
+        const result = getIconName(icon);
+        expect(result).toEqual('test-icon');
+    });
+
+    it('returns the correct icon name when icon is an object with a name property', () => {
+        const icon: string | Icon = { name: 'test-icon' };
+        const result = getIconName(icon);
+        expect(result).toEqual('test-icon');
+    });
+
+    it('returns undefined when icon is an object without a name property', () => {
+        const icon: string | Icon = { notName: 'test-icon' } as any as Icon;
+        const result = getIconName(icon);
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when icon is null', () => {
+        const icon: string | Icon = null;
+        const result = getIconName(icon);
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when icon is undefined', () => {
+        const icon: string | Icon = undefined;
+        const result = getIconName(icon);
+        expect(result).toBeUndefined();
+    });
+});
+
+[
+    {
+        func: getIconColor,
+        iconPropertyName: 'color',
+        attributeName: 'iconColor',
+    },
+    {
+        func: getIconFillColor,
+        iconPropertyName: 'color',
+        attributeName: 'fillColor',
+    },
+    {
+        func: getIconBackgroundColor,
+        iconPropertyName: 'backgroundColor',
+        attributeName: 'backgroundColor',
+    },
+    {
+        func: getIconTitle,
+        iconPropertyName: 'title',
+        attributeName: 'iconTitle',
+    },
+].forEach(({ func, iconPropertyName, attributeName }) => {
+    describe(`${func.name}`, () => {
+        let icon: string | Icon;
+        let attribute: string | undefined;
+
+        describe('when icon is a string', () => {
+            beforeEach(() => {
+                icon = 'test-icon';
+            });
+            describe(`and ${attributeName} is not provided`, () => {
+                it('returns `undefined`', () => {
+                    const result = func(icon);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is provided`, () => {
+                beforeEach(() => {
+                    attribute = 'blue';
+                });
+                it(`returns the ${attributeName} value`, () => {
+                    const result = func(icon, attribute);
+                    expect(result).toEqual('blue');
+                });
+            });
+            describe(`and ${attributeName} is \`undefined\``, () => {
+                beforeEach(() => {
+                    attribute = undefined;
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+        });
+
+        describe(`when icon is an object with a ${iconPropertyName} property`, () => {
+            beforeEach(() => {
+                icon = { name: 'test-icon' };
+                icon[iconPropertyName] = 'red';
+            });
+            describe(`and ${attributeName} is not provided`, () => {
+                it(`returns the icon.${iconPropertyName} value`, () => {
+                    const result = func(icon);
+                    expect(result).toEqual('red');
+                });
+            });
+            describe(`and ${attributeName} is provided`, () => {
+                beforeEach(() => {
+                    attributeName = 'blue';
+                });
+                it(`returns the icon.${iconPropertyName} value`, () => {
+                    const result = func(icon, attributeName);
+                    expect(result).toEqual('red');
+                });
+            });
+            describe(`and ${attributeName} is \`undefined\``, () => {
+                beforeEach(() => {
+                    attributeName = undefined;
+                });
+                it(`returns the icon.${iconPropertyName} value`, () => {
+                    const result = func(icon, attributeName);
+                    expect(result).toEqual('red');
+                });
+            });
+        });
+
+        describe(`when icon is an object withOUT the ${iconPropertyName} property`, () => {
+            beforeEach(() => {
+                icon = { name: 'test-icon' };
+            });
+            describe(`and ${attributeName} is not provided`, () => {
+                it('returns `undefined`', () => {
+                    const result = func(icon);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is provided`, () => {
+                beforeEach(() => {
+                    attribute = 'blue';
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is \`undefined\``, () => {
+                beforeEach(() => {
+                    attribute = undefined;
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+        });
+
+        describe('when icon is `null`', () => {
+            beforeEach(() => {
+                icon = null;
+            });
+            describe(`and ${attributeName} is not provided`, () => {
+                it('returns `undefined`', () => {
+                    const result = func(icon);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is provided`, () => {
+                beforeEach(() => {
+                    attribute = 'blue';
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is \`undefined\``, () => {
+                beforeEach(() => {
+                    attribute = undefined;
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+        });
+
+        describe('when icon is `undefined`', () => {
+            beforeEach(() => {
+                icon = undefined;
+            });
+            describe(`and ${attributeName} is not provided`, () => {
+                it('returns `undefined`', () => {
+                    const result = func(icon);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is provided`, () => {
+                beforeEach(() => {
+                    attribute = 'blue';
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+            describe(`and ${attributeName} is \`undefined\``, () => {
+                beforeEach(() => {
+                    attribute = undefined;
+                });
+                it('returns `undefined`', () => {
+                    const result = func(icon, attribute);
+                    expect(result).toBeUndefined();
+                });
+            });
+        });
+    });
+});

--- a/src/components/icon/get-icon-props.ts
+++ b/src/components/icon/get-icon-props.ts
@@ -10,7 +10,7 @@ import { Icon } from '../../interface';
 export function getIconName(
     icon: string | Icon | undefined,
 ): string | undefined {
-    if (typeof icon === 'object' && 'name' in icon) {
+    if (!!icon && typeof icon === 'object' && 'name' in icon) {
         return icon.name;
     }
 
@@ -35,7 +35,7 @@ export function getIconColor(
     icon: string | Icon | undefined,
     iconColor?: string | undefined,
 ): string | undefined {
-    if (typeof icon === 'object' && 'color' in icon) {
+    if (!!icon && typeof icon === 'object' && 'color' in icon) {
         return icon.color;
     }
 
@@ -59,8 +59,8 @@ export function getIconColor(
 export function getIconFillColor(
     icon: string | Icon | undefined,
     iconFillColor?: string | undefined,
-): string {
-    if (typeof icon === 'object' && 'color' in icon) {
+): string | undefined {
+    if (!!icon && typeof icon === 'object' && 'color' in icon) {
         return icon.color;
     }
 
@@ -83,7 +83,7 @@ export function getIconBackgroundColor(
     icon: string | Icon | undefined,
     iconBackgroundColor?: string | undefined,
 ): string | undefined {
-    if (typeof icon === 'object' && 'backgroundColor' in icon) {
+    if (!!icon && typeof icon === 'object' && 'backgroundColor' in icon) {
         return icon.backgroundColor;
     }
 
@@ -105,7 +105,7 @@ export function getIconTitle(
     icon: string | Icon | undefined,
     iconTitle?: string | undefined,
 ): string | undefined {
-    if (typeof icon === 'object' && 'title' in icon) {
+    if (!!icon && typeof icon === 'object' && 'title' in icon) {
         return icon.title;
     }
 


### PR DESCRIPTION
fix: #2752

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
