### PR TITLE
feat(text-editor): add secondary action bar component

### DIFF
--- a/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-basic.scss
+++ b/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-basic.scss
@@ -1,0 +1,22 @@
+:host {
+    --example-controls-column-layout: auto-fit;
+}
+
+div {
+    box-sizing: border-box;
+    overflow: auto;
+    resize: horizontal;
+
+    width: 100%;
+    max-width: 40rem;
+
+    padding: 1rem;
+
+    background: url("data:image/svg+xml;charset=utf-8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8' style='fill-rule:evenodd;'><path fill='rgba(186,186,192,0.16)' d='M0 0h4v4H0zM4 4h4v4H4z'/></svg>");
+    background-size: 0.5rem;
+}
+
+limel-text-editor-action-bar {
+    background-color: rgb(var(--contrast-100));
+    box-shadow: var(--shadow-depth-16);
+}

--- a/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-basic.tsx
+++ b/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-basic.tsx
@@ -1,0 +1,86 @@
+import { Component, h, State } from '@stencil/core';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
+
+/**
+ * Basic example
+ */
+@Component({
+    tag: 'limel-example-text-editor-action-bar-basic',
+    shadow: true,
+    styleUrl: 'text-editor-action-bar-basic.scss',
+})
+export class TextEditorActionBarExample {
+    @State()
+    private selectedToolbarAction: ActionBarItem | null = null;
+
+    private toolbarActions: Array<ActionBarItem | ListSeparator> = [
+        {
+            text: 'Add',
+            icon: {
+                name: 'add',
+                color: 'rgb(var(--color-blue-default))',
+            },
+            iconOnly: true,
+        },
+        {
+            text: 'Mention',
+            icon: 'email_sign',
+            iconOnly: true,
+        },
+        {
+            text: 'Tag',
+            icon: 'hashtag',
+            iconOnly: true,
+        },
+        {
+            text: 'Shortcut',
+            icon: 'line',
+            iconOnly: true,
+        },
+        { separator: true },
+        {
+            text: 'Undo',
+            icon: 'undo',
+            iconOnly: true,
+        },
+        {
+            text: 'Redo',
+            icon: 'redo',
+            iconOnly: true,
+            disabled: true,
+        },
+        { separator: true },
+        {
+            text: 'Add media',
+            icon: 'picture',
+            iconOnly: true,
+        },
+        {
+            text: 'Emojis',
+            icon: 'happy',
+            iconOnly: true,
+        },
+        {
+            text: 'Dictate',
+            icon: 'microphone',
+            iconOnly: true,
+        },
+    ];
+
+    public render() {
+        return [
+            <div>
+                <limel-text-editor-action-bar
+                    toolbarActions={this.toolbarActions}
+                    onToolbarItemSelect={this.handleToolbarItemSelect}
+                />
+            </div>,
+            <limel-example-value value={this.selectedToolbarAction} />,
+        ];
+    }
+
+    private handleToolbarItemSelect = (event: CustomEvent<ActionBarItem>) => {
+        event.stopPropagation();
+        this.selectedToolbarAction = event.detail;
+    };
+}

--- a/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-custom-component.tsx
+++ b/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-custom-component.tsx
@@ -1,0 +1,47 @@
+import { Component, h, State } from '@stencil/core';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
+
+/**
+ * Using the toolbar actions
+ *
+ * When a user clicks a toolbar action, you can respond to the event
+ * in various ways. For example, you can open a popover that contains
+ * a custom component for supporting the user in the action they want to perform.
+ */
+@Component({
+    tag: 'limel-example-text-editor-action-bar-custom-component',
+    shadow: true,
+    styleUrl: 'text-editor-action-bar-basic.scss',
+})
+export class TextEditorActionBarCustomComponentExample {
+    @State()
+    private selectedToolbarAction: ActionBarItem | null = null;
+
+    private toolbarActions: Array<ActionBarItem | ListSeparator> = [
+        {
+            text: 'Add',
+            icon: {
+                name: 'add',
+                color: 'rgb(var(--color-blue-default))',
+            },
+            iconOnly: true,
+        },
+    ];
+
+    public render() {
+        return [
+            <div>
+                <limel-text-editor-action-bar
+                    toolbarActions={this.toolbarActions}
+                    onToolbarItemSelect={this.handleToolbarItemSelect}
+                />
+            </div>,
+            <limel-example-value value={this.selectedToolbarAction} />,
+        ];
+    }
+
+    private handleToolbarItemSelect = (event: CustomEvent<ActionBarItem>) => {
+        event.stopPropagation();
+        this.selectedToolbarAction = event.detail;
+    };
+}

