### PR TITLE
fix(progress-flow): increase lock icon visibility

### DIFF
--- a/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
@@ -1,21 +1,23 @@
 .step {
     // `before` is circle
-    // `after` is lock icon
+
     &:before,
-    &:after {
+    .lock-icon {
         pointer-events: none;
         box-sizing: border-box;
         z-index: $limel-progress-flow-step-content;
+    }
+
+    &::before {
         position: absolute;
         right: var(--selected-indicator-right);
-
         border-radius: 50%;
     }
 
     .last & {
         &:before,
-        &:after {
-            right: functions.pxToRem(8);
+        .lock-icon {
+            right: 0.5rem;
         }
     }
 }
@@ -23,35 +25,21 @@
 .flow-item:not(.off-progress-item) {
     .step {
         &.selected {
-            &:before,
-            &:after {
+            &:before {
                 content: '';
                 width: functions.pxToRem(6);
                 height: functions.pxToRem(6);
-            }
-
-            &:before {
-                background-color: var(--step-divider-color);
+                background-color: rgb(var(--contrast-700));
                 opacity: 0.7;
             }
         }
-        &.disabled {
-            &:before,
-            &:after {
-                width: functions.pxToRem(12);
-                height: functions.pxToRem(12);
-            }
-
-            &:after {
-                content: '';
-                background: {
-                    image: url("data:image/svg+xml;charset=utf-8, <svg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg' xml:space='preserve' fill-rule='evenodd' clip-rule='evenodd' stroke-linejoin='round' stroke-miterlimit='2'><path fill='rgb(127,127,127)' d='M32.18 13.711c0-2.207-1.793-4-4.002-4H11.821c-2.208 0-4 1.793-4 4V28.29a4 4 0 0 0 4 4h16.357a4.002 4.002 0 0 0 4.001-4V13.711Z'/><path fill='rgb(127,127,127)' d='M11.211 9.758V7.673A7.489 7.489 0 0 1 18.696.188h2.608a7.489 7.489 0 0 1 7.485 7.485v2.085h-3V7.673a4.488 4.488 0 0 0-4.485-4.485h-2.608a4.488 4.488 0 0 0-4.485 4.485v2.085h-3Z'/></svg>");
-                    size: 90%;
-                    repeat: no-repeat;
-                    position: center;
-                }
-                mix-blend-mode: multiply;
-            }
-        }
     }
+}
+
+.lock-icon {
+    margin-left: 0.25rem;
+    margin-right: -0.5rem;
+    width: 0.75rem;
+    color: currentColor;
+    scale: 0.8;
 }

--- a/src/components/progress-flow/progress-flow-item/progress-flow-item.tsx
+++ b/src/components/progress-flow/progress-flow-item/progress-flow-item.tsx
@@ -74,6 +74,7 @@ export class ProgressFlowItem {
                 {this.renderIcon()}
                 <span class="text">{this.item.text}</span>
                 {this.renderDivider()}
+                {this.renderLockIcon()}
             </button>,
             this.renderSecondaryText(),
         ];
@@ -119,5 +120,13 @@ export class ProgressFlowItem {
         }
 
         return <div class="divider" />;
+    }
+
+    private renderLockIcon() {
+        if (!this.isDisabled()) {
+            return;
+        }
+
+        return <limel-icon name="lock" class="lock-icon" />;
     }
 }

--- a/src/test-assets/icons/lock.svg
+++ b/src/test-assets/icons/lock.svg
@@ -1,0 +1,6 @@
+<svg width="60" height="60" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.0">
+ <metadata>image/svg+xmlOpenclipart</metadata>
+ <g class="layer">
+  <title>lock</title>
+ </g>
+</svg>


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/2037
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
