### PR TITLE
chore(text-editor): shorten the address to the mixins.scss file

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -1,5 +1,5 @@
 @use '../../style/internal/shared_input-select-picker';
-@use '../../../src/style/mixins.scss';
+@use '../../style/mixins.scss';
 
 @include shared_input-select-picker.lime-looks-like-input-value;
 .lime-looks-like-input-value {

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -53,6 +53,9 @@
 }
 
 .notched-outline {
+    transition: bottom
+        var(--limel-h-l-grid-template-rows-transition-speed, 0.46s)
+        cubic-bezier(1, 0.09, 0, 0.89);
     pointer-events: none;
     position: absolute;
     inset: 0;
@@ -60,10 +63,6 @@
 
     display: flex;
     background-color: var(--limel-text-editor-background-color);
-
-    :host(limel-text-editor.has-helper-text) & {
-        --limel-text-editor-notched-outline-bottom: 1rem;
-    }
 }
 
 .leading-outline,
@@ -142,4 +141,12 @@ limel-prosemirror-adapter {
     min-height: 0;
     height: 100%;
     overflow: hidden auto;
+}
+
+@include mixins.hide-helper-line-when-not-needed(limel-text-editor);
+:host(limel-text-editor.has-helper-text:focus-within),
+:host(limel-text-editor.has-helper-text[invalid]) {
+    .notched-outline {
+        --limel-text-editor-notched-outline-bottom: 1rem;
+    }
 }


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/4102

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
