### PR TITLE
split button styles

### DIFF
--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -1,4 +1,4 @@
-@import '../../style/mixins';
+@use '../../style/mixins';
 
 :host(limel-split-button.has-menu) {
     --button-padding-right: 2rem;
@@ -78,11 +78,11 @@ limel-menu {
     width: 1rem;
 
     &:not(:disabled) {
-        @include is-flat-clickable(
+        @include mixins.is-flat-clickable(
             $color: 'inherit',
             $color--hovered: 'inherit'
         );
-        @include visualize-keyboard-focus();
+        @include mixins.visualize-keyboard-focus();
         cursor: pointer;
 
         &:focus-visible,

--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -91,6 +91,10 @@ limel-menu {
         }
     }
 
+    &[aria-expanded]:not([aria-expanded='false']) {
+        box-shadow: var(--button-shadow-inset-pressed);
+    }
+
     &:before {
         // prevents unintentionally activating the default action,
         // by clicking on the edge of menu trigger,


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
