### PR TITLE
Add rich text editor (prosemirror version)

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -638,6 +638,9 @@ export namespace Components {
     export interface LimelTabPanel {
         "tabs": Tab[];
     }
+    // @beta
+    export interface LimelTextEditor {
+    }
     export interface LimelTooltip {
         "elementId": string;
         "helperLabel"?: string;
@@ -985,6 +988,10 @@ namespace JSX_2 {
         "limel-tab-panel": LimelTabPanel;
         // (undocumented)
         "limel-table": LimelTable;
+        // Warning: (ae-incompatible-release-tags) The symbol ""limel-text-editor"" is marked as @public, but its signature references "JSX_2" which is marked as @beta
+        //
+        // (undocumented)
+        "limel-text-editor": LimelTextEditor;
         // (undocumented)
         "limel-tooltip": LimelTooltip;
         // (undocumented)
@@ -1551,6 +1558,10 @@ namespace JSX_2 {
         "onChangeTab"?: (event: LimelTabPanelCustomEvent<Tab>) => void;
         "tabs"?: Tab[];
     }
+    // @beta
+    interface LimelTextEditor {
+        "onChange"?: (event: LimelTextEditorCustomEvent<{ html: string }>) => void;
+    }
     interface LimelTooltip {
         "elementId": string;
         "helperLabel"?: string;
@@ -1978,6 +1989,16 @@ export interface LimelTabPanelCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     // (undocumented)
     target: HTMLLimelTabPanelElement;
+}
+
+// Warning: (ae-missing-release-tag) "LimelTextEditorCustomEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface LimelTextEditorCustomEvent<T> extends CustomEvent<T> {
+    // (undocumented)
+    detail: T;
+    // (undocumented)
+    target: HTMLLimelTextEditorElement;
 }
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,8 @@
         "number-abbreviate": "^2.0.0",
         "parse-css-color": "^0.2.1",
         "prettier": "^3.2.5",
+        "prosemirror-example-setup": "^1.2.2",
+        "prosemirror-schema-basic": "^1.2.2",
         "puppeteer": "^19.11.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3807,6 +3809,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -10129,6 +10137,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "dev": true
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -10510,6 +10524,161 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.5.2.tgz",
+      "integrity": "sha512-hgLcPaakxH8tu6YvVAaILV2tXYsW3rAdDR8WNkeKGcgeMVQg3/TMhPdVoh7iAmfgVjZGtcOSjKiQaoeKjzd2mQ==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.1.tgz",
+      "integrity": "sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-example-setup": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-example-setup/-/prosemirror-example-setup-1.2.2.tgz",
+      "integrity": "sha512-pHJc656IgYm249RNp0eQaWNmnyWGk6OrzysWfYI4+NwE14HQ7YNYOlRBLErUS6uCAHIYJLNXf0/XCmf1OCtNbQ==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-dropcursor": "^1.0.0",
+        "prosemirror-gapcursor": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-inputrules": "^1.0.0",
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-menu": "^1.0.0",
+        "prosemirror-schema-list": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
+      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.3.2.tgz",
+      "integrity": "sha512-/zm0XoU/N/+u7i5zepjmZAEnpvjDtzoPWW6VmKptcAnPadN/SStsBjMImdCEbb3seiNTpveziPTIrXQbHLtU1g==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
+      "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
+      "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.4.tgz",
+      "integrity": "sha512-S/bXlc0ODQup6aiBbWVsX/eM+xJgCTAfMq/nLqaO5ID/am4wS0tTCIkzwytmao7ypEtjj39i7YbJjAgO20mIqA==",
+      "dev": true,
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.19.4.tgz",
+      "integrity": "sha512-RPmVXxUfOhyFdayHawjuZCxiROsm9L4FCUA6pWI+l7n2yCBsWy9VpdE1hpDHUS8Vad661YLY9AzqfjLhAKQ4iQ==",
+      "dev": true,
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.2.tgz",
+      "integrity": "sha512-/dT4JFEGyO7QnNTe9UaKUhjDXbTNkiWTq/N4VpKaF79bBjSExVV2NXmJpcM7z/gD7mbqNjxbmWW5nf1iNSSGnw==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-model": "^1.19.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.3.0.tgz",
+      "integrity": "sha512-Hz/7gM4skaaYfRPNgr421CU4GSwotmEwBVvJh5ltGiffUJwm7C8GfN/Bc6DR1EKEp5pDKhODmdXXyi9uIsZl5A==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.8.0.tgz",
+      "integrity": "sha512-BaSBsIMv52F1BVVMvOmp1yzD3u65uC3HTzCBQV1WDPqJRQ2LuHKcyfn0jwqodo8sR9vVzMzZyI+Dal5W9E6a9A==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.1.tgz",
+      "integrity": "sha512-62qkYgSJIkwIMMCpuGuPzc52DiK1Iod6TWoIMxP4ja6BTD4yO8kCUL64PZ/WhH/dJ9fW0CDO39FhH1EMyhUFEg==",
+      "dev": true,
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -11484,6 +11653,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "dev": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -12923,6 +13098,12 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
@@ -16339,6 +16520,12 @@
           }
         }
       }
