### PR TITLE
feat(markdown): allow `height` and `width` in inline `style` attribute

### DIFF
--- a/src/components/markdown/allowed-css-properties.ts
+++ b/src/components/markdown/allowed-css-properties.ts
@@ -3,10 +3,12 @@ export const allowedCssProperties = [
     'color',
     'font-style',
     'font-weight',
+    'height',
     'text-decoration-color',
     'text-decoration-line',
     'text-decoration-skip-ink',
     'text-decoration-style',
     'text-decoration-thickness',
     'text-decoration',
+    'width',
 ];

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -42,7 +42,7 @@ export async function markdownToHTML(
             // Allow the `style` attribute on all elements
             attributes: {
                 ...defaultSchema.attributes,
-                '*': ['style'],
+                '*': ['height', 'style', 'width'],
             },
         })
         .use(() => {


### PR DESCRIPTION
fix: Lundalogik/limepkg-email#695

This can be tested by adding the following snippet to the composite example for `limel-markdown` in the docs for this PR and compare to the result when using the docs for the latest release.

```html
<img
    border="0"
    style="width: 0.3229in; height: 0.3229in;"
    src="https://lundalogik.github.io/lime-elements/versions/latest/favicon.svg"
    alt="signature_2123812728"
/>
<br>
<br>
<img
    border="0"
    width="31"
    height="31"
    src="https://lundalogik.github.io/lime-elements/versions/latest/favicon.svg"
    alt="signature_2123812728"
/>
```

The result should look like this:

<img width="533" alt="Both images in the screenshot are approximately 31 by 31 pixels" src="https://github.com/Lundalogik/lime-elements/assets/154725/def5987c-14e8-4011-847b-39462d36b0ed">

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
