### PR TITLE
Add a `file-input` component

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -328,6 +328,11 @@ export namespace Components {
         "helperText"?: string;
         "text": string;
     }
+    export interface LimelFileInput {
+        "accept": string;
+        "disabled": boolean;
+        "multiple": boolean;
+    }
     export interface LimelFileViewer {
         "actions": ListItem[];
         "allowDownload"?: boolean;
@@ -894,6 +899,8 @@ namespace JSX_2 {
         // (undocumented)
         "limel-file-dropzone": LimelFileDropzone;
         // (undocumented)
+        "limel-file-input": LimelFileInput;
+        // (undocumented)
         "limel-file-viewer": LimelFileViewer;
         // (undocumented)
         "limel-flatpickr-adapter": LimelFlatpickrAdapter;
@@ -1186,6 +1193,12 @@ namespace JSX_2 {
         "onFilesRejected"?: (event: LimelFileDropzoneCustomEvent<FileInfo[]>) => void;
         "onFilesSelected"?: (event: LimelFileDropzoneCustomEvent<FileInfo[]>) => void;
         "text"?: string;
+    }
+    interface LimelFileInput {
+        "accept"?: string;
+        "disabled"?: boolean;
+        "multiple"?: boolean;
+        "onFilesSelected"?: (event: LimelFileInputCustomEvent<FileInfo[]>) => void;
     }
     interface LimelFileViewer {
         "actions"?: ListItem[];
@@ -1717,6 +1730,16 @@ export interface LimelFileDropzoneCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     // (undocumented)
     target: HTMLLimelFileDropzoneElement;
+}
+
+// Warning: (ae-missing-release-tag) "LimelFileInputCustomEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface LimelFileInputCustomEvent<T> extends CustomEvent<T> {
+    // (undocumented)
+    detail: T;
+    // (undocumented)
+    target: HTMLLimelFileInputElement;
 }
 
 // Warning: (ae-missing-release-tag) "LimelFileViewerCustomEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/components/file-dropzone/file-dropzone.tsx
+++ b/src/components/file-dropzone/file-dropzone.tsx
@@ -104,7 +104,7 @@ export class FileDropzone {
     }
 
     private renderOnDragLayout = () => {
-        if (this.disabled || !this.hasFileToDrop) {
+        if (!this.hasFileToDrop) {
             return;
         }
 

--- a/src/components/file-input/examples/file-input-type-filtering.tsx
+++ b/src/components/file-input/examples/file-input-type-filtering.tsx
@@ -1,0 +1,88 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Example of a file input component with type filtering
+ */
+@Component({
+    tag: 'limel-example-file-input-type-filtering',
+    shadow: true,
+})
+export class FileInputTypeFilteringExample {
+    @State()
+    private disabled = false;
+
+    @State()
+    private readonly = false;
+
+    @State()
+    private multiple = false;
+
+    @State()
+    private files: FileInfo[] = [];
+
+    public render() {
+        return [
+            <limel-file-input
+                onFilesSelected={this.handleFilesSelected}
+                accept="image/*"
+                disabled={this.disabled || this.readonly}
+                multiple={this.multiple}
+            >
+                <limel-button label="Select an image" />
+            </limel-file-input>,
+            this.files.map((file) => (
+                <limel-chip
+                    identifier={file.id}
+                    text={file.filename}
+                    icon={file.icon}
+                    disabled={this.disabled}
+                    readonly={this.readonly}
+                    removable={true}
+                    onRemove={this.handleRemove}
+                />
+            )),
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Disabled"
+                    onChange={this.setDisabled}
+                />
+                <limel-checkbox
+                    checked={this.readonly}
+                    label="Readonly"
+                    onChange={this.setReadonly}
+                />
+                <limel-checkbox
+                    checked={this.multiple}
+                    label="Multiple"
+                    onChange={this.setMultiple}
+                />
+            </limel-example-controls>,
+            <limel-example-value value={this.files} />,
+        ];
+    }
+
+    private handleFilesSelected = (event: CustomEvent<FileInfo[]>) => {
+        this.files = [...this.files.concat(event.detail)];
+    };
+
+    private handleRemove = (event: CustomEvent<string | number>) => {
+        this.files = this.files.filter((file) => file.id !== event.detail);
+    };
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
+    };
+
+    private setMultiple = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.multiple = event.detail;
+    };
+}

--- a/src/components/file-input/examples/file-input.tsx
+++ b/src/components/file-input/examples/file-input.tsx
@@ -1,0 +1,87 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Basic example
+ */
+@Component({
+    tag: 'limel-example-file-input',
+    shadow: true,
+})
+export class FileInputExample {
+    @State()
+    private disabled = false;
+
+    @State()
+    private readonly = false;
+
+    @State()
+    private multiple = false;
+
+    @State()
+    private files: FileInfo[] = [];
+
+    public render() {
+        return [
+            <limel-file-input
+                onFilesSelected={this.handleFilesSelected}
+                disabled={this.disabled || this.readonly}
+                multiple={this.multiple}
+            >
+                <limel-button label="Select a file" />
+            </limel-file-input>,
+            this.files.map((file) => (
+                <limel-chip
+                    identifier={file.id}
+                    text={file.filename}
+                    icon={file.icon}
+                    disabled={this.disabled}
+                    readonly={this.readonly}
+                    removable={true}
+                    onRemove={this.handleRemove}
+                />
+            )),
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Disabled"
+                    onChange={this.setDisabled}
+                />
+                <limel-checkbox
+                    checked={this.readonly}
+                    label="Readonly"
+                    onChange={this.setReadonly}
+                />
+                <limel-checkbox
+                    checked={this.multiple}
+                    label="Multiple"
+                    onChange={this.setMultiple}
+                />
+            </limel-example-controls>,
+            <limel-example-value value={this.files} />,
+        ];
+    }
+
+    private handleFilesSelected = (event: CustomEvent<FileInfo[]>) => {
+        this.files = [...this.files.concat(event.detail)];
+    };
+
+    private handleRemove = (event: CustomEvent<string | number>) => {
+        this.files = this.files.filter((file) => file.id !== event.detail);
+    };
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
+    };
+
+    private setMultiple = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.multiple = event.detail;
+    };
+}

