### PR TITLE
Export helper functions `getIconForFile`, `getIconFillColorForFile`, and `getIconBackgroundColorForFile`

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -820,6 +820,15 @@ export type FormSubKeySchema<TObj> = Partial<{
 }>;
 
 // @public
+export function getIconBackgroundColorForFile(extension: string): string;
+
+// @public
+export function getIconFillColorForFile(extension: string): string;
+
+// @public
+export function getIconForFile(extension: string): string;
+
+// @public
 export interface GridLayoutOptions extends FormLayoutOptions<FormLayoutType | `${FormLayoutType}`> {
     colSpan?: 1 | 2 | 3 | 4 | 5 | 'all';
     columns?: 1 | 2 | 3 | 4 | 5;

--- a/src/components/file/icon-background-colors.ts
+++ b/src/components/file/icon-background-colors.ts
@@ -127,6 +127,17 @@ const filetypeBackgroundColorTable: Record<string, string> = {
     dbf: DATA_ICON_BACKGROUND_COLOR,
 };
 
+/**
+ * Takes a file extension as argument and returns the background color to use.
+ * While some file types have a fairly universally accepted icon color, like
+ * blue for Word documents, others are more arbitrary. This function provides
+ * a convention that we use at Lime. If you are using this code in your own
+ * project, you may or may not find this helper useful.
+ *
+ * @param extension - The file extension (without the dot).
+ * @returns The color to use for the icon.
+ * @public
+ */
 export function getIconBackgroundColorForFile(extension: string): string {
     return (
         filetypeBackgroundColorTable[extension.toLowerCase()] ||

--- a/src/components/file/icon-fill-colors.ts
+++ b/src/components/file/icon-fill-colors.ts
@@ -123,6 +123,17 @@ const filetypeFillColorTable: Record<string, string> = {
     dbf: DATA_ICON_FILL_COLOR,
 };
 
+/**
+ * Takes a file extension as argument and returns the fill color to use.
+ * While some file types have a fairly universally accepted icon color, like
+ * blue for Word documents, others are more arbitrary. This function provides
+ * a convention that we use at Lime. If you are using this code in your own
+ * project, you may or may not find this helper useful.
+ *
+ * @param extension - The file extension (without the dot).
+ * @returns The color to use for the icon.
+ * @public
+ */
 export function getIconFillColorForFile(extension: string): string {
     return (
         filetypeFillColorTable[extension.toLowerCase()] ||

--- a/src/components/file/icons.ts
+++ b/src/components/file/icons.ts
@@ -124,6 +124,15 @@ const filetypeIconTable: Record<string, string> = {
     dbf: DATA_ICON,
 };
 
+/**
+ * Takes a file extension as argument and returns the corresponding icon name.
+ * Uses the names from the private icon package `lime-icons8`. If you are using
+ * a different icon package, this functions is probably not useful for you.
+ *
+ * @param extension - The file extension (without the dot).
+ * @returns The name of the icon to use.
+ * @public
+ */
 export function getIconForFile(extension: string): string {
     return filetypeIconTable[extension.toLowerCase()] || DEFAULT_ICON;
 }

--- a/src/components/file/index.ts
+++ b/src/components/file/index.ts
@@ -1,0 +1,3 @@
+export * from './icon-background-colors';
+export * from './icon-fill-colors';
+export * from './icons';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -9,7 +9,6 @@ export * from './components/collapsible-section/action';
 export * from './components/date-picker/date.types';
 export * from './components/dialog/dialog.types';
 export * from './components/dock/dock.types';
-export * from './global/shared-types/file.types';
 export * from './components/flex-container/flex-container.types';
 export {
     EventEmitter,
@@ -48,5 +47,6 @@ export * from './components/select/option.types';
 export * from './components/spinner/spinner.types';
 export * from './components/tab-panel/tab-panel.types';
 export * from './components/table/table.types';
-export * from './global/shared-types/separator.types';
+export * from './global/shared-types/file.types';
 export * from './global/shared-types/icon.types';
+export * from './global/shared-types/separator.types';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -9,6 +9,7 @@ export * from './components/collapsible-section/action';
 export * from './components/date-picker/date.types';
 export * from './components/dialog/dialog.types';
 export * from './components/dock/dock.types';
+export * from './components/file';
 export * from './components/flex-container/flex-container.types';
 export {
     EventEmitter,


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
