### PR TITLE
feat(text-editor): enable `disabled` prop

### DIFF
--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -20,6 +20,9 @@ export class TextEditorCompositeExample {
     private required = false;
 
     @State()
+    private disabled = false;
+
+    @State()
     private allowResize = false;
 
     @State()
@@ -40,6 +43,7 @@ export class TextEditorCompositeExample {
                 onChange={this.handleChange}
                 readonly={this.readonly}
                 required={this.required}
+                disabled={this.disabled}
                 invalid={this.invalid}
                 placeholder={this.placeholder}
                 allowResize={this.allowResize}
@@ -59,6 +63,11 @@ export class TextEditorCompositeExample {
                     checked={this.required}
                     label="Required"
                     onChange={this.setRequired}
+                />
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Disabled"
+                    onChange={this.setDisabled}
                 />
                 <limel-checkbox
                     checked={this.allowResize}
@@ -109,6 +118,11 @@ export class TextEditorCompositeExample {
     private setInvalid = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.invalid = event.detail;
+    };
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
     };
 
     private setAllowResize = (event: CustomEvent<boolean>) => {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -11,6 +11,9 @@
 }
 
 :host(limel-text-editor) {
+    --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color};
+    --limel-text-editor-background-color: #{shared_input-select-picker.$background-color-normal};
+    --limel-text-editor-label-color: #{shared_input-select-picker.$label-color};
     --limel-text-editor-padding: 0.75rem 1rem;
     position: relative;
     isolation: isolate;
@@ -22,12 +25,6 @@
     min-height: 5rem;
     height: 100%;
     max-height: 100%;
-}
-
-:host(limel-text-editor:not([readonly])) {
-    --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color};
-    --limel-text-editor-background-color: #{shared_input-select-picker.$background-color-normal};
-    --limel-text-editor-label-color: #{shared_input-select-picker.$label-color};
 }
 
 :host(limel-text-editor:hover) {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -35,6 +35,14 @@
     --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color--focused};
 }
 
+:host(limel-text-editor[disabled]:not([disabled='false'])) {
+    @include shared_input-select-picker.looks-disabled;
+
+    limel-prosemirror-adapter {
+        pointer-events: none;
+    }
+}
+
 :host(limel-text-editor[invalid]:not([invalid='false'])) {
     --limel-text-editor-outline-color: var(--lime-error-text-color);
 }

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -40,7 +40,7 @@ export class TextEditor implements FormComponent<string> {
      * requirements are met, the field may become enabled again.
      */
     @Prop({ reflect: true })
-    public disabled?: boolean;
+    public disabled?: boolean = false;
 
     /**
      * Set to `true` to make the component read-only.
@@ -164,6 +164,8 @@ export class TextEditor implements FormComponent<string> {
                 value={this.value}
                 aria-controls={this.helperTextId}
                 id={this.editorId}
+                tabindex={this.disabled ? -1 : 0}
+                aria-disabled={this.disabled}
             />,
             this.renderPlaceholder(),
             this.renderHelperLine(),


### PR DESCRIPTION
We were adding specificity of "if not `readonly`" then these
are the colors. But further down, we actually specified colors for the
readonly mode. So this was an overkill. Also would complicate styles
for next commit, for the `disabled` state.
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