--- a/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-primary-action-button.tsx
+++ b/src/components/text-editor/text-editor-action-bar/examples/text-editor-action-bar-primary-action-button.tsx
@@ -1,0 +1,88 @@
+import { Component, h, State } from '@stencil/core';
+import {
+    ActionBarItem,
+    ListSeparator,
+    MenuItem,
+} from '@limetech/lime-elements';
+
+/**
+ * With primary action button
+ */
+@Component({
+    tag: 'limel-example-text-editor-action-bar-primary-action-button',
+    shadow: true,
+    styleUrl: 'text-editor-action-bar-basic.scss',
+})
+export class TextEditorPrimaryActionButtonExample {
+    @State()
+    private disabled: boolean = false;
+
+    @State()
+    private selectedSecondaryAction: MenuItem | null = null;
+
+    private toolbarActions: Array<ActionBarItem | ListSeparator> = [
+        {
+            text: 'Formatting options',
+            icon: 'text_color',
+            iconOnly: true,
+        },
+        {
+            text: 'Attach file',
+            icon: 'attach',
+            iconOnly: true,
+        },
+        {
+            text: 'Insert signature',
+            icon: 'signature',
+            iconOnly: true,
+        },
+    ];
+
+    private secondaryActions: Array<ListSeparator | MenuItem> = [
+        { text: 'Send later today', secondaryText: 'at 16:45' },
+        { text: 'Send tomorrow morning', secondaryText: 'at 08:00' },
+        { separator: true },
+        { text: 'Custom time', icon: 'calendar' },
+    ];
+
+    public render() {
+        return [
+            <div>
+                <limel-text-editor-action-bar
+                    primaryActionLabel="Send"
+                    secondaryActions={this.secondaryActions}
+                    primaryActionDisabled={this.disabled}
+                    toolbarActions={this.toolbarActions}
+                    onPrimaryActionClick={this.handlePrimaryActionClick}
+                    onSecondaryActionItemSelect={
+                        this.handleSecondaryActionItemSelect
+                    }
+                />
+            </div>,
+            <limel-example-value value={this.selectedSecondaryAction} />,
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.disabled}
+                    label="Primary Action Button Disabled"
+                    onChange={this.setDisabled}
+                />
+            </limel-example-controls>,
+        ];
+    }
+
+    private setDisabled = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disabled = event.detail;
+    };
+
+    private handlePrimaryActionClick = () => {
+        alert('Primary action clicked');
+    };
+
+    private handleSecondaryActionItemSelect = (
+        event: CustomEvent<MenuItem>,
+    ) => {
+        event.stopPropagation();
+        this.selectedSecondaryAction = event.detail;
+    };
+}

--- a/src/components/text-editor/text-editor-action-bar/text-editor-action-bar.scss
+++ b/src/components/text-editor/text-editor-action-bar/text-editor-action-bar.scss
@@ -1,0 +1,23 @@
+* {
+    box-sizing: border-box;
+}
+
+:host(limel-text-editor-action-bar) {
+    box-sizing: border-box;
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    gap: 2rem;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+}
+
+limel-action-bar {
+    min-width: 5rem;
+    flex-grow: 1;
+}
+
+limel-split-button {
+    min-width: 0;
+    flex-shrink: 0;
+}

