### PR TITLE
fix(input-field): handle keydown instead of keypress event

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -747,7 +747,7 @@ export class InputField {
                 class="material-icons mdc-text-field__icon mdc-text-field__icon--trailing"
                 tabIndex={0}
                 role="button"
-                onKeyPress={this.handleIconKeyPress}
+                onKeyDown={this.handleIconKeyPress}
                 onClick={this.handleIconClick}
             >
                 <limel-icon name={icon} />


### PR DESCRIPTION
Makes activating input field action using keypress work again in browsers that stopped supporting the deprecated keypress event. 

fix: Lundalogik/crm-feature#4182

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
