### PR TITLE
chore: tweak api-extractor config and make some minor fixes

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -363,7 +363,7 @@
          *
          * DEFAULT VALUE: "warning"
          */
-        "logLevel": "error"
+        "logLevel": "error",
 
         /**
          * When addToApiReportFile is true:  If API Extractor is configured to write an API report file (.api.md),
@@ -372,7 +372,7 @@
          *
          * DEFAULT VALUE: false
          */
-        // "addToApiReportFile": false
+        "addToApiReportFile": false
       }
 
       // "TS2551": {
@@ -392,10 +392,21 @@
      */
     "extractorMessageReporting": {
       "default": {
-        "logLevel": "error"
-        // "addToApiReportFile": false
+        "logLevel": "error",
+        "addToApiReportFile": false
       },
-
+      "ae-forgotten-export": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
+      "ae-incompatible-release-tags": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
+      "ae-internal-missing-underscore": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
       "ae-missing-release-tag": {
         "logLevel": "warning",
         // By setting `addToApiReportFile` to true, the message will be written
@@ -407,14 +418,15 @@
         // in `components.d.ts`, and there's no simple way to add a release tag
         // to those.
         "addToApiReportFile": true
+      },
+      "ae-unresolved-inheritdoc-base": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
+      "ae-unresolved-inheritdoc-reference": {
+        "logLevel": "error",
+        "addToApiReportFile": false
       }
-
-      // "ae-extra-release-tag": {
-      //   "logLevel": "warning",
-      //   "addToApiReportFile": true
-      // },
-      //
-      // . . .
     },
 
     /**
@@ -426,8 +438,8 @@
      */
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "error"
-        // "addToApiReportFile": false
+        "logLevel": "error",
+        "addToApiReportFile": false
       }
 
       // "tsdoc-link-tag-unescaped-text": {

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -18,11 +18,22 @@ export interface Action {
     label?: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ActionBarItemOnlyIcon" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "ActionBarItemWithLabel" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type ActionBarItem<T = any> = ActionBarItemOnlyIcon<T> | ActionBarItemWithLabel<T>;
+
+// @public
+export interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
+    // (undocumented)
+    icon: string | Icon;
+    // (undocumented)
+    iconOnly: true;
+}
+
+// @public
+export interface ActionBarItemWithLabel<T> extends MenuItem<T> {
+    // (undocumented)
+    iconOnly?: false;
+}
 
 // @public
 export type ActionPosition = 'top' | 'bottom';
@@ -462,7 +473,6 @@ export namespace Components {
         "iconSize": IconSize;
         "items": Array<MenuItem | ListSeparator>;
         "maxLinesSecondaryText": number;
-        // Warning: (ae-incompatible-release-tags) The symbol "type" is marked as @public, but its signature references "MenuListType" which is marked as @internal
         "type": MenuListType;
     }
     // (undocumented)
@@ -669,6 +679,14 @@ export interface DockMenu {
     };
 }
 
+// Warning: (ae-missing-release-tag) "EventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface EventEmitter<T = any> {
+    // (undocumented)
+    emit: (data?: T) => CustomEvent<T>;
+}
+
 // @public (undocumented)
 export interface FileInfo {
     contentType?: string;
@@ -706,7 +724,6 @@ export interface FlowItem extends ListItem {
 
 // @public (undocumented)
 export interface FormComponent<T = any> {
-    // Warning: (ae-forgotten-export) The symbol "EventEmitter" needs to be exported by the entry point index.d.ts
     change: EventEmitter<T>;
     disabled?: boolean;
     formInfo?: FormInfo;
@@ -1296,7 +1313,6 @@ namespace JSX_2 {
         "items"?: Array<MenuItem | ListSeparator>;
         "maxLinesSecondaryText"?: number;
         "onSelect"?: (event: LimelMenuListCustomEvent<MenuItem>) => void;
-        // Warning: (ae-incompatible-release-tags) The symbol "type" is marked as @public, but its signature references "MenuListType" which is marked as @internal
         "type"?: MenuListType;
     }
     // (undocumented)
@@ -1930,9 +1946,7 @@ export interface MenuItem<T = any> {
     value?: T;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "MenuListType" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal @deprecated
+// @public @deprecated
 export type MenuListType = 'menu';
 
 // @public

--- a/src/components/action-bar/action-bar.types.ts
+++ b/src/components/action-bar/action-bar.types.ts
@@ -14,7 +14,7 @@ export type ActionBarItem<T = any> =
  * Action bar item that only displays an icon.
  * @public
  */
-interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
+export interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
     iconOnly: true;
     icon: string | Icon;
 }
@@ -23,6 +23,6 @@ interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
  * Action bar item that displays an icon and a label.
  * @public
  */
-interface ActionBarItemWithLabel<T> extends MenuItem<T> {
+export interface ActionBarItemWithLabel<T> extends MenuItem<T> {
     iconOnly?: false;
 }

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -2,6 +2,13 @@ import { JSONSchema7 } from 'json-schema';
 import { Help } from '../help/help.types';
 import { EventEmitter } from '@stencil/core';
 
+/**
+ * EventEmitter from `@stencil/core`.
+ *
+ * @public
+ */
+export { EventEmitter } from '@stencil/core';
+
 declare module 'json-schema' {
     interface JSONSchema7 {
         /**

--- a/src/components/menu-list/menu-list.types.ts
+++ b/src/components/menu-list/menu-list.types.ts
@@ -3,8 +3,7 @@
  * Available types are:
  * `menu`: regular vertical menu.
  *
- * @internal
  * @deprecated This type is no longer used.
- * @private
+ * @public
  */
 export type MenuListType = 'menu';


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