--- a/src/components/text-editor/text-editor-action-bar/text-editor-action-bar.tsx
+++ b/src/components/text-editor/text-editor-action-bar/text-editor-action-bar.tsx
@@ -1,0 +1,182 @@
+import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
+import translate from '../../../global/translations';
+import { Languages } from '../../date-picker/date.types';
+import { ListSeparator } from '../../list/list-item.types';
+import { MenuItem } from '../../menu/menu.types';
+import { ActionBarItem } from '../../action-bar/action-bar.types';
+
+/**
+ * This private & internal component renders a secondary action bar, intended to be used
+ * together with `limel-text-editor` component.
+ *
+ * This component is responsible for:
+ * 1. Visualizing the built-in actions that our text editor natively supports, such as
+ * typing an ﹫ to mention a user, or typing a # to create a tag.
+ * 1. Visualizing custom actions that a consumer wants to add to the text editor.
+ * 1. Visualizing a split button that performs a primary action (such as `Send`),
+ * and an optional array secondary actions (such as _Schedule send_, _Send & close ticket_, etc).
+ *
+ * @exampleComponent limel-example-text-editor-action-bar-basic
+ * @exampleComponent limel-example-text-editor-action-bar-primary-action-button
+ * @exampleComponent limel-example-text-editor-action-bar-custom-component
+ *
+ * @beta
+ * @Private
+ */
+@Component({
+    tag: 'limel-text-editor-action-bar',
+    shadow: true,
+    styleUrl: 'text-editor-action-bar.scss',
+})
+export class TextEditorSecondaryActionBar {
+    /**
+     * Defines the language for translations.
+     * Will translate the translatable strings on the components.
+     */
+    @Prop({ reflect: true })
+    public language: Languages = 'en';
+
+    /**
+     * The text to show on the split button.
+     * It is the primary action of the split button.
+     */
+    @Prop({ reflect: true })
+    public primaryActionLabel?: string;
+
+    /**
+     * The text to show as a tooltip on the split button.
+     * Suitable for UIs where space is limited, or having a
+     * visible label is not desired.
+     */
+    @Prop({ reflect: true })
+    public primaryActionTooltip?: string;
+
+    /**
+     * Optional icon for the split button.
+     * Should depict the primary action, which is usually
+     * sending, adding or posting the content.
+     */
+    @Prop({ reflect: true })
+    public primaryActionIcon: string = 'send_plane_tilted';
+
+    /**
+     * Defines whether the primary action button is disabled or not.
+     */
+    @Prop({ reflect: true })
+    public primaryActionDisabled: boolean = false;
+
+    /**
+     * A list of items and separators to show
+     * for in the split button's menu.
+     */
+    @Prop()
+    public secondaryActions?: Array<MenuItem | ListSeparator> = [];
+
+    /**
+     * Items that are placed in the action bar.
+     */
+    @Prop()
+    public toolbarActions: Array<ActionBarItem | ListSeparator> = [];
+
+    /**
+     * Event emitted when the split button is clicked.
+     */
+    @Event()
+    public primaryActionClick: EventEmitter<void>;
+
+    /**
+     * Event emitted when a menu item inside the split button is selected.
+     */
+    @Event()
+    public secondaryActionItemSelect: EventEmitter<MenuItem>;
+
+    /**
+     * Event emitted when an action bar item is selected.
+     */
+    @Event()
+    public toolbarItemSelect: EventEmitter<ActionBarItem>;
+
+    public render() {
+        return [
+            this.renderLimelActionBar(),
+            this.renderLimelSplitButton(),
+            this.renderSplitButtonTooltip(),
+        ];
+    }
+
+    private renderLimelActionBar() {
+        return (
+            <limel-action-bar
+                accessibleLabel={translate.get(
+                    'secondary-action-bar',
+                    this.language,
+                )}
+                actions={this.toolbarActions}
+                onItemSelected={this.handleActionBarItemSelect}
+            />
+        );
+    }
+
+    private renderLimelSplitButton() {
+        if (!this.primaryActionLabel && !this.primaryActionTooltip) {
+            return;
+        }
+
+        return (
+            <limel-split-button
+                id="limel-text-editor-primary-action-button"
+                primary={true}
+                disabled={this.primaryActionDisabled}
+                label={this.primaryActionLabel}
+                icon={this.primaryActionIcon}
+                items={this.secondaryActions}
+                onClick={this.handleSplitButtonClick}
+                onSelect={this.handleSplitButtonItemSelect}
+            />
+        );
+    }
+
+    private renderSplitButtonTooltip() {
+        if (!this.primaryActionTooltip) {
+            return;
+        }
+
+        return (
+            <limel-tooltip
+                elementId="limel-text-editor-primary-action-button"
+                label={this.primaryActionTooltip}
+            />
+        );
+    }
+
+    private handleActionBarItemSelect = (event: CustomEvent<ActionBarItem>) => {
+        event.stopPropagation();
+        const setSelection = (item: ActionBarItem) => {
+            return {
+                ...item,
+                selected: item.text === event.detail.text,
+            };
+        };
+
+        this.toolbarActions = this.toolbarActions.map(setSelection);
+        this.toolbarItemSelect.emit(event.detail);
+    };
+
+    private handleSplitButtonClick = (event: MouseEvent) => {
+        event.stopPropagation();
+        this.primaryActionClick.emit();
+    };
+
+    private handleSplitButtonItemSelect = (event: CustomEvent<MenuItem>) => {
+        event.stopPropagation();
+        const setSelection = (item: MenuItem) => {
+            return {
+                ...item,
+                selected: item.text === event.detail.text,
+            };
+        };
+
+        this.secondaryActions = this.secondaryActions.map(setSelection);
+        this.secondaryActionItemSelect.emit(event.detail);
+    };
+}