+    },
+    "crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true
     },
     "cross-env": {
       "version": "7.0.3",
@@ -21008,6 +21195,12 @@
         "type-check": "^0.4.0"
       }
     },
+    "orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "dev": true
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -21288,6 +21481,161 @@
       "dev": true,
       "requires": {
         "xtend": "^4.0.0"
+      }
+    },
+    "prosemirror-commands": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.5.2.tgz",
+      "integrity": "sha512-hgLcPaakxH8tu6YvVAaILV2tXYsW3rAdDR8WNkeKGcgeMVQg3/TMhPdVoh7iAmfgVjZGtcOSjKiQaoeKjzd2mQ==",
+      "dev": true,
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-dropcursor": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.1.tgz",
+      "integrity": "sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==",
+      "dev": true,
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "prosemirror-example-setup": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-example-setup/-/prosemirror-example-setup-1.2.2.tgz",
+      "integrity": "sha512-pHJc656IgYm249RNp0eQaWNmnyWGk6OrzysWfYI4+NwE14HQ7YNYOlRBLErUS6uCAHIYJLNXf0/XCmf1OCtNbQ==",
+      "dev": true,
+      "requires": {
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-dropcursor": "^1.0.0",
+        "prosemirror-gapcursor": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-inputrules": "^1.0.0",
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-menu": "^1.0.0",
+        "prosemirror-schema-list": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "prosemirror-gapcursor": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
+      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "dev": true,
+      "requires": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "prosemirror-history": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.3.2.tgz",
+      "integrity": "sha512-/zm0XoU/N/+u7i5zepjmZAEnpvjDtzoPWW6VmKptcAnPadN/SStsBjMImdCEbb3seiNTpveziPTIrXQbHLtU1g==",
+      "dev": true,
+      "requires": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "prosemirror-inputrules": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
+      "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
+      "dev": true,
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-keymap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
+      "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
+      "dev": true,
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "prosemirror-menu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.4.tgz",
+      "integrity": "sha512-S/bXlc0ODQup6aiBbWVsX/eM+xJgCTAfMq/nLqaO5ID/am4wS0tTCIkzwytmao7ypEtjj39i7YbJjAgO20mIqA==",
+      "dev": true,
+      "requires": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "prosemirror-model": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.19.4.tgz",
+      "integrity": "sha512-RPmVXxUfOhyFdayHawjuZCxiROsm9L4FCUA6pWI+l7n2yCBsWy9VpdE1hpDHUS8Vad661YLY9AzqfjLhAKQ4iQ==",
+      "dev": true,
+      "requires": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "prosemirror-schema-basic": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.2.tgz",
+      "integrity": "sha512-/dT4JFEGyO7QnNTe9UaKUhjDXbTNkiWTq/N4VpKaF79bBjSExVV2NXmJpcM7z/gD7mbqNjxbmWW5nf1iNSSGnw==",
+      "dev": true,
+      "requires": {
+        "prosemirror-model": "^1.19.0"
+      }
+    },
+    "prosemirror-schema-list": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.3.0.tgz",
+      "integrity": "sha512-Hz/7gM4skaaYfRPNgr421CU4GSwotmEwBVvJh5ltGiffUJwm7C8GfN/Bc6DR1EKEp5pDKhODmdXXyi9uIsZl5A==",
+      "dev": true,
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "prosemirror-state": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "dev": true,
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "prosemirror-transform": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.8.0.tgz",
+      "integrity": "sha512-BaSBsIMv52F1BVVMvOmp1yzD3u65uC3HTzCBQV1WDPqJRQ2LuHKcyfn0jwqodo8sR9vVzMzZyI+Dal5W9E6a9A==",
+      "dev": true,
+      "requires": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "prosemirror-view": {
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.1.tgz",
+      "integrity": "sha512-62qkYgSJIkwIMMCpuGuPzc52DiK1Iod6TWoIMxP4ja6BTD4yO8kCUL64PZ/WhH/dJ9fW0CDO39FhH1EMyhUFEg==",
+      "dev": true,
+      "requires": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
       }
     },
     "proxy-from-env": {
@@ -22037,6 +22385,12 @@
           "peer": true
         }
       }
