### PR TITLE
feat(text editor): Enable use of translation strings for menu items

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -559,6 +559,7 @@ export namespace Components {
     // @beta
     export interface LimelProsemirrorAdapter {
         "contentType": 'markdown' | 'html';
+        "language": Languages;
         "value": string;
     }
     // (undocumented)
@@ -656,6 +657,7 @@ export namespace Components {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
+        "language": Languages;
         "placeholder"?: string;
         "readonly"?: boolean;
         "required"?: boolean;
@@ -1498,6 +1500,7 @@ namespace JSX_2 {
     // @beta
     interface LimelProsemirrorAdapter {
         "contentType"?: 'markdown' | 'html';
+        "language"?: Languages;
         "onChange"?: (event: LimelProsemirrorAdapterCustomEvent<string>) => void;
         "value"?: string;
     }
@@ -1610,6 +1613,7 @@ namespace JSX_2 {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
+        "language"?: Languages;
         "onChange"?: (event: LimelTextEditorCustomEvent<string>) => void;
         "placeholder"?: string;
         "readonly"?: boolean;

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
@@ -1,6 +1,7 @@
 import { ActionBarItem } from 'src/components/action-bar/action-bar.types';
 import { ListSeparator } from 'src/components/list/list-item.types';
 import { EditorMenuTypes } from './types';
+import { cloneDeep } from 'lodash-es';
 
 const getCommandSymbols = (): {
     mod: string;
@@ -17,7 +18,7 @@ const getCommandSymbols = (): {
 
 const { mod, shift } = getCommandSymbols();
 
-export const textEditorMenuItems: Array<
+const textEditorMenuItems: Array<
     ActionBarItem<EditorMenuTypes> | ListSeparator
 > = [
     {
@@ -39,7 +40,7 @@ export const textEditorMenuItems: Array<
     { separator: true },
     {
         value: EditorMenuTypes.HeaderLevel1,
-        text: 'Header Level 1',
+        text: 'Header 1',
         commandText: `${mod} ${shift} 1`,
         icon: '-lime-text-h-heading-1',
         iconOnly: true,
@@ -47,7 +48,7 @@ export const textEditorMenuItems: Array<
     },
     {
         value: EditorMenuTypes.HeaderLevel2,
-        text: 'Header Level 2',
+        text: 'Header 2',
         commandText: `${mod} ${shift} 2`,
         icon: '-lime-text-h-heading-2',
         iconOnly: true,
@@ -55,7 +56,7 @@ export const textEditorMenuItems: Array<
     },
     {
         value: EditorMenuTypes.HeaderLevel3,
-        text: 'Header Level 3',
+        text: 'Header 3',
         commandText: `${mod} ${shift} 3`,
         icon: '-lime-text-h-heading-3',
         iconOnly: true,
@@ -84,3 +85,5 @@ export const textEditorMenuItems: Array<
         selected: false,
     },
 ];
+
+export const getTextEditorMenuItems = () => cloneDeep(textEditorMenuItems);

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
@@ -87,3 +87,20 @@ const textEditorMenuItems: Array<
 ];
 
 export const getTextEditorMenuItems = () => cloneDeep(textEditorMenuItems);
+
+export const menuTranslationIDs = {
+    strong: 'editor-menu.bold',
+    em: 'editor-menu.italic',
+    headerlevel1: 'editor-menu.h1',
+    headerlevel2: 'editor-menu.h2',
+    headerlevel3: 'editor-menu.h3',
+    /* eslint-disable camelcase */
+    bullet_list: 'editor-menu.bulleted-list',
+    ordered_list: 'editor-menu.numbered-list',
+    /* eslint-enable camelcase */
+    blockquote: 'editor-menu.blockquote',
+    link: 'editor-menu.link',
+};
+
+export type menuTranslationIDs =
+    (typeof menuTranslationIDs)[keyof typeof menuTranslationIDs];

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
 import { FormComponent } from '../form/form.types';
 import { createRandomString } from 'src/util/random-string';
+import { Languages } from '../date-picker/date.types';
 /**
  * A rich text editor that offers a rich text editing experience with markdown support,
  * in the sense that you can easily type markdown syntax and see the rendered
@@ -32,6 +33,12 @@ export class TextEditor implements FormComponent<string> {
      */
     @Prop()
     public contentType: 'markdown' | 'html' = 'markdown';
+
+    /**
+     * Defines the language for translations.
+     */
+    @Prop({ reflect: true })
+    public language: Languages = 'en';
 
     /**
      * Set to `true` to disable the field.
@@ -166,6 +173,7 @@ export class TextEditor implements FormComponent<string> {
                 id={this.editorId}
                 tabindex={this.disabled ? -1 : 0}
                 aria-disabled={this.disabled}
+                language={this.language}
             />,
             this.renderPlaceholder(),
             this.renderHelperLine(),

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -18,4 +18,13 @@ export default {
     'file-viewer.open-in-fullscreen': 'Åbn i fuld skærm',
     'file-viewer.open-in-new-tab': 'Åbn i en ny fane',
     'file-viewer.more-actions': 'Mere…',
+    'editor-menu.bold': 'Fed',
+    'editor-menu.italic': 'Kursiv',
+    'editor-menu.h1': 'Overskrift 1',
+    'editor-menu.h2': 'Overskrift 2',
+    'editor-menu.h3': 'Overskrift 3',
+    'editor-menu.bulleted-list': 'Punktliste',
+    'editor-menu.numbered-list': 'Nummereret liste',
+    'editor-menu.blockquote': 'Blokcitat',
+    'editor-menu.link': 'Tilføj link',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -19,4 +19,13 @@ export default {
     'file-viewer.open-in-fullscreen': 'Open in fullscreen',
     'file-viewer.open-in-new-tab': 'Open in a new tab',
     'file-viewer.more-actions': 'More…',
+    'editor-menu.bold': 'Bold',
+    'editor-menu.italic': 'Italic',
+    'editor-menu.h1': 'Heading 1',
+    'editor-menu.h2': 'Heading 2',
+    'editor-menu.h3': 'Heading 3',
+    'editor-menu.bulleted-list': 'Bulleted list',
+    'editor-menu.numbered-list': 'Numbered list',
+    'editor-menu.blockquote': 'Blockquote',
+    'editor-menu.link': 'Link',
 };

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -19,4 +19,13 @@ export default {
     'file-viewer.open-in-fullscreen': 'Avaa koko näytössä',
     'file-viewer.open-in-new-tab': 'Avaa uudella välilehdellä',
     'file-viewer.more-actions': 'Lisää…',
+    'editor-menu.bold': 'Lihavoitu',
+    'editor-menu.italic': 'Kursivoitu',
+    'editor-menu.h1': 'Otsikkotaso 1',
+    'editor-menu.h2': 'Otsikkotaso 2',
+    'editor-menu.h3': 'Otsikkotaso 3',
+    'editor-menu.bulleted-list': 'Luettelomerkitty lista',
+    'editor-menu.numbered-list': 'Numeroitu lista',
+    'editor-menu.blockquote': 'Lohkoteksti',
+    'editor-menu.link': 'Lisää linkki',
 };

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -19,4 +19,13 @@ export default {
     'file-viewer.open-in-fullscreen': 'Open in volledig scherm',
     'file-viewer.open-in-new-tab': 'Openen op een nieuw tabblad',
     'file-viewer.more-actions': 'Meer…',
+    'editor-menu.bold': 'Vet',
+    'editor-menu.italic': 'Cursief',
+    'editor-menu.h1': 'Kopniveau 1',
+    'editor-menu.h2': 'Kopniveau 2',
+    'editor-menu.h3': 'Kopniveau 3',
+    'editor-menu.bulleted-list': 'Opsomming',
+    'editor-menu.numbered-list': 'Genummerde lijst',
+    'editor-menu.blockquote': 'Blokcitaat',
+    'editor-menu.link': 'Link toevoegen',
 };

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -18,4 +18,13 @@ export default {
     'file-viewer.open-in-fullscreen': 'Åpne i fullskjerm',
     'file-viewer.open-in-new-tab': 'Åpne i en ny fane',
     'file-viewer.more-actions': 'Mer…',
+    'editor-menu.bold': 'Fet',
+    'editor-menu.italic': 'Kursiv',
+    'editor-menu.h1': 'Overskrift 1',
+    'editor-menu.h2': 'Overskrift 2',
+    'editor-menu.h3': 'Overskrifts 3',
+    'editor-menu.bulleted-list': 'Punktliste',
+    'editor-menu.numbered-list': 'Nummerert liste',
+    'editor-menu.blockquote': 'Blokksitat',
+    'editor-menu.link': 'Legg til lenke',
 };

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -19,4 +19,13 @@ export default {
     'file-viewer.open-in-fullscreen': 'Öppna i fullskärmsläge',
     'file-viewer.open-in-new-tab': 'Öppna i ny flik',
     'file-viewer.more-actions': 'Mer…',
+    'editor-menu.bold': 'Fet',
+    'editor-menu.italic': 'Kursiv',
+    'editor-menu.h1': 'Rubrik 1',
+    'editor-menu.h2': 'Rubrik 2',
+    'editor-menu.h3': 'Rubrik 3',
+    'editor-menu.bulleted-list': 'Punktlista',
+    'editor-menu.numbered-list': 'Numrerad lista',
+    'editor-menu.blockquote': 'Blockcitat',
+    'editor-menu.link': 'Lägg till länk',
 };


### PR DESCRIPTION
In order for translations to work some streamlining of the initialisation process of the text editor and to ensure that relevant data is loaded properly was required.

Fixes https://github.com/Lundalogik/crm-feature/issues/4089
Fixes https://github.com/Lundalogik/crm-feature/issues/4118