### PR TITLE
fix(snackbar): allow snackbar to be closed if opened with deprecated show method

### DIFF
--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -167,6 +167,7 @@ export class Snackbar {
         );
         if (!this.open) {
             this.handleOpen();
+            this.isOpen = true;
         }
     }
 


### PR DESCRIPTION
fix Lundalogik/crm-feature#4285



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
