### PR TITLE
refactor(text-editor): initiate readOnly as false

### DIFF
--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -14,6 +14,9 @@ export class TextEditorCompositeExample {
     private readonly = false;
 
     @State()
+    private invalid = false;
+
+    @State()
     private label: string;
 
     @State()
@@ -27,12 +30,18 @@ export class TextEditorCompositeExample {
                 value={this.value}
                 onChange={this.handleChange}
                 readonly={this.readonly}
+                invalid={this.invalid}
             />,
             <limel-example-controls>
                 <limel-checkbox
                     checked={this.readonly}
                     label="Readonly"
                     onChange={this.setReadonly}
+                />
+                <limel-checkbox
+                    checked={this.invalid}
+                    label="Invalid"
+                    onChange={this.setInvalid}
                 />
                 <limel-input-field
                     label="label"
@@ -52,6 +61,11 @@ export class TextEditorCompositeExample {
     private setReadonly = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.readonly = event.detail;
+    };
+
+    private setInvalid = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.invalid = event.detail;
     };
 
     private handleLabelChange = (event: CustomEvent<string>) => {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -27,6 +27,9 @@
     --limel-text-editor-background-color: #{shared_input-select-picker.$background-color-normal};
     --limel-text-editor-label-color: #{shared_input-select-picker.$label-color};
 }
+:host(limel-text-editor[invalid]) {
+    --limel-text-editor-outline-color: var(--lime-error-text-color);
+}
 
 :host(limel-text-editor[readonly]) {
     --limel-text-editor-outline-color: transparent;

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -77,7 +77,7 @@ export class TextEditor implements FormComponent<string> {
      * invalid.
      */
     @Prop({ reflect: true })
-    public invalid?: boolean;
+    public invalid?: boolean = false;
 
     /**
      * Description of the text inside the editor as markdown
@@ -165,8 +165,20 @@ export class TextEditor implements FormComponent<string> {
             <limel-helper-line
                 helperText={this.helperText}
                 helperTextId={this.helperTextId}
+                invalid={this.isInvalid()}
             />
         );
+    };
+
+    private isInvalid = () => {
+        if (this.readonly) {
+            // A readonly field can never be invalid.
+            return false;
+        }
+
+        if (this.invalid) {
+            return true;
+        }
     };
 
     private handleChange = () => (event: CustomEvent<string>) => {

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -51,7 +51,7 @@ export class TextEditor implements FormComponent<string> {
      * :::
      */
     @Prop({ reflect: true })
-    public readonly?: boolean;
+    public readonly?: boolean = false;
 
     /**
      * Optional helper text to display below the input field when it has focus


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
