### PR TITLE
docs(select): add missing type import in example

### DIFF
--- a/src/components/select/examples/select-secondary-text.tsx
+++ b/src/components/select/examples/select-secondary-text.tsx
@@ -1,4 +1,4 @@
-import { Option } from '@limetech/lime-elements';
+import { LimelSelectCustomEvent, Option } from '@limetech/lime-elements';
 import { Component, h, State } from '@stencil/core';
 /**
  * Select with secondary text for options


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
