### PR TITLE
Aria busy loading button

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -94,6 +94,8 @@ export class Button {
                         outlined: this.outlined,
                     }}
                     disabled={this.disabled || this.loading}
+                    aria-busy={this.loading ? 'true' : 'false'}
+                    aria-live="polite"
                 >
                     {this.renderIcon()}
                     {this.renderLabel()}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3172

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
