### PR TITLE
test(table): prevent console.warn logging expected warning to test output

### DIFF
--- a/src/components/table/columns.spec.ts
+++ b/src/components/table/columns.spec.ts
@@ -222,8 +222,18 @@ describe('createCustomComponent', () => {
                 name: 'not-existing-component',
             };
 
+            // Mock console.warn to avoid the warning message in the test output
+            const consoleWarnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+
             const definition = factory.create(column);
             expect(definition.formatter).toBe(formatCell);
+
+            // Fail if there are unexpected warnings
+            expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+
+            jest.restoreAllMocks();
         });
 
         it('uses the default formatter if the custom component misses a name prop', () => {


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
