### PR TITLE
Aria busy info tile

### DIFF
--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -124,6 +124,8 @@ export class InfoTile {
                 tabindex="0"
                 aria-label={extendedAriaLabel}
                 aria-disabled={this.disabled}
+                aria-busy={this.loading ? 'true' : 'false'}
+                aria-live="polite"
                 class={{
                     'is-clickable': !!this.link?.href && !this.disabled,
                     'has-circular-progress':


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3171
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
