### PR TITLE
fix(text-editor): ensure menubar items won't grow tall

### DIFF
--- a/src/components/text-editor/partial-styles/_prosemirror-menu.scss
+++ b/src/components/text-editor/partial-styles/_prosemirror-menu.scss
@@ -44,7 +44,7 @@ div#editor {
     white-space: nowrap;
     line-height: 1;
 
-    min-height: 1.5rem;
+    height: 1.5rem;
     min-width: 1.5rem;
     border-radius: 0.25rem;
     color: rgb(var(--contrast-1100));


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/4042

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
