### PR TITLE
fix(list): don't deselect selected item when radio type

### DIFF
--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -239,7 +239,10 @@ export class List {
         });
 
         if (selectedItem) {
-            this.mdcList.selectedIndex = -1;
+            if (this.type !== 'radio') {
+                this.mdcList.selectedIndex = -1;
+            }
+
             this.change.emit({ ...selectedItem, selected: false });
         }
 


### PR DESCRIPTION
The mdc list will end up in a broken state if we deselect the selected item when type is radio.

Fixes #2980

Initial bug was introduced in [this](https://github.com/Lundalogik/lime-elements/pull/2821) PR.
I'm not sure if there is another solution to this instead of the "quick-fix" exception I implemented now. If you have something in mind please go ahead 🙂

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
