### PR TITLE
fix(chip-set): show clear all button

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -150,7 +150,7 @@ $leading-icon-space: 1.5rem;
         outline: none;
     }
 
-    :not(.has-chips) &,
+    .mdc-chip-set:not(.has-chips) &,
     .has-chips.mdc-text-field--disabled & {
         display: none; // Won't receive focus when disabled
     }


### PR DESCRIPTION
The clear all button was never shown when using recent version of Chrome or Edge.

This is because `:not(.has-chips) .clear-all-button` started matching when it didn't before. The selector needs to be more clear about which element containing the clear all button we're interested in.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
