### PR TITLE
fix(config): revert unintentional breaking change in 37.2.0

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -253,7 +253,6 @@ export namespace Components {
         "required": boolean;
         "value": string;
     }
-    // (undocumented)
     export interface LimelConfig {
         "config": Config;
     }
@@ -1056,7 +1055,6 @@ namespace JSX_2 {
         "required"?: boolean;
         "value"?: string;
     }
-    // (undocumented)
     interface LimelConfig {
         "config"?: Config;
     }

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -255,11 +255,7 @@ export namespace Components {
     }
     // (undocumented)
     export interface LimelConfig {
-        "config": {
-            iconPath?: string;
-            defaultLocale?: string;
-            featureSwitches: any;
-        };
+        "config": Config;
     }
     // (undocumented)
     export interface LimelDatePicker {
@@ -618,6 +614,13 @@ export namespace Components {
         "maxlength"?: number;
     }
 }
+
+// @public
+export type Config = {
+    iconPath?: string;
+    defaultLocale?: string;
+    featureSwitches?: any;
+};
 
 // @public (undocumented)
 export type DateType = 'datetime' | 'date' | 'time' | 'week' | 'month' | 'quarter' | 'year';
@@ -1055,11 +1058,7 @@ namespace JSX_2 {
     }
     // (undocumented)
     interface LimelConfig {
-        "config"?: {
-            iconPath?: string;
-            defaultLocale?: string;
-            featureSwitches: any;
-        };
+        "config"?: Config;
     }
     // (undocumented)
     interface LimelDatePicker {

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -618,7 +618,7 @@ export namespace Components {
 export type Config = {
     iconPath?: string;
     defaultLocale?: string;
-    featureSwitches?: any;
+    featureSwitches?: Record<string, boolean>;
 };
 
 // @public (undocumented)

--- a/src/components/config/config.tsx
+++ b/src/components/config/config.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop } from '@stencil/core';
-import { globalConfig } from '../../global/config';
+import { Config, globalConfig } from '../../global/config';
 
 /**
  * @private
@@ -8,16 +8,12 @@ import { globalConfig } from '../../global/config';
     tag: 'limel-config',
     shadow: true,
 })
-export class Config {
+export class ConfigComponent {
     /**
-     * Global configuration for Lime Elements
+     * Global configuration for Lime Elements.
      */
     @Prop()
-    public config: {
-        iconPath?: string;
-        defaultLocale?: string;
-        featureSwitches: any;
-    };
+    public config: Config;
 
     public componentDidLoad() {
         this.setGlobalConfig();

--- a/src/components/config/config.tsx
+++ b/src/components/config/config.tsx
@@ -2,6 +2,18 @@ import { Component, Prop } from '@stencil/core';
 import { Config, globalConfig } from '../../global/config';
 
 /**
+ * Component used to set global configuration for Lime Elements.
+ *
+ * :::warning
+ * **Building something for Lime CRM?** Then you should _NOT_ use this component.
+ * Lime CRM already uses this component to set the global configuration for
+ * Lime Elements. No matter what problem you are facing at the moment, using
+ * this component will not help, and might cause other problems.
+ * :::
+ *
+ * Building your own software, which is using Lime Elements?
+ * Then you _might_ need to use this component.
+ *
  * @private
  */
 @Component({

--- a/src/global/config.ts
+++ b/src/global/config.ts
@@ -17,7 +17,7 @@ export type Config = {
     /**
      * @internal
      */
-    featureSwitches?: any;
+    featureSwitches?: Record<string, boolean>;
 };
 
 class ConfigClass implements Config {

--- a/src/global/config.ts
+++ b/src/global/config.ts
@@ -1,4 +1,26 @@
-export class Config {
+/**
+ * Configuration options for limel-config.
+ *
+ * @public
+ */
+export type Config = {
+    /**
+     * The path to where the icon library used by limel-icon is located.
+     */
+    iconPath?: string;
+
+    /**
+     * The default locale to use for components that support localization.
+     */
+    defaultLocale?: string;
+
+    /**
+     * @internal
+     */
+    featureSwitches?: any;
+};
+
+class ConfigClass implements Config {
     public iconPath = '';
     public defaultLocale = navigator.language;
     public featureSwitches: any = getFeatureSwitches(localStorage);
@@ -20,7 +42,7 @@ function getFeatureSwitches(storage: Storage) {
     return features;
 }
 
-const config = new Config();
+const config = new ConfigClass();
 export const globalConfig = (() => {
     return config;
 })();


### PR DESCRIPTION
re 852282d

fix: #2781 

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
