### PR TITLE
fix(list): improve layout when ordering primary components in items

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -83,6 +83,7 @@ $list-mdc-list-item: 0;
     }
 
     .mdc-deprecated-list-item {
+        gap: 0.5rem;
         transition: background-color 0.2s ease;
         box-sizing: border-box;
         z-index: $list-mdc-list-item; // in Chrome on Windows, menus flicker when they have a scroll bar and user hovers on them. We may be able to remove this in future versions of Chrome. Kia 2021-May-12
@@ -206,11 +207,6 @@ $list-mdc-list-item: 0;
         width: 100%;
     }
 
-    .has-primary-component {
-        .mdc-deprecated-list-item__text {
-            margin-left: 0.5rem;
-        }
-    }
     .mdc-deprecated-list-item__primary-command-text {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
A primary component inside a list item can get `order: 2;` or `position: absolute;`. These kinds of styles should not result in keeping a hardcoded left margin in before the text

fix https://github.com/Lundalogik/crm-feature/issues/4163

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
