### PR TITLE
fix(table): only release element pool if should replace is true

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -264,8 +264,6 @@ export class Table {
 
     @Watch('data')
     protected updateData(newData: RowData[] = [], oldData: RowData[] = []) {
-        this.pool.releaseAll();
-
         const shouldReplace = this.shouldReplaceData(newData, oldData);
 
         setTimeout(() => {
@@ -274,6 +272,7 @@ export class Table {
             }
 
             if (shouldReplace) {
+                this.pool.releaseAll();
                 this.tabulator.replaceData(newData);
                 this.setSelection();
 


### PR DESCRIPTION
The element pool should only be released if all the data should be replaced. 

Fixes https://github.com/Lundalogik/crm-feature/issues/4377