### PR TITLE
fix(table): allow sorting to be updated after first render

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -348,6 +348,20 @@ export class Table {
         this.init();
     }
 
+    @Watch('sorting')
+    protected updateSorting(
+        newValue: ColumnSorter[],
+        oldValue: ColumnSorter[],
+    ) {
+        const newSorting = this.getColumnSorter(newValue);
+        const oldSorting = this.getColumnSorter(oldValue);
+        if (isEqual(newSorting, oldSorting)) {
+            return;
+        }
+
+        this.tabulator.setSort(newSorting);
+    }
+
     private areSameColumns(newColumns: Column[], oldColumns: Column[]) {
         return (
             newColumns.length === oldColumns.length &&
@@ -439,6 +453,7 @@ export class Table {
         const ajaxOptions = this.getAjaxOptions();
         const paginationOptions = this.getPaginationOptions();
         const columnOptions = this.getColumnOptions();
+        const initialSorting = this.currentSorting ?? this.sorting;
 
         return {
             data: this.data,
@@ -450,15 +465,13 @@ export class Table {
             ...paginationOptions,
             rowClick: this.onClickRow,
             rowFormatter: this.formatRow,
-            initialSort: this.getColumnSorter(),
+            initialSort: this.getColumnSorter(initialSorting),
             nestedFieldSeparator: false,
             ...columnOptions,
         };
     }
 
-    private getColumnSorter(): Tabulator.Sorter[] {
-        const sorting = this.currentSorting ?? this.sorting;
-
+    private getColumnSorter(sorting: ColumnSorter[]): Tabulator.Sorter[] {
         return sorting.map((sorter: ColumnSorter) => {
             return {
                 column: String(sorter.column.field),


### PR DESCRIPTION
This fixes the issue where setting a new `sorting` prop would not sort the table correctly

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
