### PR TITLE
fix(icon-button): allow setting focus on the internal button programm…

### DIFF
--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -88,7 +88,7 @@ interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
  */
 @Component({
     tag: 'limel-chip',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'chip.scss',
 })
 export class Chip implements ChipInterface {

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -14,7 +14,7 @@ import { createRandomString } from '../../util/random-string';
  */
 @Component({
     tag: 'limel-icon-button',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'icon-button.scss',
 })
 export class IconButton {

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -37,7 +37,7 @@ const { ACTION_EVENT } = listStrings;
  */
 @Component({
     tag: 'limel-list',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'list.scss',
 })
 export class List {

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -24,7 +24,7 @@ const { SELECTED_EVENT } = menuStrings;
  */
 @Component({
     tag: 'limel-menu-list',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'menu-list.scss',
 })
 export class MenuList {

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -20,8 +20,8 @@ import { MenuItem } from '../menu/menu.types';
  */
 @Component({
     tag: 'limel-split-button',
+    shadow: { delegatesFocus: true },
     styleUrl: 'split-button.scss',
-    shadow: true,
 })
 export class SplitButton {
     /**


### PR DESCRIPTION
…atically
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
