### PR TITLE
fix(text-editor): make content scrollable in `readonly`

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -3,6 +3,7 @@
 
 /**
  * @prop --text-editor-max-height: the tallest height the text editor can become when auto-resizing itself. Defaults to `calc(100vh - (env(safe-area-inset-top) + env(safe-area-inset-bottom)) - 4rem)`.
+ * @prop --text-editor-fade-out-background-color: the color of the fade-out effect at the top and bottom of the text editor, when the text-editor is in readonly state. Defaults to rgb(var(--contrast-100)).
  */
 
 @include shared_input-select-picker.lime-looks-like-input-value;
@@ -65,6 +66,46 @@
     limel-markdown {
         display: block;
         padding: var(--limel-text-editor-padding);
+    }
+}
+
+.content-wrapper {
+    overflow-y: auto;
+
+    &.fade-out-effect:after {
+        pointer-events: none;
+        content: '';
+        display: block;
+        position: absolute;
+        z-index: 1;
+        height: 1.75rem;
+        width: 100%;
+        top: 0;
+        background: linear-gradient(
+            var(
+                --text-editor-fade-out-background-color,
+                rgb(var(--contrast-100))
+            ),
+            transparent
+        );
+    }
+
+    &.fade-out-effect:before {
+        pointer-events: none;
+        content: '';
+        display: block;
+        position: absolute;
+        z-index: 1;
+        height: 2rem;
+        width: 100%;
+        bottom: -0.25rem;
+        background: linear-gradient(
+            transparent,
+            var(
+                --text-editor-fade-out-background-color,
+                rgb(var(--contrast-100))
+            )
+        );
     }
 }
 

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -152,11 +152,17 @@ export class TextEditor implements FormComponent<string> {
 
         if (this.readonly) {
             return [
-                <limel-markdown
-                    value={this.value}
-                    aria-controls={this.helperTextId}
-                    id={this.editorId}
-                />,
+                <div
+                    class={
+                        this.readonly ? 'content-wrapper fade-out-effect' : ''
+                    }
+                >
+                    <limel-markdown
+                        value={this.value}
+                        aria-controls={this.helperTextId}
+                        id={this.editorId}
+                    />
+                </div>,
                 this.renderPlaceholder(),
                 this.renderHelperLine(),
             ];


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3047

limel-elements:

https://github.com/user-attachments/assets/b9908bc7-d7c0-4943-a97f-4c9333ab8845


web-client:
1. link limel-elements to the webclient
2. go to a deal card
3. if text-editor is not there add it in Admin 
4. add some content inside the text editor so it could grow a bit
5. inspect elements
6. add `readonly` state to the limel-text-editor
7. if needed change the max-height to 5rem, so content will be scrollable 

https://github.com/user-attachments/assets/cfafa18e-10f5-4788-9c8d-6b40acabaa54




## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
