### PR TITLE
feat(chip-set): add `autocomplete` as a prop for `input` type

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -221,6 +221,7 @@ export namespace Components {
         "type"?: ChipType;
     }
     export interface LimelChipSet {
+        "autocomplete": string;
         "clearAllButton": boolean;
         "delimiter": string;
         "disabled": boolean;
@@ -1153,6 +1154,7 @@ namespace JSX_2 {
         "type"?: ChipType;
     }
     interface LimelChipSet {
+        "autocomplete"?: string;
         "clearAllButton"?: boolean;
         "delimiter"?: string;
         "disabled"?: boolean;

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -178,6 +178,14 @@ export class ChipSet {
     public delimiter: string = null;
 
     /**
+     * For chip-set of type `input`, defines whether the input field should have autocomplete enabled.
+     * Read more about the `autocomplete` attribute
+     * [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
+     */
+    @Prop({ reflect: true })
+    public autocomplete: string = 'off';
+
+    /**
      * Defines the language for translations.
      * Will translate the translatable strings on the components. For example, the clear all chips label.
      */
@@ -424,6 +432,7 @@ export class ChipSet {
                     onChange={this.inputFieldOnChange}
                     placeholder={this.isFull() ? '' : this.searchLabel}
                     readonly={this.isFull()}
+                    autocomplete={this.autocomplete}
                 />
                 <div
                     class={{


### PR DESCRIPTION
In the Chip set and Picker, the autocomplete creates issues. In `limel-picker` (which is a consumer of `limel-chip-set` this behavior is more annoying.
But since the `autocomplete` in the Chip set is set to `'off'` by default, the annoying problem should automatically disappear from Picker.

fix https://github.com/Lundalogik/crm-feature/issues/4386

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
