### PR TITLE
fix(snackbar): allow the snackbar to be created in its opened state

### DIFF
--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -129,20 +129,15 @@ export class Snackbar {
 
     private snackbarId: string;
     private timeoutId?: number;
-    private firstRender = true;
 
     public constructor() {
         this.snackbarId = createRandomString();
     }
 
-    public componentDidRender() {
-        if (!this.firstRender) {
-            return;
+    public componentDidLoad() {
+        if (this.open) {
+            requestAnimationFrame(this.handleOpen);
         }
-
-        this.firstRender = false;
-
-        requestAnimationFrame(() => this.watchOpen());
     }
 
     @Listen('changeOffset')
@@ -174,7 +169,6 @@ export class Snackbar {
         );
         if (!this.open) {
             this.handleOpen();
-            this.isOpen = true;
         }
     }
 
@@ -183,6 +177,7 @@ export class Snackbar {
             return;
         }
 
+        this.isOpen = true;
         this.closing = false;
         container.add(this.host);
 


### PR DESCRIPTION
fix Lundalogik/crm-feature#4288



## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
