### PR TITLE
fix(components): decrease the height and headspace of input elements

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -39,6 +39,7 @@ $leading-icon-space: 1.5rem;
 
 .mdc-chip-set {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
     min-height: shared_input-select-picker.$height-of-mdc-text-field;

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -31,7 +31,7 @@
 @include shared_input-select-picker.lime-looks-like-input-value;
 
 $height-of-chip-set-input: functions.pxToRem(36);
-$leading-icon-space: functions.pxToRem(40);
+$leading-icon-space: 1.5rem;
 
 :host(limel-chip-set) {
     isolation: isolate;
@@ -51,8 +51,7 @@ $leading-icon-space: functions.pxToRem(40);
     }
 
     &.mdc-chip-set--input {
-        padding: functions.pxToRem(8);
-
+        padding: 0.4rem 0.5rem;
         width: 100%;
     }
 
@@ -123,7 +122,7 @@ $leading-icon-space: functions.pxToRem(40);
             // vertically, when there are multiple rows of chips.
             top: functions.pxToRem(27);
 
-            transform: translateY(-34.75px) scale(0.75);
+            transform: translateY(-34.75px) scale(0.75) !important;
             font-size: shared_input-select-picker.$cropped-label-hack--font-size;
         }
     }
@@ -138,8 +137,8 @@ $leading-icon-space: functions.pxToRem(40);
     @include mixins.visualize-keyboard-focus;
 
     position: absolute;