+    },
+    "rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "dev": true
     },
     "run-parallel": {
       "version": "1.2.0",
@@ -23120,6 +23474,12 @@
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "number-abbreviate": "^2.0.0",
     "parse-css-color": "^0.2.1",
     "prettier": "^3.2.5",
+    "prosemirror-example-setup": "^1.2.2",
+    "prosemirror-schema-basic": "^1.2.2",
     "puppeteer": "^19.11.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/text-editor/examples/text-editor-basic.tsx
+++ b/src/components/text-editor/examples/text-editor-basic.tsx
@@ -1,0 +1,31 @@
+import { LimelTextEditorCustomEvent } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+/**
+ * Basic example
+ *
+ * Try typing and editing text, or copy & paste in some rendered HTML code
+ * from your browser into the editor to see how it is rendered and what you get
+ * as an output value.
+ */
+@Component({
+    tag: 'limel-example-text-editor-basic',
+    shadow: true,
+})
+export class BasicTextEditorBasicExample {
+    @State()
+    private text: { html: string } = { html: '' };
+
+    public render() {
+        return [
+            <limel-text-editor onChange={this.handleChange} />,
+            <limel-example-value value={this.text} />,
+        ];
+    }
+
+    private handleChange = (
+        event: LimelTextEditorCustomEvent<{ html: string }>,
+    ): void => {
+        event.stopPropagation();
+        this.text = event.detail;
+    };
+}

--- a/src/components/text-editor/partial-styles/_prosemirror-menu.scss
+++ b/src/components/text-editor/partial-styles/_prosemirror-menu.scss
@@ -1,0 +1,180 @@
+@use '../../../style/mixins';
+
+$size-of-caret: 0.25rem;
+
+div#editor {
+    .ProseMirror-menubar {
+        position: sticky !important;
+        z-index: 1;
+        top: 0;
+
+        &[style*='position: fixed'] {
+            // They add this dynamically as soon as you scroll.
+            // I want to catch this to detect the scroll,
+            // to add proper styles. This is a hack.
+            box-shadow: 0 0.25rem 0.5rem -0.5rem rgb(var(--color-black), 0.8);
+        }
+    }
+}
+
+.ProseMirror-menubar {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+
+    padding: 0.125rem;
+    background-color: rgb(var(--contrast-100));
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+}
+
+.ProseMirror-menuitem {
+    &:not(:has(.ProseMirror-menu-disabled)) {
+        @include mixins.is-flat-clickable;
+    }
+    position: relative;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    white-space: nowrap;
+    line-height: 1;
+
+    min-height: 1.5rem;
+    min-width: 1.5rem;
+    border-radius: 0.25rem;
+    color: rgb(var(--contrast-1100));
+    font-size: 0.8125rem;
+
+    &:has(.ProseMirror-menu-active) {
+        box-shadow: var(--button-shadow-inset);
+        color: var(--mdc-theme-primary);
+
+        svg {
+            color: var(--mdc-theme-primary);
+        }
+    }
+
+    &:has(.ProseMirror-menu-dropdown-menu) {
+        box-shadow: var(--button-shadow-inset);
+    }
+
+    svg {
+        fill: currentColor;
+        height: 1rem;
+        color: rgb(var(--contrast-1100));
+    }
+}
+
+.ProseMirror-menuseparator {
+    border-radius: 1rem;
+    background-color: rgb(var(--contrast-600));
+    width: 0.125rem;
+    height: 1rem;
+}
+
+.ProseMirror-menu-dropdown {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0 0.5rem;
+
+    &:after {
+        content: '';
+        border-left: $size-of-caret solid transparent;
+        border-right: $size-of-caret solid transparent;
+        border-top: $size-of-caret solid currentColor;
+    }
+}
+
+.ProseMirror-menu-dropdown-menu,
+.ProseMirror-menu-submenu {
+    //the same shadow as limel-menu
+    box-shadow:
+        0px 5px 5px -3px rgba(0, 0, 0, 0.2),
+        0px 8px 10px 1px rgba(0, 0, 0, 0.14),
+        0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.ProseMirror-menu-dropdown-menu {
+    position: absolute;
+    top: 100%;
+    background: rgb(var(--contrast-100));
+    border-radius: 0.25rem;
+    padding: 0.125rem;
+}
+
+.ProseMirror-menu-submenu {
+    position: absolute;
+    background: rgb(var(--contrast-100));
+    border-radius: 0.25rem;
+    padding: 0.125rem;
+    display: none;
+    min-width: 4em;
+    left: 100%;
+    top: -0.75rem;
+}
+
+.ProseMirror-menu-dropdown-item {
+    transition: background-color 0.2s ease;
+    cursor: pointer;
+    border-radius: 0.375rem;
+
+    min-height: 2.5rem;
+    display: flex;
+    align-items: center;
+    width: 100%;
+
+    > div {
+        padding: 0 1rem;
+        width: 100%;
+    }
+
+    &:not(:has(.ProseMirror-menu-disabled)) {
+        &:hover {
+            background-color: rgb(var(--contrast-300));
+        }
+    }
+}
+
+.ProseMirror-menu-submenu-wrap {
+    position: relative;
+    margin-right: -0.25rem;
+
+    &:hover {
+        .ProseMirror-menu-submenu {
+            display: block;
+        }
+    }
+}
+
+.ProseMirror-menu-submenu-label {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+
+    &:after {
+        content: '';
+        border-top: $size-of-caret solid transparent;
+        border-bottom: $size-of-caret solid transparent;
+        border-left: $size-of-caret solid currentColor;
+    }
+}
+
+.ProseMirror-menu-disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.ProseMirror-menu-submenu-wrap-active {
+    .ProseMirror-menu-submenu {
+        display: block;
+    }
+}

--- a/src/components/text-editor/partial-styles/_prosemirror.scss
+++ b/src/components/text-editor/partial-styles/_prosemirror.scss
@@ -1,0 +1,62 @@
+.ProseMirror {
+    position: relative;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    white-space: break-spaces;
+    -webkit-font-variant-ligatures: none;
+    font-variant-ligatures: none;
+    font-feature-settings: 'liga' 0;
+
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+
+    padding: 0.5rem 1rem;
+    background-color: rgb(var(--contrast-100));
+
+    [draggable][contenteditable='false'] {
+        user-select: text;
+    }
+
+    &:focus-visible {
+        outline: none;
+    }
+}
+
+.ProseMirror-hideselection {
+    * {
+        &::selection {
+            background: transparent;
+        }
+
+        &::-moz-selection {
+            background: transparent;
+        }
+    }
+
+    caret-color: transparent;
+}
+
+.ProseMirror-selectednode {
+    outline: 0.125rem solid rgb(var(--color-sky-light));
+}
+
+li.ProseMirror-selectednode {
+    outline: none;
+
+    &:after {
+        content: '';
+        position: absolute;
+        left: -2rem;
+        right: -0.125rem;
+        top: -0.125rem;
+        bottom: -0.125rem;
+        border: 0.125rem solid rgb(var(--color-sky-light));
+        pointer-events: none;
+    }
+}
+
+img.ProseMirror-separator {
+    display: inline !important;
+    border: none !important;
+    margin: 0 !important;
+}

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -1,0 +1,50 @@
+@use '../../style/internal/shared_input-select-picker.scss';
+
+:host(limel-text-editor) {
+    isolation: isolate;
+    display: block;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+.ProseMirror-menubar-wrapper {
+    transition: border 0.2s ease;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    border-radius: 0.25rem;
+    border: 1px solid;
+    border-color: shared_input-select-picker.$lime-text-field-outline-color;
+
+    &:hover {
+        border-color: shared_input-select-picker.$lime-text-field-outline-color--hovered;
+    }
+
+    &:focus-within {
+        border-color: shared_input-select-picker.$lime-text-field-outline-color--focused;
+    }
+}
+
+.ProseMirror-textblock-dropdown {
+    min-width: 3em;
+}
+
+.ProseMirror-tooltip {
+    .ProseMirror-menu {
+        width: -webkit-fit-content;
+        width: fit-content;
+        white-space: pre;
+    }
+}
+
+@import './partial-styles/prosemirror.scss';
+@import './partial-styles/prosemirror-menu.scss';
+
+@import '../markdown/partial-styles/blockquotes';
+@import '../markdown/partial-styles/body-text';
+@import '../markdown/partial-styles/definition-lists';
+@import '../markdown/partial-styles/headings';
+@import '../markdown/partial-styles/lists';
+@import '../markdown/partial-styles/pre-code';
+@import '../markdown/partial-styles/tables';

--- a/src/components/text-editor/text-editor.spec.tsx
+++ b/src/components/text-editor/text-editor.spec.tsx
@@ -1,0 +1,25 @@
+import { h } from '@stencil/core';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { TextEditor } from './text-editor';
+
+let page: SpecPage;
+
+describe('limel-text-editor', () => {
+    let editor: HTMLElement;
+
+    beforeEach(async () => {
+        page = await newSpecPage({
+            components: [TextEditor],
+            template: () => <limel-text-editor />,
+        });
+
+        editor = page.root.shadowRoot.querySelector('#editor');
+    });
+
+    it('should render the component', () => {
+        expect(editor).toBeTruthy();
+        expect(
+            editor.querySelector('.ProseMirror-menubar-wrapper'),
+        ).toBeTruthy();
+    });
+});

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -1,0 +1,76 @@
+import {
+    Component,
+    Element,
+    Event,
+    EventEmitter,
+    State,
+    h,
+} from '@stencil/core';
+import { EditorState } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { Schema, DOMParser } from 'prosemirror-model';
+import { schema } from 'prosemirror-schema-basic';
+import { exampleSetup } from 'prosemirror-example-setup';
+
+/**
+ * This editor offers a rich text editing experience with markdown support,
+ * in the sense that you can easily type markdown syntax and see the rendered
+ * result as rich text in real-time. For instance, you can type `# Hello, world!`
+ * and see it directly turning to a heading 1 (an `<h1>` HTML element).
+ *
+ * Naturally, you can use standard keyboard hotkeys such as <kbd>Ctrl</kbd> + <kbd>B</kbd>
+ * to toggle bold text, <kbd>Ctrl</kbd> + <kbd>I</kbd> to toggle italic text, and so on.
+ *
+ * @exampleComponent limel-example-text-editor-basic
+ * @beta
+ * @private
+ */
+@Component({
+    tag: 'limel-text-editor',
+    shadow: true,
+    styleUrl: 'text-editor.scss',
+})
+export class TextEditor {
+    @Element()
+    private host: HTMLLimelTextEditorElement;
+
+    @State()
+    private view: EditorView;
+
+    /**
+     * Dispatched when a change is made to the editor
+     */
+    @Event()
+    private change: EventEmitter<{ html: string }>;
+
+    public componentWillLoad() {}
+
+    public render() {
+        return <div id="editor" />;
+    }
+
+    public componentDidLoad() {
+        const mySchema = new Schema({
+            nodes: schema.spec.nodes,
+            marks: schema.spec.marks,
+        });
+
+        this.view = new EditorView(
+            this.host.shadowRoot.querySelector('#editor'),
+            {
+                state: EditorState.create({
+                    doc: DOMParser.fromSchema(mySchema).parse(
+                        this.host.shadowRoot.querySelector('#editor'),
+                    ),
+                    plugins: exampleSetup({ schema: mySchema }),
+                }),
+                dispatchTransaction: (transaction) => {
+                    const newState = this.view.state.apply(transaction);
+                    this.view.updateState(newState);
+
+                    this.change.emit({ html: this.view.dom.innerHTML });
+                },
+            },
+        );
+    }
+}


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#3977

This PR in its current state just shows how the examples from the documentation might be added to the CRM, to show that things do work. But we still have to write a more robust editor from the ground up.

For reviewing:
To see what is available in Prosemirror, you may want to have a look at the Prosemirror repositories here:

https://github.com/orgs/ProseMirror/repositories?type=all 

The guide is excellent, and found at https://prosemirror.net/docs/guide/

The tutorials are also excellent https://prosemirror.net/examples/

From investigating this, I would say there are no real limitations. But implementation is generally much harder. In this issue we want to create a wrapper around a Prosemirror view, and construct the editor to have

1) Custom "lime-ish" icons
2) Custom buttons
3) Default schema (we could define our schema ourselves, but this is tricky and prone to error)
4) Emit custom events relevant to and at the right level of our use case
5) Headers, bold, italic and lined text
6) Images upload
7) Undo, redo (this comes quite readily with the history plugin)
8) Code blocks
9) Ordered and unordered lists
10) Lime-ish font and related serialisation choices for marks and nodes

In the future it will certainly be possible to add links to limeobjects, and even define their appearance in the editor.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
