### PR TITLE
fix(file-dropzone): no highlight on disable

### DIFF
--- a/src/components/file-dropzone/file-dropzone.tsx
+++ b/src/components/file-dropzone/file-dropzone.tsx
@@ -104,7 +104,7 @@ export class FileDropzone {
     }
 
     private renderOnDragLayout = () => {
-        if (!this.hasFileToDrop) {
+        if (this.disabled || !this.hasFileToDrop) {
             return;
         }
 


### PR DESCRIPTION
There should be no dropzone highlight if the its is disabled.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
