### PR TITLE
fix(limel-picker): align event types with values types

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1999,7 +1999,7 @@ export interface RowLayoutOptions extends FormLayoutOptions<FormLayoutType | `${
 }
 
 // @public
-export type Searcher = (query: string) => Promise<ListItem[]>;
+export type Searcher = (query: string) => Promise<ListItem[] | ListSeparator>;
 
 // @public
 export type SpinnerSize = 'mini' | 'x-small' | 'small' | 'medium' | 'large';

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -498,14 +498,7 @@ export namespace Components {
         "required": boolean;
         "searcher": Searcher;
         "searchLabel": string;
-        "value": | ListItem<
-        number | string | { id: string | number; [key: string]: any }
-        >
-        | Array<
-        ListItem<
-        number | string | { id: string | number; [key: string]: any }
-        >
-        >;
+        "value": ListItem<PickerValue> | Array<ListItem<PickerValue>>;
     }
     export interface LimelPopover {
         "open": boolean;
@@ -1362,20 +1355,13 @@ namespace JSX_2 {
         "leadingIcon"?: string;
         "multiple"?: boolean;
         "onAction"?: (event: LimelPickerCustomEvent<Action>) => void;
-        "onChange"?: (event: LimelPickerCustomEvent<ListItem<number | string> | Array<ListItem<number | string>>>) => void;
-        "onInteract"?: (event: LimelPickerCustomEvent<ListItem<number | string>>) => void;
+        "onChange"?: (event: LimelPickerCustomEvent<ListItem<PickerValue> | Array<ListItem<PickerValue>>>) => void;
+        "onInteract"?: (event: LimelPickerCustomEvent<ListItem<PickerValue>>) => void;
         "readonly"?: boolean;
         "required"?: boolean;
         "searcher"?: Searcher;
         "searchLabel"?: string;
-        "value"?: | ListItem<
-        number | string | { id: string | number; [key: string]: any }
-        >
-        | Array<
-        ListItem<
-        number | string | { id: string | number; [key: string]: any }
-        >
-        >;
+        "value"?: ListItem<PickerValue> | Array<ListItem<PickerValue>>;
     }
     interface LimelPopover {
         "onClose"?: (event: LimelPopoverCustomEvent<void>) => void;
@@ -1997,6 +1983,12 @@ interface Option_2<T extends string = string> {
     value: T;
 }
 export { Option_2 as Option }
+
+// @public
+export type PickerValue = number | string | {
+    id: string | number;
+    [key: string]: any;
+};
 
 // @public
 export type ReplaceObjectType<T, AllowedType, ElseType> = T extends any[] ? ElseType : T extends Record<string, any> ? AllowedType : ElseType;

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -33,6 +33,7 @@ import {
     LimelListCustomEvent,
 } from '../../components';
 import { getIconFillColor, getIconName } from '../icon/get-icon-props';
+import { PickerValue } from './value.types';
 
 const SEARCH_DEBOUNCE = 500;
 const CHIP_SET_TAG_NAME = 'limel-chip-set';
@@ -113,15 +114,7 @@ export class Picker {
      * Currently selected value or values. Where the value can be an object.
      */
     @Prop()
-    public value:
-        | ListItem<
-              number | string | { id: string | number; [key: string]: any }
-          >
-        | Array<
-              ListItem<
-                  number | string | { id: string | number; [key: string]: any }
-              >
-          >;
+    public value: ListItem<PickerValue> | Array<ListItem<PickerValue>>;
 
     /**
      * A search function that takes a search-string as an argument,
@@ -180,14 +173,14 @@ export class Picker {
      */
     @Event()
     private change: EventEmitter<
-        ListItem<number | string> | Array<ListItem<number | string>>
+        ListItem<PickerValue> | Array<ListItem<PickerValue>>
     >;
 
     /**
      * Fired when clicking on a selected value
      */
     @Event()
-    private interact: EventEmitter<ListItem<number | string>>;
+    private interact: EventEmitter<ListItem<PickerValue>>;
 
     /**
      * Emitted when the user selects an action.
@@ -562,7 +555,7 @@ export class Picker {
 
         // If the search-query is an empty string, bypass debouncing.
         const searchFn = query === '' ? this.searcher : this.debouncedSearch;
-        const result = await searchFn(query);
+        const result = (await searchFn(query)) as Array<ListItem<PickerValue>>;
         this.handleSearchResult(query, result);
     }
 
@@ -571,12 +564,18 @@ export class Picker {
      *
      * @param event - event
      */
-    private handleListChange(event: LimelListCustomEvent<ListItem>) {
+    private handleListChange(
+        event: LimelListCustomEvent<ListItem<PickerValue>>,
+    ) {
         event.stopPropagation();
         if (!this.value || this.value !== event.detail) {
-            let newValue: ListItem | ListItem[] = event.detail;
+            let newValue: ListItem<PickerValue> | Array<ListItem<PickerValue>> =
+                event.detail;
             if (this.multiple) {
-                newValue = [...(this.value as ListItem[]), event.detail];
+                newValue = [
+                    ...(this.value as Array<ListItem<PickerValue>>),
+                    event.detail,
+                ];
             }
 
             this.change.emit(newValue);
@@ -612,7 +611,9 @@ export class Picker {
     private async handleInputFieldFocus() {
         this.loading = true;
         const query = this.textValue;
-        const result = await this.searcher(query);
+        const result = (await this.searcher(query)) as Array<
+            ListItem<PickerValue>
+        >;
         this.handleSearchResult(query, result);
     }
 

--- a/src/components/picker/searcher.types.ts
+++ b/src/components/picker/searcher.types.ts
@@ -1,4 +1,5 @@
 import { ListItem } from '../list/list-item.types';
+import { ListSeparator } from '../../global/shared-types/separator.types';
 
 /**
  * A search function that takes a search-string as an argument, and returns
@@ -9,4 +10,4 @@ import { ListItem } from '../list/list-item.types';
  * @returns The search result.
  * @public
  */
-export type Searcher = (query: string) => Promise<ListItem[]>;
+export type Searcher = (query: string) => Promise<ListItem[] | ListSeparator>;

--- a/src/components/picker/value.types.ts
+++ b/src/components/picker/value.types.ts
@@ -1,0 +1,8 @@
+/**
+ * The type of the value that the picker can handle
+ * @public
+ */
+export type PickerValue =
+    | number
+    | string
+    | { id: string | number; [key: string]: any };


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