--- a/src/components/text-editor/text-editor-action-bar/text-editor-action-bar.tsx
+++ b/src/components/text-editor/text-editor-action-bar/text-editor-action-bar.tsx
@@ -79,6 +79,41 @@ export class TextEditorSecondaryActionBar {
     public toolbarActions: Array<ActionBarItem | ListSeparator> = [];
 
     /**
+     * When true, displays a button that:
+     * 1. Allows end users to open their operating system's File Manager.
+     * 1. Allows you to limit which file types are allowed,
+     * and how many files can be chosen by the user.
+     */
+    @Prop({ reflect: true })
+    public fileInput: boolean = false;
+
+    /**
+     * Specifies the types of files that the dropzone will accept. By default, all file types are accepted.
+     *
+     * For media files, formats can be specified using: `audio/*`, `video/*`, `image/*`.
+     * Unique file type specifiers can also be used, for example: `.jpg`, `.pdf`.
+     * A comma-separated list of file extensions or MIME types is also acceptable, e.g., `image/png, image/jpeg` or
+     * `.png, .jpg, .jpeg`.
+     *
+     * @see [HTML attribute: accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) for more
+     * details.
+     */
+    @Prop({ reflect: true })
+    public fileInputAccept: string = '*';
+
+    /**
+     * Set to `true` to enable selection of multiple files
+     */
+    @Prop({ reflect: true })
+    public fileInputMultiple: boolean = false;
+
+    /**
+     * Set to `true` to disable file input selection.
+     */
+    @Prop({ reflect: true })
+    public fileInputDisabled: boolean = false;
+
+    /**
      * Event emitted when the split button is clicked.
      */
     @Event()
@@ -98,10 +133,38 @@ export class TextEditorSecondaryActionBar {
 
     public render() {
         return [
+            this.renderFileInput(),
             this.renderLimelActionBar(),
             this.renderLimelSplitButton(),
             this.renderSplitButtonTooltip(),
         ];
+    }
+
+    private renderFileInput() {
+        if (!this.fileInput) {
+            return;
+        }
+
+        return (
+            <limel-file-input
+                accept={this.fileInputAccept}
+                multiple={this.fileInputMultiple}
+                disabled={this.fileInputDisabled}
+            >
+                <limel-icon-button
+                    icon="attach"
+                    id="attach-file"
+                    disabled={this.fileInputDisabled}
+                />
+                <limel-tooltip
+                    elementId="attach-file"
+                    label="Click to attach files"
+                    helperLabel="or drag & drop them here…"
+                    maxlength={20}
+                    openDirection="right"
+                />
+            </limel-file-input>
+        );
     }
 
     private renderLimelActionBar() {

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -19,6 +19,7 @@ import { createRandomString } from '../../util/random-string';
  * @exampleComponent limel-example-text-editor-size
  * @exampleComponent limel-example-text-editor-ui
  * @exampleComponent limel-example-text-editor-composite
+ *
  * @beta
  */
 @Component({

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -35,4 +35,5 @@ export default {
     'editor-menu.code-block': 'Kodeblok',
     'editor-menu.code': 'Kode',
     'progress-bar': 'Fremskridtsindikator',
+    'secondary-action-bar': 'Sekundær værktøjslinje',
 };

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -37,4 +37,5 @@ export default {
     'editor-menu.code-block': 'Codeblock',
     'editor-menu.code': 'Code',
     'progress-bar': 'Fortschrittsbalken',
+    'secondary-action-bar': 'Sekundäre Aktionsleiste',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -36,4 +36,5 @@ export default {
     'editor-menu.code-block': 'Code block',
     'editor-menu.code': 'Code',
     'progress-bar': 'Progress bar',
+    'secondary-action-bar': 'Secondary action bar',
 };

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -36,4 +36,5 @@ export default {
     'editor-menu.code-block': 'Koodilohko',
     'editor-menu.code': 'Koodi',
     'progress-bar': 'Edistymispalkki',
+    'secondary-action-bar': 'Toissijainen toimintopalkki',
 };

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -37,4 +37,5 @@ export default {
     'editor-menu.code-block': 'Bloc de code',
     'editor-menu.code': 'Code',
     'progress-bar': 'Barre de progression',
+    'secondary-action-bar': "Barre d'actions secondaire",
 };

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -36,4 +36,5 @@ export default {
     'editor-menu.code-block': 'Codeblok',
     'editor-menu.code': 'Code',
     'progress-bar': 'Voortgangsbalk',
+    'secondary-action-bar': 'Secundaire actiebalk',
 };

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -35,4 +35,5 @@ export default {
     'editor-menu.code-block': 'Kodeblokk',
     'editor-menu.code': 'Kode',
     'progress-bar': 'Fremdriftsindikator',
+    'secondary-action-bar': 'Sekundær verktøylinje',
 };

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -36,4 +36,5 @@ export default {
     'editor-menu.code-block': 'Kodblock',
     'editor-menu.code': 'Kod',
     'progress-bar': 'Förloppsindikator',
+    'secondary-action-bar': 'Sekundär verktygsrad',
 };


### PR DESCRIPTION
<img width="696" alt="Screenshot 2024-10-21 at 12 38 08" src="https://github.com/user-attachments/assets/17e474f1-9116-4e0d-94eb-d640c8e20839">

Adds a component, intended to be used together with `limel-text-editor`.

This component should later be used to:
- render the default actions of the text editor, for examples `@` and `#` 
- allow consumers to add their own custom actions
- render a primary action button, or a split-button with optional array of secondary actions 

### from the PR
<img width="732" alt="image" src="https://github.com/user-attachments/assets/d7c90965-fd70-4edb-97fe-dda91c0cd455">


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
