### PR TITLE
fix(limel-picker): searcher returns array of ListItem or ListSeparator

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -2025,7 +2025,7 @@ export interface RowLayoutOptions extends FormLayoutOptions<FormLayoutType | `${
 }
 
 // @public
-export type Searcher = (query: string) => Promise<ListItem[] | ListSeparator>;
+export type Searcher = (query: string) => Promise<Array<ListItem | ListSeparator>>;
 
 // @public
 export type SpinnerSize = 'mini' | 'x-small' | 'small' | 'medium' | 'large';

--- a/src/components/picker/searcher.types.ts
+++ b/src/components/picker/searcher.types.ts
@@ -10,4 +10,6 @@ import { ListSeparator } from '../../global/shared-types/separator.types';
  * @returns The search result.
  * @public
  */
-export type Searcher = (query: string) => Promise<ListItem[] | ListSeparator>;
+export type Searcher = (
+    query: string,
+) => Promise<Array<ListItem | ListSeparator>>;


### PR DESCRIPTION

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
