### PR TITLE
fix(text-editor): better visualization of readonly state

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -50,6 +50,7 @@
 :host(limel-text-editor[readonly]:not([readonly='false'])) {
     --limel-text-editor-placeholder-top: 0;
     --limel-text-editor-outline-color: transparent;
+    --limel-text-editor-background-color: transparent;
 
     limel-markdown {
         display: block;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3015

https://github.com/Lundalogik/lime-elements/assets/50618208/be881ef0-074b-43a0-8c7c-da8ffabc04ff

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
