### PR TITLE
Don't block all pointer events on disabled components, just block the click event instead

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -146,6 +146,7 @@
 
     &.disabled {
         @include shared_input-select-picker.looks-disabled;
+        pointer-events: none;
     }
 }
 

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -11,10 +11,6 @@
     display: none;
 }
 
-:host([disabled]) {
-    pointer-events: none;
-}
-
 @include mixins.visualize-aria-expanded('button');
 
 button.mdc-button {
@@ -46,6 +42,8 @@ button {
     width: 100%;
 
     &:disabled {
+        cursor: not-allowed;
+
         &.outlined {
             border-color: rgba(var(--contrast-1700), 0.2);
         }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Watch, Element } from '@stencil/core';
+import { Component, h, Prop, State, Watch, Element, Host } from '@stencil/core';
 import {
     makeEnterClickable,
     removeEnterClickable,
@@ -85,20 +85,22 @@ export class Button {
 
     public render() {
         return (
-            <button
-                class={{
-                    loading: this.loading,
-                    'just-loaded': this.justLoaded && !this.loadingFailed,
-                    'just-failed': this.justLoaded && this.loadingFailed,
-                    outlined: this.outlined,
-                }}
-                disabled={this.disabled || this.loading}
-            >
-                {this.renderIcon()}
-                {this.renderLabel()}
-                {this.renderSpinner()}
-                <svg viewBox="0 0 30 30">{this.renderLoadingIcons()}</svg>
-            </button>
+            <Host onClick={this.filterClickWhenDisabled}>
+                <button
+                    class={{
+                        loading: this.loading,
+                        'just-loaded': this.justLoaded && !this.loadingFailed,
+                        'just-failed': this.justLoaded && this.loadingFailed,
+                        outlined: this.outlined,
+                    }}
+                    disabled={this.disabled || this.loading}
+                >
+                    {this.renderIcon()}
+                    {this.renderLabel()}
+                    {this.renderSpinner()}
+                    <svg viewBox="0 0 30 30">{this.renderLoadingIcons()}</svg>
+                </button>
+            </Host>
         );
     }
 
@@ -153,4 +155,10 @@ export class Button {
 
         return <limel-spinner limeBranded={false} />;
     }
+
+    private filterClickWhenDisabled = (e) => {
+        if (this.disabled) {
+            e.preventDefault();
+        }
+    };
 }

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -184,6 +184,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 
     &.disabled:not(.mdc-chip-set--input) {
         @include shared_input-select-picker.looks-disabled;
+        pointer-events: none;
     }
 }
 
@@ -256,6 +257,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
 
     &.disabled {
         @include shared_input-select-picker.looks-disabled;
+        pointer-events: none;
     }
 }
 

--- a/src/components/chip-set/partial-styles/_file-picker.scss
+++ b/src/components/chip-set/partial-styles/_file-picker.scss
@@ -54,6 +54,7 @@
                 &:after {
                     // Drop zone visualization
                     @include shared_input-select-picker.looks-disabled;
+                    pointer-events: none;
                 }
             }
         }

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -18,10 +18,6 @@
     display: none;
 }
 
-:host([disabled]) {
-    pointer-events: none;
-}
-
 .open-close-toggle {
     all: unset;
     position: absolute;

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -8,18 +8,16 @@
     display: none;
 }
 
-:host([disabled]) {
-    pointer-events: none;
-}
-
 @include mixins.visualize-aria-expanded('button');
 
 button {
     all: unset;
-    @include mixins.is-flat-clickable(
-        $background-color: var(--icon-background-color, transparent)
-    );
-    @include mixins.visualize-keyboard-focus;
+    &:not(:disabled) {
+        @include mixins.is-flat-clickable(
+            $background-color: var(--icon-background-color, transparent)
+        );
+        @include mixins.visualize-keyboard-focus;
+    }
 
     display: inline-flex;
     align-items: center;
@@ -29,14 +27,19 @@ button {
     width: 2.25rem;
     border-radius: 50%;
 
-    :host([elevated]) & {
-        &:not(:hover):not(:active):not(:focus-visible) {
+    &:disabled {
+        cursor: not-allowed;
+
+        color: var(--mdc-theme-text-disabled-on-background);
+    }
+}
+
+:host([elevated]) {
+    button {
+        box-shadow: var(--button-shadow-normal);
+        &:disabled {
             box-shadow: var(--button-shadow-normal);
         }
-    }
-
-    &:disabled {
-        color: var(--mdc-theme-text-disabled-on-background);
     }
 }
 

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 import {
     makeEnterClickable,
     removeEnterClickable,
@@ -79,14 +79,16 @@ export class IconButton {
         }
 
         return (
-            <button
-                disabled={this.disabled}
-                id={this.tooltipId}
-                {...buttonAttributes}
-            >
-                <limel-icon name={this.icon} badge={true} />
-                {this.renderTooltip(this.tooltipId)}
-            </button>
+            <Host onClick={this.filterClickWhenDisabled}>
+                <button
+                    disabled={this.disabled}
+                    id={this.tooltipId}
+                    {...buttonAttributes}
+                >
+                    <limel-icon name={this.icon} badge={true} />
+                    {this.renderTooltip(this.tooltipId)}
+                </button>
+            </Host>
         );
     }
     private renderTooltip(tooltipId) {
@@ -94,4 +96,10 @@ export class IconButton {
             return <limel-tooltip elementId={tooltipId} label={this.label} />;
         }
     }
+
+    private filterClickWhenDisabled = (e) => {
+        if (this.disabled) {
+            e.preventDefault();
+        }
+    };
 }

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -65,6 +65,7 @@
 .lime-text-field--empty {
     .mdc-text-field__icon--trailing {
         @include shared_input-select-picker.looks-disabled;
+        pointer-events: none;
         box-shadow: none !important;
     }
 }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -105,6 +105,7 @@
     &.mdc-select--disabled {
         .limel-select-trigger {
             @include shared_input-select-picker.looks-disabled;
+            box-shadow: var(--button-shadow-normal);
         }
         .mdc-select__dropdown-icon {
             svg {

--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -13,10 +13,6 @@
     }
 }
 
-:host([disabled]) {
-    pointer-events: none;
-}
-
 limel-button {
     width: 100%;
 }

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -66,6 +66,7 @@ export class SplitButton {
                 class={{
                     'has-menu': !!this.items.length,
                 }}
+                onClick={this.filterClickWhenDisabled}
             >
                 <limel-button
                     label={this.label}
@@ -101,5 +102,11 @@ export class SplitButton {
                 </button>
             </limel-menu>
         );
+    };
+
+    private filterClickWhenDisabled = (e) => {
+        if (this.disabled) {
+            e.preventDefault();
+        }
     };
 }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -78,10 +78,8 @@ label {
     @include lime-typography.typography(body2);
     color: var(--mdc-theme-on-surface);
 
-    cursor: pointer;
-
-    &.disabled {
-        @include shared_input-select-picker.looks-disabled;
+    &:not(.disabled) {
+        cursor: pointer;
     }
 }
 

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -35,7 +35,6 @@ $cropped-label-hack--font-size: 0.875rem; //14px
 
 @mixin looks-disabled() {
     cursor: not-allowed;
-    pointer-events: none;
     opacity: 0.4;
 }
 


### PR DESCRIPTION
When the host element is disabled, but has an `onClick`
event defined, we filter that out now, instead of preventing
clicks using a CSS hack.

fix https://github.com/Lundalogik/crm-feature/issues/3317

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
