### PR TITLE
fix(table): prevent rendering rows with very short height

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -99,6 +99,7 @@ $table--limel-table--row-selector: 1;
 
 .tabulator-row {
     transition: background-color 0.2s ease;
+    min-height: 2.25rem;
 
     &:hover {
         transition: background-color 0.1s ease;
@@ -121,6 +122,8 @@ $table--limel-table--row-selector: 1;
 
         display: inline-flex;
         align-items: center;
+        min-height: inherit;
+
         &[style*='text-align: right;'] {
             justify-content: flex-end;
         }


### PR DESCRIPTION
The table component dynamically adds inline styles such as `height` to its rows and cells. The height is added in `px`, and is calculated based on the content of the cells. In some scenarios where the cells have no content or hold web-components that load with delay, after the table is rendered, the dynamic inlined `height` styles used to be calculated very strangely, causing the rows and cells to be very short height. This change will prevent these things, by applying a proper default `min-height`.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
