### PR TITLE
refactor(circular-progress): automatic migration to remove slash as division in scss

### DIFF
--- a/src/components/circular-progress/partial-styles/_percentage-colors.scss
+++ b/src/components/circular-progress/partial-styles/_percentage-colors.scss
@@ -1,7 +1,7 @@
 @for $i from 0 through 100 {
     .displays-percentage-colors {
         &[style*='--percentage: #{$i}%'] {
-            $range: floor($i / 10) * 10;
+            $range: floor($i * 0.1) * 10;
             --circular-progress-fill-color: var(
                 --color-percent--#{$range}to#{($range + 10)}
             );


### PR DESCRIPTION
See https://sass-lang.com/documentation/breaking-changes/slash-div/

(This PR removes a deprecation warning when building lime-elements, by removing our usage of the deprecated functionality in question.)

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
