### PR TITLE
fix(date-picker): avoid closing before input click

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -299,9 +299,6 @@ export class DatePicker {
         document.addEventListener('mousedown', this.documentClickListener, {
             passive: true,
         });
-        document.addEventListener('keydown', this.documentClickListener, {
-            passive: true,
-        });
 
         document.addEventListener(
             'blur',
@@ -328,7 +325,6 @@ export class DatePicker {
             this.showPortal = false;
         });
         document.removeEventListener('mousedown', this.documentClickListener);
-        document.removeEventListener('keydown', this.documentClickListener);
         document.removeEventListener(
             'blur',
             this.preventBlurFromCalendarContainer,
@@ -348,11 +344,8 @@ export class DatePicker {
         mdcTextField.getDefaultFoundation().deactivateFocus();
     }
 
-    private documentClickListener = (event: MouseEvent | KeyboardEvent) => {
-        if (
-            event.type === 'keydown' &&
-            (event as KeyboardEvent).key !== 'Tab'
-        ) {
+    private documentClickListener = (event: MouseEvent) => {
+        if (event.composedPath().includes(this.textField)) {
             return;
         }
 


### PR DESCRIPTION
When the date picker is already open, clicking the input field (or tabbing to focus the clear button) would first hide the date picker on mouse down and then show it again on mouse up.

This is fixed by ignoring mousedown events from the input field. We also don't need to listen to keydown events, since we're already hiding the date picker on blur.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
