### PR TITLE
fix(dock): change opening direction of popover menus

### DIFF
--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -53,6 +53,10 @@ limel-popover {
     // makes buttons that are wrapped in a popover become fullwidth
     display: grid;
     grid-template-columns: 100%;
+
+    button[slot='trigger'][aria-expanded='true'] {
+        box-shadow: var(--button-shadow-inset);
+    }
 }
 
 .text {

--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -95,7 +95,7 @@ export class DockButton {
 
         return (
             <limel-popover
-                openDirection={this.useMobileLayout ? 'top' : 'right'}
+                openDirection={this.useMobileLayout ? 'top' : 'right-start'}
                 open={this.isOpen || this.item.dockMenu.menuOpen}
                 onClose={this.onPopoverClose}
             >


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
