### PR TITLE
fix(markdown): fix broken default config - allow target attribute on links and more

### DIFF
--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -65,8 +65,11 @@ function getWhiteList(allowedComponents: CustomElement[]): Schema {
         ],
         attributes: {
             ...defaultSchema.attributes,
-            p: [['className', 'MsoNormal']], // Allow the class 'MsoNormal' on <p> elements
-            '*': ['style', 'width'], // Allow `style` and 'width' attribute on all elements
+            p: [
+                ...(defaultSchema.attributes.p ?? []),
+                ['className', 'MsoNormal'],
+            ], // Allow the class 'MsoNormal' on <p> elements
+            '*': [...(defaultSchema.attributes['*'] ?? []), 'style'], // Allow `style` attribute on all elements
         },
     };
 


### PR DESCRIPTION
This was broken back in 43e89bfc4e936e4d1c2c300820ac87888d3aa6ec, which was only partially fixed in c452f3076e1c7dbe36539adb83d684c046f86062.

fix: Lundalogik/crm-feature#4348

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
