### PR TITLE
fix(tooltip): display the tooltip, when the element is focused using …

### DIFF
--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -153,13 +153,15 @@ export class Tooltip {
     private addListeners() {
         this.ownerElement?.addEventListener('mouseover', this.showTooltip);
         this.ownerElement?.addEventListener('mouseout', this.hideTooltip);
-        this.ownerElement?.addEventListener('click', this.hideTooltip);
+        this.ownerElement?.addEventListener('focus', this.showTooltip);
+        this.ownerElement?.addEventListener('blur', this.hideTooltip);
     }
 
     private removeListeners() {
         this.ownerElement?.removeEventListener('mouseover', this.showTooltip);
         this.ownerElement?.removeEventListener('mouseout', this.hideTooltip);
-        this.ownerElement?.removeEventListener('click', this.hideTooltip);
+        this.ownerElement?.removeEventListener('focus', this.showTooltip);
+        this.ownerElement?.removeEventListener('blur', this.hideTooltip);
     }
 
     private showTooltip = () => {


### PR DESCRIPTION
…keyboard

Previously the tooltip was shown only when the element was hovered using mouse. This is an undesirable accessibility issue for sighted users who use keyboard to navigate the interface.

fix https://github.com/Lundalogik/lime-elements/issues/1858

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
