### PR TITLE
ensure external links are properly normalized with https

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -114,7 +114,7 @@ export class ProsemirrorAdapter {
     > = [];
 
     @State()
-    private link: EditorTextLink = { href: '' };
+    private link: EditorTextLink = { href: 'https://' };
 
     /**
      * Open state of the dialog
@@ -425,7 +425,7 @@ export class ProsemirrorAdapter {
         event.stopPropagation();
 
         this.isLinkMenuOpen = false;
-        this.link = { text: '', href: '' };
+        this.link = { text: '', href: 'https://' };
     };
 
     private handleSaveLinkMenu = () => {
@@ -439,7 +439,7 @@ export class ProsemirrorAdapter {
         });
         this.view.dom.dispatchEvent(saveLinkEvent);
 
-        this.link = { href: '' };
+        this.link = { href: 'https://' };
     };
 
     private handleLinkChange = (event: CustomEvent<EditorTextLink>) => {
@@ -452,7 +452,7 @@ export class ProsemirrorAdapter {
 
     private handleNewLinkSelection = (text: string, href: string) => {
         this.link.text = text;
-        this.link.href = href;
+        this.link.href = href || 'https://';
     };
 
     private handleOpenLinkMenu = (


### PR DESCRIPTION
The text field in the link popup window will now have a default value of `https://` so the user does not have to enter it manuallt. Additionally, you cannot press "Save" unless the URL is valid

fix: https://github.com/Lundalogik/crm-feature/issues/4349

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
