### PR TITLE
Use new dropzone/input component in `limel-file`

### DIFF
--- a/src/components/file/examples/file.tsx
+++ b/src/components/file/examples/file.tsx
@@ -10,7 +10,11 @@ import { Component, h, State } from '@stencil/core';
 })
 export class FileExample {
     @State()
-    private value: FileInfo = { filename: 'letter.docx', id: 123 };
+    private value: FileInfo = {
+        filename: 'cute-cat.jpg',
+        id: 123,
+        href: 'https://www.boredpanda.com/blog/wp-content/uploads/2014/02/funny-wet-cats-36.jpg',
+    };
 
     @State()
     private required = false;

--- a/src/components/file/file.scss
+++ b/src/components/file/file.scss
@@ -2,8 +2,3 @@
  * @prop --icon-background-color: Background color of the icon. Defaults to `--contrast-400`.
  * @prop --icon-color: Color of the icon. Defaults to `--contrast-1100`.
  */
-
-:host {
-    --icon-background-color: rgb(var(--contrast-400));
-    --icon-color: rgb(var(--contrast-1100));
-}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -1,15 +1,7 @@
 import translate from '../../global/translations';
 import { Chip } from '../chip-set/chip.types';
 import { Languages } from '../date-picker/date.types';
-import { MDCTextField } from '@material/textfield';
-import {
-    Component,
-    Element,
-    Event,
-    EventEmitter,
-    h,
-    Prop,
-} from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
 import {
     getFileBackgroundColor,
     getFileColor,
@@ -18,7 +10,6 @@ import {
 } from '../../util/file-metadata';
 import { FileInfo } from '../../global/shared-types/file.types';
 
-const CHIP_SET_TAG_NAME = 'limel-chip-set';
 const DEFAULT_FILE_CHIP: Chip = {
     id: null,
     text: null,
@@ -127,37 +118,6 @@ export class File {
     @Event()
     private interact: EventEmitter<number | string>;
 
-    @Element()
-    private element: HTMLLimelFileElement;
-
-    private chipSet;
-    private mdcTextField;
-
-    public connectedCallback() {
-        this.initialize();
-    }
-
-    public componentDidLoad() {
-        this.chipSet = this.element.shadowRoot.querySelector(CHIP_SET_TAG_NAME);
-        this.initialize();
-    }
-
-    private initialize() {
-        if (!this.chipSet) {
-            return;
-        }
-
-        this.mdcTextField = new MDCTextField(
-            this.chipSet.shadowRoot.querySelector('.mdc-text-field'),
-        );
-    }
-
-    public disconnectedCallback() {
-        if (this.mdcTextField) {
-            this.mdcTextField.destroy();
-        }
-    }
-
     public render() {
         return (
             <limel-file-dropzone
@@ -231,12 +191,8 @@ export class File {
     private handleChipSetChange = (event: CustomEvent) => {
         event.stopPropagation();
         const file = !event.detail.length ? event.detail[0] : null;
-        this.chipSet.blur();
         if (!file) {
             this.change.emit(file);
-            if (this.required) {
-                this.mdcTextField.valid = false;
-            }
         }
     };
 


### PR DESCRIPTION
Makes use of the new `limel-file-dropzone` and `limel-file-input` component in `limel-file`. All the other functionality of `limel-file` should be unchanged.

Fixes https://github.com/Lundalogik/crm-feature/issues/3941
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
