### PR TITLE
fix(input-field): make a placeholder text visible in dark mode

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -35,6 +35,7 @@
         height: var(--textarea-height, 100%);
 
         .mdc-text-field__input {
+            @include shared_input-select-picker.input-field-placeholder;
             margin-top: functions.pxToRem(8);
             margin-bottom: 0;
         }

--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -21,6 +21,7 @@ $label-color: rgba(var(--contrast-1200), 1);
 $label-color-disabled: rgba(var(--contrast-1200), 0.5);
 $input-text-color: rgba(var(--contrast-1400), 1);
 $input-text-leading-icon-color: rgb(var(--contrast-900));
+$input-placeholder-color: $input-text-leading-icon-color;
 
 $input-text-color-disabled: rgba(var(--contrast-1400), 0.5);
 $helper-text-color: $label-color;
@@ -85,7 +86,7 @@ $cropped-label-hack--font-size: 0.875rem; //14px
 
 @mixin input-field-placeholder {
     &::placeholder {
-        color: rgb(var(--contrast-900)) !important;
+        color: $input-placeholder-color !important;
     }
 }
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/3959

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
