### PR TITLE
fix(button): allow setting focus on button

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -19,7 +19,7 @@ import {
  */
 @Component({
     tag: 'limel-button',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'button.scss',
 })
 export class Button {


### PR DESCRIPTION
Allows giving a button focus programmatically, using `myButton.focus()`.

I think this worked before without `{ delegatesFocus: true }`, but either browsers or Stencil changed something.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
