### PR TITLE
feat(text-editor): add `required` prop

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -652,6 +652,7 @@ export namespace Components {
         "label"?: string;
         "placeholder"?: string;
         "readonly"?: boolean;
+        "required"?: boolean;
         "value": string;
     }
     export interface LimelTooltip {
@@ -1591,6 +1592,7 @@ namespace JSX_2 {
         "onChange"?: (event: LimelTextEditorCustomEvent<string>) => void;
         "placeholder"?: string;
         "readonly"?: boolean;
+        "required"?: boolean;
         "value"?: string;
     }
     interface LimelTooltip {

--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -1,4 +1,4 @@
-import { Component, h, State } from '@stencil/core';
+import { Component, h, State, Watch } from '@stencil/core';
 /**
  * Composite example
  */
@@ -17,6 +17,9 @@ export class TextEditorCompositeExample {
     private invalid = false;
 
     @State()
+    private required = false;
+
+    @State()
     private label: string;
 
     @State()
@@ -33,6 +36,7 @@ export class TextEditorCompositeExample {
                 value={this.value}
                 onChange={this.handleChange}
                 readonly={this.readonly}
+                required={this.required}
                 invalid={this.invalid}
                 placeholder={this.placeholder}
             />,
@@ -46,6 +50,16 @@ export class TextEditorCompositeExample {
                     checked={this.invalid}
                     label="Invalid"
                     onChange={this.setInvalid}
+                />
+                <limel-checkbox
+                    checked={this.required}
+                    label="Required"
+                    onChange={this.setRequired}
+                />
+                <hr
+                    style={{
+                        'grid-column': '1/-1',
+                    }}
                 />
                 <limel-input-field
                     label="label"
@@ -67,9 +81,20 @@ export class TextEditorCompositeExample {
         ];
     }
 
+    @Watch('required')
+    @Watch('value')
+    protected checkValidity() {
+        this.invalid = this.required && !this.value;
+    }
+
     private setReadonly = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.readonly = event.detail;
+    };
+
+    private setRequired = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.required = event.detail;
     };
 
     private setInvalid = (event: CustomEvent<boolean>) => {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -103,6 +103,12 @@ label {
     color: var(--limel-text-editor-label-color);
     font-size: 0.65rem; // `10.4px` similar to MDC's floating label
     letter-spacing: var(--mdc-typography-subtitle1-letter-spacing, 0.009375em);
+
+    :host(limel-text-editor[required]) & {
+        &::after {
+            content: '*';
+        }
+    }
 }
 
 .placeholder {

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -86,6 +86,18 @@ export class TextEditor implements FormComponent<string> {
     public value: string;
 
     /**
+     * Set to `true` to indicate that the field is required.
+     *
+     * :::important
+     * An empty but required field is not automatically considered invalid.
+     * You must make sure to check the validity of the field on your own,
+     * and properly handle the `invalid` state.
+     * :::
+     */
+    @Prop({ reflect: true })
+    public required?: boolean = false;
+
+    /**
      * Dispatched when a change is made to the editor
      */
     @Event()


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
