### PR TITLE
fix(list): avoid error when `items` is undefined

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -277,7 +277,7 @@ export class List {
     };
 
     private triggerIconColorWarning() {
-        if (this.items.some((item) => 'iconColor' in item)) {
+        if (this.items?.some((item) => 'iconColor' in item)) {
             /* eslint-disable-next-line no-console */
             console.warn(
                 "The `iconColor` prop is deprecated now! Use the new `Icon` interface and instead of `iconColor: 'color-name'` write `icon {name: 'icon-name', color: 'color-name'}`.",


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
