### PR TITLE
fix(split-button): remove unnecessary padding left

### DIFF
--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -2,7 +2,6 @@
 
 :host(limel-split-button.has-menu) {
     --button-padding-right: 2rem;
-    --button-padding-left: 1rem;
 }
 
 :host(limel-split-button) {


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
