### PR TITLE
fix(icons): icons according to size rhythms

### DIFF
--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -1,5 +1,3 @@
-@use '../../style/functions';
-
 /**
  * @prop --icon-background-color: Background color when attribute `badge` is set to `true`. Defaults to `transparent`.
  */
@@ -28,43 +26,43 @@
 }
 
 :host([size='x-small']) {
-    height: functions.pxToRem(15) !important;
-    width: functions.pxToRem(15) !important;
+    height: 1rem !important;
+    width: 1rem !important;
 }
 :host([size='small']) {
-    height: functions.pxToRem(20) !important;
-    width: functions.pxToRem(20) !important;
+    height: 1.25rem !important;
+    width: 1.25rem !important;
 }
 :host([size='medium']) {
-    height: functions.pxToRem(25) !important;
-    width: functions.pxToRem(25) !important;
+    height: 1.5rem !important;
+    width: 1.5rem !important;
 }
 :host([size='large']) {
-    height: functions.pxToRem(30) !important;
-    width: functions.pxToRem(30) !important;
+    height: 1.75rem !important;
+    width: 1.75rem !important;
 }
 
 :host([badge][size='x-small']) {
-    height: functions.pxToRem(23) !important;
-    width: functions.pxToRem(23) !important;
+    height: 1.5rem !important;
+    width: 1.5rem !important;
 
-    --limel-icon-svg-margin: #{functions.pxToRem(4)};
+    --limel-icon-svg-margin: 0.25rem;
 }
 :host([badge][size='small']) {
-    height: functions.pxToRem(30) !important;
-    width: functions.pxToRem(30) !important;
+    height: 1.75rem !important;
+    width: 1.75rem !important;
 
-    --limel-icon-svg-margin: #{functions.pxToRem(5)};
+    --limel-icon-svg-margin: 0.25rem;
 }
 :host([badge][size='medium']) {
-    height: functions.pxToRem(40) !important;
-    width: functions.pxToRem(40) !important;
+    height: 2.5rem !important;
+    width: 2.5rem !important;
 
-    --limel-icon-svg-margin: #{functions.pxToRem(8)};
+    --limel-icon-svg-margin: 0.5rem;
 }
 :host([badge][size='large']) {
-    height: functions.pxToRem(46) !important;
-    width: functions.pxToRem(46) !important;
+    height: 2.75rem !important;
+    width: 2.75rem !important;
 
-    --limel-icon-svg-margin: #{functions.pxToRem(8)};
+    --limel-icon-svg-margin: 0.5rem;
 }


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/1854

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
