### PR TITLE
fix(table-view): only release element pool if should replace is true

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -264,8 +264,6 @@ export class Table {
 
     @Watch('data')
     protected updateData(newData: RowData[] = [], oldData: RowData[] = []) {
-        this.pool.releaseAll();
-
         const shouldReplace = this.shouldReplaceData(newData, oldData);
 
         setTimeout(() => {
@@ -274,6 +272,7 @@ export class Table {
             }
 
             if (shouldReplace) {
+                this.pool.releaseAll();
                 this.tabulator.replaceData(newData);
                 this.setSelection();
 


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
