### PR TITLE
fix(text-editor): render an empty value for `readonly`

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -1,7 +1,13 @@
+@use '../../style/internal/shared_input-select-picker';
+
+@include shared_input-select-picker.lime-empty-value-for-readonly;
+@include shared_input-select-picker.lime-looks-like-input-value;
+
 :host(limel-text-editor) {
     display: flex;
     flex-direction: column;
     width: 100%;
+    position: relative;
 }
 
 fieldset {

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -90,6 +90,14 @@ export class TextEditor implements FormComponent<string> {
     }
 
     private renderEditor() {
+        if (this.readonly && !this.value) {
+            return (
+                <span class="lime-empty-value-for-readonly lime-looks-like-input-value">
+                    –
+                </span>
+            );
+        }
+
         if (this.readonly) {
             return <limel-markdown value={this.value} />;
         }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/4079

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
