### PR TITLE
fix(file-picker): improve UI for readOnly

### DIFF
--- a/src/style/internal/shared_input-select-picker.scss
+++ b/src/style/internal/shared_input-select-picker.scss
@@ -270,6 +270,13 @@ $cropped-label-hack--font-size: 0.875rem; //14px
             color: $input-text-color;
         }
 
+        &.mdc-text-field--with-leading-icon,
+        &.has-leading-icon {
+            .lime-looks-like-input-value {
+                padding-left: 1rem;
+            }
+        }
+
         .lime-looks-like-input-value {
             color: $input-text-color;
             opacity: 1;


### PR DESCRIPTION

#
![Screenshot 2024-08-16 at 10 24 43](https://github.com/user-attachments/assets/24232e7a-b8b1-4307-83a9-e5b4dffdfbde)

# Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
