### PR TITLE
feat(text editor): handle keyboard navigation for link menu

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5944,11 +5944,11 @@ export namespace Components {
      */
     interface LimelTextEditorLinkMenu {
         /**
-          * Open state of the dialog
+          * Open state of the link-menu dialog
          */
         "isOpen": boolean;
         /**
-          * Defines the language for translations. Will translate the translatable strings on the components.
+          * Defines the language for translations.
          */
         "language": Languages;
         /**
@@ -18822,11 +18822,11 @@ declare namespace LocalJSX {
      */
     interface LimelTextEditorLinkMenu {
         /**
-          * Open state of the dialog
+          * Open state of the link-menu dialog
          */
         "isOpen"?: boolean;
         /**
-          * Defines the language for translations. Will translate the translatable strings on the components.
+          * Defines the language for translations.
          */
         "language"?: Languages;
         /**

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -182,13 +182,16 @@ export class ProsemirrorAdapter {
                         'max-height': 'inherit',
                     }}
                 >
-                    <limel-text-editor-link-menu
-                        link={this.link}
-                        isOpen={this.isLinkMenuOpen}
-                        onLinkChange={this.handleLinkChange}
-                        onCancel={this.handleCancelLinkMenu}
-                        onSave={this.handleSaveLinkMenu}
-                    />
+                    {this.isLinkMenuOpen && (
+                        <limel-text-editor-link-menu
+                            link={this.link}
+                            isOpen={this.isLinkMenuOpen}
+                            onLinkChange={this.handleLinkChange}
+                            onCancel={this.handleCancelLinkMenu}
+                            onSave={this.handleSaveLinkMenu}
+                        />
+                    )}
+                    ,
                 </limel-menu-surface>
             </limel-portal>,
         ];
@@ -346,7 +349,9 @@ export class ProsemirrorAdapter {
         const { value } = event.detail;
 
         if (value === EditorMenuTypes.Link) {
-            this.isLinkMenuOpen = true;
+            requestAnimationFrame(() => {
+                this.isLinkMenuOpen = true;
+            });
 
             return;
         }
@@ -357,22 +362,27 @@ export class ProsemirrorAdapter {
         this.view.dom.dispatchEvent(actionBarEvent);
     };
 
-    private handleCancelLinkMenu = () => {
+    private handleCancelLinkMenu = (event: CustomEvent<void>) => {
+        event.preventDefault();
+        event.stopPropagation();
+
         this.isLinkMenuOpen = false;
     };
 
     private handleSaveLinkMenu = () => {
-        this.isLinkMenuOpen = false;
+        requestAnimationFrame(() => {
+            this.isLinkMenuOpen = false;
 
-        const saveLinkEvent = new CustomEvent('saveLinkMenu', {
-            detail: {
-                type: EditorMenuTypes.Link,
-                link: this.link,
-            },
+            const saveLinkEvent = new CustomEvent('saveLinkMenu', {
+                detail: {
+                    type: EditorMenuTypes.Link,
+                    link: this.link,
+                },
+            });
+            this.view.dom.dispatchEvent(saveLinkEvent);
+
+            this.link = { href: '' };
         });
-        this.view.dom.dispatchEvent(saveLinkEvent);
-
-        this.link = { href: '' };
     };
 
     private handleLinkChange = (event: CustomEvent<EditorTextLink>) => {


### PR DESCRIPTION
- Tabbing within the link menu no longer closes the menu
- Hitting enter will save the link
- Hitting escape will close the link menu

Fixes https://github.com/Lundalogik/crm-feature/issues/4164