### PR TITLE
perf(portal): do DOM manipulation when portal becomes visible

### DIFF
--- a/src/components/portal/portal.scss
+++ b/src/components/portal/portal.scss
@@ -14,3 +14,7 @@
 :host([hidden]) {
     display: none;
 }
+
+slot {
+    display: none;
+}

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -140,6 +140,17 @@ export class Portal {
             return;
         }
 
+        if (this.visible) {
+            this.init();
+        }
+    }
+
+    public componentDidLoad() {
+        this.loaded = true;
+        this.connectedCallback();
+    }
+
+    private init() {
         this.createContainer();
         this.hideContainer();
         this.attachContainer();
@@ -161,17 +172,16 @@ export class Portal {
         }
     }
 
-    public componentDidLoad() {
-        this.loaded = true;
-        this.connectedCallback();
-    }
-
     public render() {
         return <slot />;
     }
 
     @Watch('visible')
     protected onVisible() {
+        if (!this.container && this.visible) {
+            this.init();
+        }
+
         if (!this.visible) {
             this.hideContainer();
             this.styleContainer();


### PR DESCRIPTION
If many portals are rendered on a page there might be a heavy performance hit when all the elements are moved around in the DOM at the same time. We only need to actually move the elements once the portal becomes visible.


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
