### PR TITLE
Fix text editor gets dirty

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -8,7 +8,7 @@ import {
     Watch,
     h,
 } from '@stencil/core';
-import { EditorState, Plugin, PluginKey } from 'prosemirror-state';
+import { EditorState, Plugin, PluginKey, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { Schema, DOMParser } from 'prosemirror-model';
 import { schema } from 'prosemirror-schema-basic';
@@ -226,9 +226,14 @@ export class ProsemirrorAdapter {
         this.view.dispatch(tr);
     }
 
-    private handleTransaction = (transaction) => {
+    private handleTransaction = (transaction: Transaction) => {
         const newState = this.view.state.apply(transaction);
         this.view.updateState(newState);
+
+        if (transaction.getMeta('pointer')) {
+            return;
+        }
+
         this.change.emit(
             this.contentConverter.serialize(this.view, this.schema),
         );


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#4099

**How to test:**

I've done my best to test it. Here's what to look for.

Thinking of edge cases, there's only one, which is when the initial value is empty. Try and check if this has any strange behaviour.

Also, the save button should disappear when the value goes back to what it originally was. So if your text editor says "some sentence", and you edit it to something else, and then back to "some sentence", we should not see the save button.

We believe the cause of the original bug was the fact that the default content type was changed from "html" to "markdown". To test, try and change the content type in the card component in lime admin and see if the bug persists.

Make sure saving continues to work as expected.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
