### PR TITLE
Hide chip set counter when maxItems = 1

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -605,8 +605,9 @@ export class ChipSet {
         );
     };
 
-    private renderInputChip(chip: Chip, index: number) {
+    private renderInputChip(chip: Chip, index: number, chips: Chip[]) {
         const chipProps = this.getChipProps(chip, 'default');
+        const isLastChip = index === chips.length - 1;
 
         return [
             <limel-chip
@@ -616,7 +617,7 @@ export class ChipSet {
                 }}
                 {...chipProps}
             />,
-            this.renderDelimiter(),
+            !(isLastChip && this.inputHidden()) && this.renderDelimiter(),
         ];
     }
 

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -589,14 +589,16 @@ export class ChipSet {
     };
 
     private renderHelperLine = () => {
-        if (!this.maxItems && !this.hasHelperText()) {
+        const maxItems = this.maxItems === 1 ? undefined : this.maxItems;
+
+        if (!maxItems && !this.hasHelperText()) {
             return;
         }
 
         return (
             <limel-helper-line
                 length={this.value.length}
-                maxLength={this.maxItems}
+                maxLength={maxItems}
                 helperText={this.helperText}
                 invalid={this.isInvalid()}
             />


### PR DESCRIPTION
Also hides the delimiter after the last chip as long as it is not followed by an input. 

Fixes #2299

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
