### PR TITLE
fix(text-editor): transition outlines & correctly visualize states

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -29,6 +29,15 @@
     --limel-text-editor-background-color: #{shared_input-select-picker.$background-color-normal};
     --limel-text-editor-label-color: #{shared_input-select-picker.$label-color};
 }
+
+:host(limel-text-editor:hover) {
+    --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color--hovered};
+}
+
+:host(limel-text-editor:focus-within) {
+    --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color--focused};
+}
+
 :host(limel-text-editor[invalid]) {
     --limel-text-editor-outline-color: var(--lime-error-text-color);
 }
@@ -60,6 +69,7 @@
 .leading-outline,
 .notch,
 .trailing-outline {
+    transition: border-color 0.2s ease;
     border-width: 1px;
     border-style: solid;
     border-color: var(--limel-text-editor-outline-color);


### PR DESCRIPTION
for `hover` and `focus-within`



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
