### PR TITLE
fix(flatpicker-adapter): fix label and number cut-off

### DIFF
--- a/src/components/date-picker/flatpickr-adapter/_flatpickr.scss
+++ b/src/components/date-picker/flatpickr-adapter/_flatpickr.scss
@@ -497,7 +497,7 @@ span.flatpickr-weekday {
 // }
 .flatpickr-days {
     position: relative;
-    overflow: hidden;
+    // overflow: hidden;
     // display: flex;
     // align-items: flex-start;
     // width: 307.875px;


### PR DESCRIPTION

fix:https://github.com/Lundalogik/lime-elements/issues/1922

https://github.com/user-attachments/assets/40b70660-1303-4105-a5ef-a98bb5080e1d


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
