### PR TITLE
refactor(chip-set): replace mdc-chip with limel-chip 

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -66,6 +66,9 @@ export interface Chip<T = any> {
     value?: T;
 }
 
+// @beta
+export type ChipType = 'default' | 'filter';
+
 // @public (undocumented)
 export type CircularProgressSize = 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
 
@@ -191,7 +194,8 @@ export namespace Components {
         "removable": boolean;
         "selected": boolean;
         "text": string;
-        "type"?: 'filter';
+        // @beta
+        "type"?: ChipType;
     }
     // (undocumented)
     export interface LimelChipSet {
@@ -993,7 +997,8 @@ namespace JSX_2 {
         "removable"?: boolean;
         "selected"?: boolean;
         "text"?: string;
-        "type"?: 'filter';
+        // @beta
+        "type"?: ChipType;
     }
     // (undocumented)
     interface LimelChipSet {

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -184,6 +184,7 @@ export namespace Components {
         "badge"?: string | number;
         "disabled": boolean;
         "icon"?: string | Icon;
+        "identifier"?: number | string;
         "language": Languages;
         "link"?: Omit<Link, 'text'>;
         "readonly": boolean;
@@ -984,9 +985,10 @@ namespace JSX_2 {
         "badge"?: string | number;
         "disabled"?: boolean;
         "icon"?: string | Icon;
+        "identifier"?: number | string;
         "language"?: Languages;
         "link"?: Omit<Link, 'text'>;
-        "onRemove"?: (event: LimelChipCustomEvent<void>) => void;
+        "onRemove"?: (event: LimelChipCustomEvent<number | string>) => void;
         "readonly"?: boolean;
         "removable"?: boolean;
         "selected"?: boolean;

--- a/src/components/chip-set/chip-set.e2e.ts
+++ b/src/components/chip-set/chip-set.e2e.ts
@@ -26,7 +26,7 @@ describe('limel-chip-set', () => {
             await page.waitForChanges();
 
             label = await page.find('limel-chip-set >>> .chip-set__label');
-            chips = await page.findAll('limel-chip-set >>> .mdc-chip');
+            chips = await page.findAll('limel-chip-set >>> limel-chip');
 
             spy = await chipSet.spyOnEvent('interact');
         });
@@ -37,8 +37,8 @@ describe('limel-chip-set', () => {
 
         it('renders the chips', () => {
             expect(chips.length).toEqual(2);
-            expect(chips[0]).toEqualText('Lime');
-            expect(chips[1]).toEqualText('Apple');
+            expect(chips[0].getAttribute('text')).toEqualText('Lime');
+            expect(chips[1].getAttribute('text')).toEqualText('Apple');
         });
 
         describe('when a chip is clicked', () => {
@@ -78,7 +78,7 @@ describe('limel-chip-set', () => {
             await page.waitForChanges();
 
             label = await page.find('limel-chip-set >>> .chip-set__label');
-            chips = await page.findAll('limel-chip-set >>> .mdc-chip');
+            chips = await page.findAll('limel-chip-set >>> limel-chip');
 
             spy = await chipSet.spyOnEvent('change');
         });
@@ -89,11 +89,8 @@ describe('limel-chip-set', () => {
 
         it('renders the chips correctly', () => {
             expect(chips.length).toEqual(2);
-            expect(chips[0]).toEqualText('Lime');
-            expect(chips[1]).toEqualText('Apple');
-
-            expect(chips[0]).toHaveClass('mdc-chip--selected');
-            expect(chips[1]).not.toHaveClass('mdc-chip--selected');
+            expect(chips[0].getAttribute('text')).toEqualText('Lime');
+            expect(chips[1].getAttribute('text')).toEqualText('Apple');
         });
 
         describe('when the first chip is clicked', () => {
@@ -111,11 +108,7 @@ describe('limel-chip-set', () => {
             });
 
             it('deselects the first chip', () => {
-                expect(chips[0]).not.toHaveClass('mdc-chip--selected');
-            });
-
-            it('does not select the second chip', () => {
-                expect(chips[1]).not.toHaveClass('mdc-chip--selected');
+                expect(chips[0].getAttribute('selected')).toBeNull();
             });
         });
 
@@ -124,14 +117,8 @@ describe('limel-chip-set', () => {
                 await chips[1].click();
             });
 
-            it('emits two change events', () => {
-                expect(spy).toHaveReceivedEventTimes(2);
+            it('emits a change event', () => {
                 expect(spy.events[0].detail).toEqual({
-                    id: '1',
-                    text: 'Lime',
-                    selected: false,
-                });
-                expect(spy.events[1].detail).toEqual({
                     id: '2',
                     text: 'Apple',
                     selected: true,
@@ -139,11 +126,11 @@ describe('limel-chip-set', () => {
             });
 
             it('deselects the first chip', async () => {
-                expect(chips[0]).not.toHaveClass('mdc-chip--selected');
+                expect(chips[0].getAttribute('selected')).toBeNull();
             });
 
             it('selects the second chip', async () => {
-                expect(chips[1]).toHaveClass('mdc-chip--selected');
+                expect(chips[1].getAttribute('selected')).not.toBeNull();
             });
         });
     });
@@ -169,18 +156,18 @@ describe('limel-chip-set', () => {
 
             await page.waitForChanges();
 
-            chips = await page.findAll('limel-chip-set >>> .mdc-chip');
+            chips = await page.findAll('limel-chip-set >>> limel-chip');
 
             spy = await chipSet.spyOnEvent('change');
         });
 
         it('renders the chips correctly', () => {
             expect(chips.length).toEqual(2);
-            expect(chips[0]).toEqualText('Lime');
-            expect(chips[1]).toEqualText('Apple');
+            expect(chips[0].getAttribute('text')).toEqualText('Lime');
+            expect(chips[1].getAttribute('text')).toEqualText('Apple');
 
-            expect(chips[0]).toHaveClass('mdc-chip--selected');
-            expect(chips[1]).not.toHaveClass('mdc-chip--selected');
+            expect(chips[0].getAttribute('selected')).not.toBeNull();
+            expect(chips[1].getAttribute('selected')).toBeNull();
         });
 
         describe('when the first chip is clicked', () => {
@@ -198,11 +185,11 @@ describe('limel-chip-set', () => {
             });
 
             it('deselects the first chip', () => {
-                expect(chips[0]).not.toHaveClass('mdc-chip--selected');
+                expect(chips[0].getAttribute('selected')).toBeNull();
             });
 
             it('does not select the second chip', () => {
-                expect(chips[1]).not.toHaveClass('mdc-chip--selected');
+                expect(chips[1].getAttribute('selected')).toBeNull();
             });
         });
 
@@ -220,12 +207,12 @@ describe('limel-chip-set', () => {
                 });
             });
 
-            it('deselects the first chip', () => {
-                expect(chips[0]).toHaveClass('mdc-chip--selected');
+            it('selects the first chip', () => {
+                expect(chips[0].getAttribute('selected')).not.toBeNull();
             });
 
             it('selects the second chip', () => {
-                expect(chips[1]).toHaveClass('mdc-chip--selected');
+                expect(chips[1].getAttribute('selected')).not.toBeNull();
             });
         });
     });
@@ -254,20 +241,18 @@ describe('limel-chip-set', () => {
 
             await page.waitForChanges();
 
-            chips = await page.findAll('limel-chip-set >>> .mdc-chip');
+            chips = await page.findAll('limel-chip-set >>> limel-chip');
 
-            firstChipRemoveButton = await chips[0].find(
-                'button.mdc-deprecated-chip-trailing-action',
-            );
-            secondChipRemoveButton = await chips[1].find(
-                'button.mdc-deprecated-chip-trailing-action',
-            );
+            firstChipRemoveButton =
+                await chips[0].shadowRoot.querySelector('.remove-button');
+            secondChipRemoveButton =
+                await chips[1].shadowRoot.querySelector('.remove-button');
         });
 
-        it('renders the chips correctly', () => {
+        it('renders the chips correctly', async () => {
             expect(chips.length).toEqual(2);
-            expect(chips[0]).toEqualText('Lime');
-            expect(chips[1]).toEqualText('Apple');
+            expect(chips[0].getAttribute('text')).toEqualText('Lime');
+            expect(chips[1].getAttribute('text')).toEqualText('Apple');
 
             expect(firstChipRemoveButton).toBeTruthy();
             expect(secondChipRemoveButton).toBeFalsy();
@@ -308,38 +293,21 @@ describe('limel-chip-set', () => {
             });
         });
 
-        describe('when a chip delete button is clicked', () => {
-            beforeEach(async () => {
-                spy = await chipSet.spyOnEvent('change');
-                await firstChipRemoveButton.click();
-            });
-
-            it('emits a change event where the removed chip is not present', () => {
-                expect(spy).toHaveReceivedEventTimes(1);
-                expect(spy.events[0].detail).toEqual([
-                    {
-                        id: '2',
-                        text: 'Apple',
-                    },
-                ]);
-            });
-        });
-
         describe('when disabled', () => {
             beforeEach(async () => {
                 chipSet.setAttribute('disabled', true);
                 await page.waitForChanges();
 
                 firstChipRemoveButton =
-                    await chips[0].find('div[role="button"]');
+                    await chips[0].shadowRoot.querySelector('.remove-button');
                 secondChipRemoveButton =
-                    await chips[1].find('div[role="button"]');
+                    await chips[1].shadowRoot.querySelector('.remove-button');
             });
 
             it('renders the chips without delete-buttons', async () => {
                 expect(chips.length).toEqual(2);
-                expect(chips[0]).toEqualText('Lime');
-                expect(chips[1]).toEqualText('Apple');
+                expect(chips[0].getAttribute('text')).toEqualText('Lime');
+                expect(chips[1].getAttribute('text')).toEqualText('Apple');
 
                 expect(firstChipRemoveButton).toBeFalsy();
                 expect(secondChipRemoveButton).toBeFalsy();
@@ -352,15 +320,15 @@ describe('limel-chip-set', () => {
                 await page.waitForChanges();
 
                 firstChipRemoveButton =
-                    await chips[0].find('div[role="button"]');
+                    await chips[0].shadowRoot.querySelector('.remove-button');
                 secondChipRemoveButton =
-                    await chips[1].find('div[role="button"]');
+                    await chips[1].shadowRoot.querySelector('.remove-button');
             });
 
             it('renders the chips without delete-buttons', async () => {
                 expect(chips.length).toEqual(2);
-                expect(chips[0]).toEqualText('Lime');
-                expect(chips[1]).toEqualText('Apple');
+                expect(chips[0].getAttribute('text')).toEqualText('Lime');
+                expect(chips[1].getAttribute('text')).toEqualText('Apple');
 
                 expect(firstChipRemoveButton).toBeFalsy();
                 expect(secondChipRemoveButton).toBeFalsy();

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -9,7 +9,6 @@
 @use '@material/notched-outline/mdc-notched-outline';
 @use '@material/floating-label';
 @use '@material/floating-label/mdc-floating-label';
-@use '@material/chips/deprecated/mdc-chips';
 
 /**
  * @prop --icon-background-color: Background color of the icon. Defaults to transparent.
@@ -33,118 +32,15 @@
 
 $height-of-chip-set-input: functions.pxToRem(36);
 $leading-icon-space: functions.pxToRem(40);
-$background-color-of-remove-chip-buton-when-hovered: rgba(
-    var(--color-red-default),
-    0.2
-);
-$scale-of-remove-chip-x-when-hovered: scale(0.7);
 
 :host(limel-chip-set) {
     isolation: isolate;
 }
 
-.mdc-chip {
-    // As long as this component is depended on MDC,
-    // we need to force it to be font-agnostic.
-    // When MDC-dependency is removed, this block can also be removed.
-    // However, on removal of MDC-dependency, we should also make sure to check
-    // other font-related styles that might be set by MDC,
-    // such as `letter-spacing` or `font-size`.
-    font-family: inherit;
-}
-
-.mdc-chip {
-    @include mixins.is-elevated-inset-clickable();
-    max-width: 100%;
-    min-width: functions.pxToRem(32);
-    padding: 0 functions.pxToRem(1);
-    display: inline-grid;
-    grid-auto-flow: column;
-
-    span[role='gridcell'] {
-        min-width: 0; // This is needed to force mdc-chip__text (which is inside this span) to truncate
-
-        &:only-child {
-            .mdc-chip__text {
-                padding-left: functions.pxToRem(12);
-            }
-        }
-
-        &:first-child {
-            .mdc-chip__text {
-                padding-left: functions.pxToRem(12);
-            }
-        }
-
-        a[role='button'],
-        span[role='checkbox'] {
-            &:focus-visible {
-                &:after {
-                    // visualizes keyboard navigation on Chrome & Firefox
-                    // only when non-pointer input is being used,
-                    // e.g. tabbed into using keyboard
-                    content: '';
-                    display: block;
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    bottom: 0;
-                    left: 0;
-                    border-radius: functions.pxToRem(60);
-                    box-shadow: var(--shadow-depth-8-focused);
-                }
-            }
-        }
-    }
-
-    &.mdc-chip--selected {
-        color: var(--mdc-theme-primary) !important;
-        background-color: var(--mdc-theme-surface) !important;
-        box-shadow: var(--button-shadow-inset);
-
-        &:active {
-            box-shadow: var(--button-shadow-inset-pressed);
-        }
-
-        .mdc-chip__icon--leading {
-            color: var(--mdc-theme-primary) !important;
-        }
-    }
-}
-
-.mdc-chip.mdc-chip--selected .mdc-chip__checkmark,
-.mdc-chip__checkmark {
-    margin-right: functions.pxToRem(4);
-    margin-left: functions.pxToRem(8);
-}
-
-limel-badge {
-    margin-right: functions.pxToRem(4);
-    margin-left: functions.pxToRem(-4);
-}
-
-.mdc-chip__text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: block;
-    padding: 0 functions.pxToRem(12) 0 functions.pxToRem(4);
-    color: inherit;
-    text-decoration: none;
-
-    &:focus,
-    &:focus-visible {
-        outline: none;
-    }
-}
-
-limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
-    background-color: var(--icon-background-color, transparent);
-    margin: 0 !important;
-    color: var(--icon-color, rgb(var(--contrast-1100)));
-}
-
 .mdc-chip-set {
+    display: flex;
     align-items: center;
+    gap: 0.5rem;
     min-height: shared_input-select-picker.$height-of-mdc-text-field;
     position: relative;
 
@@ -158,20 +54,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
         padding: functions.pxToRem(8);
 
         width: 100%;
-
-        .mdc-chip--selected {
-            // When chip is selected with keyboard (backspace / arrow-keys) to be deleted
-            box-shadow: var(--shadow-depth-8-error);
-
-            .mdc-chip__icon--trailing {
-                color: rgb(var(--color-red-dark));
-                background-color: $background-color-of-remove-chip-buton-when-hovered;
-
-                svg {
-                    transform: $scale-of-remove-chip-x-when-hovered;
-                }
-            }
-        }
     }
 
     &.has-clear-all-button {
@@ -183,45 +65,16 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     }
 }
 
-.mdc-chip__icon {
-    &.mdc-chip__icon--trailing {
-        transition:
-            background-color 0.2s ease,
-            color 0.2s ease;
-
-        color: var(--mdc-theme-on-surface);
-        margin-left: 0;
-        margin-right: functions.pxToRem(5);
-
-        width: functions.pxToRem(22);
-        height: functions.pxToRem(22);
-
-        &:hover {
-            background-color: $background-color-of-remove-chip-buton-when-hovered;
-
-            svg {
-                transform: $scale-of-remove-chip-x-when-hovered;
-            }
-        }
-
-        svg {
-            transition: transform 0.2s ease;
-            display: block;
-            transform: scale(0.9);
-        }
-    }
-}
-
 .mdc-text-field {
     height: auto;
     cursor: text;
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
 
     .mdc-text-field__input {
         @include shared_input-select-picker.input-field-placeholder;
 
         width: auto;
-        height: $height-of-chip-set-input;
-        line-height: $height-of-chip-set-input;
         padding: 0 functions.pxToRem(12);
 
         flex-grow: 1;
@@ -244,15 +97,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
                 display: none; // removes the default X button
             }
         }
-    }
-}
-
-.mdc-text-field--disabled .mdc-chip {
-    pointer-events: all;
-
-    &.disabled {
-        @include shared_input-select-picker.looks-disabled;
-        pointer-events: none;
     }
 }
 
@@ -328,7 +172,7 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
         }
     }
 
-    .mdc-chip {
+    limel-chip {
         &:first-of-type {
             margin-left: 40px;
         }
@@ -350,6 +194,15 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
     opacity: 0.5;
     padding: 0 functions.pxToRem(2);
     color: var(--mdc-theme-on-surface);
+}
+
+limel-chip {
+    border-radius: 2rem;
+
+    &.can-be-removed {
+        // When chip is selected with keyboard (backspace / arrow-keys) to be deleted
+        box-shadow: var(--shadow-depth-8-error);
+    }
 }
 
 @import './partial-styles/_readonly';

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -80,7 +80,7 @@ export interface Chip<T = any> {
     value?: T;
 
     /**
-     * The value of the badge. Only valid for `filter`.
+     * The value of the badge.
      */
     badge?: number;
 

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -89,3 +89,10 @@ export interface Chip<T = any> {
      */
     href?: string;
 }
+
+/**
+ * This type is used to determine the visual style and behavior of a Chip component.
+ *
+ * @beta
+ */
+export type ChipType = 'default' | 'filter';

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -23,6 +23,9 @@ import {
 import { Chip as OldChipInterface } from '../chip-set/chip.types';
 
 interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
+    /**
+     * The value of the badge.
+     */
     badge?: string | number;
 }
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -20,7 +20,7 @@ import {
     DELETE,
     DELETE_KEY_CODE,
 } from '../../util/keycodes';
-import { Chip as OldChipInterface } from '../chip-set/chip.types';
+import { ChipType, Chip as OldChipInterface } from '../chip-set/chip.types';
 
 interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
     /**
@@ -142,9 +142,11 @@ export class Chip implements ChipInterface {
     /**
      * Set to `filter` to render the chip with a distinct style
      * suitable for visualizing filters.
+     *
+     * @beta
      */
     @Prop({ reflect: true })
-    public type?: 'filter';
+    public type?: ChipType = 'default';
 
     /**
      * Identifier for the chip. Must be unique.

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -24,6 +24,11 @@ import { Chip as OldChipInterface } from '../chip-set/chip.types';
 
 interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
     /**
+     * Identifier for the chip. Must be unique.
+     */
+    identifier?: number | string;
+
+    /**
      * The value of the badge.
      */
     badge?: string | number;
@@ -142,10 +147,17 @@ export class Chip implements ChipInterface {
     public type?: 'filter';
 
     /**
+     * Identifier for the chip. Must be unique.
+     */
+    @Prop({ reflect: true })
+    public identifier?: number | string = crypto.randomUUID();
+
+    /**
      * Fired when clicking on the remove button of a `removable` chip.
+     * The value of `identifier` is emitted as the event detail.
      */
     @Event()
-    public remove: EventEmitter<void>;
+    public remove: EventEmitter<number | string>;
 
     @Element()
     private host: HTMLLimelChipElement;
@@ -158,8 +170,6 @@ export class Chip implements ChipInterface {
         removeEnterClickable(this.host);
     }
 
-    private chipId = 'chip-' + crypto.randomUUID();
-
     public render() {
         return (
             <Host onClick={this.filterClickWhenDisabled}>
@@ -171,7 +181,7 @@ export class Chip implements ChipInterface {
     private renderAsButton = () => {
         return [
             <button
-                id={this.chipId}
+                id={'chip-' + this.identifier}
                 class="chip"
                 role="button"
                 disabled={this.disabled || this.readonly}
@@ -188,7 +198,7 @@ export class Chip implements ChipInterface {
     private renderAsLink = () => {
         return [
             <a
-                id={this.chipId}
+                id={'chip-' + this.identifier}
                 class="chip"
                 href={this.link.href}
                 title={this.link.title}
@@ -251,7 +261,7 @@ export class Chip implements ChipInterface {
                 class="trailing-button remove-button"
                 tabIndex={-1}
                 aria-label={this.removeChipLabel}
-                aria-controls={this.chipId}
+                aria-controls={'chip-' + this.identifier}
                 innerHTML={svgData}
                 onClick={this.handleRemoveClick}
             />
@@ -266,7 +276,7 @@ export class Chip implements ChipInterface {
 
     private handleRemoveClick = (event: MouseEvent | KeyboardEvent) => {
         event.stopPropagation();
-        this.remove.emit();
+        this.remove.emit(this.identifier);
     };
 
     private handleDeleteKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
Only possible to see this when the chip has a `href`,
is `removable`, and is `disabled`

fix https://github.com/Lundalogik/crm-feature/issues/3917

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
