### PR TITLE
fix(snackbar): open snackbar when created programatically

### DIFF
--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -129,13 +129,20 @@ export class Snackbar {
 
     private snackbarId: string;
     private timeoutId?: number;
+    private firstRender = true;
 
     public constructor() {
         this.snackbarId = createRandomString();
     }
 
-    public componentWillLoad() {
-        this.isOpen = this.open;
+    public componentDidRender() {
+        if (!this.firstRender) {
+            return;
+        }
+
+        this.firstRender = false;
+
+        requestAnimationFrame(() => this.watchOpen());
     }
 
     @Listen('changeOffset')


### PR DESCRIPTION
The snackbar would not open if an HTML element was created and added to the DOM programatically

fix Lundalogik/crm-feature#4341

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
