### PR TITLE
fix(chip-set): keep chips clickable when `type` is `input` & `readonl…

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -589,7 +589,9 @@ export class ChipSet {
     }
 
     private getChipProps(chip: Chip, chipType: ChipType) {
-        const removable = this.type === 'input' && chip.removable;
+        const removable =
+            this.type === 'input' && chip.removable && !this.readonly;
+        const readonly = this.readonly && this.type !== 'input';
 
         return {
             role: 'row',
@@ -599,7 +601,7 @@ export class ChipSet {
             badge: chip.badge,
             selected: chip.selected,
             disabled: this.disabled,
-            readonly: this.readonly,
+            readonly: readonly,
             type: chipType,
             removable: removable,
             onClick: this.catchInputChipClicks(chip),

--- a/src/components/chip-set/examples/chip-set-input.tsx
+++ b/src/components/chip-set/examples/chip-set-input.tsx
@@ -7,6 +7,12 @@ import { ENTER, ENTER_KEY_CODE } from '../../../util/keycodes';
  *
  * Useful for collections of tags or labels. Can also be used as an advanced
  * search input, with leading icon and a delimiter between search terms.
+ *
+ * :::note
+ * Setting `readonly` to `true` when the `type="input"`, the chips that are displayed
+ * will remain interactive. This means that the user can still click on them.
+ * However, the chips cannot be removed or added in `readonly` mode.
+ * :::
  */
 @Component({
     tag: 'limel-example-chip-set-input',

--- a/src/components/chip-set/partial-styles/_readonly.scss
+++ b/src/components/chip-set/partial-styles/_readonly.scss
@@ -9,3 +9,11 @@
         }
     }
 }
+
+:host(limel-chip-set[readonly]) {
+    .mdc-text-field {
+        &.mdc-text-field--disabled {
+            pointer-events: auto;
+        }
+    }
+}


### PR DESCRIPTION
…y` is `true`

fix https://github.com/Lundalogik/crm-feature/issues/3942

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [ ] iOS
