### PR TITLE
fix(text-editor): always keep toolbar's backdrop blur effect

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
 
-    limel-action-bar {
+    .toolbar {
         order: 1;
     }
 
@@ -36,27 +36,35 @@
     }
 }
 
-limel-action-bar {
+.toolbar {
     --action-bar-border-radius: 0.25rem;
+    border-radius: var(--action-bar-border-radius);
+    flex-shrink: 0;
 
     position: sticky;
     z-index: 1;
     top: 1px;
-    background-color: shared_input-select-picker.$background-color-normal;
-    backdrop-filter: blur(0.5rem);
-    -webkit-backdrop-filter: blur(0.5rem);
-
-    opacity: 0.6;
-    transition: opacity 0.5s ease;
-    :host(limel-prosemirror-adapter:focus-within) &,
-    :host(limel-prosemirror-adapter:hover) & {
-        opacity: 1;
-    }
 
     // prevents visual defects that can appears
     // due to the backdrop-filter and closeness to borders
     margin: 0 1px;
     width: calc(100% - 2px);
+
+    background-color: shared_input-select-picker.$background-color-normal;
+    backdrop-filter: blur(0.5rem);
+    -webkit-backdrop-filter: blur(0.5rem);
+}
+
+limel-action-bar {
+    min-width: 0;
+    opacity: var(--limel-prosemirror-adapter-toolbar-opacity);
+    transition: opacity;
+    transition-duration: 0.3s;
+    transition-timing-function: var(
+        --limel-prosemirror-adapter-toolbar-transition-timing-function
+    );
+    padding: 0.125rem 0.25rem;
+    background-color: transparent;
 }
 
 .ProseMirror {

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -166,12 +166,14 @@ export class ProsemirrorAdapter {
     public render() {
         return [
             <div id="editor" />,
-            <limel-action-bar
-                ref={(el) => (this.actionBarElement = el)}
-                accessibleLabel="Toolbar"
-                actions={this.actionBarItems}
-                onItemSelected={this.handleActionBarItem}
-            />,
+            <div class="toolbar">
+                <limel-action-bar
+                    ref={(el) => (this.actionBarElement = el)}
+                    accessibleLabel="Toolbar"
+                    actions={this.actionBarItems}
+                    onItemSelected={this.handleActionBarItem}
+                />
+            </div>,
             this.renderLinkMenu(),
         ];
     }

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -20,6 +20,14 @@
     --limel-text-editor-background-color: #{shared_input-select-picker.$background-color-normal};
     --limel-text-editor-label-color: #{shared_input-select-picker.$label-color};
     --limel-text-editor-padding: 0.75rem 1rem;
+    --limel-prosemirror-adapter-toolbar-opacity: 0.6;
+    --limel-prosemirror-adapter-toolbar-transition-timing-function: cubic-bezier(
+        0.19,
+        0.23,
+        0.26,
+        0.89
+    );
+
     position: relative;
     isolation: isolate;
     display: flex;
@@ -36,6 +44,11 @@
                 4rem
         )
     );
+}
+
+:host(limel-text-editor:focus-within),
+:host(limel-text-editor:hover) {
+    --limel-prosemirror-adapter-toolbar-opacity: 1;
 }
 
 :host(limel-text-editor:hover) {


### PR DESCRIPTION
Toolbar didn't keep its backdrop blur effect
when editor isn't focused or hovered.
This was due the rendering conflict.
An element which has transparency does
not properly display backgrop effects.

fix https://github.com/Lundalogik/lime-elements/issues/3119

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
