### PR TITLE
refactor(list): rename `rendertext` function for clarity

### DIFF
--- a/src/components/list/list-renderer.tsx
+++ b/src/components/list/list-renderer.tsx
@@ -121,7 +121,7 @@ export class ListRenderer {
         if ('separator' in item) {
             return (
                 <li class="mdc-deprecated-list-divider" role="separator">
-                    {this.rendertext(item)}
+                    {this.renderTextForSeparator(item)}
                     <div class="limel-list-divider-line" />
                 </li>
             );
@@ -160,7 +160,7 @@ export class ListRenderer {
         );
     };
 
-    private rendertext = (item: ListSeparator) => {
+    private renderTextForSeparator = (item: ListSeparator) => {
         if ('text' in item) {
             return <h2 class="limel-list-divider-title">{item.text}</h2>;
         }


### PR DESCRIPTION
There is already a `renderText` function. Yes, we had two separate functions, called `rendertext` and `renderText`.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
