### PR TITLE
Fix date picker custom formatter called with extra args

### DIFF
--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
@@ -136,7 +136,7 @@ export class DatePickerCalendar {
                 break;
         }
 
-        this.picker.formatDate = this.formatter;
+        this.picker.formatter = this.formatter;
     }
 
     public componentDidUpdate() {

--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
@@ -142,6 +142,8 @@ export class DatePickerCalendar {
     public componentDidUpdate() {
         if (!this.flatPickrCreated) {
             this.createFlatpickr();
+        } else if (!this.isOpen) {
+            this.picker.setValue(this.value);
         }
 
         this.tryFixConfusingWidthBug();

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -37,16 +37,14 @@ export abstract class Picker {
         this.getWeek = this.getWeek.bind(this);
         this.handleClose = this.handleClose.bind(this);
         this.handleOnClose = this.handleOnClose.bind(this);
-        this.parseDate = this.parseDate.bind(this);
         this.getFlatpickrLang = this.getFlatpickrLang.bind(this);
     }
 
     public init(element: HTMLElement, container: HTMLElement, value?: Date) {
-        let config: flatpickr.Options.Options = {
+        const config: flatpickr.Options.Options = {
             clickOpens: this.nativePicker,
             disableMobile: !this.nativePicker,
             formatDate: this.nativePicker ? undefined : this.formatDate,
-            parseDate: this.nativePicker ? undefined : this.parseDate,
             appendTo: container,
             onClose: this.handleOnClose,
             defaultDate: value,
@@ -56,8 +54,8 @@ export abstract class Picker {
                 FlatpickrLanguages[this.getFlatpickrLang()] ||
                 FlatpickrLanguages.en,
             getWeek: this.getWeek,
+            ...this.getConfig(this.nativePicker),
         };
-        config = { ...config, ...this.getConfig(this.nativePicker) };
 
         // Week numbers designate weeks as starting with Monday and
         // ending with Sunday. To make the week numbers make sense,
@@ -133,10 +131,6 @@ export abstract class Picker {
 
     private getWeek(date) {
         return moment(date).isoWeek();
-    }
-
-    private parseDate(date: string) {
-        return moment(date, this.dateFormat, this.getMomentLang()).toDate();
     }
 
     private handleOnClose() {

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -65,6 +65,10 @@ export abstract class Picker {
         this.flatpickr = flatpickr(element, config) as flatpickr.Instance;
     }
 
+    public setValue(value: Date) {
+        this.flatpickr.setDate(value, false);
+    }
+
     public redraw() {
         this.flatpickr.redraw();
     }

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -113,10 +113,6 @@ export abstract class Picker {
         return selectedDates[0] ? new Date(selectedDates[0].toJSON()) : null;
     }
 
-    private getWeek(date) {
-        return moment(date).isoWeek();
-    }
-
     private get formatDate() {
         const longDateFormat = new Intl.DateTimeFormat(this.language, {
             dateStyle: 'long',
@@ -133,6 +129,10 @@ export abstract class Picker {
 
             return this.formatter(date);
         };
+    }
+
+    private getWeek(date) {
+        return moment(date).isoWeek();
     }
 
     private parseDate(date: string) {

--- a/src/components/date-picker/pickers/Picker.ts
+++ b/src/components/date-picker/pickers/Picker.ts
@@ -11,8 +11,10 @@ import 'moment/locale/sv';
 import moment from 'moment/moment';
 import { isAndroidDevice, isIOSDevice } from '../../../util/device';
 
+const ARIA_DATE_FORMAT = 'F j, Y';
+
 export abstract class Picker {
-    public formatDate: (date: Date) => string;
+    public formatter: (date: Date) => string;
 
     protected dateFormat: string;
     protected language: string = 'en';
@@ -113,6 +115,24 @@ export abstract class Picker {
 
     private getWeek(date) {
         return moment(date).isoWeek();
+    }
+
+    private get formatDate() {
+        const longDateFormat = new Intl.DateTimeFormat(this.language, {
+            dateStyle: 'long',
+        });
+
+        return (date: Date | null, format: string): string => {
+            if (!date) {
+                return '';
+            }
+
+            if (format === ARIA_DATE_FORMAT) {
+                return longDateFormat.format(date);
+            }
+
+            return this.formatter(date);
+        };
     }
 
     private parseDate(date: string) {


### PR DESCRIPTION
The date formatter function used with the date picker was called lots of times, and sometimes directly by flatpickr that passed its extra args `format` and `locale`.

Now we only call the custom formatter to format the value of the date picker, passing only the value argument, and not for formatting aria labels that flatpickr sometimes renders for pickable dates.

Also updates the value of a closed date picker when set programmatically 

fixes: Lundalogik/crm-feature/issues/3182

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
