### PR TITLE
feat(select): enable separators in dropdown list items

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -562,7 +562,7 @@ export namespace Components {
         "invalid": boolean;
         "label": string;
         "multiple": boolean;
-        "options": Option_2[];
+        "options": Array<Option_2 | ListSeparator>;
         "readonly": boolean;
         "required": boolean;
         "value": Option_2 | Option_2[];
@@ -1485,7 +1485,7 @@ namespace JSX_2 {
         "label"?: string;
         "multiple"?: boolean;
         "onChange"?: (event: LimelSelectCustomEvent<Option_2 | Option_2[]>) => void;
-        "options"?: Option_2[];
+        "options"?: Array<Option_2 | ListSeparator>;
         "readonly"?: boolean;
         "required"?: boolean;
         "value"?: Option_2 | Option_2[];

--- a/src/components/select/examples/select-separators.tsx
+++ b/src/components/select/examples/select-separators.tsx
@@ -1,0 +1,246 @@
+import { Option, ListSeparator } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+/**
+ * Select with separators between options
+ *
+ * Separators are simple yet powerful design elements that can be
+ * employed in lists of items. They offer significant usability advantages
+ * by providing valuable visual cues that aid users in perceiving
+ * and navigating through lists. Read more about advantages of using
+ * separators in the
+ * [List component's documentations](/#/component/limel-list/).
+ */
+@Component({
+    shadow: true,
+    tag: 'limel-example-select-with-separators',
+})
+export class SelectSeparatorsExample {
+    @State()
+    public value: Option;
+
+    private options: Array<Option | ListSeparator> = [
+        { separator: true, text: 'Alaskan / Hawaiian' },
+        {
+            text: 'Alaska',
+            value: 'AK',
+        },
+        {
+            text: 'Hawaii',
+            value: 'HI',
+        },
+        { separator: true, text: 'Pacific' },
+        {
+            text: 'California',
+            value: 'CA',
+        },
+        {
+            text: 'Nevada',
+            value: 'NV',
+        },
+        {
+            text: 'Oregon',
+            value: 'OR',
+        },
+        {
+            text: 'Washington',
+            value: 'WA',
+        },
+        { separator: true, text: 'Mountain' },
+        {
+            text: 'Arizona',
+            value: 'AZ',
+        },
+        {
+            text: 'Colorado',
+            value: 'CO',
+        },
+        {
+            text: 'Idaho',
+            value: 'ID',
+        },
+        {
+            text: 'Montana',
+            value: 'MT',
+        },
+        {
+            text: 'Nebraska',
+            value: 'NE',
+        },
+        {
+            text: 'North Dakota',
+            value: 'ND',
+        },
+        {
+            text: 'New Mexico',
+            value: 'NM',
+        },
+        {
+            text: 'Utah',
+            value: 'UT',
+        },
+        {
+            text: 'Wyoming',
+            value: 'WY',
+        },
+        { separator: true, text: 'Central Time Zone' },
+        {
+            text: 'Alabama',
+            value: 'AL',
+        },
+        {
+            text: 'Arkansas',
+            value: 'AR',
+        },
+        {
+            text: 'Illinois',
+            value: 'IL',
+        },
+        {
+            text: 'Iowa',
+            value: 'IA',
+        },
+        {
+            text: 'Kansas',
+            value: 'KS',
+        },
+        {
+            text: 'Louisiana',
+            value: 'LA',
+        },
+        {
+            text: 'Minnesota',
+            value: 'MN',
+        },
+        {
+            text: 'Mississippi',
+            value: 'MS',
+        },
+        {
+            text: 'Missouri',
+            value: 'MO',
+        },
+        {
+            text: 'Oklahoma',
+            value: 'OK',
+        },
+        {
+            text: 'Texas',
+            value: 'TX',
+        },
+        {
+            text: 'Wisconsin',
+            value: 'WI',
+        },
+        { separator: true, text: 'Eastern Time Zone' },
+        {
+            text: 'Connecticut',
+            value: 'CT',
+        },
+        {
+            text: 'Delaware',
+            value: 'DE',
+        },
+        {
+            text: 'Florida',
+            value: 'FL',
+        },
+        {
+            text: 'Georgia',
+            value: 'GA',
+        },
+        {
+            text: 'Indiana',
+            value: 'IN',
+        },
+        {
+            text: 'Kentucky',
+            value: 'KY',
+        },
+        {
+            text: 'Maine',
+            value: 'ME',
+        },
+        {
+            text: 'Maryland',
+            value: 'MD',
+        },
+        {
+            text: 'Massachusetts',
+            value: 'MA',
+        },
+        {
+            text: 'Michigan',
+            value: 'MI',
+        },
+        {
+            text: 'New Hampshire',
+            value: 'NH',
+        },
+        {
+            text: 'New Jersey',
+            value: 'NJ',
+        },
+        {
+            text: 'New York',
+            value: 'NY',
+        },
+        {
+            text: 'North Carolina',
+            value: 'NC',
+        },
+        {
+            text: 'Ohio',
+            value: 'OH',
+        },
+        {
+            text: 'Pennsylvania',
+            value: 'PA',
+        },
+        {
+            text: 'Rhode Island',
+            value: 'RI',
+        },
+        {
+            text: 'South Carolina',
+            value: 'SC',
+        },
+        {
+            text: 'Tennessee',
+            value: 'TN',
+        },
+        {
+            text: 'Vermont',
+            value: 'VT',
+        },
+        {
+            text: 'Virginia',
+            value: 'VA',
+        },
+        {
+            text: 'West Virginia',
+            value: 'WV',
+        },
+        {
+            text: 'Washington D.C.',
+            value: 'DC',
+        },
+    ];
+
+    public render() {
+        return (
+            <section>
+                <limel-select
+                    label="Timezone"
+                    value={this.value}
+                    options={this.options}
+                    onChange={this.handleChange}
+                />
+                <limel-example-value value={this.value} />
+            </section>
+        );
+    }
+
+    private handleChange = (event) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from '../list/list-item.types';
+import { ListItem, ListSeparator } from '../list/list-item.types';
 import { Option } from '../select/option.types';
 import { MDCFloatingLabel } from '@material/floating-label';
 import { MDCSelectHelperText } from '@material/select/helper-text';
@@ -26,6 +26,7 @@ import { SelectTemplate, triggerIconColorWarning } from './select.template';
 /**
  * @exampleComponent limel-example-select
  * @exampleComponent limel-example-select-with-icons
+ * @exampleComponent limel-example-select-with-separators
  * @exampleComponent limel-example-select-with-secondary-text
  * @exampleComponent limel-example-select-multiple
  * @exampleComponent limel-example-select-with-empty-option
@@ -94,7 +95,7 @@ export class Select {
      * List of options.
      */
     @Prop()
-    public options: Option[] = [];
+    public options: Array<Option | ListSeparator> = [];
 
     /**
      * Set to `true` to allow multiple values to be selected.
@@ -148,7 +149,7 @@ export class Select {
 
     public componentDidLoad() {
         this.initialize();
-        triggerIconColorWarning(this.options);
+        triggerIconColorWarning(this.getOptionsExcludingSeparators());
     }
 
     private initialize() {
@@ -280,7 +281,7 @@ export class Select {
     private openMenu() {
         if (this.emitFirstChangeEvent()) {
             this.hasChanged = true;
-            this.change.emit(this.options[0]);
+            this.change.emit(this.getOptionsExcludingSeparators()[0]);
         }
 
         this.menuOpen = true;
@@ -317,7 +318,7 @@ export class Select {
                 return !!optionElement.selected;
             })
             .map((optionElement: HTMLOptionElement) => {
-                return this.options.find(
+                return this.getOptionsExcludingSeparators().find(
                     (o) => o.value === optionElement.value,
                 );
             });
@@ -330,5 +331,11 @@ export class Select {
 
         this.change.emit(options[0]);
         this.menuOpen = false;
+    }
+
+    private getOptionsExcludingSeparators(): Option[] {
+        return this.options.filter(
+            (option): option is Option => !('separator' in option),
+        );
     }
 }


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/4054

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
