### PR TITLE
fix(breadcrumbs): use the same `id` for items & their tooltips…

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -125,7 +125,7 @@ export class Breadcrumbs {
         return [
             <a
                 role="listitem"
-                id={createRandomString()}
+                id={tooltipId}
                 class="step"
                 href={item.link.href}
                 title={item.link.title}


### PR DESCRIPTION
when items are rendered as links

fix https://github.com/Lundalogik/lime-elements/issues/2704

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
