### PR TITLE
feat(text-editor): add support for `underline` formatting

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command.spec.tsx
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command.spec.tsx
@@ -8,7 +8,7 @@ import { exampleSetup } from 'prosemirror-example-setup';
 import { EditorView } from 'prosemirror-view';
 import { MenuCommandFactory } from './menu-commands';
 import { EditorMenuTypes } from './types';
-import { strikethrough } from './menu-schema-extender';
+import { strikethrough, underline } from './menu-schema-extender';
 
 describe('MenuCommandFactory', () => {
     let mySchema: Schema;
@@ -25,6 +25,7 @@ describe('MenuCommandFactory', () => {
                 'block',
             ),
             marks: basicSchema.spec.marks.append({
+                underline: underline,
                 strikethrough: strikethrough,
             }),
         });

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -294,6 +294,7 @@ export class MenuCommandFactory {
             'Mod-Shift-1': this.getCommand(EditorMenuTypes.HeaderLevel1),
             'Mod-Shift-2': this.getCommand(EditorMenuTypes.HeaderLevel2),
             'Mod-Shift-3': this.getCommand(EditorMenuTypes.HeaderLevel3),
+            'Mod-U': this.getCommand(EditorMenuTypes.Underline),
             'Mod-Shift-X': this.getCommand(EditorMenuTypes.Strikethrough),
             'Mod-`': this.getCommand(EditorMenuTypes.Code),
             'Mod-Shift-C': this.getCommand(EditorMenuTypes.CodeBlock),

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-items.ts
@@ -38,6 +38,14 @@ const textEditorMenuItems: Array<
         selected: false,
     },
     {
+        value: EditorMenuTypes.Underline,
+        text: 'Underline',
+        commandText: `${mod} U`,
+        icon: '-lime-text-underline',
+        iconOnly: true,
+        selected: false,
+    },
+    {
         value: EditorMenuTypes.Strikethrough,
         text: 'Strikethrough',
         commandText: `${mod} ${shift} X`,
@@ -125,6 +133,7 @@ export const menuTranslationIDs = {
     /* eslint-enable camelcase */
     blockquote: 'editor-menu.blockquote',
     link: 'editor-menu.link',
+    underline: 'editor-menu.underline',
     strikethrough: 'editor-menu.strikethrough',
     code: 'editor-menu.code',
 };

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-schema-extender.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-schema-extender.ts
@@ -1,5 +1,12 @@
 import { MarkSpec } from 'prosemirror-model';
 
+export const underline: MarkSpec = {
+    parseDOM: [{ tag: 'u' }, { style: 'text-decoration=underline' }],
+    toDOM: () => {
+        return ['u', 0];
+    },
+};
+
 export const strikethrough: MarkSpec = {
     parseDOM: [
         { tag: 's' },

--- a/src/components/text-editor/prosemirror-adapter/menu/types.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/types.ts
@@ -15,6 +15,7 @@ export const EditorMenuTypes = {
     Link: 'link',
     OrderedList: 'ordered_list',
     BulletList: 'bullet_list',
+    Underline: 'underline',
     Strikethrough: 'strikethrough',
     Code: 'code',
     CodeBlock: 'code_block',

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -27,7 +27,7 @@ import translate from 'src/global/translations';
 import { isItem } from 'src/components/action-bar/isItem';
 import { cloneDeep } from 'lodash-es';
 import { Languages } from '../../date-picker/date.types';
-import { strikethrough } from './menu/menu-schema-extender';
+import { strikethrough, underline } from './menu/menu-schema-extender';
 
 /**
  * The ProseMirror adapter offers a rich text editing experience with markdown support.
@@ -171,6 +171,7 @@ export class ProsemirrorAdapter {
         return new Schema({
             nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
             marks: schema.spec.marks.append({
+                underline: underline,
                 strikethrough: strikethrough,
             }),
         });

--- a/src/components/text-editor/utils/markdown-converter.ts
+++ b/src/components/text-editor/utils/markdown-converter.ts
@@ -12,6 +12,12 @@ const customMarkdownSerializer = new MarkdownSerializer(
     },
     {
         ...defaultMarkdownSerializer.marks,
+        underline: {
+            open: '<u>',
+            close: '</u>',
+            mixable: true,
+            expelEnclosingWhitespace: true,
+        },
         strikethrough: {
             open: '~~',
             close: '~~',


### PR DESCRIPTION
We're unsure as to how to go about handling underline with markdown as it is not supported. 

Probably we'll need to have conditional availability on the menu item for underline, but this is not part of MVP. Customisable menu items is on the wishlist from addons. We can tackle implementation of this at the same time. 


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
