### PR TITLE
feat(text editor): Add custom menu

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -1,0 +1,93 @@
+import { toggleMark, setBlockType, wrapIn } from 'prosemirror-commands';
+import { Schema, MarkType } from 'prosemirror-model';
+import { wrapInList } from 'prosemirror-schema-list';
+
+export class MenuCommandFactory {
+    private schema: Schema;
+
+    constructor(schema: Schema) {
+        this.schema = schema;
+    }
+
+    private markNames = {
+        bold: 'strong',
+        italic: 'em',
+        underline: 'underline',
+        blockquote: 'blockquote',
+        headerlevel1: 'headerlevel1',
+        headerlevel2: 'headerlevel2',
+        headerlevel3: 'headerlevel3',
+        addorremovelink: 'link',
+        numberedlist: 'ordered_list',
+        list: 'bullet_list',
+    };
+
+    createCommand(mark: string) {
+        if (this.markNames[mark]) {
+            mark = this.markNames[mark];
+        }
+
+        switch (mark) {
+            case 'strong':
+            case 'em':
+            case 'underline':
+                return this.createToggleMarkCommand(mark);
+            case 'paragraph':
+                return this.createSetNodeTypeCommand(mark);
+            case 'headerlevel1':
+            case 'headerlevel2':
+            case 'headerlevel3':
+                return this.createSetNodeTypeCommand(
+                    'heading',
+                    parseInt(mark[mark.length - 1], 10),
+                );
+            case 'blockquote':
+                return this.createWrapInCommand(mark);
+            case 'ordered_list':
+            case 'bullet_list':
+                return this.createListCommand(mark);
+            default:
+                throw new Error(`The Mark "${mark}" is not supported`);
+        }
+    }
+
+    private createToggleMarkCommand(markName: string) {
+        const markType: MarkType | undefined = this.schema.marks[markName];
+        if (!markType) {
+            throw new Error(`Mark "${markName}" not found in schema`);
+        }
+
+        return toggleMark(markType);
+    }
+
+    private createSetNodeTypeCommand(nodeType: string, level?: number) {
+        const type = this.schema.nodes[nodeType];
+        if (!type) {
+            throw new Error(`Node type "${nodeType}" not found in schema`);
+        }
+
+        if (nodeType === 'heading' && level) {
+            return setBlockType(type, { level: level });
+        } else {
+            return setBlockType(type);
+        }
+    }
+
+    private createWrapInCommand(nodeType: string) {
+        const type = this.schema.nodes[nodeType];
+        if (!type) {
+            throw new Error(`Node type "${nodeType}" not found in schema`);
+        }
+
+        return wrapIn(type);
+    }
+
+    private createListCommand(listType: string) {
+        const type = this.schema.nodes[listType];
+        if (!type) {
+            throw new Error(`List type "${listType}" not found in schema`);
+        }
+
+        return wrapInList(type);
+    }
+}

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
@@ -1,0 +1,55 @@
+import { ActionBarItem } from 'src/components/action-bar/action-bar.types';
+import { ListSeparator } from 'src/components/list/list-item.types';
+
+export const textEditorMenuItems: Array<ActionBarItem | ListSeparator> = [
+    {
+        text: 'Bold',
+        commandText: '⌘ B',
+        icon: 'bold',
+        iconOnly: true,
+    },
+    {
+        text: 'Italic',
+        commandText: '⌘ I',
+        icon: 'italic',
+        iconOnly: true,
+    },
+    {
+        text: 'Add or remove link',
+        commandText: '⌘ shift U',
+        icon: 'link',
+        iconOnly: true,
+    },
+    { separator: true },
+    {
+        text: 'Header Level 1',
+        icon: 'header_1',
+        iconOnly: true,
+    },
+    {
+        text: 'Header Level 2',
+        icon: 'header_2',
+        iconOnly: true,
+    },
+    {
+        text: 'Header Level 3',
+        icon: 'header_3',
+        iconOnly: true,
+    },
+    { separator: true },
+    {
+        text: 'List',
+        icon: 'list',
+        iconOnly: true,
+    },
+    {
+        text: 'Numbered list',
+        icon: 'numbered_list',
+        iconOnly: true,
+    },
+    {
+        text: 'Blockquote',
+        icon: 'quote_right',
+        iconOnly: true,
+    },
+];

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.spec.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.spec.tsx
@@ -18,8 +18,5 @@ describe('prosemirror-adapter', () => {
 
     it('should render the component', () => {
         expect(editor).toBeTruthy();
-        expect(
-            editor.querySelector('.ProseMirror-menubar-wrapper'),
-        ).toBeTruthy();
     });
 });

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -13,9 +13,10 @@ import { Schema, DOMParser } from 'prosemirror-model';
 import { schema } from 'prosemirror-schema-basic';
 import { addListNodes } from 'prosemirror-schema-list';
 import { exampleSetup } from 'prosemirror-example-setup';
