### PR TITLE
fix(input-field): show number input when editing

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -89,7 +89,8 @@
 
     pointer-events: none;
 
-    :not(.mdc-text-field--focused):not(.mdc-text-field--invalid) & {
+    .mdc-text-field:not(.mdc-text-field--focused):not(.mdc-text-field--invalid)
+        & {
         display: block;
     }
 
@@ -98,7 +99,7 @@
     }
 }
 
-:not(.mdc-text-field--focused):not(.mdc-text-field--invalid) {
+.mdc-text-field:not(.mdc-text-field--focused):not(.mdc-text-field--invalid) {
     .mdc-text-field__input[type='number'] {
         color: transparent;
         -webkit-text-fill-color: transparent;


### PR DESCRIPTION
fix: Lundalogik/crm-feature#4127

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
