### PR TITLE
feat(text-editor): reinitialise editor on reconnect

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -133,6 +133,12 @@ export class ProsemirrorAdapter {
         setTimeout(() => {
             this.initializeTextEditor();
         }, 0);
+    }
+
+    public connectedCallback() {
+        if (this.view) {
+            this.initializeTextEditor();
+        }
 
         this.host.addEventListener(
             'open-editor-link-menu',


### PR DESCRIPTION
Fixes Lundalogik/lime-elements#3010

How to test:

I have been using this code below, which replaces the existing basic prosemirror editor example

```
import { LimelProsemirrorAdapterCustomEvent } from '@limetech/lime-elements';
import { Component, Element, h, State } from '@stencil/core';
/**
 * Basic example
 *
 * Try typing and editing text, or copy & paste in some rendered HTML code
 * from your browser into the editor to see how it is rendered and what you get
 * as an output value.
 */
@Component({
    tag: 'limel-example-prosemirror-adapter-basic',
    shadow: true,
})
export class ProsemirrorAdapterBasicExample {
    @Element()
    private host: HTMLElement;

    @State()
    private text: string = '';

    private prosemirrorAdapter: HTMLElement;

    private handleChange = (
        event: LimelProsemirrorAdapterCustomEvent<string>,
    ): void => {
        event.stopPropagation();

        this.text = event.detail;
        (this.prosemirrorAdapter as any).value = event.detail;
    };

    public componentWillLoad() {
        this.prosemirrorAdapter = document.createElement(
            'limel-prosemirror-adapter',
        );
        this.prosemirrorAdapter.onchange = this.handleChange;
    }

    public render() {
        return [<limel-example-value value={this.text} />];
    }

    public componentDidLoad() {
        this.host.shadowRoot.appendChild(this.prosemirrorAdapter);

        setTimeout(() => {
            this.host.shadowRoot.removeChild(this.prosemirrorAdapter);
        }, 10000);

        setTimeout(() => {
            this.host.shadowRoot.appendChild(this.prosemirrorAdapter);
        }, 20000);
    }
}
```

This creates a prosemirror adapter, connects it to the DOM, then after `10` seconds disconnects it, and after `20` seconds reconnects it. You can put breakpoints in the `connectedCallback` and `disconnectedCallback` functions to test the behaviour, and set attributes on the element itself (as we did with `onchange`).

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
