### PR TITLE
fix(icon): render visual size always the same, no matter badge is `…

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -55,6 +55,8 @@
         transition: color 0.2s ease;
         display: flex;
         align-items: center;
+        justify-content: center;
+
         &:has(> limel-badge) {
             .mdc-chip__text {
                 padding-right: 0.25rem;
@@ -147,6 +149,10 @@
     &.disabled {
         @include shared_input-select-picker.looks-disabled;
     }
+}
+
+limel-icon {
+    width: 1.25rem;
 }
 
 limel-badge {

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -155,8 +155,6 @@ export class ButtonGroup {
                 class="mdc-chip__icon"
                 aria-label={button.title}
                 name={button.icon}
-                size="small"
-                badge={true}
             />,
             <limel-tooltip elementId={iconId} label={button.title} />,
         ];

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -139,8 +139,10 @@ limel-badge {
 
 limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     background-color: var(--icon-background-color, transparent);
-    margin: 0 !important;
+    margin: 0 0 0 0.25rem !important;
     color: var(--icon-color, rgb(var(--contrast-1100)));
+    height: 1.5rem;
+    width: 1.5rem;
 }
 
 .mdc-chip-set {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -731,8 +731,6 @@ export class ChipSet {
                 class="mdc-chip__icon mdc-chip__icon--leading"
                 name={name}
                 style={style}
-                size="small"
-                badge={true}
                 title={title}
             />
         );

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -117,7 +117,7 @@ export class Header {
             return;
         }
 
-        return <limel-icon class="icon" badge={true} name={icon} />;
+        return <limel-icon class="icon" name={icon} />;
     }
 
     private renderSupportingText() {

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -84,7 +84,7 @@ export class IconButton {
                 id={this.tooltipId}
                 {...buttonAttributes}
             >
-                <limel-icon name={this.icon} badge={true} />
+                <limel-icon name={this.icon} />
                 {this.renderTooltip(this.tooltipId)}
             </button>
         );

--- a/src/components/icon/examples/icon-color.tsx
+++ b/src/components/icon/examples/icon-color.tsx
@@ -8,7 +8,6 @@ import { Component, h } from '@stencil/core';
  *:::note
  * Note that `badge` is set to `true` to provide more space around the icon,
  * and make sure the background color is nicely displayed.
- * But the `bade` has effect, only when the `size` attribute is also set.
  *:::
  */
 @Component({

--- a/src/components/icon/examples/icon-size-ui.scss
+++ b/src/components/icon/examples/icon-size-ui.scss
@@ -14,7 +14,7 @@ limel-icon {
 
 th,
 td {
-    padding: 0.25rem 0.5rem;
+    padding: 0 0.5rem;
 
     &:not(:first-child) {
         border-left: 1px dotted rgb(var(--contrast-700));
@@ -22,7 +22,7 @@ td {
 }
 
 th:first-child {
-    width: 4rem;
+    width: 5rem;
 }
 
 p,

--- a/src/components/icon/examples/icon-size.tsx
+++ b/src/components/icon/examples/icon-size.tsx
@@ -3,8 +3,8 @@ import { Component, h } from '@stencil/core';
  * Size
  * There are preset sizes.
  * :::note
- * Setting the `bade` prop to `true` affects how big the icon is rendered,
- * but only when the `size` attribute is also set.
+ * Setting the `bade` prop to `true` adds some space around the visual motif,
+ * of the component, naturally resulting in smaller visual appearance.
  * :::
  */
 @Component({
@@ -31,6 +31,7 @@ export class IconSizeExample {
                     <tr>
                         <td>
                             <code>x-small</code>
+                            <p>1rem</p>
                         </td>
                         <td>
                             <limel-icon
@@ -76,6 +77,7 @@ export class IconSizeExample {
                     <tr>
                         <td>
                             <code>small</code>
+                            <p>1.5rem</p>
                         </td>
                         <td>
                             <limel-icon
@@ -117,6 +119,7 @@ export class IconSizeExample {
                     <tr>
                         <td>
                             <code>medium</code>
+                            <p>1.75rem</p>
                         </td>
                         <td>
                             <limel-icon
@@ -161,6 +164,7 @@ export class IconSizeExample {
                     <tr>
                         <td>
                             <code>large</code>
+                            <p>2rem</p>
                         </td>
                         <td>
                             <limel-icon name="frog" size="large" badge={true} />

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -4,22 +4,19 @@
  * @prop --icon-background-color: Background color when attribute `badge` is set to `true`. Defaults to `transparent`.
  */
 
-:host {
+:host(limel-icon) {
     background-color: var(--icon-background-color, transparent);
     border-radius: 50%;
     display: inline-block;
     line-height: 0;
     box-sizing: border-box;
+    padding: var(--limel-icon-svg-margin, 0);
 
     svg {
         fill: currentColor;
         height: 100%;
         pointer-events: none;
         width: 100%;
-    }
-
-    div {
-        margin: var(--limel-icon-svg-margin, 0);
     }
 }
 
@@ -28,43 +25,29 @@
 }
 
 :host([size='x-small']) {
-    height: functions.pxToRem(15) !important;
-    width: functions.pxToRem(15) !important;
+    height: 1rem;
+    width: 1rem;
 }
 :host([size='small']) {
-    height: functions.pxToRem(20) !important;
-    width: functions.pxToRem(20) !important;
+    height: 1.5rem;
+    width: 1.5rem;
 }
 :host([size='medium']) {
-    height: functions.pxToRem(25) !important;
-    width: functions.pxToRem(25) !important;
+    height: 1.75rem;
+    width: 1.75rem;
 }
 :host([size='large']) {
-    height: functions.pxToRem(30) !important;
-    width: functions.pxToRem(30) !important;
+    height: 2rem;
+    width: 2rem;
 }
 
+:host([badge]) {
+    --limel-icon-svg-margin: 0.25rem;
+}
 :host([badge][size='x-small']) {
-    height: functions.pxToRem(23) !important;
-    width: functions.pxToRem(23) !important;
-
-    --limel-icon-svg-margin: #{functions.pxToRem(4)};
+    --limel-icon-svg-margin: 0.0625rem;
 }
-:host([badge][size='small']) {
-    height: functions.pxToRem(30) !important;
-    width: functions.pxToRem(30) !important;
-
-    --limel-icon-svg-margin: #{functions.pxToRem(5)};
-}
+:host([badge][size='small']),
 :host([badge][size='medium']) {
-    height: functions.pxToRem(40) !important;
-    width: functions.pxToRem(40) !important;
-
-    --limel-icon-svg-margin: #{functions.pxToRem(8)};
-}
-:host([badge][size='large']) {
-    height: functions.pxToRem(46) !important;
-    width: functions.pxToRem(46) !important;
-
-    --limel-icon-svg-margin: #{functions.pxToRem(8)};
+    --limel-icon-svg-margin: 0.125rem;
 }

--- a/src/components/table/examples/table-food.tsx
+++ b/src/components/table/examples/table-food.tsx
@@ -50,7 +50,7 @@ export class TableFood implements TableComponent<Bird> {
                 title={capitalize(value)}
                 badge={true}
                 name={nameMap[value]}
-                size="x-small"
+                size="small"
             />
         );
     }


### PR DESCRIPTION
…true` or `false`

From now on, it does not matter whether the `badge` property
is set to `true` or `false`. The visual size of `limel-icon` is not
affected by the badge anymore. What happens now is that
the badge adds some visual space around the visual motif
of the icon.

BREAKING CHANGE:
If you have used either `size` or `badge` properties of `limel-icon`
component, you will get a different visual size when the component
is rendered. This might negatively affect your UI design, and some
further adjustments might be required.

fix https://github.com/Lundalogik/lime-elements/issues/2741

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
