### PR TITLE
improvements in `limel-chip`

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -183,14 +183,14 @@ export namespace Components {
     export interface LimelChip {
         "badge"?: string | number;
         "disabled": boolean;
-        "icon": string | Icon;
+        "icon"?: string | Icon;
         "language": Languages;
         "link"?: Omit<Link, 'text'>;
         "readonly": boolean;
         "removable": boolean;
         "selected": boolean;
         "text": string;
-        "type": 'filter';
+        "type"?: 'filter';
     }
     // (undocumented)
     export interface LimelChipSet {

--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -181,11 +181,6 @@ limel-icon.mdc-chip__icon.mdc-chip__icon--leading {
             ); // This leaves space for "clear all" button and avoids overlapping with chips
         }
     }
-
-    &.disabled:not(.mdc-chip-set--input) {
-        @include shared_input-select-picker.looks-disabled;
-        pointer-events: none;
-    }
 }
 
 .mdc-chip__icon {

--- a/src/components/chip/chip.e2e.ts
+++ b/src/components/chip/chip.e2e.ts
@@ -16,25 +16,18 @@ describe('limel-chip', () => {
     });
 
     it('renders as a link when the link prop is provided', async () => {
-        await page.setContent(
-            '<limel-chip text="Test chip" link="{ href: \'https://example.com\' }"></limel-chip>',
-        );
+        await page.setContent('<limel-chip></limel-chip>');
 
         const element = await page.find('limel-chip');
-        element.setProperty('link', { href: 'https://example.com' });
-
+        element.setProperty('link', { href: 'http://example.com' });
         await page.waitForChanges();
 
-        expect(element)
-            .toEqualHtml(`<limel-chip class="hydrated" language="en" link="{ href: 'https://example.com' }" text="Test chip">
-        <mock:shadow-root>
-          <a class="chip" href="https://example.com" tabindex="0">
-            <span class="text">
-              Test chip
-            </span>
-          </a>
-        </mock:shadow-root>
-      </limel-chip>`);
+        const linkElement = await page.find('limel-chip >>> a');
+        expect(linkElement).toBeTruthy();
+
+        // Check if id starts with "chip-"
+        const id = await linkElement.getAttribute('id');
+        expect(id).toMatch(/^chip-/);
     });
 
     it('renders with a badge when the badge prop is provided', async () => {

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -54,6 +54,14 @@
     &:has(+ .remove-button:hover) {
         box-shadow: var(--shadow-depth-8-error);
     }
+
+    &:has(+ .trailing-button) {
+        padding-right: calc(var(--limel-chip-height) + 0.125rem);
+
+        .text {
+            padding-right: 0;
+        }
+    }
 }
 
 :host(limel-chip[disabled]) {
@@ -86,16 +94,6 @@
     }
     .text {
         color: var(--mdc-theme-primary);
-    }
-}
-
-:host(limel-chip[removable]) {
-    .chip:not([disabled]) {
-        padding-right: calc(var(--limel-chip-height) + 0.125rem);
-
-        .text {
-            padding-right: 0;
-        }
     }
 }
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -90,7 +90,7 @@ export class Chip implements ChipInterface {
      * Icon of the chip.
      */
     @Prop()
-    public icon: string | Icon;
+    public icon?: string | Icon;
 
     /**
      * If supplied, the chip will become a clickable link.
@@ -136,7 +136,7 @@ export class Chip implements ChipInterface {
      * suitable for visualizing filters.
      */
     @Prop({ reflect: true })
-    public type: 'filter';
+    public type?: 'filter';
 
     /**
      * Fired when clicking on the remove button of a `removable` chip.

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -155,6 +155,8 @@ export class Chip implements ChipInterface {
         removeEnterClickable(this.host);
     }
 
+    private chipId = 'chip-' + crypto.randomUUID();
+
     public render() {
         return (
             <Host onClick={this.filterClickWhenDisabled}>
@@ -166,6 +168,7 @@ export class Chip implements ChipInterface {
     private renderAsButton = () => {
         return [
             <button
+                id={this.chipId}
                 class="chip"
                 role="button"
                 disabled={this.disabled || this.readonly}
@@ -182,6 +185,7 @@ export class Chip implements ChipInterface {
     private renderAsLink = () => {
         return [
             <a
+                id={this.chipId}
                 class="chip"
                 href={this.link.href}
                 title={this.link.title}
@@ -244,6 +248,7 @@ export class Chip implements ChipInterface {
                 class="trailing-button remove-button"
                 tabIndex={-1}
                 aria-label={this.removeChipLabel}
+                aria-controls={this.chipId}
                 innerHTML={svgData}
                 onClick={this.handleRemoveClick}
             />


### PR DESCRIPTION
Only possible to see this when the chip has a `href`,
is `removable`, and is `disabled`
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
