### PR TITLE
fix(dialog): let footer's height be based on its children

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -121,6 +121,11 @@ slot[name='button'] {
     justify-content: flex-end;
 }
 
+footer.mdc-dialog__actions {
+    min-height: unset;
+    padding: 0.375rem; // 6px
+}
+
 @media screen and (max-width: 760px) {
     slot[name='button'] {
         flex-direction: column-reverse;

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -95,8 +95,6 @@ export class Dialog {
 
     private id: string;
 
-    private showFooter = true;
-
     constructor() {
         this.handleMdcOpened = this.handleMdcOpened.bind(this);
         this.handleMdcClosed = this.handleMdcClosed.bind(this);
@@ -109,7 +107,6 @@ export class Dialog {
 
     public componentWillLoad() {
         this.id = createRandomString();
-        this.showFooter = !!this.host.querySelector('[slot="button"]');
     }
 
     public componentDidLoad() {
@@ -258,13 +255,11 @@ export class Dialog {
     }
 
     private renderFooter() {
-        if (this.showFooter) {
-            return (
-                <footer class="mdc-dialog__actions">
-                    <slot name="button" />
-                </footer>
-            );
-        }
+        return (
+            <footer class="mdc-dialog__actions">
+                <slot name="button" />
+            </footer>
+        );
     }
 
     private setClosingActions() {


### PR DESCRIPTION
By removing MDC's hard-coded `min-height`.

This renders a smaller footer, when the footer only contains elements with `display: none;` visualized below: 👇 

https://github.com/user-attachments/assets/f69475da-945a-44bf-a487-548db0ff07de

This is still not perfect, since the footer has some hardcoded padding too (coming form MDC) which will anyway render it in the UI as a white block.

fix: https://github.com/Lundalogik/lime-elements/issues/1009
fix: https://github.com/Lundalogik/lime-elements/issues/3265

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
