### PR TITLE
fix(text editor): ensure the link menu is correctly displayed

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -184,7 +184,6 @@ export class ProsemirrorAdapter {
                 openDirection="top"
                 inheritParentWidth={true}
                 anchor={this.actionBarElement}
-                containerStyle={{ 'z-index': 1 }}
             >
                 <limel-text-editor-link-menu
                     link={this.link}


### PR DESCRIPTION
The z-index being set on the lime portal rendered from the prosemirror adaptor was incorrect and causing the link menu to be rendered behind other elements. 

Fixes https://github.com/Lundalogik/crm-feature/issues/4215