### PR TITLE
fix(input-field): ensure `aria-controls` get ids of both helper text …

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -299,9 +299,23 @@ export class InputField {
         properties.readonly = this.readonly;
         properties.disabled = this.disabled || this.readonly;
 
+        let ariaControls = '';
+
         if (this.hasHelperText()) {
-            properties['aria-controls'] = this.helperTextId;
+            ariaControls += this.helperTextId;
             properties['aria-describedby'] = this.helperTextId;
+        }
+
+        if (this.renderAutocompleteList()) {
+            if (ariaControls) {
+                ariaControls += ' ';
+            }
+
+            ariaControls += this.portalId;
+        }
+
+        if (ariaControls) {
+            properties['aria-controls'] = ariaControls;
         }
 
         return [


### PR DESCRIPTION
…& portal

fix https://github.com/Lundalogik/crm-feature/issues/3503


closes https://github.com/Lundalogik/crm-feature/issues/3502


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
