### PR TITLE
visualize different types of progress on `limel-chip`

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -191,6 +191,7 @@ export namespace Components {
         "language": Languages;
         "link"?: Omit<Link, 'text'>;
         "loading"?: boolean;
+        "progress"?: number;
         "readonly": boolean;
         "removable": boolean;
         "selected": boolean;
@@ -994,6 +995,7 @@ namespace JSX_2 {
         "link"?: Omit<Link, 'text'>;
         "loading"?: boolean;
         "onRemove"?: (event: LimelChipCustomEvent<number | string>) => void;
+        "progress"?: number;
         "readonly"?: boolean;
         "removable"?: boolean;
         "selected"?: boolean;

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -190,6 +190,7 @@ export namespace Components {
         "identifier"?: number | string;
         "language": Languages;
         "link"?: Omit<Link, 'text'>;
+        "loading"?: boolean;
         "readonly": boolean;
         "removable": boolean;
         "selected": boolean;
@@ -991,6 +992,7 @@ namespace JSX_2 {
         "identifier"?: number | string;
         "language"?: Languages;
         "link"?: Omit<Link, 'text'>;
+        "loading"?: boolean;
         "onRemove"?: (event: LimelChipCustomEvent<number | string>) => void;
         "readonly"?: boolean;
         "removable"?: boolean;

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -182,3 +182,5 @@ limel-badge {
         }
     }
 }
+
+@import './partial-styles/_loading.scss';

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -2,6 +2,7 @@
 
 /**
 * @prop --chip-max-width: Maximum width of the chip. Defaults to `10rem`. Keep in mind that the chips should not appear too big.
+* @prop --chip-progress-color: Color of the progress bar. Defaults to `rgb(var(--contrast-700))`.
 */
 
 :host(limel-chip) {
@@ -184,3 +185,4 @@ limel-badge {
 }
 
 @import './partial-styles/_loading.scss';
+@import './partial-styles/_progress.scss';

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -73,6 +73,7 @@ interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
  * @exampleComponent limel-example-chip-badge
  * @exampleComponent limel-example-chip-filter
  * @exampleComponent limel-example-chip-removable
+ * @exampleComponent limel-example-chip-loading
  * @exampleComponent limel-example-chip-aria-role
  */
 @Component({
@@ -149,6 +150,14 @@ export class Chip implements ChipInterface {
     public type?: ChipType = 'default';
 
     /**
+     * Set to `true` to put the component in the `loading` state,
+     * and render an indeterminate progress indicator inside the chip.
+     * This does _not_ disable the interactivity of the chip!
+     */
+    @Prop({ reflect: true })
+    public loading? = false;
+
+    /**
      * Identifier for the chip. Must be unique.
      */
     @Prop({ reflect: true })
@@ -189,6 +198,7 @@ export class Chip implements ChipInterface {
                 disabled={this.disabled || this.readonly}
                 onKeyDown={this.handleDeleteKeyDown}
             >
+                {this.renderSpinner()}
                 {this.renderIcon()}
                 {this.renderLabel()}
                 {this.renderBadge()}
@@ -209,6 +219,7 @@ export class Chip implements ChipInterface {
                 tabindex={this.disabled || this.readonly ? -1 : 0}
                 onKeyDown={this.handleDeleteKeyDown}
             >
+                {this.renderSpinner()}
                 {this.renderIcon()}
                 {this.renderLabel()}
                 {this.renderBadge()}
@@ -296,5 +307,13 @@ export class Chip implements ChipInterface {
 
     private removeChipLabel = (): string => {
         return translate.get('chip-set.remove-chip', this.language);
+    };
+
+    private renderSpinner() {
+        if (!this.loading) {
+            return;
+        }
+
+        return <limel-linear-progress indeterminate={true} />;
     };
 }

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -74,6 +74,7 @@ interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
  * @exampleComponent limel-example-chip-filter
  * @exampleComponent limel-example-chip-removable
  * @exampleComponent limel-example-chip-loading
+ * @exampleComponent limel-example-chip-progress
  * @exampleComponent limel-example-chip-aria-role
  */
 @Component({
@@ -158,6 +159,14 @@ export class Chip implements ChipInterface {
     public loading? = false;
 
     /**
+     * Reflects the current value of a progress bar on the chip,
+     * visualizing the percentage of an ongoing process.
+     * Must be a number between `0` and `100`.
+     */
+    @Prop({ reflect: true })
+    public progress?: number;
+
+    /**
      * Identifier for the chip. Must be unique.
      */
     @Prop({ reflect: true })
@@ -202,6 +211,7 @@ export class Chip implements ChipInterface {
                 {this.renderIcon()}
                 {this.renderLabel()}
                 {this.renderBadge()}
+                {this.renderProgressBar()}
             </button>,
             this.renderRemoveButton(),
         ];
@@ -223,6 +233,7 @@ export class Chip implements ChipInterface {
                 {this.renderIcon()}
                 {this.renderLabel()}
                 {this.renderBadge()}
+                {this.renderProgressBar()}
             </a>,
             this.renderRemoveButton(),
         ];
@@ -315,5 +326,29 @@ export class Chip implements ChipInterface {
         }
 
         return <limel-linear-progress indeterminate={true} />;
-    };
+    }
+
+    private renderProgressBar() {
+        if (!this.progress) {
+            return;
+        }
+
+        const currentPercentage = this.progress + '%';
+        const progress = Math.round(this.progress);
+
+        return (
+            <div
+                role="progressbar"
+                aria-label="%"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow={this.progress}
+                style={{
+                    '--limel-chip-progress-percentage': currentPercentage,
+                }}
+            >
+                <span>{progress}%</span>
+            </div>
+        );
+    }
 }

--- a/src/components/chip/examples/chip-loading.scss
+++ b/src/components/chip/examples/chip-loading.scss
@@ -1,0 +1,5 @@
+:host {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}

--- a/src/components/chip/examples/chip-loading.tsx
+++ b/src/components/chip/examples/chip-loading.tsx
@@ -1,0 +1,94 @@
+import { Component, State, h } from '@stencil/core';
+
+/**
+ * Loading state
+ * Setting the `loading` to `true` puts the component in the `loading` state,
+ * and renders an indeterminate progress indicator inside the chip.
+ *
+ * :::note
+ * Note that this does _not_ disable the interactivity of the chip,
+ * and most probably you do not need it to be disabled either.
+ * If the chip should be disabled while loading, the
+ * `disabled` property should separately be set to `true` as well.
+ * :::
+ * :::tip
+ * Consider using [aria-live](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live)
+ * where appropriate, or to inform the user about what is being loaded
+ * use a [tooltip](#/component/limel-tooltip) on the component.
+ * This is mainly to improve the accessibility for users of assistive technologies.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-loading',
+    shadow: true,
+    styleUrl: 'chip-loading.scss',
+})
+export class ChipLoadingExample {
+    @State()
+    private disabled: boolean = false;
+
+    @State()
+    private readonly: boolean = false;
+
+    @State()
+    public loading = false;
+
+    public render() {
+        return [
+            <limel-chip
+                text="FunnyCats"
+                icon="hashtag"
+                onClick={this.onClick}
+                disabled={this.disabled}
+                readonly={this.readonly}
+                loading={this.loading}
+                badge={this.loading ? null : '123'}
+            />,
+            <limel-chip
+                text={this.loading ? 'Loading...' : 'FunnyCats'}
+                onClick={this.onClick}
+                disabled={this.disabled}
+                removable={true}
+                readonly={this.readonly}
+                loading={this.loading}
+                aria-live="polite"
+            />,
+            <limel-example-controls>
+                <limel-checkbox
+                    label="Loading"
+                    checked={this.loading}
+                    onChange={this.setLoading}
+                />
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Disabled"
+                    onChange={this.setDisabled}
+                />
+                <limel-checkbox
+                    checked={this.readonly}
+                    label="Readonly"
+                    onChange={this.setReadonly}
+                />
+            </limel-example-controls>,
+        ];
+    }
+
+    private onClick() {
+        console.log('Chip is clicked.');
+    }
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
+    };
+
+    private setLoading = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.loading = event.detail;
+    };
+}

--- a/src/components/chip/examples/chip-progress.scss
+++ b/src/components/chip/examples/chip-progress.scss
@@ -1,0 +1,21 @@
+:host {
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+limel-example-controls {
+    --example-controls-column-layout: auto-fit;
+    padding: 0.5rem;
+    flex-grow: 1;
+}
+
+limel-slider {
+    width: 100%;
+}
+
+.custom-progress-color {
+    --chip-progress-color: rgb(var(--color-orange-default));
+    --chip-max-width: 30rem;
+}

--- a/src/components/chip/examples/chip-progress.tsx
+++ b/src/components/chip/examples/chip-progress.tsx
@@ -1,0 +1,66 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Displaying a progress bar
+ * By defining a numeric `progress` (from `0` to `100`),
+ * you can display a progress bar on the chip
+ * to inform the user about an ongoing progress and also
+ * visualize the amount of progress that has been made so far.
+ *
+ * :::important
+ * 1. Do not use `loading={true}` and `progress` at the same time.
+ * 2. When the progress has completed, unset the `progress` property!
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-progress',
+    shadow: true,
+    styleUrl: 'chip-progress.scss',
+})
+export class ChipProgressExample {
+    @State()
+    private progress = 60.4325;
+
+    private sliderMinValue = 0;
+    private sliderMaxValue = 100;
+
+    public render() {
+        return [
+            <limel-chip
+                text="resume.pdf"
+                icon={{
+                    name: 'PDF_2',
+                    color: 'rgb(var(--color-red-default))',
+                }}
+                progress={this.progress}
+                removable={true}
+            />,
+            <limel-chip
+                text="my-cv.pdf"
+                icon="PDF_2"
+                progress={this.progress}
+                type="filter"
+            />,
+            <limel-chip
+                class="custom-progress-color"
+                text="I've my own progress color"
+                progress={this.progress}
+                badge="nice"
+            />,
+            <limel-example-controls>
+                <limel-slider
+                    label="Progress value"
+                    unit=" %"
+                    value={this.progress}
+                    valuemax={this.sliderMaxValue}
+                    valuemin={this.sliderMinValue}
+                    onChange={this.handleChange}
+                />
+            </limel-example-controls>,
+        ];
+    }
+
+    private handleChange = (event: CustomEvent<number>) => {
+        this.progress = event.detail;
+    };
+}

--- a/src/components/chip/partial-styles/_loading.scss
+++ b/src/components/chip/partial-styles/_loading.scss
@@ -1,0 +1,35 @@
+.text {
+    transition: padding-left 0.4s ease;
+}
+
+limel-linear-progress {
+    position: absolute;
+    z-index: 1;
+    margin: auto;
+    left: 0.25rem;
+
+    width: 1.25rem;
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+:host(limel-chip[loading]) {
+    .chip {
+        &:before {
+            content: '';
+            position: absolute;
+            left: 0;
+            width: var(--limel-chip-height);
+            height: var(--limel-chip-height);
+            border-radius: 50%;
+            scale: 0.9;
+            background-color: rgba(var(--contrast-600), 0.8);
+        }
+
+        &:not(:has(limel-icon)) {
+            .text {
+                padding-left: calc(var(--limel-chip-height) + 0.25rem);
+            }
+        }
+    }
+}

--- a/src/components/chip/partial-styles/_progress.scss
+++ b/src/components/chip/partial-styles/_progress.scss
@@ -1,0 +1,68 @@
+div[role='progressbar'] {
+    --limel-chip-progressbar-offset: 0.1875rem;
+    --limel-chip-progressbar-stripe-color: rgb(var(--contrast-100), 0.3);
+    --limel-chip-progressbar-stripe-size: 1.5rem;
+
+    pointer-events: none;
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: end;
+
+    inset: var(--limel-chip-progressbar-offset);
+    max-width: calc(100% - calc(var(--limel-chip-progressbar-offset) * 2));
+
+    border-radius: inherit;
+    background-color: var(--chip-progress-color, rgb(var(--contrast-700)));
+    width: var(--limel-chip-progress-percentage);
+    opacity: 0.8;
+
+    mix-blend-mode: var(--limel-chip-progress-mix-blend-mode);
+
+    span {
+        padding: 0 0.125rem;
+        border-radius: inherit;
+        height: 100%;
+        font-size: 0.625rem;
+        text-align: center;
+        transform: translateY(calc(-50% - 0.125rem));
+    }
+
+    &:after {
+        content: '';
+        transform: translate3d(0, 0, 0);
+        position: absolute;
+        inset: 1px;
+        background-image: linear-gradient(
+            -45deg,
+            var(--limel-chip-progressbar-stripe-color) 25%,
+            transparent 25%,
+            transparent 50%,
+            var(--limel-chip-progressbar-stripe-color) 50%,
+            var(--limel-chip-progressbar-stripe-color) 75%,
+            transparent 75%,
+            transparent
+        );
+        z-index: 1;
+        background-size: var(--limel-chip-progressbar-stripe-size)
+            var(--limel-chip-progressbar-stripe-size);
+        animation: move 2.5s linear infinite;
+        border-radius: inherit;
+
+        @media (prefers-reduced-motion) {
+            animation: none;
+        }
+    }
+}
+
+@keyframes move {
+    0% {
+        background-position: 0 0;
+    }
+    100% {
+        background-position: calc(
+                var(--limel-chip-progressbar-stripe-size) * -1
+            )
+            calc(var(--limel-chip-progressbar-stripe-size) * -1);
+    }
+}

--- a/src/style/color-palette-extended.css
+++ b/src/style/color-palette-extended.css
@@ -7,6 +7,7 @@
  */
 
 :root {
+    --limel-chip-progress-mix-blend-mode: multiply;
     /* Lime Technologies Brand Colors (Do not have dark/light mode variants) */
     --lime-brand-color-deep-red: 240, 87, 80; /* #f05750 */
     --lime-brand-color-sellable-orange: 255, 112, 67; /* #ff7043 (FIXME: or 247-107-7; // #f76b07 ? --> can be replaced with orange-dark in light mode in this case) */
@@ -166,6 +167,8 @@
 }
 
 :root[data-theme="force-dark"] {
+    --limel-chip-progress-mix-blend-mode: screen;
+
     --contrast-100: 20, 20, 42; /* #14142a */
     --contrast-200: 25, 25, 44; /* #19192c */
     --contrast-300: 35, 35, 53; /* #232335 */
@@ -322,6 +325,8 @@
 
 @media (prefers-color-scheme: dark) {
     :root:not([data-theme="force-light"]) {
+        --limel-chip-progress-mix-blend-mode: screen;
+
         --contrast-100: 20, 20, 37; /* #141425 */
         --contrast-200: 25, 25, 44; /* #19192c */
         --contrast-300: 35, 35, 53; /* #232335 */


### PR DESCRIPTION
This renders the chip with an indeterminate progress indicator, showing to the end user that something is being loaded or calculated.

fix https://github.com/Lundalogik/crm-feature/issues/3933

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [x] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [x] Chrome on Android
- [x] iOS
