### PR TITLE
fix(input-field): revert synchronisation with invalid property

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -287,8 +287,6 @@ export class InputField {
     public componentDidUpdate() {
         if (this.invalid) {
             this.mdcTextField.valid = false;
-        } else {
-            this.mdcTextField.valid = true;
         }
 
         this.mdcTextField.disabled = this.disabled || this.readonly;
@@ -393,8 +391,6 @@ export class InputField {
 
         if (this.invalid) {
             this.mdcTextField.valid = false;
-        } else {
-            this.mdcTextField.valid = true;
         }
 
         this.mapCompletions();


### PR DESCRIPTION
This reverts commit e33141ad1c954cb116897f2359700da8b11217f8.

When rendering an input field with `invalid` unset or set to `false`, we would set `this.mdcTextField.valid = true` and ignore the native validation state, but might still render an error icon.

For example, it might look like this:

<img width="592" alt="image" src="https://github.com/Lundalogik/lime-elements/assets/5563232/072cd5b6-208c-4c40-890e-db2617f7029e">

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
