### PR TITLE
feat(text-editor): enable end users to resize the editor

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -645,6 +645,7 @@ export namespace Components {
     }
     // @beta
     export interface LimelTextEditor {
+        "allowResize": boolean;
         "contentType": 'markdown' | 'html';
         "disabled"?: boolean;
         "helperText"?: string;
@@ -1584,6 +1585,7 @@ namespace JSX_2 {
     }
     // @beta
     interface LimelTextEditor {
+        "allowResize"?: boolean;
         "contentType"?: 'markdown' | 'html';
         "disabled"?: boolean;
         "helperText"?: string;

--- a/src/components/text-editor/examples/text-editor-allow-resize.scss
+++ b/src/components/text-editor/examples/text-editor-allow-resize.scss
@@ -1,0 +1,4 @@
+limel-text-editor {
+    min-height: 8rem;
+    max-height: 20rem;
+}

--- a/src/components/text-editor/examples/text-editor-allow-resize.tsx
+++ b/src/components/text-editor/examples/text-editor-allow-resize.tsx
@@ -1,0 +1,60 @@
+import { Component, h, State } from '@stencil/core';
+/**
+ * Allow resize
+ * The text editor automatically adjusts its own height to fit the content inside.
+ * So as the user types, the editor will grow taller, potentially resizing its own
+ * container element.
+ *
+ * By default, the user can also manually change the height of the text editor
+ * by dragging its bottom right corner.
+ *
+ * As soon as the user has changed the height, this will override the automatic
+ * resizing, and the editor will no longer adjust its height to fit the content inside.
+ *
+ * By setting `allowResize` to `false`, you can disable the end user
+ * to resize the text editor vertically.
+ *
+ * :::tip
+ * Using `max-height` and `min-height` CSS properties, you can limit the
+ * resizing to a specific range.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-text-editor-allow-resize',
+    shadow: true,
+    styleUrl: 'text-editor-allow-resize.scss',
+})
+export class TextEditorAllowResizeExample {
+    @State()
+    private value: string;
+
+    @State()
+    private allowResize = true;
+
+    public render() {
+        return [
+            <limel-text-editor
+                value={this.value}
+                onChange={this.handleChange}
+                allowResize={this.allowResize}
+            />,
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.allowResize}
+                    label="Allow resize"
+                    onChange={this.setAllowResize}
+                />
+            </limel-example-controls>,
+            <limel-example-value value={this.value} />,
+        ];
+    }
+
+    private setAllowResize = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.allowResize = event.detail;
+    };
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -20,6 +20,9 @@ export class TextEditorCompositeExample {
     private required = false;
 
     @State()
+    private allowResize = false;
+
+    @State()
     private label: string;
 
     @State()
@@ -39,6 +42,7 @@ export class TextEditorCompositeExample {
                 required={this.required}
                 invalid={this.invalid}
                 placeholder={this.placeholder}
+                allowResize={this.allowResize}
             />,
             <limel-example-controls>
                 <limel-checkbox
@@ -55,6 +59,11 @@ export class TextEditorCompositeExample {
                     checked={this.required}
                     label="Required"
                     onChange={this.setRequired}
+                />
+                <limel-checkbox
+                    checked={this.allowResize}
+                    label="Allow resize"
+                    onChange={this.setAllowResize}
                 />
                 <hr
                     style={{
@@ -100,6 +109,11 @@ export class TextEditorCompositeExample {
     private setInvalid = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.invalid = event.detail;
+    };
+
+    private setAllowResize = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.allowResize = event.detail;
     };
 
     private handleLabelChange = (event: CustomEvent<string>) => {

--- a/src/components/text-editor/examples/text-editor-size.scss
+++ b/src/components/text-editor/examples/text-editor-size.scss
@@ -1,4 +1,4 @@
-:host(limel-example-text-editor-height) {
+:host(limel-example-text-editor-size) {
     box-sizing: border-box;
     position: relative;
     display: block;

--- a/src/components/text-editor/examples/text-editor-size.tsx
+++ b/src/components/text-editor/examples/text-editor-size.tsx
@@ -1,12 +1,12 @@
 import { Component, h } from '@stencil/core';
 /**
- * Height of the editor
+ * Resize with container
+ * Sometimes, you may want to make the text editor to follow the size of its container,
+ * both in width and height; for instance, when the container is resizable by the user.
  *
- * The text editor automatically adjusts its own height to fit the content inside.
- * So as the user types, the editor will grow taller, potentially resizing its own
- * container element.
+ * In such cases, make sure to set `allowResize={false}` on the component.
  *
- * However, you can constrain the text editor to never grow beyond a certain height,
+ * However, you can still constrain the text editor to never grow beyond a certain height,
  * by either
  * - setting a fixed `height` or `max-height` the component itself,
  * - or alternatively by setting a fixed `height` or `max-height` on the container
@@ -19,12 +19,12 @@ import { Component, h } from '@stencil/core';
  * the editor will try to fill the available surface area, until its height reaches `15rem`.
  */
 @Component({
-    tag: 'limel-example-text-editor-height',
+    tag: 'limel-example-text-editor-size',
     shadow: true,
-    styleUrl: 'text-editor-height.scss',
+    styleUrl: 'text-editor-size.scss',
 })
-export class TextEditorHeightExample {
+export class TextEditorSizeExample {
     public render() {
-        return <limel-text-editor />;
+        return <limel-text-editor allowResize={false} />;
     }
 }

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -19,7 +19,7 @@
 
     width: 100%;
     min-width: 5rem;
-    min-height: 4rem;
+    min-height: 5rem;
     height: 100%;
     max-height: 100%;
 }

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -150,3 +150,9 @@ limel-prosemirror-adapter {
         --limel-text-editor-notched-outline-bottom: 1rem;
     }
 }
+
+:host(limel-text-editor[allow-resize]) {
+    limel-prosemirror-adapter {
+        resize: vertical;
+    }
+}

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -12,10 +12,11 @@ import { createRandomString } from 'src/util/random-string';
  *
  * @exampleComponent limel-example-text-editor-basic
  * @exampleComponent limel-example-text-editor-as-form-component
- * @exampleComponent limel-example-text-editor-composite
  * @exampleComponent limel-example-text-editor-with-markdown
  * @exampleComponent limel-example-text-editor-with-html
- * @exampleComponent limel-example-text-editor-height
+ * @exampleComponent limel-example-text-editor-allow-resize
+ * @exampleComponent limel-example-text-editor-size
+ * @exampleComponent limel-example-text-editor-composite
  * @beta
  * @private
  */
@@ -96,6 +97,13 @@ export class TextEditor implements FormComponent<string> {
      */
     @Prop({ reflect: true })
     public required?: boolean = false;
+
+    /**
+     * Set to `true` to allow the user to vertically resize the editor.
+     * Set to `false` to disable the resize functionality.
+     */
+    @Prop({ reflect: true })
+    public allowResize: boolean = true;
 
     /**
      * Dispatched when a change is made to the editor


### PR DESCRIPTION
Also enable consumers to turn this resizing possibility off.

fix https://github.com/Lundalogik/crm-feature/issues/4097

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
