### PR TITLE
perf(form): render collapsed children when they become visible

### DIFF
--- a/src/components/form/templates/array-field-collapsible-item.ts
+++ b/src/components/form/templates/array-field-collapsible-item.ts
@@ -34,19 +34,24 @@ interface CollapsibleItemProps {
 
 export class CollapsibleItemTemplate extends React.Component {
     public refs: { section: any };
-    private isOpen: boolean;
+    state = {
+        isOpen: false,
+    };
 
     constructor(public props: CollapsibleItemProps) {
         super(props);
         this.handleAction = this.handleAction.bind(this);
         this.isDeepEmpty = this.isDeepEmpty.bind(this);
 
-        this.isOpen = this.isDeepEmpty(props.data);
+        this.setState({
+            isOpen: this.isDeepEmpty(props.data),
+        });
     }
 
     public componentDidMount() {
         const section: HTMLLimelCollapsibleSectionElement = this.refs.section;
         section.addEventListener('action', this.handleAction);
+        section.addEventListener('open', this.handleOpen);
 
         this.setActions(section);
     }
@@ -59,10 +64,15 @@ export class CollapsibleItemTemplate extends React.Component {
     public componentWillUnmount() {
         const section: HTMLLimelCollapsibleSectionElement = this.refs.section;
         section.removeEventListener('action', this.handleAction);
+        section.removeEventListener('open', this.handleOpen);
     }
 
     public render() {
         const { data, schema, formSchema } = this.props;
+        let children: any;
+        if (this.state.isOpen) {
+            children = this.props.item.children;
+        }
 
         return React.createElement(
             'limel-collapsible-section',
@@ -70,9 +80,9 @@ export class CollapsibleItemTemplate extends React.Component {
                 header: findTitle(data, schema, formSchema) || 'New item',
                 class: 'limel-form-array-item--object',
                 ref: 'section',
-                'is-open': this.isOpen,
+                'is-open': this.state.isOpen,
             },
-            this.props.item.children,
+            children,
         );
     }
 
@@ -106,6 +116,12 @@ export class CollapsibleItemTemplate extends React.Component {
         event.stopPropagation();
         event.detail.run(event);
     }
+
+    private handleOpen = () => {
+        this.setState({
+            isOpen: true,
+        });
+    };
 
     private isDeepEmpty(data) {
         if (typeof data !== 'object') {


### PR DESCRIPTION
Very large forms can becomve very slow since there are a lot of elements that are rendered. Many forms contain collapsible sections, and elements in collapsed sections do not need to be rendered until the section is first opened



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
