### PR TITLE
chip: add an ellipsis menu for additional actions

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -199,6 +199,7 @@ export namespace Components {
         "readonlyLabels"?: Array<Label<boolean>>;
         "required": boolean;
     }
+    // @beta
     export interface LimelChip {
         "badge"?: string | number;
         "disabled": boolean;
@@ -215,7 +216,6 @@ export namespace Components {
         "removable": boolean;
         "selected": boolean;
         "text": string;
-        // @beta
         "type"?: ChipType;
     }
     export interface LimelChipSet {
@@ -910,6 +910,8 @@ namespace JSX_2 {
         "limel-callout": LimelCallout;
         // (undocumented)
         "limel-checkbox": LimelCheckbox;
+        // Warning: (ae-incompatible-release-tags) The symbol ""limel-chip"" is marked as @public, but its signature references "JSX_2" which is marked as @beta
+        //
         // (undocumented)
         "limel-chip": LimelChip;
         // (undocumented)
@@ -1093,6 +1095,7 @@ namespace JSX_2 {
         "readonlyLabels"?: Array<Label<boolean>>;
         "required"?: boolean;
     }
+    // @beta
     interface LimelChip {
         "badge"?: string | number;
         "disabled"?: boolean;
@@ -1111,7 +1114,6 @@ namespace JSX_2 {
         "removable"?: boolean;
         "selected"?: boolean;
         "text"?: string;
-        // @beta
         "type"?: ChipType;
     }
     interface LimelChipSet {

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -209,6 +209,7 @@ export namespace Components {
         "language": Languages;
         "link"?: Omit<Link, 'text'>;
         "loading"?: boolean;
+        "menuItems"?: Array<MenuItem | ListSeparator>;
         "progress"?: number;
         "readonly": boolean;
         "removable": boolean;
@@ -1102,6 +1103,8 @@ namespace JSX_2 {
         "language"?: Languages;
         "link"?: Omit<Link, 'text'>;
         "loading"?: boolean;
+        "menuItems"?: Array<MenuItem | ListSeparator>;
+        "onMenuItemSelected"?: (event: LimelChipCustomEvent<MenuItem>) => void;
         "onRemove"?: (event: LimelChipCustomEvent<number | string>) => void;
         "progress"?: number;
         "readonly"?: boolean;
@@ -2106,7 +2109,7 @@ export interface ListSeparator {
 export type ListType = 'selectable' | 'radio' | 'checkbox';
 
 // @public
-export interface MenuItem<T = any> {
+interface MenuItem<T = any> {
     badge?: number | string;
     commandText?: string;
     disabled?: boolean;
@@ -2121,6 +2124,8 @@ export interface MenuItem<T = any> {
     text: string;
     value?: T;
 }
+export { MenuItem }
+export { MenuItem as MenuItem1 }
 
 // @public @deprecated
 export type MenuListType = 'menu';

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -68,7 +68,7 @@
     }
 }
 
-:host(limel-chip[disabled]) {
+:host(limel-chip[disabled]:not([disabled='false'])) {
     .chip {
         // Similar to `limel-button[disabled]`
         color: rgba(var(--contrast-1600), 0.37);
@@ -77,13 +77,13 @@
     }
 }
 
-:host(limel-chip[readonly]) {
+:host(limel-chip[readonly]:not([readonly='false'])) {
     .chip {
         box-shadow: 0 0 0 1px rgba(var(--contrast-800), 0.5);
     }
 }
 
-:host(limel-chip[selected]) {
+:host(limel-chip[selected]:not([selected='false'])) {
     .chip {
         box-shadow: var(--button-shadow-inset);
 

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -59,6 +59,7 @@
         box-shadow: var(--shadow-depth-8-error);
     }
 
+    &:has(+ limel-menu),
     &:has(+ .trailing-button) {
         padding-right: calc(var(--limel-chip-height) + 0.125rem);
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -26,6 +26,9 @@ import { ChipType, Chip as OldChipInterface } from '../chip-set/chip.types';
 import { Image } from '../../global/shared-types/image.types';
 import { isEmpty } from 'lodash-es';
 
+import { ListSeparator } from '../list/list-item.types';
+import { LimelMenuCustomEvent, MenuItem } from '../../components';
+
 interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
     /**
      * Identifier for the chip. Must be unique.
@@ -78,6 +81,7 @@ interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
  * @exampleComponent limel-example-chip-badge
  * @exampleComponent limel-example-chip-filter
  * @exampleComponent limel-example-chip-removable
+ * @exampleComponent limel-example-chip-menu
  * @exampleComponent limel-example-chip-loading
  * @exampleComponent limel-example-chip-progress
  * @exampleComponent limel-example-chip-aria-role
@@ -190,11 +194,25 @@ export class Chip implements ChipInterface {
     public identifier?: number | string = crypto.randomUUID();
 
     /**
+     * When provided, the chip will render an ellipsis menu with the supplied items.
+     * Also, this will hide the "remove button" when `removable={true}`, as
+     * the remove button will automatically become the last item in the menu.
+     */
+    @Prop()
+    public menuItems?: Array<MenuItem | ListSeparator> = [];
+
+    /**
      * Fired when clicking on the remove button of a `removable` chip.
      * The value of `identifier` is emitted as the event detail.
      */
     @Event()
     public remove: EventEmitter<number | string>;
+
+    /**
+     * Emitted when a menu item is selected from the actions menu.
+     */
+    @Event()
+    public menuItemSelected: EventEmitter<MenuItem>;
 
     @Element()
     private host: HTMLLimelChipElement;
@@ -231,6 +249,7 @@ export class Chip implements ChipInterface {
                 {this.renderProgressBar()}
             </button>,
             this.renderRemoveButton(),
+            this.renderActionsMenu(),
         ];
     };
 
@@ -253,6 +272,7 @@ export class Chip implements ChipInterface {
                 {this.renderProgressBar()}
             </a>,
             this.renderRemoveButton(),
+            this.renderActionsMenu(),
         ];
     };
 
@@ -296,7 +316,12 @@ export class Chip implements ChipInterface {
     }
 
     private renderRemoveButton() {
-        if (!this.removable || this.readonly || this.disabled) {
+        if (
+            !this.removable ||
+            this.readonly ||
+            this.disabled ||
+            !!this.menuItems?.length
+        ) {
             return;
         }
 
@@ -313,6 +338,53 @@ export class Chip implements ChipInterface {
                 onClick={this.handleRemoveClick}
             />
         );
+    }
+
+    private renderActionsMenu() {
+        if (!this.menuItems?.length) {
+            return;
+        }
+
+        const svgData =
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" xml:space="preserve"><circle cx="16" cy="16" r="2"/><circle cx="16" cy="24" r="2"/><circle cx="16" cy="8" r="2"/></svg>';
+
+        const menuItems = this.getMenuItems();
+
+        return (
+            <limel-menu
+                items={menuItems}
+                onSelect={this.handleActionMenuSelect}
+            >
+                <button
+                    slot="trigger"
+                    class="trailing-button"
+                    tabIndex={-1}
+                    aria-label={this.actionMenuLabel}
+                    innerHTML={svgData}
+                />
+            </limel-menu>
+        );
+    }
+
+    private getMenuItems() {
+        let menuItems = [...this.menuItems];
+
+        if (this.removable) {
+            menuItems = [
+                ...menuItems,
+                { separator: true },
+                {
+                    text: this.removeChipLabel(),
+                    icon: {
+                        name: 'delete_sign',
+                        color: 'rgb(var(--color-red-default))',
+                    },
+                    value: '_remove',
+                },
+            ];
+        }
+
+        return menuItems;
     }
 
     private filterClickWhenDisabled = (e) => {
@@ -343,6 +415,10 @@ export class Chip implements ChipInterface {
         return translate.get('remove', this.language) + ' ' + this.text;
     };
 
+    private actionMenuLabel = (): string => {
+        return translate.get('file-viewer.more-actions', this.language);
+    };
+
     private renderSpinner() {
         if (!this.loading) {
             return;
@@ -371,4 +447,24 @@ export class Chip implements ChipInterface {
             />
         );
     }
+
+    private handleActionMenuSelect = (
+        event: LimelMenuCustomEvent<MenuItem>,
+    ) => {
+        const menuItem = event.detail;
+
+        if (!menuItem) {
+            return;
+        }
+
+        const { value } = menuItem;
+
+        if (value === '_remove') {
+            this.remove.emit(this.identifier);
+
+            return;
+        }
+
+        this.menuItemSelected.emit(value);
+    };
 }

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -340,7 +340,7 @@ export class Chip implements ChipInterface {
     };
 
     private removeChipLabel = (): string => {
-        return translate.get('chip-set.remove-chip', this.language);
+        return translate.get('remove', this.language) + ' ' + this.text;
     };
 
     private renderSpinner() {

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -73,7 +73,7 @@ interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
  * or navigating to a page with more information about the item in the shopping list.
  * :::
  *
- * @private
+ * @beta
  * @exampleComponent limel-example-chip-button
  * @exampleComponent limel-example-chip-link
  * @exampleComponent limel-example-chip-icon-colors

--- a/src/components/chip/examples/chip-menu.tsx
+++ b/src/components/chip/examples/chip-menu.tsx
@@ -1,0 +1,80 @@
+import { LimelChipCustomEvent } from '@limetech/lime-elements';
+import { Component, State, h } from '@stencil/core';
+import { ListSeparator, MenuItem } from 'src/interface';
+
+/**
+ * When an array of menu items is provided, the chip will render
+ * an ellipsis menu with the supplied items. When an item is selected,
+ * the `onMenuItemSelected` event will be emitted, reflecting the
+ * `value` of the selected item.
+ *
+ * :::note
+ * This will hide the "remove button" on the chip, when `removable={true}`,
+ * as the remove button will automatically become the last item in the menu.
+ *
+ * Clicking the remove button will emit the same `onRemove` event.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-menu',
+    shadow: true,
+})
+export class ChipMenuExample {
+    @State()
+    private removeButtonClicked: boolean = false;
+
+    @State()
+    private menuItemSelected: MenuItem | ListSeparator = null;
+
+    @State()
+    private menuItems: Array<MenuItem | ListSeparator> = [
+        {
+            text: 'Email',
+            secondaryText: 'beffie@lime.tech',
+            icon: 'email_sign',
+            value: 1,
+        },
+        {
+            text: 'Direct phone',
+            secondaryText: '+46 987 654 321',
+            icon: 'phone',
+            value: 2,
+        },
+        {
+            text: 'Mobile',
+            secondaryText: '+46 123 456 789',
+            icon: 'touchscreen_smartphone',
+            value: 3,
+        },
+    ];
+
+    public render() {
+        return [
+            <limel-chip
+                text="Beffie Kiaskompis"
+                removable={true}
+                onRemove={this.handleRemove}
+                menuItems={this.menuItems}
+                onMenuItemSelected={this.handleMenuItemSelected}
+            />,
+            <limel-example-value
+                label="Menu item clicked"
+                value={this.menuItemSelected}
+            />,
+            <limel-example-value
+                label="Remove"
+                value={this.removeButtonClicked}
+            />,
+        ];
+    }
+
+    private handleRemove = () => {
+        this.removeButtonClicked = true;
+    };
+
+    private handleMenuItemSelected = (
+        event: LimelChipCustomEvent<MenuItem>,
+    ) => {
+        this.menuItemSelected = event.detail;
+    };
+}

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -1,4 +1,5 @@
 export default {
+    remove: 'Fjern',
     'callout.note': 'Bemærk',
     'callout.important': 'Vigtig',
     'callout.tip': 'Tip',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,4 +1,5 @@
 export default {
+    remove: 'Remove',
     'callout.note': 'Note',
     'callout.important': 'Important',
     'callout.tip': 'Tip',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -10,7 +10,6 @@ export default {
     'date-picker.quarter.heading': 'Quarter',
     'date-picker.year.heading': 'Year',
     'chip-set.clear-all': 'Clear all',
-    'chip-set.remove-chip': 'Remove chip',
     'snackbar.dismiss': 'Dismiss',
     'file.drag-and-drop-tips':
         'Drag and drop your file here, or click to browse.',

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -1,4 +1,5 @@
 export default {
+    remove: 'Poista',
     'callout.note': 'Huomio',
     'callout.important': 'Tärkeää',
     'callout.tip': 'Vinkki',

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -1,4 +1,5 @@
 export default {
+    remove: 'Verwijder',
     'callout.note': 'Opmerking',
     'callout.important': 'Belangrijk',
     'callout.tip': 'Tip',

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -1,4 +1,5 @@
 export default {
+    remove: 'Fjerne',
     'callout.note': 'Note',
     'callout.important': 'Viktig',
     'callout.tip': 'Tip',

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -1,4 +1,5 @@
 export default {
+    remove: 'Ta bort',
     'callout.note': 'Obs',
     'callout.important': 'Viktigt',
     'callout.tip': 'Tips',

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -10,7 +10,6 @@ export default {
     'date-picker.quarter.heading': 'Kvartal',
     'date-picker.year.heading': 'År',
     'chip-set.clear-all': 'Rensa alla',
-    'chip-set.remove-chip': 'Ta bort chip',
     'snackbar.dismiss': 'Stäng',
     'file.drag-and-drop-tips':
         'Dra och släpp filen här eller klicka om du vill bläddra.',


### PR DESCRIPTION
See the description in the linked issue

fix https://github.com/Lundalogik/crm-feature/issues/4023

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
