### PR TITLE
fix(button):  make loading feedback visible

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -106,7 +106,7 @@ svg {
     width: functions.pxToRem(30);
 
     line {
-        stroke: rgb(var(--color-white));
+        stroke: rgb(var(--contrast-600));
         stroke-width: 2;
     }
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3070

## Review:



https://github.com/user-attachments/assets/b1094d36-df37-4408-9b03-bd2e4034e7ab



go to `limel-example-button-composite` example 
1. uncheck primary
2. check/uncheck loading state

- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
