### PR TITLE
feat(text-editor): implement `readonly` prop

### DIFF
--- a/src/components/text-editor/examples/text-editor-as-form-component.tsx
+++ b/src/components/text-editor/examples/text-editor-as-form-component.tsx
@@ -1,20 +1,28 @@
 import { Component, h, State } from '@stencil/core';
 import { FormComponentFormData, schema } from './text-editor-form-data';
 /**
- * Basic example
+ * Using the text editor as a form component
  *
- * Here we have a simple form that uses the `limel-text-editor` component
+ * Here we have a simple form that uses the `limel-text-editor` component,
+ * instead of a regular text input field.
+ *
+ * :::note
+ * This allows the user to write rich text, with markdown support, in the form.
+ * But keep in mind that the value will be saved as a markdown string,
+ * and can also contain HTML tags, depending on what the users input
+ * in the filed.
+ * :::
  * @sourceFile text-editor-form-data.ts
  */
 @Component({
-    tag: 'limel-example-text-editor-basic',
+    tag: 'limel-example-text-editor-as-form-component',
     shadow: true,
 })
-export class TextEditorBasicExample {
+export class TextEditorAsFormComponentExample {
     @State()
     private formData: FormComponentFormData = {
-        name: 'Ali',
-        value: '<p>I am the greatest</p>',
+        name: 'Muhammad Ali',
+        value: '<p>I am the <b>greatest</b>.</p>',
     };
 
     public render() {

--- a/src/components/text-editor/examples/text-editor-basic.tsx
+++ b/src/components/text-editor/examples/text-editor-basic.tsx
@@ -1,0 +1,26 @@
+import { Component, h, State } from '@stencil/core';
+/**
+ * Basic example
+ */
+@Component({
+    tag: 'limel-example-text-editor-basic',
+    shadow: true,
+})
+export class TextEditorBasicExample {
+    @State()
+    private value: string;
+
+    public render() {
+        return [
+            <limel-text-editor
+                value={this.value}
+                onChange={this.handleChange}
+            />,
+            <limel-example-value value={this.value} />,
+        ];
+    }
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -1,0 +1,42 @@
+import { Component, h, State } from '@stencil/core';
+/**
+ * Composite example
+ */
+@Component({
+    tag: 'limel-example-text-editor-composite',
+    shadow: true,
+})
+export class TextEditorCompositeExample {
+    @State()
+    private value: string = 'Hello, world!';
+
+    @State()
+    private readonly = false;
+
+    public render() {
+        return [
+            <limel-text-editor
+                value={this.value}
+                onChange={this.handleChange}
+                readonly={this.readonly}
+            />,
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.readonly}
+                    label="Readonly"
+                    onChange={this.setReadonly}
+                />
+            </limel-example-controls>,
+            <limel-example-value value={this.value} />,
+        ];
+    }
+
+    private setReadonly = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.readonly = event.detail;
+    };
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/text-editor/prosemirror-adapter/partial-styles/_prosemirror-menu.scss
+++ b/src/components/text-editor/prosemirror-adapter/partial-styles/_prosemirror-menu.scss
@@ -15,6 +15,14 @@ div#editor {
             box-shadow: 0 0.25rem 0.5rem -0.5rem rgb(var(--color-black), 0.8);
         }
     }
+
+    .ProseMirror-menubar-spacer {
+        // This is a div that they add to keep the menubar in place.
+        // as they are using `position: fixed`.
+        // However, this causes layout shift as the user scrolls,
+        // due to our usage of `position: sticky`.
+        display: none;
+    }
 }
 
 .ProseMirror-menubar {

--- a/src/components/text-editor/prosemirror-adapter/partial-styles/_prosemirror.scss
+++ b/src/components/text-editor/prosemirror-adapter/partial-styles/_prosemirror.scss
@@ -10,7 +10,7 @@
     border-bottom-left-radius: 0.5rem;
     border-bottom-right-radius: 0.5rem;
 
-    padding: 0.5rem 1rem;
+    padding: var(--limel-text-editor-padding);
     background-color: rgb(var(--contrast-100));
 
     [draggable][contenteditable='false'] {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -1,0 +1,8 @@
+:host(limel-text-editor) {
+    --limel-text-editor-padding: 0.5rem 1rem;
+}
+
+limel-markdown {
+    display: block;
+    padding: var(--limel-text-editor-padding);
+}

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -9,7 +9,7 @@ import { FormComponent } from '../form/form.types';
  * Naturally, you can use standard keyboard hotkeys such as <kbd>Ctrl</kbd> + <kbd>B</kbd>
  * to toggle bold text, <kbd>Ctrl</kbd> + <kbd>I</kbd> to toggle italic text, and so on.
  *
- * @exampleComponent limel-example-text-editor-basic
+ * @exampleComponent limel-example-text-editor-as-form-component
  * @beta
  * @private
  */

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -9,6 +9,7 @@ import { FormComponent } from '../form/form.types';
  * Naturally, you can use standard keyboard hotkeys such as <kbd>Ctrl</kbd> + <kbd>B</kbd>
  * to toggle bold text, <kbd>Ctrl</kbd> + <kbd>I</kbd> to toggle italic text, and so on.
  *
+ * @exampleComponent limel-example-text-editor-basic
  * @exampleComponent limel-example-text-editor-as-form-component
  * @beta
  * @private

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -11,6 +11,7 @@ import { FormComponent } from '../form/form.types';
  *
  * @exampleComponent limel-example-text-editor-basic
  * @exampleComponent limel-example-text-editor-as-form-component
+ * @exampleComponent limel-example-text-editor-composite
  * @beta
  * @private
  */
@@ -80,6 +81,14 @@ export class TextEditor implements FormComponent<string> {
     public change: EventEmitter<string>;
 
     public render() {
+        return this.renderEditor();
+    }
+
+    private renderEditor() {
+        if (this.readonly) {
+            return <limel-markdown value={this.value} />;
+        }
+
         return (
             <limel-prosemirror-adapter
                 onChange={this.handleChange}


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
