### PR TITLE
fix(text-editor): selected text now used for copying link text 

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
@@ -30,7 +30,7 @@ const updateLink = (
         const fromInNode = Math.max(0, from - pos);
         const toInNode = Math.min(node.text.length, to - pos);
 
-        text = node.text.slice(fromInNode, toInNode);
+        text += node.text.slice(fromInNode, toInNode);
 
         node.marks.forEach((mark: Mark) => {
             if (mark.type.name === 'link') {

--- a/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
@@ -22,15 +22,21 @@ const updateLink = (
 
     let text = '';
     let href = '';
-    view.state.doc.nodesBetween(from, to, (node) => {
-        if (node.type.name === 'text') {
-            text = node.text;
-            node.marks.forEach((mark: Mark) => {
-                if (mark.type.name === 'link') {
-                    href = mark.attrs.href;
-                }
-            });
+    view.state.doc.nodesBetween(from, to, (node, pos) => {
+        if (node.type.name !== 'text') {
+            return;
         }
+
+        const fromInNode = Math.max(0, from - pos);
+        const toInNode = Math.min(node.text.length, to - pos);
+
+        text = node.text.slice(fromInNode, toInNode);
+
+        node.marks.forEach((mark: Mark) => {
+            if (mark.type.name === 'link') {
+                href = mark.attrs.href;
+            }
+        });
     });
 
     if (updateLinkCallback) {


### PR DESCRIPTION
Fixes Lundalogik/crm-feature#4213

The problem here is that when we select some text, the text may only be part of the text node. However, in the selection handler (ProseMirror view transaction callback) we copy the text from the whole node.

So if you mark your text like `<b>alpha</b> beta gamma`, and you select "gamma", what will be pasted is "beta gamma" because they occupy the same text node.

There is a slight change with how things used to be done. It used to only check for the node in which we find the selected text. But now we recurse over all nodes. This fixes a separate issue where, say, in the previous example, you selected "alpha beta" (note that alpha is in bold), you would only get the text "beta".

## How to Test
We can test manually. The important things are that:
1) When selecting only partial text in a text node, not the whole text is pasted
2) When there's a selection crossing several nodes, all of the text is used

Edge cases include empty selection, selection of the whole text node, partial text node, selection with one side touching the end of the node, selection crossing several nodes. Try editing around a bit as well--if the document becomes "broken" (unparseable) ProseMirror will fail to paste the value into the editor, and the editor becomes unusuable.

With ProseMirror it's always important to check the emitted value.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
