### PR TITLE
Use 'selected' to show the user which menu item is active

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -147,6 +147,7 @@ export namespace Components {
     export interface LimelActionBarItem {
         "isVisible": boolean;
         "item": ActionBarItem | ListSeparator;
+        "selected": boolean;
     }
     // (undocumented)
     export interface LimelActionBarOverflowMenu {
@@ -1041,6 +1042,7 @@ namespace JSX_2 {
         "isVisible"?: boolean;
         "item": ActionBarItem | ListSeparator;
         "onSelect"?: (event: LimelActionBarItemCustomEvent<ActionBarItem | ListSeparator>) => void;
+        "selected"?: boolean;
     }
     // (undocumented)
     interface LimelActionBarOverflowMenu {

--- a/src/components/action-bar/action-bar-item/action-bar-item.tsx
+++ b/src/components/action-bar/action-bar-item/action-bar-item.tsx
@@ -44,6 +44,12 @@ export class ActionBarButton {
     @Prop({ reflect: true })
     public isVisible: boolean = true;
 
+    /**
+     * When the item is selected, this will be `true`.
+     */
+    @Prop({ reflect: true })
+    public selected: boolean = false;
+
     @Element()
     private host: HTMLLimelActionBarItemElement;
 

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
@@ -26,6 +26,7 @@ export const textEditorMenuItems: Array<
         commandText: `${mod} B`,
         icon: '-lime-text-bold',
         iconOnly: true,
+        selected: false,
     },
     {
         value: EditorMenuTypes.Italic,
@@ -33,6 +34,7 @@ export const textEditorMenuItems: Array<
         commandText: `${mod} I`,
         icon: '-lime-text-italic',
         iconOnly: true,
+        selected: false,
     },
     { separator: true },
     {
@@ -41,6 +43,7 @@ export const textEditorMenuItems: Array<
         commandText: `${mod} ${shift} 1`,
         icon: '-lime-text-h-heading-1',
         iconOnly: true,
+        selected: false,
     },
     {
         value: EditorMenuTypes.HeaderLevel2,
@@ -48,6 +51,7 @@ export const textEditorMenuItems: Array<
         commandText: `${mod} ${shift} 2`,
         icon: '-lime-text-h-heading-2',
         iconOnly: true,
+        selected: false,
     },
     {
         value: EditorMenuTypes.HeaderLevel3,
@@ -55,6 +59,7 @@ export const textEditorMenuItems: Array<
         commandText: `${mod} ${shift} 3`,
         icon: '-lime-text-h-heading-3',
         iconOnly: true,
+        selected: false,
     },
     { separator: true },
     {
@@ -62,17 +67,20 @@ export const textEditorMenuItems: Array<
         text: 'Bullet list',
         icon: '-lime-text-bulleted-list',
         iconOnly: true,
+        selected: false,
     },
     {
         value: EditorMenuTypes.OrderedList,
         text: 'Numbered list',
         icon: '-lime-text-ordered-list',
         iconOnly: true,
+        selected: false,
     },
     {
         value: EditorMenuTypes.Blockquote,
         text: 'Blockquote',
         icon: '-lime-text-blockquote',
         iconOnly: true,
+        selected: false,
     },
 ];


### PR DESCRIPTION
Updated the command factory to include functionality to check whether the mark, eg: 'strong', 'em', 'heading' ... is active at the cursor or on the selection and update the menu items accordingly. 

Fixes [Implement selected in limel-text-editor](https://github.com/Lundalogik/crm-feature/issues/4116)