### PR TITLE
refactor(text-editor): reduce code complexity for `readonly` fade-out edge effects

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -64,48 +64,43 @@
     --limel-text-editor-background-color: transparent;
 
     limel-markdown {
+        // displayed when `readonly` instead of the adapter
         display: block;
         padding: var(--limel-text-editor-padding);
-    }
-}
+        overflow-y: auto;
 
-.content-wrapper {
-    overflow-y: auto;
+        &:before,
+        &:after {
+            z-index: 1;
+            pointer-events: none;
+            content: '';
+            display: block;
+            position: absolute;
+            width: 100%;
+        }
+        &:after {
+            height: 1.75rem;
+            top: 0;
+            background: linear-gradient(
+                var(
+                    --text-editor-fade-out-background-color,
+                    rgb(var(--contrast-100))
+                ),
+                transparent
+            );
+        }
 
-    &.fade-out-effect:after {
-        pointer-events: none;
-        content: '';
-        display: block;
-        position: absolute;
-        z-index: 1;
-        height: 1.75rem;
-        width: 100%;
-        top: 0;
-        background: linear-gradient(
-            var(
-                --text-editor-fade-out-background-color,
-                rgb(var(--contrast-100))
-            ),
-            transparent
-        );
-    }
-
-    &.fade-out-effect:before {
-        pointer-events: none;
-        content: '';
-        display: block;
-        position: absolute;
-        z-index: 1;
-        height: 2rem;
-        width: 100%;
-        bottom: -0.25rem;
-        background: linear-gradient(
-            transparent,
-            var(
-                --text-editor-fade-out-background-color,
-                rgb(var(--contrast-100))
-            )
-        );
+        &:before {
+            height: 2rem;
+            bottom: -0.25rem;
+            background: linear-gradient(
+                transparent,
+                var(
+                    --text-editor-fade-out-background-color,
+                    rgb(var(--contrast-100))
+                )
+            );
+        }
     }
 }
 

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -152,17 +152,11 @@ export class TextEditor implements FormComponent<string> {
 
         if (this.readonly) {
             return [
-                <div
-                    class={
-                        this.readonly ? 'content-wrapper fade-out-effect' : ''
-                    }
-                >
-                    <limel-markdown
-                        value={this.value}
-                        aria-controls={this.helperTextId}
-                        id={this.editorId}
-                    />
-                </div>,
+                <limel-markdown
+                    value={this.value}
+                    aria-controls={this.helperTextId}
+                    id={this.editorId}
+                />,
                 this.renderPlaceholder(),
                 this.renderHelperLine(),
             ];


### PR DESCRIPTION
removes these white gradients from readonly
![image](https://github.com/user-attachments/assets/86b33caf-5de9-4316-9f0a-2ee188f81b1d)


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
