### PR TITLE
fix(input-field): handle change better to keep value in sync

### DIFF
--- a/src/components/input-field/examples/input-field-pattern.tsx
+++ b/src/components/input-field/examples/input-field-pattern.tsx
@@ -16,7 +16,7 @@ export class InputFieldPatternExample {
             <limel-input-field
                 label="Personal identity number (YYYYMMDD-XXXX)"
                 value={this.value}
-                pattern={'[0-9]{8}[-][0-9]{4}'}
+                pattern={'[0-9]{8}-[0-9]{4}'}
                 onChange={this.handleChange}
             />
         );

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -402,7 +402,7 @@ export class InputField {
             'mdc-text-field--disabled': this.disabled || this.readonly,
             'lime-text-field--readonly': this.readonly,
             'mdc-text-field--required': this.required,
-            'lime-text-field--empty': !this.value,
+            'lime-text-field--empty': this.isEmpty(),
             'lime-has-prefix': this.hasPrefix(),
             'lime-has-suffix': this.hasSuffix(),
         };
@@ -418,6 +418,28 @@ export class InputField {
         }
 
         return classList;
+    };
+
+    private isEmpty = () => {
+        if (this.type === 'number') {
+            const element = this.getInputElement();
+            if (element && element.validity.badInput) {
+                return false;
+            }
+        }
+
+        return !this.getCurrentValue();
+    };
+
+    private getCurrentValue = () => {
+        if (this.changeWaiting) {
+            const element = this.getInputElement();
+            if (element) {
+                return element.value;
+            }
+        }
+
+        return this.value;
     };
 
     private renderInput = (
@@ -508,7 +530,7 @@ export class InputField {
     };
 
     private renderHelperLine = () => {
-        const text: string = this.value || '';
+        const text: string = this.getCurrentValue() || '';
         const length = text.length;
 
         if (!this.hasHelperLine()) {
@@ -527,7 +549,7 @@ export class InputField {
     };
 
     private renderEmptyValueForReadonly = () => {
-        if (this.readonly && !this.value) {
+        if (this.readonly && this.isEmpty()) {
             return (
                 <span class="lime-empty-value-for-readonly lime-looks-like-input-value">
                     –
@@ -617,7 +639,7 @@ export class InputField {
         const labelClassList = {
             'mdc-floating-label': true,
             'mdc-floating-label--float-above':
-                !!this.value || this.isFocused || this.readonly,
+                !this.isEmpty() || this.isFocused || this.readonly,
         };
 
         if (!this.label) {
@@ -699,7 +721,7 @@ export class InputField {
             <a
                 {...linkProps}
                 class="material-icons mdc-text-field__icon lime-trailing-icon-for-link"
-                tabindex={this.disabled || !this.value ? '-1' : '0'}
+                tabindex={this.disabled || this.isEmpty() ? '-1' : '0'}
                 role="button"
             >
                 <limel-icon name={icon} />
@@ -762,6 +784,9 @@ export class InputField {
             renderValue = new Intl.NumberFormat(this.locale).format(
                 Number(this.value),
             );
+            if (renderValue === 'NaN') {
+                return;
+            }
         }
 
         return (
@@ -876,7 +901,7 @@ export class InputField {
 
     private renderListResult = () => {
         const filteredCompletions: ListItem[] = this.filterCompletions(
-            this.value,
+            this.getCurrentValue(),
         );
         if (!filteredCompletions || filteredCompletions.length === 0) {
             return null;

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -379,6 +379,10 @@ export class InputField {
             this.mdcTextField.value = this.value;
         }
 
+        if (this.invalid) {
+            this.mdcTextField.valid = false;
+        }
+
         this.mapCompletions();
 
         window.addEventListener('resize', this.layout, { passive: true });

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -252,6 +252,7 @@ export class InputField {
     @State()
     public showCompletions: boolean = false;
 
+    private inputElement?: HTMLInputElement | HTMLTextAreaElement;
     private mdcTextField: MDCTextField;
     private completionsList: ListItem[] = [];
     private portalId: string;
@@ -293,6 +294,7 @@ export class InputField {
         const properties = this.getAdditionalProps();
         properties['aria-labelledby'] = this.labelId;
         properties.class = 'mdc-text-field__input';
+        properties.ref = this.setInputElement;
         properties.onInput = this.handleInput;
         properties.onChange = this.handleChange;
         properties.onFocus = this.onFocus;
@@ -421,22 +423,16 @@ export class InputField {
     };
 
     private isEmpty = () => {
-        if (this.type === 'number') {
-            const element = this.getInputElement();
-            if (element && element.validity.badInput) {
-                return false;
-            }
+        if (this.type === 'number' && this.inputElement?.validity.badInput) {
+            return false;
         }
 
         return !this.getCurrentValue();
     };
 
     private getCurrentValue = () => {
-        if (this.changeWaiting) {
-            const element = this.getInputElement();
-            if (element) {
-                return element.value;
-            }
+        if (this.changeWaiting && this.inputElement) {
+            return this.inputElement.value;
         }
 
         return this.value;
@@ -616,23 +612,17 @@ export class InputField {
             return;
         }
 
-        const element = this.getInputElement();
-
-        if (element) {
-            this.wasInvalid = !element.checkValidity();
+        if (this.inputElement) {
+            this.wasInvalid = !this.inputElement.checkValidity();
         }
     };
 
-    private getInputElement = ():
-        | HTMLInputElement
-        | HTMLTextAreaElement
-        | null => {
-        let elementName = 'input';
-        if (this.type === 'textarea') {
-            elementName = 'textarea';
+    private setInputElement = (
+        element?: HTMLInputElement | HTMLTextAreaElement,
+    ) => {
+        if (element) {
+            this.inputElement = element;
         }
-
-        return this.limelInputField.shadowRoot.querySelector(elementName);
     };
 
     private renderLabel = () => {

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -247,7 +247,7 @@ export class InputField {
     private isFocused: boolean = false;
 
     @State()
-    private isModified: boolean = false;
+    private wasInvalid: boolean = false;
 
     @State()
     public showCompletions: boolean = false;
@@ -353,6 +353,10 @@ export class InputField {
 
         if (newValue !== this.mdcTextField.value) {
             this.mdcTextField.value = newValue || '';
+        }
+
+        if (this.wasInvalid) {
+            this.validate();
         }
     }
 
@@ -491,7 +495,7 @@ export class InputField {
 
     private onBlur = () => {
         this.isFocused = false;
-        this.isModified = true;
+        this.validate();
         this.changeEmitter.flush();
     };
 
@@ -580,16 +584,27 @@ export class InputField {
             return true;
         }
 
-        if (!this.isModified) {
-            return false;
+        return this.wasInvalid;
+    };
+
+    private validate = () => {
+        if (this.readonly || this.invalid) {
+            this.wasInvalid = false;
+
+            return;
         }
 
         const element = this.getInputElement();
 
-        return !(element && element.checkValidity());
+        if (element) {
+            this.wasInvalid = !element.checkValidity();
+        }
     };
 
-    private getInputElement = (): HTMLInputElement | HTMLTextAreaElement => {
+    private getInputElement = ():
+        | HTMLInputElement
+        | HTMLTextAreaElement
+        | null => {
         let elementName = 'input';
         if (this.type === 'textarea') {
             elementName = 'textarea';


### PR DESCRIPTION
Avoids rendering a value that's out of sync with input while the user is typing.

- Waits until any debounced change event has been emitted before rendering new value
- Flushes any debounced change event on blur

Also changes validation of input to avoid triggering `invalid` events while rendering, and to remove some inconsistent behaviour when input is invalid.

Fixes #1425 
fix: #2742
fix: #1267

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
