### PR TITLE
fix(markdown): don't use height as a property to render an image

### DIFF
--- a/src/components/markdown/allowed-css-properties.ts
+++ b/src/components/markdown/allowed-css-properties.ts
@@ -3,7 +3,6 @@ export const allowedCssProperties = [
     'color',
     'font-style',
     'font-weight',
-    'height',
     'text-decoration-color',
     'text-decoration-line',
     'text-decoration-skip-ink',

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -42,7 +42,7 @@ export async function markdownToHTML(
             // Allow the `style` attribute on all elements
             attributes: {
                 ...defaultSchema.attributes,
-                '*': ['height', 'style', 'width'],
+                '*': ['style', 'width'],
             },
         })
         .use(() => {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2938
## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
