### PR TITLE
fix(text-editor): ensure tabbing into the editor will focus on input …

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -1,7 +1,16 @@
 @use '../../../style/internal/shared_input-select-picker.scss';
 
 :host(limel-prosemirror-adapter) {
-    display: block;
+    display: flex;
+    flex-direction: column;
+
+    limel-action-bar {
+        order: 1;
+    }
+
+    div#editor {
+        order: 2;
+    }
 }
 
 * {

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -86,12 +86,12 @@ export class ProsemirrorAdapter {
 
     public render() {
         return [
+            <div id="editor" />,
             <limel-action-bar
                 accessibleLabel="Toolbar"
                 actions={this.actionBarItems}
                 onItemSelected={this.handleActionBarItem}
             />,
-            <div id="editor" />,
         ];
     }
 


### PR DESCRIPTION
…area first

and next time you press Tab, the action bar items
will receive focus.

fix https://github.com/Lundalogik/crm-feature/issues/4101

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
