### PR TITLE
Menu search less loading

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1347,7 +1347,7 @@ namespace JSX_2 {
         "gridLayout"?: boolean;
         "items"?: Array<MenuItem | ListSeparator>;
         "onCancel"?: (event: LimelMenuCustomEvent<void>) => void;
-        "onNavigateMenu"?: (event: LimelMenuCustomEvent<MenuItem>) => void;
+        "onNavigateMenu"?: (event: LimelMenuCustomEvent<MenuItem | null>) => void;
         "onSelect"?: (event: LimelMenuCustomEvent<MenuItem>) => void;
         "open"?: boolean;
         "openDirection"?: OpenDirection;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -190,6 +190,7 @@ export class Menu {
     private searchInput: HTMLLimelInputFieldElement;
     private portalId: string;
     private triggerElement: HTMLSlotElement;
+    private selectedMenuItem?: MenuItem;
 
     constructor() {
         this.portalId = createRandomString();
@@ -601,6 +602,7 @@ export class Menu {
         selectOnEmptyChildren: boolean = true,
     ) => {
         if (Array.isArray(menuItem?.items) && menuItem.items.length > 0) {
+            this.selectedMenuItem = menuItem;
             this.clearSearch();
             this.currentSubMenu = menuItem;
             this.navigateMenu.emit(menuItem);
@@ -610,8 +612,14 @@ export class Menu {
             return;
         } else if (isFunction(menuItem?.items)) {
             const menuLoader = menuItem.items as MenuLoader;
+            this.selectedMenuItem = menuItem;
             this.loadingSubItems = true;
             const subItems = await menuLoader(menuItem);
+
+            if (this.selectedMenuItem !== menuItem) {
+                return;
+            }
+
             menuItem.items = subItems;
             this.loadingSubItems = false;
 
@@ -629,6 +637,9 @@ export class Menu {
         if (!selectOnEmptyChildren) {
             return;
         }
+
+        this.selectedMenuItem = menuItem;
+        this.loadingSubItems = false;
 
         this.select.emit(menuItem);
         this.open = false;

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -169,7 +169,7 @@ export class Menu {
      * Is emitted when a menu item with a sub-menu is selected.
      */
     @Event()
-    public navigateMenu: EventEmitter<MenuItem>;
+    public navigateMenu: EventEmitter<MenuItem | null>;
 
     @Element()
     private host: HTMLLimelMenuElement;
@@ -184,7 +184,7 @@ export class Menu {
     private searchValue: string;
 
     @State()
-    private searchResults: Array<MenuItem | ListSeparator>;
+    private searchResults: Array<MenuItem | ListSeparator> | null;
 
     private list: HTMLLimelMenuListElement;
     private searchInput: HTMLLimelInputFieldElement;


### PR DESCRIPTION
Removes additional debouncing of search in `limel-menu` since we already have debounced change events from the text input.

This means we avoid rendering a loading animation for more than half a second when the searcher resolves instantly.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
