### PR TITLE
fix(dialog): avoid keyboard automatically opening when dialog opens on android

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -164,7 +164,7 @@ export class Dialog {
                             the focus trap to use. Read more here:
                             https://github.com/material-components/material-components-web/tree/v11.0.0/packages/mdc-dialog#handling-focus-trapping
                         */}
-                        <input type="text" id="initialFocusElement" />
+                        <input type="button" id="initialFocusElement" />
                         {this.renderHeading()}
                         <div
                             class="mdc-dialog__content"


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2420


https://github.com/Lundalogik/lime-elements/assets/50618208/42daedb6-8f6b-40f3-bedf-72b699d878a9


but:

https://github.com/Lundalogik/lime-elements/assets/50618208/d322dfb9-024d-42bd-a284-1d3a259de210

However, if we change the input type to "button" everything magically works 🥹






## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
