### PR TITLE
chore(text-editor): fix `ae-incompatible-release-tags` warning in api

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -564,7 +564,7 @@ export namespace Components {
     export interface LimelProsemirrorAdapter {
         "contentType": 'markdown' | 'html';
         "language": Languages;
-        // Warning: (ae-incompatible-release-tags) The symbol "plugins" is marked as @beta, but its signature references "CustomElement" which is marked as @alpha
+        // @alpha
         "plugins": CustomElement[];
         "value": string;
     }
@@ -670,7 +670,7 @@ export namespace Components {
         "label"?: string;
         "language": Languages;
         "placeholder"?: string;
-        // Warning: (ae-incompatible-release-tags) The symbol "plugins" is marked as @beta, but its signature references "CustomElement" which is marked as @alpha
+        // @alpha
         "plugins": CustomElement[];
         "readonly"?: boolean;
         "required"?: boolean;
@@ -1542,7 +1542,7 @@ namespace JSX_2 {
         "contentType"?: 'markdown' | 'html';
         "language"?: Languages;
         "onChange"?: (event: LimelProsemirrorAdapterCustomEvent<string>) => void;
-        // Warning: (ae-incompatible-release-tags) The symbol "plugins" is marked as @beta, but its signature references "CustomElement" which is marked as @alpha
+        // @alpha
         "plugins"?: CustomElement[];
         "value"?: string;
     }
@@ -1662,7 +1662,7 @@ namespace JSX_2 {
         "language"?: Languages;
         "onChange"?: (event: LimelTextEditorCustomEvent<string>) => void;
         "placeholder"?: string;
-        // Warning: (ae-incompatible-release-tags) The symbol "plugins" is marked as @beta, but its signature references "CustomElement" which is marked as @alpha
+        // @alpha
         "plugins"?: CustomElement[];
         "readonly"?: boolean;
         "required"?: boolean;

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -81,8 +81,10 @@ export class ProsemirrorAdapter {
     public language: Languages;
 
     /**
-     * @private
      * set to private to avoid usage while under development
+     *
+     * @private
+     * @alpha
      */
     @Prop()
     plugins: CustomElement[] = [];

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -97,8 +97,10 @@ export class TextEditor implements FormComponent<string> {
     public value: string;
 
     /**
-     * @private
      * set to private to avoid usage while under development
+     *
+     * @private
+     * @alpha
      */
     @Prop()
     public plugins: CustomElement[] = [];


### PR DESCRIPTION
re: #3139

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
