### PR TITLE
Feat/form expose schema interface

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { JSONSchema7 } from 'json-schema';
+
 // @public (undocumented)
 export interface Action {
     // (undocumented)
@@ -341,11 +343,8 @@ export namespace Components {
     export interface LimelForm {
         "disabled": boolean;
         "errors": ValidationError;
-        "propsFactory"?: (schema: Record<string, any>) => Record<string, any>;
-        "schema": {
-            id?: string;
-            [key: string]: any;
-        };
+        "propsFactory"?: (schema: FormSchema) => Record<string, any>;
+        "schema": FormSchema;
         "transformErrors"?: (errors: FormError[]) => FormError[];
         "value": object;
     }
@@ -737,26 +736,30 @@ export interface FormError {
 export interface FormInfo {
     errorSchema?: object;
     name?: string;
-    rootSchema?: object;
+    rootSchema?: FormSchema;
     rootValue?: any;
-    schema?: object;
+    schema?: FormSchema;
     schemaPath?: string[];
 }
 
 // @public (undocumented)
-export interface FormLayoutOptions<T = FormLayoutType.Default> {
+export interface FormLayoutOptions<T extends FormLayoutType | `${FormLayoutType}` = FormLayoutType.Default> {
     type: T;
 }
 
-// @public (undocumented)
+// @public
 export enum FormLayoutType {
     Default = "default",
     Grid = "grid",
     Row = "row"
 }
 
-// @public (undocumented)
-export interface GridLayoutOptions extends FormLayoutOptions<FormLayoutType.Grid> {
+// @public
+export interface FormSchema extends JSONSchema7 {
+}
+
+// @public
+export interface GridLayoutOptions extends FormLayoutOptions<FormLayoutType | `${FormLayoutType}`> {
     colSpan?: 1 | 2 | 3 | 4 | 5 | 'all';
     columns?: 1 | 2 | 3 | 4 | 5;
     dense?: boolean;
@@ -1170,11 +1173,8 @@ namespace JSX_2 {
         "errors"?: ValidationError;
         "onChange"?: (event: LimelFormCustomEvent<object>) => void;
         "onValidate"?: (event: LimelFormCustomEvent<ValidationStatus>) => void;
-        "propsFactory"?: (schema: Record<string, any>) => Record<string, any>;
-        "schema"?: {
-            id?: string;
-            [key: string]: any;
-        };
+        "propsFactory"?: (schema: FormSchema) => Record<string, any>;
+        "schema"?: FormSchema;
         "transformErrors"?: (errors: FormError[]) => FormError[];
         "value"?: object;
     }
@@ -1526,6 +1526,9 @@ export interface LimelActionBarOverflowMenuCustomEvent<T> extends CustomEvent<T>
     target: HTMLLimelActionBarOverflowMenuElement;
 }
 
+// @public
+export type LimeLayoutOptions = GridLayoutOptions & RowLayoutOptions;
+
 // Warning: (ae-missing-release-tag) "LimelBreadcrumbsCustomEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1873,8 +1876,8 @@ export interface LimeSchemaOptions {
     component?: FormComponentOptions;
     disabled?: boolean;
     // (undocumented)
-    help?: string | Help;
-    layout?: FormLayoutOptions<any>;
+    help?: string | Partial<Help>;
+    layout?: LimeLayoutOptions;
 }
 
 // @public
@@ -1961,8 +1964,8 @@ interface Option_2<T extends string = string> {
 }
 export { Option_2 as Option }
 
-// @public (undocumented)
-export interface RowLayoutOptions extends FormLayoutOptions<FormLayoutType.Row> {
+// @public
+export interface RowLayoutOptions extends FormLayoutOptions<FormLayoutType | `${FormLayoutType}`> {
     icon?: string;
 }
 

--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -2,7 +2,6 @@ import React from 'react';
 import { WidgetProps } from '../widgets/types';
 import { LimeElementsAdapter } from './base-adapter';
 import { capitalize } from 'lodash-es';
-import { LimeSchemaOptions } from '../form.types';
 import { getHelpComponent } from '../help';
 
 interface WidgetAdapterProps {
@@ -133,7 +132,7 @@ export class LimeElementsWidgetAdapter extends React.Component {
 
     private isDisabled() {
         const widgetProps = this.props.widgetProps;
-        const options: LimeSchemaOptions = widgetProps.schema.lime;
+        const options = widgetProps.schema.lime;
 
         return (
             widgetProps.disabled ||

--- a/src/components/form/examples/basic-schema.ts
+++ b/src/components/form/examples/basic-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     title: 'Registration form',
     description: 'Please enter your personal information',
     type: 'object',

--- a/src/components/form/examples/custom-component-schema.ts
+++ b/src/components/form/examples/custom-component-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     type: 'object',
     properties: {
         name: {

--- a/src/components/form/examples/custom-error-message-schema.ts
+++ b/src/components/form/examples/custom-error-message-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     title: 'Personal identity number form',
     description: 'Please enter your personal identity number',
     type: 'object',

--- a/src/components/form/examples/dynamic-form.tsx
+++ b/src/components/form/examples/dynamic-form.tsx
@@ -1,5 +1,5 @@
 import { Component, h, State } from '@stencil/core';
-import { ValidationStatus } from '@limetech/lime-elements';
+import { FormSchema, ValidationStatus } from '@limetech/lime-elements';
 
 /**
  * Dynamic schema
@@ -18,7 +18,7 @@ export class DynamicFormExample {
     private errors = null;
 
     @State()
-    private schema: any = {
+    private schema: FormSchema = {
         $id: 'test',
         title: 'My form',
         description: 'Lorem ipsum dolor sit amet',

--- a/src/components/form/examples/help-form-schema.ts
+++ b/src/components/form/examples/help-form-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     type: 'object',
     properties: {
         address: {

--- a/src/components/form/examples/layout-schema.ts
+++ b/src/components/form/examples/layout-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     title: 'Registration form',
     description:
         'This main form has no specified layout, so it gets the default 1 column.',

--- a/src/components/form/examples/list-schema.ts
+++ b/src/components/form/examples/list-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     type: 'object',
     properties: {
         villains: {

--- a/src/components/form/examples/nested-schema.ts
+++ b/src/components/form/examples/nested-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     type: 'object',
     properties: {
         name: {

--- a/src/components/form/examples/props-factory-form.tsx
+++ b/src/components/form/examples/props-factory-form.tsx
@@ -1,5 +1,6 @@
 import { Component, h, State } from '@stencil/core';
 import { schema } from './props-factory-schema';
+import { FormSchema } from '@limetech/lime-elements';
 
 /**
  * Using `propsFactory`
@@ -34,7 +35,7 @@ export class PropsFactoryFormExample {
         ];
     }
 
-    private propsFactory = (subSchema: Record<string, any>) => {
+    private propsFactory = (subSchema: FormSchema) => {
         if (
             subSchema.lime?.component?.name ===
             'limel-example-props-factory-picker'

--- a/src/components/form/examples/props-factory-schema.ts
+++ b/src/components/form/examples/props-factory-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     type: 'object',
     properties: {
         hero: {

--- a/src/components/form/examples/row-layout-schema.ts
+++ b/src/components/form/examples/row-layout-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '../form.types';
+
+export const schema: FormSchema = {
     description: 'This form has the row layout',
     type: 'object',
     properties: {

--- a/src/components/form/examples/span-fields-schema.ts
+++ b/src/components/form/examples/span-fields-schema.ts
@@ -1,4 +1,6 @@
-export const schema = {
+import { FormSchema } from '@limetech/lime-elements';
+
+export const schema: FormSchema = {
     title: 'A form with fields that span columns and rows',
     description:
         'This main form has a grid layout with 5 columns. Notice how fields reorder to fill holes when the "Dense layout" is enabled. You may need to resize your browser window to see this responsive layout in effect.',

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -11,7 +11,12 @@ import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import JSONSchemaForm, { AjvError } from '@rjsf/core';
 import retargetEvents from 'react-shadow-dom-retarget-events';
-import { FormError, ValidationError, ValidationStatus } from './form.types';
+import {
+    FormError,
+    FormSchema,
+    ValidationError,
+    ValidationStatus,
+} from './form.types';
 import {
     ArrayFieldTemplate,
     FieldTemplate,
@@ -50,10 +55,7 @@ export class Form {
      * The schema used to render the form
      */
     @Prop()
-    public schema: {
-        id?: string;
-        [key: string]: any;
-    } = {};
+    public schema: FormSchema = {};
 
     /**
      * Value of the form
@@ -77,7 +79,7 @@ export class Form {
      * that should be set, along with its value.
      */
     @Prop()
-    public propsFactory?: (schema: Record<string, any>) => Record<string, any>;
+    public propsFactory?: (schema: FormSchema) => Record<string, any>;
 
     /**
      * Custom function to customize the default error messages
@@ -109,7 +111,7 @@ export class Form {
     private host: HTMLLimelFormElement;
 
     private isValid = true;
-    private modifiedSchema: object;
+    private modifiedSchema: FormSchema;
     private validator: Ajv.ValidateFunction;
     private root: Root;
 

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -1,5 +1,23 @@
+import { JSONSchema7 } from 'json-schema';
 import { Help } from '../help/help.types';
 import { EventEmitter } from '@stencil/core';
+
+declare module 'json-schema' {
+    interface JSONSchema7 {
+        /**
+         * @internal
+         * Unique identifier for the schema
+         */
+        id?: string;
+
+        /**
+         * Lime elements specific options that can be specified in a schema
+         */
+        lime?: Omit<LimeSchemaOptions, 'layout'> & {
+            layout?: Partial<LimeLayoutOptions>;
+        };
+    }
+}
 
 /**
  * @public
@@ -110,12 +128,12 @@ export interface FormInfo {
     /**
      * The schema of the current property
      */
-    schema?: object;
+    schema?: FormSchema;
 
     /**
      * The schema of the whole form
      */
-    rootSchema?: object;
+    rootSchema?: FormSchema;
 
     /**
      * A tree of errors for this property and its children
@@ -177,15 +195,21 @@ export interface LimeSchemaOptions {
      * When specified on an object it will render the sub components with the
      * specified layout
      */
-    layout?: FormLayoutOptions<any>;
+    layout?: LimeLayoutOptions;
 
     /**
      * Mark the field as disabled
      */
     disabled?: boolean;
 
-    help?: string | Help;
+    help?: string | Partial<Help>;
 }
+
+/**
+ * @public
+ * Options for a layout to be used in a form
+ */
+export type LimeLayoutOptions = GridLayoutOptions & RowLayoutOptions;
 
 /**
  * Options for a component to be rendered inside a form
@@ -208,7 +232,9 @@ export interface FormComponentOptions {
 /**
  * @public
  */
-export interface FormLayoutOptions<T = FormLayoutType.Default> {
+export interface FormLayoutOptions<
+    T extends FormLayoutType | `${FormLayoutType}` = FormLayoutType.Default,
+> {
     /**
      * The type of layout to use
      */
@@ -217,9 +243,10 @@ export interface FormLayoutOptions<T = FormLayoutType.Default> {
 
 /**
  * @public
+ * Layout options for a grid layout
  */
 export interface GridLayoutOptions
-    extends FormLayoutOptions<FormLayoutType.Grid> {
+    extends FormLayoutOptions<FormLayoutType | `${FormLayoutType}`> {
     /**
      * When specified on a component within the grid, the component will take
      * up the the specified number of columns in the form
@@ -249,9 +276,10 @@ export interface GridLayoutOptions
 
 /**
  * @public
+ * Layout options for a row layout
  */
 export interface RowLayoutOptions
-    extends FormLayoutOptions<FormLayoutType.Row> {
+    extends FormLayoutOptions<FormLayoutType | `${FormLayoutType}`> {
     /**
      * When specified on a field, the chosen icon will be displayed
      * on the left side of the row, beside the title.
@@ -261,6 +289,7 @@ export interface RowLayoutOptions
 
 /**
  * @public
+ * Represents the layout types for a form.
  */
 export enum FormLayoutType {
     /**
@@ -282,3 +311,9 @@ export enum FormLayoutType {
      */
     Row = 'row',
 }
+
+/**
+ * @public
+ * Represents the JSON schema with Lime specific options
+ */
+export interface FormSchema extends JSONSchema7 {}

--- a/src/components/form/help/help.ts
+++ b/src/components/form/help/help.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import { LimeElementsAdapter } from '../adapters/base-adapter';
-import { LimeJSONSchema } from '../internal.types';
+import { FormSchema } from '../form.types';
 
-export function getHelpComponent(schema: LimeJSONSchema) {
+export function getHelpComponent(schema: FormSchema) {
     const help = schema.lime?.help;
 
     if (!help) {

--- a/src/components/form/internal.types.ts
+++ b/src/components/form/internal.types.ts
@@ -1,6 +1,0 @@
-import { JSONSchema7 } from 'json-schema';
-import { LimeSchemaOptions } from './form.types';
-
-export interface LimeJSONSchema extends JSONSchema7 {
-    lime?: LimeSchemaOptions;
-}

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -1,6 +1,10 @@
 import React from 'react';
-import { FormLayoutOptions, FormLayoutType } from '../form.types';
-import { LimeJSONSchema } from '../internal.types';
+import {
+    FormLayoutType,
+    FormSchema,
+    LimeLayoutOptions,
+    FormLayoutOptions,
+} from '../form.types';
 import { renderDescription, renderTitle } from './common';
 import { GridLayout } from './grid-layout';
 import { RowLayout } from './row-layout';
@@ -47,7 +51,7 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
     );
 }
 
-function getSchemaObjectPropertyPath(schema: any, subSchema: LimeJSONSchema) {
+function getSchemaObjectPropertyPath(schema: any, subSchema: FormSchema) {
     const refPrefixLength = 2;
     const matchAllForwardSlashes = /\//g;
     const rootPath = (schema.$ref as string)
@@ -60,18 +64,18 @@ function getSchemaObjectPropertyPath(schema: any, subSchema: LimeJSONSchema) {
 
 function renderProperties(
     properties: ObjectFieldProperty[],
-    schema: LimeJSONSchema,
+    schema: FormSchema,
 ) {
-    const layout: FormLayoutOptions = schema.lime?.layout;
+    const layout = schema.lime?.layout;
 
     return renderLayout(properties, layout);
 }
 
 function renderLayout(
     properties: ObjectFieldProperty[],
-    layout: FormLayoutOptions,
+    layout: Partial<LimeLayoutOptions>,
 ) {
-    const type = layout?.type || FormLayoutType.Default;
+    const type = layout?.type || 'default';
     const layouts: Record<FormLayoutType, Function> = {
         default: renderDefaultLayout,
         grid: renderGridLayout,
@@ -112,10 +116,10 @@ function renderRowLayout(properties: ObjectFieldProperty[]) {
     );
 }
 
-function isCollapsible(schema: LimeJSONSchema) {
+function isCollapsible(schema: FormSchema) {
     return !!schema.lime?.collapsible;
 }
 
-function isCollapsed(schema: LimeJSONSchema) {
+function isCollapsed(schema: FormSchema) {
     return schema.lime.collapsed !== false;
 }

--- a/src/components/form/templates/types.ts
+++ b/src/components/form/templates/types.ts
@@ -1,5 +1,5 @@
 import { ObjectFieldTemplateProps, ArrayFieldTemplateProps } from '@rjsf/core';
-import { LimeJSONSchema } from '../internal.types';
+import { FormSchema } from '../form.types';
 export { FieldTemplateProps, ArrayFieldTemplateProps } from '@rjsf/core';
 
 export type TemplateProps = ObjectFieldTemplateProps | ArrayFieldTemplateProps;
@@ -9,7 +9,7 @@ export type ObjectFieldProperty = ObjectFieldTemplateProps['properties'][0];
 export type ArrayFieldItem = ArrayFieldTemplateProps['items'][0];
 
 export interface LimeObjectFieldTemplateProps extends ObjectFieldTemplateProps {
-    schema: LimeJSONSchema;
+    schema: FormSchema;
 }
 
 export interface Runnable {

--- a/src/components/form/widgets/types.ts
+++ b/src/components/form/widgets/types.ts
@@ -1,6 +1,6 @@
 import { WidgetProps as RjsfWidgetProps } from '@rjsf/core';
-import { LimeJSONSchema } from '../internal.types';
+import { FormSchema } from '../form.types';
 
 export interface WidgetProps extends RjsfWidgetProps {
-    schema: LimeJSONSchema;
+    schema: FormSchema;
 }


### PR DESCRIPTION
While building the ViewFactory for the CardView for the web client we're gonna return the JSON schema for a limel-form.
Then it would be nice to have a public interface to type it with. We found that we had almost a finished interface for internal use here so we fixed the last pieces and want to expose it publicly and type the `schema` prop in `limel-form` as well.

This will make it easier to use the limel-form and FormComponents because you will get help from your IDE while writing code.

The PR tests itself because we don't get any type errors in the examples after adding our interface to those schemas.

Fix [Lundalogik/limepkg-basic-helpdesk#19](https://github.com/Lundalogik/limepkg-basic-helpdesk/issues/19)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
