### PR TITLE
fix(text-editor): ensure editor resizes with its container

### DIFF
--- a/src/components/text-editor/examples/text-editor-height.scss
+++ b/src/components/text-editor/examples/text-editor-height.scss
@@ -19,3 +19,7 @@
         bottom: 0.25rem;
     }
 }
+
+limel-text-editor {
+    max-height: 15rem;
+}

--- a/src/components/text-editor/examples/text-editor-height.tsx
+++ b/src/components/text-editor/examples/text-editor-height.tsx
@@ -5,6 +5,18 @@ import { Component, h } from '@stencil/core';
  * The text editor automatically adjusts its own height to fit the content inside.
  * So as the user types, the editor will grow taller, potentially resizing its own
  * container element.
+ *
+ * However, you can constrain the text editor to never grow beyond a certain height,
+ * by either
+ * - setting a fixed `height` or `max-height` the component itself,
+ * - or alternatively by setting a fixed `height` or `max-height` on the container
+ * element of the component.
+ *
+ * In this example, the maximum height is set to `15rem`, which means that:
+ * 1. the editor will adjust itself to the content inside,
+ * pushing out its container and making it taller, until it reaches `15rem` in height.
+ * 1. and also when you manually resize the container,
+ * the editor will try to fill the available surface area, until its height reaches `15rem`.
  */
 @Component({
     tag: 'limel-example-text-editor-height',

--- a/src/components/text-editor/prosemirror-adapter/partial-styles/_prosemirror.scss
+++ b/src/components/text-editor/prosemirror-adapter/partial-styles/_prosemirror.scss
@@ -7,7 +7,7 @@
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0;
 
-    padding-top: 0.75rem;
+    padding: var(--limel-text-editor-padding);
 
     [draggable][contenteditable='false'] {
         user-select: text;

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -30,19 +30,15 @@ limel-action-bar {
 
     position: sticky;
     z-index: 1;
-    top: 0;
+    top: 1px;
     background-color: shared_input-select-picker.$background-color-normal;
     backdrop-filter: blur(0.5rem);
     -webkit-backdrop-filter: blur(0.5rem);
 
     // prevents visual defects that can appears
     // due to the backdrop-filter and closeness to borders
-    margin: 1px;
+    margin: 0 1px;
     width: calc(100% - 2px);
-}
-
-div#editor {
-    padding: 0 0.75rem;
 }
 
 @import './partial-styles/prosemirror.scss';

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -1,43 +1,103 @@
 @use '../../style/internal/shared_input-select-picker';
+@use '../../../src/style/mixins.scss';
 
 @include shared_input-select-picker.lime-empty-value-for-readonly;
 @include shared_input-select-picker.lime-looks-like-input-value;
 
-$_label-margin: 0.75rem;
+* {
+    box-sizing: border-box;
+}
 
 :host(limel-text-editor) {
+    --limel-text-editor-padding: 0.75rem;
     position: relative;
     isolation: isolate;
     display: flex;
     flex-direction: column;
+
     width: 100%;
-    min-height: max(4rem, 100%);
+    min-width: 5rem;
+    min-height: 4rem;
+    height: 100%;
+    max-height: 100%;
 }
 
-fieldset {
+:host(limel-text-editor:not([readonly])) {
+    --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color};
+    --limel-text-editor-background-color: #{shared_input-select-picker.$background-color-normal};
+    --limel-text-editor-label-color: #{shared_input-select-picker.$label-color};
+}
+
+:host(limel-text-editor[readonly]) {
+    --limel-text-editor-outline-color: transparent;
+
+    limel-markdown {
+        display: block;
+        padding: var(--limel-text-editor-padding);
+    }
+}
+
+.notched-outline {
+    position: absolute;
+    inset: 0;
+
+    display: flex;
+    background-color: var(--limel-text-editor-background-color);
+}
+
+.leading-outline,
+.notch,
+.trailing-outline {
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--limel-text-editor-outline-color);
+}
+
+.leading-outline {
+    flex-shrink: 0;
+    width: 0.75rem;
+    border-right-width: 0;
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+}
+
+.notch {
+    flex-shrink: 0;
+
+    position: relative;
+    z-index: 2;
+
+    border-top-width: 0;
+    border-right-width: 0;
+    border-left-width: 0;
+
+    max-width: calc(100% - 1.5rem);
+}
+
+.trailing-outline {
+    flex-grow: 1;
+    border-left-width: 0;
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+}
+
+label {
+    transform: translateY(-50%);
+
+    @include mixins.truncate-text;
+    display: block;
+    padding: 0 0.25rem;
+
+    color: var(--limel-text-editor-label-color);
+    font-size: 0.65rem; // `10.4px` similar to MDC's floating label
+    letter-spacing: var(--mdc-typography-subtitle1-letter-spacing, 0.009375em);
+}
+
+limel-prosemirror-adapter {
     flex-grow: 1;
 
     min-width: 0;
     min-height: 0;
     height: 100%;
-    max-height: 100%;
-
-    padding-inline-start: 0 !important;
-    padding-inline-end: 0 !important;
+    overflow: hidden auto;
 }
-
-legend {
-    position: relative;
-    z-index: 2;
-    margin-left: $_label-margin;
-    max-width: calc(100% - #{$_label-margin * 2}) !important;
-}
-
-:host(limel-text-editor[readonly]) {
-    limel-markdown {
-        display: block;
-        padding: $_label-margin;
-    }
-}
-
-@import '../../style/internal/fieldset.scss';

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -30,6 +30,7 @@
 
 :host(limel-text-editor[readonly]) {
     --limel-text-editor-outline-color: transparent;
+    min-height: shared_input-select-picker.$height-of-mdc-text-field;
 
     limel-markdown {
         display: block;

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -82,12 +82,14 @@ export class TextEditor implements FormComponent<string> {
     public change: EventEmitter<string>;
 
     public render() {
-        return (
-            <fieldset disabled={this.readonly || this.disabled}>
+        return [
+            <span class="notched-outline">
+                <span class="leading-outline" />
                 {this.renderLabel()}
-                {this.renderEditor()}
-            </fieldset>
-        );
+                <span class="trailing-outline" />
+            </span>,
+            this.renderEditor(),
+        ];
     }
 
     private renderEditor() {
@@ -116,7 +118,11 @@ export class TextEditor implements FormComponent<string> {
             return;
         }
 
-        return <legend>{this.label}</legend>;
+        return (
+            <span class="notch">
+                <label>{this.label}</label>
+            </span>
+        );
     }
 
     private handleChange = () => (event: CustomEvent<string>) => {


### PR DESCRIPTION
and never grows taller or wider than its own container
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