--- a/src/components/file-input/file-input.tsx
+++ b/src/components/file-input/file-input.tsx
@@ -1,0 +1,148 @@
+import {
+    h,
+    Event,
+    EventEmitter,
+    Host,
+    Component,
+    Element,
+    Prop,
+} from '@stencil/core';
+import { createRandomString } from '../../util/random-string';
+import { FileInfo } from '../../global/shared-types/file.types';
+import { createFileInfo } from '../../util/files';
+
+/**
+ * This component enables you to seamlessly transform any other clickable component that
+ * generates a `click` event into a file input selector.
+ *
+ * To use it, just wrap any clickable component inside the `limel-file-input` component.
+ * Upon reception of the `click` event this component will open the native file selection
+ * dialog.
+ *
+ * After receiving the files, the component emits a `filesSelected` event.
+ *
+ * The event detail would be an array of `FileInfo` objects,
+ * each representing a file dropped into the dropzone.
+ *
+ * @exampleComponent limel-example-file-input
+ * @exampleComponent limel-example-file-input-type-filtering
+ * @private
+ */
+@Component({
+    tag: 'limel-file-input',
+    shadow: true,
+})
+export class FileInput {
+    /**
+     * Specifies the types of files that the dropzone will accept. By default, all file types are accepted.
+     *
+     * For media files, formats can be specified using: `audio/*`, `video/*`, `image/*`.
+     * Unique file type specifiers can also be used, for example: `.jpg`, `.pdf`.
+     * A comma-separated list of file extensions or MIME types is also acceptable, e.g., `image/png, image/jpeg` or
+     * `.png, .jpg, .jpeg`.
+     *
+     * @see [HTML attribute: accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) for more
+     * details.
+     */
+    @Prop({ reflect: true })
+    public accept: string = '*';
+
+    /**
+     * Set to `true` to disable file input selection.
+     */
+    @Prop({ reflect: true })
+    public disabled: boolean = false;
+
+    /**
+     * Set to `true` to enable selection of multiple files
+     */
+    @Prop({ reflect: true })
+    public multiple: boolean = false;
+
+    /**
+     * Emitted when files are selected
+     */
+    @Event()
+    filesSelected: EventEmitter<FileInfo[]>;
+
+    @Element()
+    private element: HTMLLimelFileElement;
+
+    private fileInput: HTMLInputElement;
+    private fileInputId = createRandomString();
+
+    public componentDidLoad() {
+        this.fileInput = this.element.shadowRoot.getElementById(
+            this.fileInputId,
+        ) as HTMLInputElement;
+    }
+
+    public render() {
+        return (
+            <Host
+                onClick={this.handleClick}
+                onKeyUp={this.handleKeyUp}
+                onKeyDown={this.handleKeyDown}
+            >
+                <input
+                    hidden={true}
+                    id={this.fileInputId}
+                    onChange={this.handleFileChange}
+                    type="file"
+                    accept={this.accept}
+                    disabled={this.disabled}
+                    multiple={this.multiple}
+                />
+                <slot />
+            </Host>
+        );
+    }
+
+    private handleClick = (event: Event) => {
+        if (this.disabled) {
+            event.stopPropagation();
+            event.preventDefault();
+
+            return;
+        }
+
+        this.triggerFileDialog();
+
+        event.stopPropagation();
+    };
+
+    private handleKeyUp = (event: KeyboardEvent) => {
+        event.stopPropagation();
+        event.preventDefault();
+
+        if (event.code === 'Enter') {
+            this.triggerFileDialog();
+        }
+    };
+
+    private handleKeyDown(event: KeyboardEvent) {
+        if (
+            event.code === 'Tab' ||
+            event.code === 'Backspace' ||
+            event.code === 'Enter'
+        ) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    }
+
+    private triggerFileDialog() {
+        this.fileInput.click();
+    }
+
+    private handleFileChange = (event: Event) => {
+        const files = Array.from(this.fileInput.files);
+        if (files.length > 0) {
+            event.stopPropagation();
+            this.filesSelected.emit(files.map(createFileInfo));
+            this.fileInput.value = '';
+        }
+    };
+}


### PR DESCRIPTION
Adds a limel-file-input component that can wrap any clickable element that generates a `click` event. It will catch all click events and trigger the file input dialog to open.

The file types to be selectable can be controlled with the `accept` prop. It should conform to the HTML attribute accept format https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept

Following is example usage of the file-dropzone and file-input components working together.  A user can select files both by dragging them into the `<limel-file-dropzone>` or by clicking the `<limel-button>` wrapped in `limel-file-input`

```tsx
<limel-file-dropzone onFilesSelected={files: FileInfo[] => console.log(files)}>
    <my-component />
    <limel-file-input>
        <limel-button label="Select files" />
     </limel-file-input>
 </limel-file-dropzone>
```

Fixes https://github.com/Lundalogik/crm-feature/issues/3941
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
