### PR TITLE
text editor `helperText`

### DIFF
--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -16,10 +16,14 @@ export class TextEditorCompositeExample {
     @State()
     private label: string;
 
+    @State()
+    private helperText: string;
+
     public render() {
         return [
             <limel-text-editor
                 label={this.label}
+                helperText={this.helperText}
                 value={this.value}
                 onChange={this.handleChange}
                 readonly={this.readonly}
@@ -31,9 +35,14 @@ export class TextEditorCompositeExample {
                     onChange={this.setReadonly}
                 />
                 <limel-input-field
-                    label="Label"
+                    label="label"
                     value={this.label}
                     onChange={this.handleLabelChange}
+                />
+                <limel-input-field
+                    label="helperText"
+                    value={this.helperText}
+                    onChange={this.handleHelperTextChange}
                 />
             </limel-example-controls>,
             <limel-example-value value={this.value} />,
@@ -48,6 +57,11 @@ export class TextEditorCompositeExample {
     private handleLabelChange = (event: CustomEvent<string>) => {
         event.stopPropagation();
         this.label = event.detail;
+    };
+
+    private handleHelperTextChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.helperText = event.detail;
     };
 
     private handleChange = (event: CustomEvent<string>) => {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -9,7 +9,7 @@
 }
 
 :host(limel-text-editor) {
-    --limel-text-editor-padding: 0.75rem;
+    --limel-text-editor-padding: 0.75rem 1rem;
     position: relative;
     isolation: isolate;
     display: flex;

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -41,9 +41,14 @@
 .notched-outline {
     position: absolute;
     inset: 0;
+    bottom: var(--limel-text-editor-notched-outline-bottom, 0);
 
     display: flex;
     background-color: var(--limel-text-editor-background-color);
+
+    :host(limel-text-editor.has-helper-text) & {
+        --limel-text-editor-notched-outline-bottom: 1rem;
+    }
 }
 
 .leading-outline,


### PR DESCRIPTION
…Text`
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
