### PR TITLE
feat(text-editor): add a CSS variable to control component's max height

### DIFF
--- a/src/components/text-editor/examples/text-editor-allow-resize.tsx
+++ b/src/components/text-editor/examples/text-editor-allow-resize.tsx
@@ -15,8 +15,15 @@ import { Component, h, State } from '@stencil/core';
  * to resize the text editor vertically.
  *
  * :::tip
- * Using `max-height` and `min-height` CSS properties, you can limit the
- * resizing to a specific range.
+ * 1. The text editor makes sure that it never becomes taller than the viewport's height.
+ * This way, its toolbar and resize control will remain reasonably visible, when
+ * the component is auto resizing itself based on the content it holds.
+ * This behavior is controlled by the `--text-editor-max-height` CSS variable,
+ * which defaults to `calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)) - 4rem)`,
+ * taking also into account the safe zones which are defined by the environment variables.
+ *
+ * 1. Using `max-height` and `min-height` CSS properties on the component itself,
+ * (or using `--text-editor-max-height`), you can limit the resizing to a specific range.
  * :::
  */
 @Component({

--- a/src/components/text-editor/examples/text-editor-size.tsx
+++ b/src/components/text-editor/examples/text-editor-size.tsx
@@ -8,7 +8,8 @@ import { Component, h } from '@stencil/core';
  *
  * However, you can still constrain the text editor to never grow beyond a certain height,
  * by either
- * - setting a fixed `height` or `max-height` the component itself,
+ * - setting a fixed `height` or `max-height` the component itself, or using
+ * `--text-editor-max-height` CSS variable;
  * - or alternatively by setting a fixed `height` or `max-height` on the container
  * element of the component.
  *

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -1,6 +1,10 @@
 @use '../../style/internal/shared_input-select-picker';
 @use '../../style/mixins.scss';
 
+/**
+ * @prop --text-editor-max-height: the tallest height the text editor can become when auto-resizing itself. Defaults to `calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)) - 4rem)`.
+ */
+
 @include shared_input-select-picker.lime-looks-like-input-value;
 .lime-looks-like-input-value {
     padding: var(--limel-text-editor-padding);
@@ -24,7 +28,13 @@
     min-width: 5rem;
     min-height: 5rem;
     height: 100%;
-    max-height: 100%;
+    max-height: var(
+        --text-editor-max-height,
+        calc(
+            100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)) -
+                4rem
+        )
+    );
 }
 
 :host(limel-text-editor:hover) {


### PR DESCRIPTION
fixes: https://github.com/Lundalogik/crm-feature/issues/4171

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