-    right: functions.pxToRem(8);
-    top: functions.pxToRem(18);
+    right: 0.5rem;
+    top: calc(#{shared_input-select-picker.$height-of-mdc-text-field} / 4);
 
     opacity: 0; // Is hidden, but can receive focus (such as when navigating through tab indexes).
 
@@ -174,15 +173,15 @@ $leading-icon-space: functions.pxToRem(40);
 
     limel-chip {
         &:first-of-type {
-            margin-left: 40px;
+            margin-left: 1.5rem;
         }
     }
 
     .search-icon {
         transition: transform 0.2s ease;
         position: absolute;
-        top: functions.pxToRem(16);
-        left: functions.pxToRem(16);
+        top: functions.pxToRem(9);
+        left: 0.25rem;
     }
 
     limel-icon {
@@ -208,3 +207,10 @@ limel-chip {
 @import './partial-styles/_readonly';
 @import './partial-styles/_file-picker';
 @import './partial-styles/_helper-text';
+
+// To make the input field render smaller than the default MDC UI
+.mdc-text-field {
+    &.mdc-text-field--outlined {
+        min-height: shared_input-select-picker.$height-of-mdc-text-field;
+    }
+}

--- a/src/components/chip-set/partial-styles/_file-picker.scss
+++ b/src/components/chip-set/partial-styles/_file-picker.scss
@@ -1,5 +1,5 @@
 :host {
-    --dropzone-margin: 0.25rem;
+    --dropzone-margin: 0.125rem;
     --dropzone-color: rgb(var(--contrast-600));
 }
 

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -10,6 +10,7 @@
     isolation: isolate;
     display: inline-flex;
     align-items: center;
+    min-width: 0;
 }
 
 * {
@@ -20,6 +21,7 @@
     all: unset;
     position: relative;
 
+    min-width: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -155,6 +157,7 @@ limel-badge {
     );
 
     z-index: 1;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -1,5 +1,6 @@
 @use '../../style/internal/lime-theme';
 @use '../../style/mixins';
+@use '../../style/internal/shared_input-select-picker';
 
 /**
  * @prop --closed-header-background-color: background color for header when closed
@@ -74,8 +75,7 @@ header {
     justify-content: space-between;
 
     padding-left: 0.5rem;
-    padding-right: 0.5rem;
-    height: 3rem;
+    height: shared_input-select-picker.$height-of-mdc-text-field;
 }
 
 .title {

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -1,14 +1,16 @@
 @use '../../style/mixins';
+@use '../../style/internal/shared_input-select-picker';
 @import './partial-styles/lime-admin-hack';
 
 :host {
+    position: relative;
     --popover-surface-width: 50rem;
     --color-picker-default-background: url("data:image/svg+xml;charset=utf-8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8' style='fill-rule:evenodd;'><path fill='rgba(186,186,192,0.16)' d='M0 0h4v4H0zM4 4h4v4H4z'/></svg>");
 }
 
 .color-picker {
     display: grid;
-    gap: 0.5rem;
+    gap: 0.25rem;
     grid-template-columns: auto 1fr;
 }
 
@@ -28,8 +30,8 @@
     box-sizing: border-box;
     position: relative;
     isolation: isolate;
-    width: 3.5rem;
-    height: 3.5rem;
+    width: shared_input-select-picker.$height-of-mdc-text-field;
+    height: shared_input-select-picker.$height-of-mdc-text-field;
 
     &:before,
     &:after {
@@ -63,5 +65,12 @@
 }
 
 .chosen-color-input[readonly] {
-    transform: translateY(1rem);
+    transform: translateX(
+            calc(
+                #{shared_input-select-picker.$height-of-mdc-text-field} / 4 * -1
+            )
+        )
+        translateY(
+            calc(#{shared_input-select-picker.$height-of-mdc-text-field} / 4)
+        );
 }

--- a/src/components/form/form.scss
+++ b/src/components/form/form.scss
@@ -1,5 +1,6 @@
 @use '../../style/internal/lime-theme';
 @use '../../style/internal/lime-typography';
+@use '../../style/internal/shared_input-select-picker';
 
 /**
  * @prop --form-body-padding: space around content of the form. Defaults to `1rem`.
@@ -42,7 +43,7 @@ limel-code-editor {
 }
 
 .limel-form-layout--grid {
-    --min-height-of-one-row: 3.5rem;
+    --min-height-of-one-row: #{shared_input-select-picker.$height-of-mdc-text-field};
     display: grid;
     column-gap: var(--form-column-gap, 1rem);
     row-gap: var(--form-row-gap, 1rem);
@@ -140,7 +141,7 @@ limel-code-editor {
         min-height: var(--min-height-of-one-row);
     }
     limel-checkbox {
-        margin-top: 0.5rem;
+        //  margin-top: 0.5rem;
         display: block;
     }
     limel-switch {

--- a/src/components/header/examples/header-slot-actions.tsx
+++ b/src/components/header/examples/header-slot-actions.tsx
@@ -1,28 +1,24 @@
 import { Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
 /**
- * Narrow layout
- * The `limel-select` component has the same height and layout as other input types
- * in Lime elements. This makes the UI nice and tidy, when elements are placed
- * beside or on top of each other; for instance in a form.
+ * Using the "actions" slot
+ * The component offers a place for including custom actions, or
+ * any other component that you want to include in the header.
+ * To include any component in the `actions` area,
+ * you can simply use the `slot="actions"` attribute.
  *
- * However, sometimes you may need to render the `limel-select` component with a
- * narrower layout (smaller in height). For instance when the component is used
- * in a header, or when it is placed beside a component like `limel-button-group`.
- *
- * For such cases, you can simply apply the class of `is-narrow` to your component.
- * :::tip
- * In such use cases, the select usually does not need a `label`. Consider having
- * its first `option` pre-chosen and displayed by default instead. Also avoid using
- * `helperText` if possible.
- * :::
+ * :::note
+ * In small containers when having the default layout, the `actions` area
+ * wins the battle of limited space! It means, if you have a very wide
+ * component in the actions area, it will never shrink in size, and instead
+ * forces the headings to truncate.
+ *:::
  */
 @Component({
     shadow: true,
-    tag: 'limel-example-select-narrow',
-    styleUrl: 'select-narrow.scss',
+    tag: 'limel-example-header-slot-actions',
 })
-export class SelectExample {
+export class HeaderSlotActionsExample {
     @State()
     public value: Option = {
         text: 'select a colleague',
@@ -61,7 +57,7 @@ export class SelectExample {
                 subheading="Choose a colleague to see their statistics"
             >
                 <limel-select
-                    class="is-narrow"
+                    slot="actions"
                     value={this.value}
                     options={this.options}
                     onChange={this.handleChange}

--- a/src/components/header/examples/header.tsx
+++ b/src/components/header/examples/header.tsx
@@ -1,15 +1,7 @@
 import { Component, h } from '@stencil/core';
 
 /**
- * How default layout of header works
- * All content of a header by default are placed on a horizontal row.
- * This will always render the headings on the left side, and the actions
- * on the right side.
- *
- * In small containers when having the default layout, the `actions` area
- * wins the battle of limited space! It means, if you have a very wide
- * component in the actions area, it will never shrink in size, and instead
- * forces the headings to truncate.
+ * Basic example
  *
  * :::tip
  * Users can still hover the cursor on the truncated headings to read the full
@@ -30,19 +22,7 @@ export class HeaderExample {
                 heading="Useful information"
                 subheading="Note"
                 supportingText="Data couldn't be loaded!"
-            >
-                <limel-icon-button
-                    slot="actions"
-                    icon="multiply"
-                    label="Close"
-                    onClick={this.handleActionClick()}
-                />
-            </limel-header>
+            />
         );
     }
-
-    private handleActionClick = () => (event: MouseEvent) => {
-        event.stopPropagation();
-        console.log('close');
-    };
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -43,6 +43,7 @@ import { getIconName } from '../icon/get-icon-props';
  * :::
  *
  * @exampleComponent limel-example-header
+ * @exampleComponent limel-example-header-slot-actions
  * @exampleComponent limel-example-header-colors
  * @exampleComponent limel-example-header-responsive
  * @exampleComponent limel-example-header-narrow

--- a/src/components/helper-line/helper-line.scss
+++ b/src/components/helper-line/helper-line.scss
@@ -9,6 +9,7 @@
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
     font-size: 0.6875rem;
+    line-height: normal;
 
     color: rgb(var(--contrast-1200));
 }

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -56,12 +56,6 @@
 @include shared_input-select-picker.lime-empty-value-for-readonly;
 @include shared_input-select-picker.lime-looks-like-input-value;
 
-.mdc-text-field--with-trailing-icon {
-    .mdc-text-field__icon--trailing {
-        margin-right: functions.pxToRem(8);
-    }
-}
-
 .lime-text-field--empty {
     .mdc-text-field__icon--trailing {
         @include shared_input-select-picker.looks-disabled;
@@ -172,3 +166,24 @@ input.mdc-text-field__input {
 
 @import './partial-styles/trailing-icon.scss';
 @import './partial-styles/readonly';
+
+// To make the input field render smaller than the default MDC UI
+.mdc-text-field {
+    &.mdc-text-field--outlined {
+        height: shared_input-select-picker.$height-of-mdc-text-field;
+    }
+}
+.mdc-text-field--with-trailing-icon {
+    .mdc-text-field__icon--trailing {
+        padding: 0.25rem;
+        margin-right: 0.25rem;
+    }
+}
+.mdc-text-field--outlined.mdc-text-field--with-leading-icon {
+    .mdc-text-field__icon--leading {
+        margin-left: 0.25rem;
+    }
+    .mdc-floating-label {
+        left: 1.5rem;
+    }
+}

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -86,6 +86,7 @@ $list-mdc-list-item: 0;
         transition: background-color 0.2s ease;
         box-sizing: border-box;
         z-index: $list-mdc-list-item; // in Chrome on Windows, menus flicker when they have a scroll bar and user hovers on them. We may be able to remove this in future versions of Chrome. Kia 2021-May-12
+        min-height: 2.5rem;
 
         &:not(.mdc-deprecated-list-item--disabled) {
             &:hover {
@@ -182,9 +183,6 @@ $list-mdc-list-item: 0;
         .mdc-deprecated-list-item__text {
             padding-top: functions.pxToRem(8);
             padding-bottom: functions.pxToRem(8);
-        }
-        .mdc-deprecated-list-item__primary-text {
-            margin-bottom: functions.pxToRem(4);
         }
     }
 

--- a/src/components/list/partial-styles/enable-multiline-text.scss
+++ b/src/components/list/partial-styles/enable-multiline-text.scss
@@ -3,12 +3,11 @@
 // But MDC Web does not currently support three-line lists.
 
 :host {
-    --line-height-of-secondary-text: 1.2rem;
+    --line-height-of-secondary-text: 1rem;
 }
 
 .mdc-deprecated-list-item {
     height: auto !important; // `!important` because MD adds different fixed `height`s to different lists, such as `mdc-list--two-line` or `mdc-list--avatar-list` and we don't want to overwride them all separately
-    min-height: 3rem; // in MD, `3rem` is the default `height`.
 
     .mdc-deprecated-list-item__secondary-text {
         line-height: var(--line-height-of-secondary-text);

--- a/src/components/progress-flow/progress-flow.scss
+++ b/src/components/progress-flow/progress-flow.scss
@@ -13,7 +13,7 @@
 */
 
 :host {
-    --step-height: 2.5rem;
+    --step-height: 2rem;
     --selected-indicator-right: -0.5rem;
     --max-text-width: 10rem;
 

--- a/src/components/select/examples/select-narrow.scss
+++ b/src/components/select/examples/select-narrow.scss
@@ -1,8 +1,0 @@
-limel-header {
-    max-width: 35rem;
-    margin: 0 auto;
-}
-
-limel-select {
-    margin-right: 0.25rem;
-}

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -49,10 +49,12 @@
 
     align-self: center;
     min-width: 0; // makes it truncate and prevents the select to grow wider than its container
+    padding: 0 0.25rem 0 1rem;
 }
 
 .limel-select__selected-option__icon {
     margin-right: functions.pxToRem(8);
+    margin-left: functions.pxToRem(-8);
     flex-shrink: 0;
 }
 
@@ -73,6 +75,10 @@
         }
     }
 
+    .mdc-select__anchor {
+        height: functions.pxToRem(36);
+        padding-left: functions.pxToRem(0);
+    }
     .limel-select-trigger {
         border: none;
         height: shared_input-select-picker.$height-of-mdc-text-field;
@@ -88,7 +94,7 @@
             ); //This forces the label to truncate when container is too little.
             &.mdc-floating-label--float-above {
                 font-size: shared_input-select-picker.$cropped-label-hack--font-size;
-                transform: translateY(functions.pxToRem(-34.75)) scale(0.75);
+                transform: translateY(functions.pxToRem(-27)) scale(0.75);
             }
         }
     }
@@ -99,6 +105,7 @@
     }
 
     .mdc-select__dropdown-icon {
+        margin-right: 0.25rem;
         margin-left: 0.25rem;
     }
 
@@ -182,33 +189,6 @@ select.limel-select__native-control {
     height: 100%;
     opacity: 0;
     border: 0;
-}
-
-:host(.is-narrow) {
-    .limel-select {
-        .mdc-select__anchor {
-            height: functions.pxToRem(36);
-            padding-left: functions.pxToRem(0);
-        }
-
-        .mdc-select__dropdown-icon {
-            margin-right: 0.25rem;
-        }
-    }
-
-    .mdc-floating-label {
-        &.mdc-floating-label--float-above {
-            top: functions.pxToRem(28);
-        }
-    }
-
-    .limel-select__selected-option {
-        padding: 0 0.25rem 0 1rem;
-    }
-
-    .limel-select__selected-option__icon {
-        margin-left: functions.pxToRem(-8);
-    }
 }
 
 @import './partial-styles/_readonly';

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -30,7 +30,6 @@ import { SelectTemplate, triggerIconColorWarning } from './select.template';
  * @exampleComponent limel-example-select-with-empty-option
  * @exampleComponent limel-example-select-preselected
  * @exampleComponent limel-example-select-change-options
- * @exampleComponent limel-example-select-narrow
  * @exampleComponent limel-example-select-dialog
  */
 @Component({

--- a/src/components/slider/partial-styles/_thumb.scss
+++ b/src/components/slider/partial-styles/_thumb.scss
@@ -42,6 +42,9 @@
 }
 
 .mdc-slider {
+    .mdc-slider__thumb {
+        top: -0.25rem;
+    }
     .mdc-slider__value-indicator-container {
         z-index: 1; //FIXME
     }

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -13,7 +13,11 @@
 
     display: flex;
     flex-direction: column;
-    margin-top: functions.pxToRem(4);
+}
+
+.mdc-slider {
+    height: shared_input-select-picker.$height-of-mdc-text-field;
+    margin: 0 0.75rem;
 }
 
 .mdc-floating-label,
@@ -29,9 +33,7 @@
 
 .slider__label {
     padding-left: functions.pxToRem(20);
-    top: functions.pxToRem(
-        9
-    ); // To place its label on the same height as other `floating-label`s in a form
+    top: 0.75rem; // To place its label on the same height as other `floating-label`s in a form
 
     color: shared_input-select-picker.$label-color;
     :host(limel-slider.disabled:not(.readonly)) & {
@@ -43,22 +45,18 @@
     display: flex;
     order: 2;
     justify-content: space-between;
-    width: calc(100% - #{functions.pxToRem(24)});
     margin: 0 auto;
-    margin-top: functions.pxToRem(-16);
+    margin-top: -0.75rem;
+    width: 100%;
 }
 
 .slider__content-min-label,
 .slider__content-max-label {
+    line-height: 1;
     transition: opacity 0.2s ease;
     opacity: 0.7;
     font-size: functions.pxToRem(12);
-    top: functions.pxToRem(20);
     color: shared_input-select-picker.$helper-text-color;
-
-    .slider:hover & {
-        opacity: 1;
-    }
 }
 
 .mdc-slider__track {

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -25,7 +25,7 @@ $input-text-leading-icon-color: rgb(var(--contrast-900));
 $input-text-color-disabled: rgba(var(--contrast-1400), 0.5);
 $helper-text-color: $label-color;
 
-$height-of-mdc-text-field: 3.5rem; //This is written directly in rem, beucase the vaiable used to calculate things elsewhere
+$height-of-mdc-text-field: 2.5rem; //This is written directly in `rem`, becurse the variable used to calculate things elsewhere
 $height-of-mdc-helper-text-block: 0.9375rem;
 
 $mdc-chip-background-color: rgb(var(--contrast-100));
@@ -117,6 +117,15 @@ $cropped-label-hack--font-size: 0.875rem; //14px
             .mdc-text-field__input {
                 color: $input-text-color-disabled;
             }
+        }
+    }
+
+    .mdc-floating-label--float-above {
+        transform: translateY(#{functions.pxToRem(-27)}) scale(0.75) !important;
+
+        .mdc-text-field--with-leading-icon & {
+            transform: translateY(#{functions.pxToRem(-25)})
+                translateX(#{functions.pxToRem(-20)}) scale(0.75) !important;
         }
     }
 }
@@ -325,7 +334,7 @@ $cropped-label-hack--font-size: 0.875rem; //14px
 
                 limel-icon {
                     width: 1.5rem;
-                    margin-right: 0.5rem;
+                    margin-right: 0.25rem;
                 }
             }
 


### PR DESCRIPTION
The input field was necessarily tall and the height and the UI design of
all other input elements such as slider, select, picker, etc… was based
on the height & visual density of the `limel-input-field`. This resulted in
UI designs in consuming applications which were too "airy" and had a
low information density. This change will make all input elements smaller
which prevent such UI and layout design issues. Additionally, `limel-select`
used to offer a narrow UI design, which was enabled by adding an `is-narrow`
class on the component. That would render it smaller in height.
Since the component will render with the same narrow hight now by default,
that feature is removed and adding that class will not have any
visible effects.

BREAKING CHANGE:
If you have layout designs with hardcoded size values (for instance
heights, margins or paddings) which are added only for the purpose of
horizontally or vertically aligning the elements in the UI,
there is a big chance that your layouts now will render
in a messy way after this change and elements will not align as before.
Note that for UI designs nowadays,
you should not need to have hardcoded values. You must rather
think "responsive design", and incorporate `flex` or `grid` to achieve
a more flawless, smooth and responsive layout.

fix https://github.com/Lundalogik/crm-feature/issues/3916

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
