### PR TITLE
perf(dock): avoid re-creating observer whenever menu is opened

### DIFF
--- a/src/components/dock/dock-button/dock-button.tsx
+++ b/src/components/dock/dock-button/dock-button.tsx
@@ -65,6 +65,7 @@ export class DockButton {
 
     private tooltipId: string;
     private customComponentElement: HTMLElement;
+    private intersectionObserver?: IntersectionObserver;
 
     constructor() {
         this.tooltipId = createRandomString();
@@ -84,10 +85,17 @@ export class DockButton {
             return;
         }
 
-        const observer = new IntersectionObserver(
-            this.focusCustomComponentElement,
-        );
-        observer.observe(this.customComponentElement);
+        if (!this.intersectionObserver) {
+            this.intersectionObserver = new IntersectionObserver(
+                this.focusCustomComponentElement,
+            );
+            this.intersectionObserver.observe(this.customComponentElement);
+        }
+    }
+
+    public disconnectedCallback() {
+        this.intersectionObserver?.disconnect();
+        this.intersectionObserver = undefined;
     }
 
     private renderPopover() {
@@ -197,7 +205,20 @@ export class DockButton {
         }
     }
 
-    private focusCustomComponentElement = () => {
+    private focusCustomComponentElement = (
+        entries: IntersectionObserverEntry[],
+    ) => {
+        const entry = entries.find(
+            (e) => e.target === this.customComponentElement,
+        );
+        if (!entry) {
+            return;
+        }
+
+        if (!entry.isIntersecting) {
+            return;
+        }
+
         if (this.customComponentElement?.shadowRoot?.delegatesFocus) {
             this.customComponentElement?.focus();
         }


### PR DESCRIPTION
The intersection observer was re-created every time the button in the menu was clicked, causing the callback to be invoked multiple times



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
