### PR TITLE
fix(markdown): better heading styles

### DIFF
--- a/src/components/markdown/examples/markdown-headings.tsx
+++ b/src/components/markdown/examples/markdown-headings.tsx
@@ -1,19 +1,19 @@
 import { Component, h } from '@stencil/core';
 
 const markdown = `
-# H1
-## H2
-### H3
-#### H4
-##### H5
-###### H6
+# Headline 1
+## Headline 2
+### Headline 3
+#### Headline 4
+##### Headline 5
+###### Headline 6
 
 Alternatively, H1 and H2 can be typed underline-ish style like this:
 
-Alt-H1
+Alternative H1
 ===
 
-Alt-H2
+Alternative H2
 ---
 `;
 

--- a/src/components/markdown/partial-styles/_body-text.scss
+++ b/src/components/markdown/partial-styles/_body-text.scss
@@ -9,12 +9,15 @@
 }
 
 p,
-a,
 li {
     font-size: 0.875rem;
     word-break: break-word;
     hyphens: auto;
     -webkit-hyphens: auto;
+}
+
+a {
+    word-break: break-all;
 }
 
 p {

--- a/src/components/markdown/partial-styles/_body-text.scss
+++ b/src/components/markdown/partial-styles/_body-text.scss
@@ -12,6 +12,9 @@ p,
 a,
 li {
     font-size: 0.875rem;
+    word-break: break-word;
+    hyphens: auto;
+    -webkit-hyphens: auto;
 }
 
 p {

--- a/src/components/markdown/partial-styles/_headings.scss
+++ b/src/components/markdown/partial-styles/_headings.scss
@@ -1,39 +1,42 @@
-@use '../../../style/functions.scss';
-
 h1 {
-    font-size: functions.pxToRem(30);
-    line-height: functions.pxToRem(30);
-    margin-top: functions.pxToRem(24);
-    margin-bottom: functions.pxToRem(12);
-    letter-spacing: functions.pxToRem(-1);
+    font-size: 1.5rem;
 }
+
 h2 {
-    font-size: functions.pxToRem(26);
-    line-height: functions.pxToRem(26);
-    margin-top: functions.pxToRem(20);
-    margin-bottom: functions.pxToRem(12);
+    font-size: 1.25rem;
 }
+
 h3 {
-    font-size: functions.pxToRem(22);
-    line-height: functions.pxToRem(22);
-    margin-top: functions.pxToRem(16);
-    margin-bottom: functions.pxToRem(12);
+    font-size: 1.125rem;
 }
+
 h4 {
-    font-size: functions.pxToRem(20);
-    line-height: functions.pxToRem(20);
-    margin-top: functions.pxToRem(12);
-    margin-bottom: functions.pxToRem(8);
+    font-size: 1rem;
 }
+
 h5 {
-    font-size: functions.pxToRem(18);
-    line-height: functions.pxToRem(18);
-    margin-top: functions.pxToRem(12);
-    margin-bottom: functions.pxToRem(8);
+    font-size: 0.875rem;
 }
+
 h6 {
-    font-size: functions.pxToRem(16);
-    line-height: functions.pxToRem(16);
-    margin-top: functions.pxToRem(12);
-    margin-bottom: functions.pxToRem(8);
+    font-size: 0.75rem;
+}
+
+h1,
+h2 {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    letter-spacing: -0.03125rem; // 0.5px
+}
+
+h3,
+h4 {
+    margin-top: 0.75rem;
+    margin-bottom: 0.25rem;
+}
+
+h5,
+h6 {
+    margin-top: 0.5rem;
+    margin-bottom: 0.125rem;
 }

--- a/src/components/markdown/partial-styles/_headings.scss
+++ b/src/components/markdown/partial-styles/_headings.scss
@@ -50,6 +50,10 @@ h3,
 h4,
 h5,
 h6 {
+    word-break: break-word;
+    hyphens: auto;
+    -webkit-hyphens: auto;
+
     :not([contenteditable='true']) & {
         text-wrap: balance;
     }

--- a/src/components/markdown/partial-styles/_headings.scss
+++ b/src/components/markdown/partial-styles/_headings.scss
@@ -43,3 +43,18 @@ h6 {
     margin-bottom: 0.125rem;
     font-weight: 600;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    :not([contenteditable='true']) & {
+        text-wrap: balance;
+    }
+
+    [contenteditable='true'] & {
+        text-wrap: initial;
+    }
+}

--- a/src/components/markdown/partial-styles/_headings.scss
+++ b/src/components/markdown/partial-styles/_headings.scss
@@ -27,16 +27,19 @@ h2 {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     letter-spacing: -0.03125rem; // 0.5px
+    font-weight: 500;
 }
 
 h3,
 h4 {
     margin-top: 0.75rem;
     margin-bottom: 0.25rem;
+    font-weight: 600;
 }
 
 h5,
 h6 {
     margin-top: 0.5rem;
     margin-bottom: 0.125rem;
+    font-weight: 600;
 }


### PR DESCRIPTION
These styles are used when markdown is renderer.
Previously headings were being rendered too large.
The result was not intended for rendering a web-page or
a presentation, where large headings improves
 the presentation.
It was rather small blocks of text, for instance
representing or rendering content of "email",
or an "article".

fix https://github.com/Lundalogik/crm-feature/issues/4033

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
