### PR TITLE
fix(file-input): make sure disabled styling is applied

### DIFF
--- a/src/components/file-input/examples/file-input-type-filtering.tsx
+++ b/src/components/file-input/examples/file-input-type-filtering.tsx
@@ -29,7 +29,10 @@ export class FileInputTypeFilteringExample {
                 disabled={this.disabled || this.readonly}
                 multiple={this.multiple}
             >
-                <limel-button label="Select an image" />
+                <limel-button
+                    label="Select an image"
+                    disabled={this.disabled || this.readonly}
+                />
             </limel-file-input>,
             this.files.map((file) => (
                 <limel-chip

--- a/src/components/file-input/examples/file-input-type-filtering.tsx
+++ b/src/components/file-input/examples/file-input-type-filtering.tsx
@@ -13,9 +13,6 @@ export class FileInputTypeFilteringExample {
     private disabled = false;
 
     @State()
-    private readonly = false;
-
-    @State()
     private multiple = false;
 
     @State()
@@ -26,12 +23,12 @@ export class FileInputTypeFilteringExample {
             <limel-file-input
                 onFilesSelected={this.handleFilesSelected}
                 accept="image/*"
-                disabled={this.disabled || this.readonly}
+                disabled={this.disabled}
                 multiple={this.multiple}
             >
                 <limel-button
                     label="Select an image"
-                    disabled={this.disabled || this.readonly}
+                    disabled={this.disabled}
                 />
             </limel-file-input>,
             this.files.map((file) => (
@@ -40,7 +37,6 @@ export class FileInputTypeFilteringExample {
                     text={file.filename}
                     icon={file.icon}
                     disabled={this.disabled}
-                    readonly={this.readonly}
                     removable={true}
                     onRemove={this.handleRemove}
                 />
@@ -50,11 +46,6 @@ export class FileInputTypeFilteringExample {
                     checked={this.disabled}
                     label="Disabled"
                     onChange={this.setDisabled}
-                />
-                <limel-checkbox
-                    checked={this.readonly}
-                    label="Readonly"
-                    onChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.multiple}
@@ -77,11 +68,6 @@ export class FileInputTypeFilteringExample {
     private setDisabled = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.disabled = event.detail;
-    };
-
-    private setReadonly = (event: CustomEvent<boolean>) => {
-        event.stopPropagation();
-        this.readonly = event.detail;
     };
 
     private setMultiple = (event: CustomEvent<boolean>) => {

--- a/src/components/file-input/examples/file-input.tsx
+++ b/src/components/file-input/examples/file-input.tsx
@@ -28,7 +28,10 @@ export class FileInputExample {
                 disabled={this.disabled || this.readonly}
                 multiple={this.multiple}
             >
-                <limel-button label="Select a file" />
+                <limel-button
+                    label="Select a file"
+                    disabled={this.disabled || this.readonly}
+                />
             </limel-file-input>,
             this.files.map((file) => (
                 <limel-chip

--- a/src/components/file-input/examples/file-input.tsx
+++ b/src/components/file-input/examples/file-input.tsx
@@ -13,9 +13,6 @@ export class FileInputExample {
     private disabled = false;
 
     @State()
-    private readonly = false;
-
-    @State()
     private multiple = false;
 
     @State()
@@ -25,13 +22,10 @@ export class FileInputExample {
         return [
             <limel-file-input
                 onFilesSelected={this.handleFilesSelected}
-                disabled={this.disabled || this.readonly}
+                disabled={this.disabled}
                 multiple={this.multiple}
             >
-                <limel-button
-                    label="Select a file"
-                    disabled={this.disabled || this.readonly}
-                />
+                <limel-button label="Select a file" disabled={this.disabled} />
             </limel-file-input>,
             this.files.map((file) => (
                 <limel-chip
@@ -39,7 +33,6 @@ export class FileInputExample {
                     text={file.filename}
                     icon={file.icon}
                     disabled={this.disabled}
-                    readonly={this.readonly}
                     removable={true}
                     onRemove={this.handleRemove}
                 />
@@ -49,11 +42,6 @@ export class FileInputExample {
                     checked={this.disabled}
                     label="Disabled"
                     onChange={this.setDisabled}
-                />
-                <limel-checkbox
-                    checked={this.readonly}
-                    label="Readonly"
-                    onChange={this.setReadonly}
                 />
                 <limel-checkbox
                     checked={this.multiple}
@@ -76,11 +64,6 @@ export class FileInputExample {
     private setDisabled = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.disabled = event.detail;
-    };
-
-    private setReadonly = (event: CustomEvent<boolean>) => {
-        event.stopPropagation();
-        this.readonly = event.detail;
     };
 
     private setMultiple = (event: CustomEvent<boolean>) => {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/4353
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
