### PR TITLE
fix(table): apply correct sorting

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -447,7 +447,6 @@ export class Table {
         const ajaxOptions = this.getAjaxOptions();
         const paginationOptions = this.getPaginationOptions();
         const columnOptions = this.getColumnOptions();
-        const initialSorting = this.currentSorting ?? this.sorting;
 
         return {
             data: this.data,
@@ -459,10 +458,18 @@ export class Table {
             ...paginationOptions,
             rowClick: this.onClickRow,
             rowFormatter: this.formatRow,
-            initialSort: this.getColumnSorter(initialSorting),
+            initialSort: this.getInitialSorting(),
             nestedFieldSeparator: false,
             ...columnOptions,
         };
+    }
+
+    private getInitialSorting(): Tabulator.Sorter[] {
+        if (this.currentSorting && this.currentSorting.length) {
+            return this.getColumnSorter(this.currentSorting);
+        }
+
+        return this.getColumnSorter(this.sorting);
     }
 
     private getColumnSorter(sorting: ColumnSorter[]): Tabulator.Sorter[] {


### PR DESCRIPTION
Applies the correct sorting if `this.currentSorting` is an empty array

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
