### PR TITLE
fix(action-bar): highlight the floating action bar

### DIFF
--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -48,10 +48,11 @@
 
 :host(limel-action-bar.is-floating) {
     --action-bar-border-radius: 100vw;
+    border: 1px solid rgb(var(--contrast-400));
 
     padding-right: 0.125rem;
     padding-left: 0.125rem;
 
     max-width: calc(100% - 2rem);
-    box-shadow: var(--shadow-depth-16);
+    box-shadow: var(--shadow-depth-16), var(--shadow-depth-8);
 }


### PR DESCRIPTION

## Review:
before:
![Screenshot 2024-04-22 at 16 48 54](https://github.com/Lundalogik/lime-elements/assets/50618208/4a550e72-8de8-4f8d-bf2a-94150ad59f42)


after:
![Screenshot 2024-04-22 at 16 47 15](https://github.com/Lundalogik/lime-elements/assets/50618208/d171dce4-f141-454b-9a1a-82c6b04b4dbd)

- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
