### PR TITLE
fix(percentage-colors): properly display percentage colors

### DIFF
--- a/src/components/circular-progress/partial-styles/_percentage-colors.scss
+++ b/src/components/circular-progress/partial-styles/_percentage-colors.scss
@@ -1,42 +1,16 @@
-.displays-percentage-colors {
-    &[style^='--percentage:1'] {
-        --circular-progress-fill-color: var(--color-percent--10to20);
+@for $i from 0 through 100 {
+    .displays-percentage-colors {
+        &[style*='--percentage: #{$i}%'] {
+            $range: floor($i / 10) * 10;
+            --circular-progress-fill-color: var(
+                --color-percent--#{$range}to#{($range + 10)}
+            );
+        }
     }
-    &[style^='--percentage:2'] {
-        --circular-progress-fill-color: var(--color-percent--20to30);
-    }
-    &[style^='--percentage:3'] {
-        --circular-progress-fill-color: var(--color-percent--30to40);
-    }
-    &[style^='--percentage:4'] {
-        --circular-progress-fill-color: var(--color-percent--40to50);
-    }
-    &[style^='--percentage:5'] {
-        --circular-progress-fill-color: var(--color-percent--50to60);
-    }
-    &[style^='--percentage:6'] {
-        --circular-progress-fill-color: var(--color-percent--60to70);
-    }
-    &[style^='--percentage:7'] {
-        --circular-progress-fill-color: var(--color-percent--70to80);
-    }
-    &[style^='--percentage:8'] {
-        --circular-progress-fill-color: var(--color-percent--80to90);
-    }
-    &[style^='--percentage:9'],
-    &[style='--percentage:100%;'] {
-        --circular-progress-fill-color: var(--color-percent--90to100);
-    }
+}
 
-    &[style='--percentage:1%;'],
-    &[style='--percentage:2%;'],
-    &[style='--percentage:3%;'],
-    &[style='--percentage:4%;'],
-    &[style='--percentage:5%;'],
-    &[style='--percentage:6%;'],
-    &[style='--percentage:7%;'],
-    &[style='--percentage:8%;'],
-    &[style='--percentage:9%;'] {
-        --circular-progress-fill-color: var(--color-percent--0to10);
+.displays-percentage-colors {
+    &[style='--percentage: 100%;'] {
+        --circular-progress-fill-color: var(--color-percent--100);
     }
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/4070


https://github.com/Lundalogik/lime-elements/assets/50618208/1f0463e3-b246-4510-bf8c-8b16a92b3bee



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
