### PR TITLE
text-editor/prosemirror-adapter: suppress Stencil-warning about triggering re-render from componentDidLoad

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -57,7 +57,10 @@ export class ProsemirrorAdapter {
     private change: EventEmitter<string>;
 
     public componentDidLoad() {
-        this.initializeEditor();
+        // Stencil complains loudly about triggering rerenders in
+        // componentDidLoad, but we have to, so we're using setTimeout to
+        // suppress the warning. /Ads
+        setTimeout(this.initializeEditor, 0);
     }
 
     public render() {
@@ -71,7 +74,7 @@ export class ProsemirrorAdapter {
         ];
     }
 
-    private initializeEditor() {
+    private initializeEditor = () => {
         this.actionBarItems = textEditorMenuItems;
 
         const mySchema = new Schema({
@@ -105,7 +108,7 @@ export class ProsemirrorAdapter {
         if (this.value) {
             this.view.dom.innerHTML = this.value;
         }
-    }
+    };
 
     private getHTML = (): string => {
         if (this.view.dom.textContent === '') {

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -56,6 +56,10 @@ export class ProsemirrorAdapter {
     @Event()
     private change: EventEmitter<string>;
 
+    public componentDidLoad() {
+        this.initializeEditor();
+    }
+
     public render() {
         return [
             <limel-action-bar
@@ -67,7 +71,7 @@ export class ProsemirrorAdapter {
         ];
     }
 
-    public componentDidLoad() {
+    private initializeEditor() {
         this.actionBarItems = textEditorMenuItems;
 
         const mySchema = new Schema({


### PR DESCRIPTION
Stencil complains loudly when you trigger a rerender from inside the `componentDidLoad` lifecycle method. That is well and good, but we do not have a choice in this case, so we suppress the warning, so that legitimate warnings stand out better.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
