### PR TITLE
fix(dialog): have border-radius consistent with the header

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -16,7 +16,6 @@
  * @prop --dialog-heading-icon-background-color: Background color of the icon when displayed as a badge.
  * @prop --dialog-max-width: Max width of the dialog.
  * @prop --dialog-max-height: Max height of the dialog.
- * @prop --dialog-border-radius: Border radius of the dialog corners
  * @prop --dialog-padding-top-bottom: Padding on top and bottom of dialog content. Affects the height of fade-out effects on top and bottom edges when the content is scrollable and has overflowed out of the content area. Defaults to `1.5rem`. Note that if you use this variable and set it to numbers smaller than 1rem, you will loose the fade-out effects on the edges. If you have set these paddings to `0`, losing the fade out effects should be however fine for your use case! Because in such a case your intention is to handle the `overflow` internally in the component that is displayed in the dialog's content.
  * @prop --dialog-padding-left-right: Padding on the sides of dialog content. Defaults to `1.25rem`.
  */
@@ -81,7 +80,7 @@ $responsive-body-padding: 3vw; // 3% of viewport's width
 
         max-width: var(--dialog-max-width, calc(100vw - 2rem));
         max-height: var(--dialog-max-height, calc(100% - 2rem));
-        border-radius: var(--dialog-border-radius, 0.25rem);
+        border-radius: 0.75rem;
     }
 
     .mdc-dialog__content {


### PR DESCRIPTION

<img width="445" alt="Screenshot 2024-08-15 at 13 15 28" src="https://github.com/user-attachments/assets/5a8c5fd3-636f-45b5-b0f2-04a4b66fa308">

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