-import { MenuElement, MenuItem } from 'prosemirror-menu';
-import { buildFullMenu } from './menu/full-menu';
-import { getFilteredMenu } from './menu/menu-filter';
+import { ActionBarItem } from 'src/components/action-bar/action-bar.types';
+import { ListSeparator } from 'src/components/list/list-item.types';
+import { MenuCommandFactory } from './menu/menu-commands';
+import { textEditorMenuItems } from './menu/menu-items';
 
 /**
  * The ProseMirror adapter offers a rich text editing experience with markdown support.
@@ -44,27 +45,38 @@ export class ProsemirrorAdapter {
     @State()
     private view: EditorView;
 
+    @State()
+    private actionBarItems: Array<ActionBarItem | ListSeparator> = [];
+
+    private menuCommandFactory: MenuCommandFactory;
+
     /**
      * Dispatched when a change is made to the editor
      */
     @Event()
     private change: EventEmitter<string>;
 
-    public componentWillLoad() {}
-
     public render() {
-        return <div id="editor" />;
+        return (
+            <div>
+                <limel-action-bar
+                    accessibleLabel="Toolbar"
+                    actions={this.actionBarItems}
+                    layout="fullWidth"
+                    onItemSelected={this.handleActionBarItem}
+                />
+                <div id="editor" />
+            </div>
+        );
     }
 
     public componentDidLoad() {
+        this.actionBarItems = textEditorMenuItems;
+
         const mySchema = new Schema({
             nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
             marks: schema.spec.marks,
         });
-
-        const menu: MenuElement[][] = buildFullMenu(mySchema)
-            .map((items) => getFilteredMenu(items, undefined))
-            .filter((items) => items.length);
 
         this.view = new EditorView(
             this.host.shadowRoot.querySelector('#editor'),
@@ -75,7 +87,7 @@ export class ProsemirrorAdapter {
                     ),
                     plugins: exampleSetup({
                         schema: mySchema,
-                        menuContent: menu as MenuItem[][],
+                        menuBar: false,
                     }),
                 }),
                 dispatchTransaction: (transaction) => {
@@ -86,6 +98,8 @@ export class ProsemirrorAdapter {
                 },
             },
         );
+
+        this.menuCommandFactory = new MenuCommandFactory(mySchema);
 
         if (this.value) {
             this.view.dom.innerHTML = this.value;
@@ -99,4 +113,35 @@ export class ProsemirrorAdapter {
             return this.view.dom.innerHTML;
         }
     };
+
+    private handleActionBarItem = (event: CustomEvent<ActionBarItem>) => {
+        event.preventDefault();
+
+        const { text } = event.detail;
+        const mark = text.replace(/\s/g, '').toLowerCase();
+        try {
+            const command = this.menuCommandFactory.createCommand(mark);
+            this.executeCommand(command);
+        } catch (error) {
+            throw new Error(`Error executing command: ${error}`);
+        }
+    };
+
+    private executeCommand(command) {
+        const { state } = this.view;
+        const selection = state.selection;
+
+        let transaction = state.tr;
+
+        if (!selection.empty) {
+            transaction.setSelection(selection);
+        }
+
+        command(state, (tr) => {
+            transaction = tr;
+        });
+        this.view.dispatch(transaction);
+
+        this.view.focus();
+    }
 }


### PR DESCRIPTION
With this PR we use our action bar to create the menu items.

Commands for the various actions tied to those menu items are created and dispatched to the Editor via transactions. 

This decouples us from the built-in limitations of Prose-Mirror's menu enabling us to modify or add to the menu when we want.

A good example of a use-case for this would be add-ons wanting to add functionality to allow the user to pre-populate the text editor with a pre-built template. 

We can provide the foundation to implement that type of functionality from the consumer without worrying about navigating Prose-mirror restrictions. 

Further iteration on the action bar will be taken to distinguish menu items that will be used for prose-mirror(editor) functions but that won't be required for the intents and purposes of this PR.

Fixes https://github.com/Lundalogik/crm-feature/issues/4077