### PR TITLE
fix(text-editor): improve accessibility of `label`

### DIFF
--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -92,9 +92,11 @@ export class TextEditor implements FormComponent<string> {
     public change: EventEmitter<string>;
 
     private helperTextId: string;
+    private editorId: string;
 
     public constructor() {
         this.helperTextId = createRandomString();
+        this.editorId = createRandomString();
     }
 
     public render() {
@@ -127,6 +129,7 @@ export class TextEditor implements FormComponent<string> {
                 <limel-markdown
                     value={this.value}
                     aria-controls={this.helperTextId}
+                    id={this.editorId}
                 />,
                 this.renderPlaceholder(),
                 this.renderHelperLine(),
@@ -140,6 +143,7 @@ export class TextEditor implements FormComponent<string> {
                 onChange={this.handleChange}
                 value={this.value}
                 aria-controls={this.helperTextId}
+                id={this.editorId}
             />,
             this.renderPlaceholder(),
             this.renderHelperLine(),
@@ -153,7 +157,7 @@ export class TextEditor implements FormComponent<string> {
 
         return (
             <span class="notch">
-                <label>{this.label}</label>
+                <label htmlFor={this.editorId}>{this.label}</label>
             </span>
         );
     }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
