### PR TITLE
fix(file-dropzone): display the component as a block element

### DIFF
--- a/src/components/file-dropzone/examples/file-dropzone-type-filtering.scss
+++ b/src/components/file-dropzone/examples/file-dropzone-type-filtering.scss
@@ -4,16 +4,11 @@
     gap: 1.5rem;
 }
 
-limel-input-field,
-div {
-    min-height: 10rem;
-    background-color: rgb(var(--contrast-100));
-    border-radius: 0.5rem;
-}
-
 div {
     display: flex;
     align-items: center;
     justify-content: center;
     border: 1px solid rgb(var(--contrast-800));
+    border-radius: 0.5rem;
+    min-height: 10rem;
 }

--- a/src/components/file-dropzone/file-dropzone.scss
+++ b/src/components/file-dropzone/file-dropzone.scss
@@ -1,5 +1,5 @@
 :host(limel-file-dropzone) {
-    display: grid;
+    display: block;
     position: relative;
 }
 


### PR DESCRIPTION
Previously, it was a unnecessarily a `grid`,
which used to set certain expectations on its children. A block element is generic, and the consumer
can change it to whatever is suitable where they use it.

required for https://github.com/Lundalogik/lime-crm-components/pull/2187/

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
