### PR TITLE
Handle clicks within the text editor

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/menu/types.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/types.ts
@@ -58,3 +58,16 @@ export type EditorTextLink = {
     text?: string;
     href: string;
 };
+
+/**
+ * The `MouseButtons` type is used to represent the different mouse buttons.
+ * The values correspond to the button codes used in the `MouseEvent` interface.
+ * @beta
+ */
+export const MouseButtons = {
+    Left: 0,
+    Middle: 1,
+    Right: 2,
+};
+
+export type MouseButtons = (typeof MouseButtons)[keyof typeof MouseButtons];

--- a/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
@@ -3,7 +3,7 @@ import { EditorView } from 'prosemirror-view';
 import { schema } from 'prosemirror-schema-basic';
 import { Mark } from 'prosemirror-model';
 import { isExternalLink, isValidUrl } from '../menu/menu-commands';
-import { EditorMenuTypes } from '../menu/types';
+import { EditorMenuTypes, MouseButtons } from '../menu/types';
 
 export const linkPluginKey = new PluginKey('linkPlugin');
 
@@ -153,10 +153,7 @@ let lastClickTime = 0;
 const DOUBLE_CLICK_DELAY = 200;
 let clickTimeout;
 
-const processDoubleClickEvent = (
-    view: EditorView,
-    event: MouseEvent,
-): boolean => {
+const processClickEvent = (view: EditorView, event: MouseEvent): boolean => {
     const now = Date.now();
 
     if (now - lastClickTime < DOUBLE_CLICK_DELAY) {
@@ -236,7 +233,12 @@ export const createLinkPlugin = (updateLinkCallback?: UpdateLinkCallback) => {
                         return processModClickEvent(view, event);
                     }
 
-                    return processDoubleClickEvent(view, event);
+                    if (event.button !== MouseButtons.Right) {
+                        // We want to ignore right-clicks
+                        return processClickEvent(view, event);
+                    }
+
+                    return true;
                 },
             },
         },

--- a/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
@@ -240,6 +240,18 @@ export const createLinkPlugin = (updateLinkCallback?: UpdateLinkCallback) => {
 
                     return true;
                 },
+                click: (_view, event) => {
+                    if (!(event.target instanceof HTMLElement)) {
+                        return;
+                    }
+
+                    // Prevent unhandled navigation and bubbling for link clicks
+                    const link = event.target.closest('a');
+                    if (link) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                    }
+                },
             },
         },
         view: () => ({


### PR DESCRIPTION
* Allow only browser behaviour on right clicks (open context menu)
* Prevent default on link clicks within the text editor

Fixes https://github.com/Lundalogik/crm-feature/issues/4218