### PR TITLE
Trigger plugin

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -479,7 +479,7 @@ export namespace Components {
     export interface LimelMarkdown {
         "value": string;
         // @alpha
-        "whitelist"?: CustomElement[];
+        "whitelist"?: CustomElementDefinition[];
     }
     // (undocumented)
     export interface LimelMenu {
@@ -563,9 +563,11 @@ export namespace Components {
     // @beta
     export interface LimelProsemirrorAdapter {
         "contentType": 'markdown' | 'html';
+        // @alpha
+        "customElements": CustomElementDefinition[];
         "language": Languages;
         // @alpha
-        "plugins": CustomElement[];
+        "triggerCharacters": TriggerCharacter[];
         "value": string;
     }
     // (undocumented)
@@ -664,16 +666,18 @@ export namespace Components {
     export interface LimelTextEditor {
         "allowResize": boolean;
         "contentType": 'markdown' | 'html';
+        // @alpha
+        "customElements": CustomElementDefinition[];
         "disabled"?: boolean;
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
         "language": Languages;
         "placeholder"?: string;
-        // @alpha
-        "plugins": CustomElement[];
         "readonly"?: boolean;
         "required"?: boolean;
+        // @alpha
+        "triggers": TriggerCharacter[];
         "ui"?: 'standard' | 'minimal';
         "value": string;
     }
@@ -705,7 +709,12 @@ export type Config = {
 };
 
 // @alpha
-export interface CustomElement {
+export type CustomElement = Omit<CustomElementDefinition, 'attributes'> & {
+    attributes: Record<string, any>;
+};
+
+// @alpha
+export interface CustomElementDefinition {
     // (undocumented)
     attributes: string[];
     // (undocumented)
@@ -1447,7 +1456,7 @@ namespace JSX_2 {
     interface LimelMarkdown {
         "value"?: string;
         // @alpha
-        "whitelist"?: CustomElement[];
+        "whitelist"?: CustomElementDefinition[];
     }
     // (undocumented)
     interface LimelMenu {
@@ -1540,10 +1549,12 @@ namespace JSX_2 {
     // @beta
     interface LimelProsemirrorAdapter {
         "contentType"?: 'markdown' | 'html';
+        // @alpha
+        "customElements"?: CustomElementDefinition[];
         "language"?: Languages;
         "onChange"?: (event: LimelProsemirrorAdapterCustomEvent<string>) => void;
         // @alpha
-        "plugins"?: CustomElement[];
+        "triggerCharacters"?: TriggerCharacter[];
         "value"?: string;
     }
     // (undocumented)
@@ -1655,17 +1666,25 @@ namespace JSX_2 {
     interface LimelTextEditor {
         "allowResize"?: boolean;
         "contentType"?: 'markdown' | 'html';
+        // @alpha
+        "customElements"?: CustomElementDefinition[];
         "disabled"?: boolean;
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
         "language"?: Languages;
         "onChange"?: (event: LimelTextEditorCustomEvent<string>) => void;
-        "placeholder"?: string;
         // @alpha
-        "plugins"?: CustomElement[];
+        "onTriggerChange"?: (event: LimelTextEditorCustomEvent<TriggerEventDetail>) => void;
+        // @alpha
+        "onTriggerStart"?: (event: LimelTextEditorCustomEvent<TriggerEventDetail>) => void;
+        // @alpha
+        "onTriggerStop"?: (event: LimelTextEditorCustomEvent<TriggerEventDetail>) => void;
+        "placeholder"?: string;
         "readonly"?: boolean;
         "required"?: boolean;
+        // @alpha
+        "triggers"?: TriggerCharacter[];
         "ui"?: 'standard' | 'minimal';
         "value"?: string;
     }
@@ -2297,6 +2316,27 @@ export interface TableParams {
 export interface TabPanelComponent {
     changeTab?: EventEmitter<Tab>;
     tab: Tab;
+}
+
+// @alpha (undocumented)
+export interface TextEditor {
+    insert: (input: TextEditorNode | string) => void;
+}
+
+// @alpha (undocumented)
+export type TextEditorNode = {
+    node: CustomElement | string;
+    children?: Array<TextEditorNode | string>;
+};
+
+// @alpha (undocumented)
+export type TriggerCharacter = '@' | '#' | '$' | '!' | '?' | '&' | '*' | '%' | '+' | '-' | '=' | '/' | '\\' | '^' | '~' | '`' | ':' | ';' | '|' | '.' | ',' | '<' | '>' | '[' | ']' | '{' | '}' | '(' | ')' | "'";
+
+// @alpha (undocumented)
+export interface TriggerEventDetail {
+    textEditor: TextEditor;
+    trigger: TriggerCharacter;
+    value: string;
 }
 
 // @public (undocumented)

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -10,7 +10,7 @@ import { visit } from 'unist-util-visit';
 import { sanitizeStyle } from './sanitize-style';
 import { Node } from 'unist';
 import { Schema } from 'rehype-sanitize/lib';
-import { CustomElement } from '../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 
 /**
  * Takes a string as input and returns a new string
@@ -56,7 +56,7 @@ export async function markdownToHTML(
     return file.toString();
 }
 
-function getWhiteList(allowedComponents: CustomElement[]): Schema {
+function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
     const defaultSchemaClone = [...(defaultSchema.attributes['*'] ?? [])];
     const asteriskAttributeWhitelist = defaultSchemaClone.filter((attr) => {
         return attr !== 'height';
@@ -94,5 +94,5 @@ export interface markdownToHTMLOptions {
      * Set to `true` to convert all soft line breaks to hard line breaks.
      */
     forceHardLineBreaks?: boolean;
-    whitelist?: CustomElement[];
+    whitelist?: CustomElementDefinition[];
 }

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, Watch } from '@stencil/core';
 import { markdownToHTML } from './markdown-parser';
-import { CustomElement } from '../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 
 /**
  * The Markdown component receives markdown syntax
@@ -41,7 +41,7 @@ export class Markdown {
      * @alpha
      */
     @Prop()
-    public whitelist?: CustomElement[];
+    public whitelist?: CustomElementDefinition[];
 
     @Watch('value')
     public async textChanged() {

--- a/src/components/text-editor/examples/text-editor-custom-element.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-element.tsx
@@ -24,7 +24,7 @@ export class TextEditorCustomElementExample {
             <limel-text-editor
                 value={this.value}
                 onChange={this.handleChange}
-                plugins={[
+                customElements={[
                     {
                         tagName: 'limel-chip',
                         attributes: ['text', 'icon'],

--- a/src/components/text-editor/examples/text-editor-custom-element.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-element.tsx
@@ -25,7 +25,10 @@ export class TextEditorCustomElementExample {
                 value={this.value}
                 onChange={this.handleChange}
                 plugins={[
-                    { tagName: 'limel-chip', attributes: ['text', 'icon'] },
+                    {
+                        tagName: 'limel-chip',
+                        attributes: ['text', 'icon'],
+                    },
                 ]}
             />,
             <limel-example-value value={this.value} />,

--- a/src/components/text-editor/examples/text-editor-custom-triggers.scss
+++ b/src/components/text-editor/examples/text-editor-custom-triggers.scss
@@ -1,0 +1,22 @@
+limel-button-group {
+    min-width: 8rem;
+}
+
+limel-example-controls {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.mode {
+    display: flex;
+    flex-wrap: nowrap;
+}
+
+.value {
+    display: flex;
+    gap: 0.5rem;
+}
+
+limel-portal {
+    width: auto;
+}

--- a/src/components/text-editor/examples/text-editor-custom-triggers.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-triggers.tsx
@@ -1,0 +1,270 @@
+import {
+    Button,
+    LimelListCustomEvent,
+    ListItem,
+} from '@limetech/lime-elements';
+import {
+    Component,
+    h,
+    State,
+    Element,
+    Event,
+    EventEmitter,
+    Watch,
+} from '@stencil/core';
+import { createRandomString } from 'src/util/random-string';
+import { portalContains } from '../../portal/contains';
+import { ESCAPE } from '../../../util/keycodes';
+import { TextEditor, TriggerEventDetail } from '../text-editor.types';
+
+/**
+ * Custom triggers
+ *
+ * A trigger is a character or sequence of characters that if typed in the text editor
+ * will initiate a trigger session. The session is initialized with a `triggerStart`
+ * event. Subsequent characters written after the trigger sequence will be sent in a
+ * `triggerChange` event. When the focus is removed from the trigger a `triggerStop`
+ * event will be sent.
+ *
+ * The `triggerStart` event contains a `TextEditorInserter` object containing functions
+ * to manipulate the state of the text editor around the trigger. Using any of the
+ * supplied methods will effectivly replace the trigger content in the text editor with
+ * the content of choice.
+ *
+ * In this example we pass either a text or a `limel-chip` representing some chosen user
+ * in a mention like situation.
+ */
+@Component({
+    tag: 'limel-example-text-editor-triggers',
+    shadow: true,
+    styleUrl: 'text-editor-custom-triggers.scss',
+})
+export class TextEditorCustomTriggersExample {
+    constructor() {
+        this.portalId = createRandomString();
+        this.globalClickListener = this.globalClickListener.bind(this);
+    }
+    @State()
+    private value: string = '';
+
+    @State()
+    private triggerState: string = '';
+
+    @State()
+    private inputText: string = '';
+
+    @State()
+    private isPickerOpen: boolean = false;
+
+    @State()
+    private textEditorElement: HTMLElement;
+
+    @State()
+    private insertMode: 'text' | 'chip' = 'text';
+
+    @Element()
+    private host: HTMLLimelPopoverElement;
+
+    /**
+     * Emits an event when the component is closing
+     */
+    @Event()
+    private close: EventEmitter<void>;
+
+    @Watch('isPickerOpen')
+    protected watchOpen() {
+        this.setupGlobalHandlers();
+    }
+
+    public componentWillLoad() {
+        this.setupGlobalHandlers();
+    }
+
+    private setupGlobalHandlers() {
+        if (this.isPickerOpen) {
+            document.addEventListener('click', this.globalClickListener, {
+                capture: true,
+            });
+            document.addEventListener('keyup', this.handleGlobalKeyPress);
+        } else {
+            document.removeEventListener('click', this.globalClickListener);
+            document.removeEventListener('keyup', this.handleGlobalKeyPress);
+        }
+    }
+
+    private handleGlobalKeyPress = (event: KeyboardEvent) => {
+        if (event.key !== ESCAPE) {
+            return;
+        }
+
+        event.stopPropagation();
+        event.preventDefault();
+        this.close.emit();
+    };
+
+    private insertModeButtons: Button[] = [
+        {
+            id: '1',
+            title: 'text',
+            selected: true,
+        },
+        {
+            id: '2',
+            title: 'chip',
+        },
+    ];
+
+    private portalId: string;
+    private items: Array<ListItem<number>> = [
+        { text: 'Wolverine', value: 1, icon: 'wolf' },
+        { text: 'Captain America', value: 2, icon: 'captain_america' },
+        { text: 'Superman', value: 3, icon: 'superman' },
+        { text: 'Tony Stark', value: 4, icon: 'iron_man' },
+        { text: 'Batman', value: 5, icon: 'batman_old' },
+    ];
+
+    private triggerFunction?: TextEditor;
+
+    public render() {
+        return [
+            <limel-text-editor
+                style={{ display: 'block' }}
+                ref={(el) => (this.textEditorElement = el)}
+                value={this.value}
+                plugins={[
+                    { tagName: 'limel-chip', attributes: ['text', 'icon'] },
+                ]}
+                triggers={['@']}
+                onTriggerStart={this.handleTriggerStart}
+                onTriggerStop={this.handleTriggerStop}
+                onTriggerChange={this.handleTriggerChange}
+                onChange={this.handleChange}
+            />,
+            <limel-example-controls>
+                Insert mode:
+                <limel-button-group
+                    class="mode"
+                    value={this.insertModeButtons}
+                    onChange={this.handleInsertModeChange}
+                />
+                <div class="value">
+                    <limel-example-value
+                        label="Action"
+                        value={this.triggerState}
+                    />
+                    <limel-example-value
+                        label="Tag value"
+                        value={this.inputText}
+                    />
+                </div>
+            </limel-example-controls>,
+            this.renderPicker(),
+            <limel-example-value value={this.value} />,
+        ];
+    }
+
+    private handleTriggerStart = (event: CustomEvent<TriggerEventDetail>) => {
+        this.triggerState = 'start';
+        this.isPickerOpen = true;
+        this.triggerFunction = event.detail.textEditor;
+    };
+
+    private handleTriggerStop = () => {
+        this.triggerState = 'stop';
+        this.inputText = '';
+        this.isPickerOpen = false;
+    };
+
+    private handleTriggerChange = (event: CustomEvent<TriggerEventDetail>) => {
+        this.inputText = event.detail.value.toLowerCase();
+    };
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+
+    private renderPicker = () => {
+        if (!this.isPickerOpen) {
+            return;
+        }
+
+        const items = this.items.filter((item: ListItem<number>) =>
+            item.text.toLowerCase().includes(this.inputText),
+        );
+
+        const dropdownZIndex = getComputedStyle(this.host).getPropertyValue(
+            '--dropdown-z-index',
+        );
+
+        return [
+            <limel-portal
+                containerStyle={{
+                    'background-color': 'rgb(var(--contrast-100))',
+                    'border-radius': '0.5rem',
+                    'box-shadow': 'var(--shadow-depth-16)',
+                    'z-index': dropdownZIndex,
+                }}
+                containerId={this.portalId}
+                visible={this.isPickerOpen}
+                openDirection="bottom-start"
+                inheritParentWidth={true}
+                anchor={this.textEditorElement}
+            >
+                {this.renderList(items)}
+            </limel-portal>,
+        ];
+    };
+
+    private globalClickListener(event: MouseEvent) {
+        const element: HTMLElement = event.target as HTMLElement;
+        const clickedInside = portalContains(this.host, element);
+        if (this.isPickerOpen && !clickedInside) {
+            event.stopPropagation();
+            event.preventDefault();
+            this.isPickerOpen = false;
+            this.close.emit();
+        }
+    }
+
+    private renderList = (items: Array<ListItem<number>>) => {
+        if (items.length === 0) {
+            return (
+                <div style={{ padding: '0.5rem' }}>
+                    Couldn't find. Not a hero yet! 🥲
+                </div>
+            );
+        }
+
+        return (
+            <limel-list
+                items={items}
+                onChange={this.handleListChange}
+                type="selectable"
+            />
+        );
+    };
+
+    private handleListChange = (
+        event: LimelListCustomEvent<ListItem<number>>,
+    ) => {
+        if (this.insertMode === 'text') {
+            this.triggerFunction.insert('@' + event.detail.text);
+
+            return;
+        }
+
+        this.triggerFunction.insert({
+            node: {
+                tagName: 'limel-chip',
+                attributes: {
+                    icon: event.detail.icon,
+                    text: event.detail.text,
+                },
+            },
+        });
+    };
+
+    private handleInsertModeChange = (event: CustomEvent<Button>) => {
+        this.insertMode = event.detail.title as any;
+    };
+}

--- a/src/components/text-editor/examples/text-editor-custom-triggers.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-triggers.tsx
@@ -131,7 +131,7 @@ export class TextEditorCustomTriggersExample {
                 style={{ display: 'block' }}
                 ref={(el) => (this.textEditorElement = el)}
                 value={this.value}
-                plugins={[
+                customElements={[
                     { tagName: 'limel-chip', attributes: ['text', 'icon'] },
                 ]}
                 triggers={['@']}

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
@@ -1,0 +1,227 @@
+import { Plugin, PluginKey, EditorState, Transaction } from 'prosemirror-state';
+import { ReplaceStep, ReplaceAroundStep } from 'prosemirror-transform';
+import { EditorView } from 'prosemirror-view';
+import { inserterFactory } from './inserter';
+import {
+    TriggerCharacter,
+    TriggerEventDetail,
+} from 'src/components/text-editor/text-editor.types';
+
+const isTrigger = (
+    key: string,
+    validTriggers: TriggerCharacter[],
+): key is TriggerCharacter => {
+    return key.length === 1 && validTriggers.includes(key as TriggerCharacter);
+};
+
+const shouldTrigger = (state: EditorState): boolean => {
+    const { $from } = state.selection;
+
+    if ($from.pos === 1) {
+        return true;
+    }
+
+    // Getting the position immediately before the current selection
+    const prevPos = $from.pos - 1;
+
+    if (prevPos > 0) {
+        // allow trigger if the cursor is at the start of a new paragraph
+        if ($from.parentOffset === 0) {
+            return true;
+        }
+
+        const prevChar = state.doc.textBetween(prevPos, $from.pos);
+
+        return prevChar === ' ' || prevChar === '\n';
+    }
+
+    return false;
+};
+
+const stillHasTrigger = (
+    state: EditorState,
+    activeTrigger: string,
+    triggerPosition: number,
+    triggerLength: number,
+): boolean => {
+    const cursorPosition = state.selection.$from.pos;
+
+    if (
+        cursorPosition < triggerPosition ||
+        cursorPosition > triggerPosition + triggerLength + 1
+    ) {
+        return false;
+    }
+
+    return (
+        state.doc.textBetween(triggerPosition, triggerPosition + 1) ===
+        activeTrigger
+    );
+};
+
+const getTriggerEventDetail = (
+    view: EditorView,
+    trigger: TriggerCharacter,
+    value: string,
+): TriggerEventDetail => {
+    return {
+        trigger: trigger,
+        textEditor: inserterFactory(view),
+        value: value,
+    };
+};
+
+const sendTriggerEvent = (
+    type: 'triggerStart' | 'triggerStop' | 'triggerChange',
+    view: EditorView,
+    trigger: TriggerCharacter,
+    value: string,
+) => {
+    const event = new CustomEvent<TriggerEventDetail>(type, {
+        detail: getTriggerEventDetail(view, trigger, value),
+        bubbles: true,
+        composed: true,
+    });
+    view.dom.dispatchEvent(event);
+};
+
+const processTransactions = (
+    text: string,
+    transactions: Transaction[],
+    oldState: EditorState,
+): string => {
+    let textAdded = '';
+    let textRemoved = '';
+
+    transactions.forEach((transaction) => {
+        if (transaction.docChanged) {
+            transaction.steps.forEach((step) => {
+                if (
+                    step instanceof ReplaceStep ||
+                    step instanceof ReplaceAroundStep
+                ) {
+                    const slice = step.slice;
+                    const fromPos = step.from;
+                    const toPos = step.to;
+
+                    if (slice?.size) {
+                        // Text added
+                        textAdded += slice.content.textBetween(0, slice.size);
+                    } else if (fromPos !== toPos) {
+                        // Text removed
+                        const removedText = oldState.doc.textBetween(
+                            fromPos,
+                            toPos,
+                        );
+                        textRemoved += removedText;
+                    }
+                }
+            });
+        }
+    });
+
+    if (textAdded) {
+        text += textAdded;
+    } else if (textRemoved) {
+        text = text.slice(0, -textRemoved.length);
+    }
+
+    return text;
+};
+
+export const createTriggerPlugin = (triggerCharacters: TriggerCharacter[]) => {
+    let activeTrigger: TriggerCharacter | null = null;
+    let triggerText = '';
+    let pluginView: EditorView | null = null;
+    let triggerPosition: number | null = null;
+
+    const stopTrigger = () => {
+        triggerText = '';
+        sendTriggerEvent('triggerStop', pluginView, activeTrigger, triggerText);
+        triggerPosition = null;
+        activeTrigger = null;
+    };
+
+    const handleKeyDown = (view: EditorView, event: any) => {
+        const { state } = view;
+
+        if (event.key === 'Escape') {
+            stopTrigger();
+
+            return true;
+        }
+
+        if (isTrigger(event.key, triggerCharacters) && shouldTrigger(state)) {
+            activeTrigger = event.key;
+            triggerText = '';
+            triggerPosition = state.selection.$from.pos - triggerText.length;
+            sendTriggerEvent('triggerStart', view, activeTrigger, triggerText);
+
+            return false;
+        }
+
+        return false;
+    };
+
+    const appendTransactions = (
+        transactions: Transaction[],
+        oldState: EditorState,
+        newState: EditorState,
+    ): Transaction => {
+        if (!activeTrigger || !triggerPosition || !pluginView) {
+            return;
+        }
+
+        if (
+            !stillHasTrigger(
+                newState,
+                activeTrigger,
+                triggerPosition,
+                triggerText.length,
+            )
+        ) {
+            return;
+        }
+
+        const updatedText = processTransactions(
+            triggerText,
+            transactions,
+            oldState,
+        );
+
+        if (updatedText !== triggerText) {
+            triggerText = updatedText;
+            sendTriggerEvent(
+                'triggerChange',
+                pluginView,
+                activeTrigger,
+                triggerText.slice(1),
+            );
+        }
+    };
+
+    return new Plugin({
+        key: new PluginKey('triggerPlugin'),
+        view: (view: EditorView) => {
+            pluginView = view;
+
+            return {};
+        },
+        state: {
+            init: () => {
+                return {};
+            },
+            apply: (transaction: Transaction) => {
+                if (transaction.getMeta('stopTrigger')) {
+                    stopTrigger();
+                }
+
+                return {};
+            },
+        },
+        props: {
+            handleKeyDown: handleKeyDown,
+        },
+        appendTransaction: appendTransactions,
+    });
+};

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
@@ -1,0 +1,80 @@
+import { Node, NodeType, Schema } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
+import {
+    TextEditor,
+    TextEditorNode,
+} from 'src/components/text-editor/text-editor.types';
+
+export const inserterFactory = (view: EditorView): TextEditor => {
+    const startPos = getTriggerStartPosition(view);
+
+    return {
+        insert: (input: TextEditorNode | string) => {
+            const { state, dispatch } = view;
+            const { schema, selection } = state;
+            const { $from } = selection;
+
+            let node: Node;
+
+            try {
+                node = createNode(input, schema);
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error(error.message);
+
+                return;
+            }
+
+            const spaceNode = schema.text(' ');
+
+            const fragment = schema.nodes.doc.create(null, [node, spaceNode]);
+
+            const transaction = state.tr.replaceWith(
+                startPos,
+                $from.pos,
+                fragment,
+            );
+
+            transaction.setMeta('stopTrigger', true);
+            dispatch(transaction);
+        },
+    };
+};
+
+const createNode = (input: TextEditorNode | string, schema: Schema): Node => {
+    if (typeof input === 'string') {
+        return schema.text(input);
+    }
+
+    const node = input.node;
+
+    if (typeof node === 'string') {
+        return schema.text(node);
+    }
+
+    const customNode = getCustomNode(node.tagName, schema);
+
+    const childNodes: Node[] = (input.children ?? [])
+        .map((child) => createNode(child, schema))
+        .filter(Boolean);
+
+    return customNode.create(node.attributes, childNodes);
+};
+
+const getCustomNode = (name: string, schema: Schema): NodeType => {
+    const customNode = Object.values(schema.nodes).find(
+        (prosemirrorNode) => prosemirrorNode.name === name,
+    );
+
+    if (!customNode) {
+        throw new Error(
+            `A custom element hasn't been registered for node ${name}`,
+        );
+    }
+
+    return customNode;
+};
+
+const getTriggerStartPosition = (view: EditorView): number => {
+    return view.state?.selection?.$from?.pos;
+};

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -89,7 +89,7 @@ export class ProsemirrorAdapter {
      * @alpha
      */
     @Prop()
-    plugins: CustomElementDefinition[] = [];
+    customElements: CustomElementDefinition[] = [];
 
     /**
      * set to private to avoid usage while under development
@@ -244,7 +244,7 @@ export class ProsemirrorAdapter {
 
     private setupContentConverter() {
         if (this.contentType === 'markdown') {
-            this.contentConverter = new MarkdownConverter(this.plugins);
+            this.contentConverter = new MarkdownConverter(this.customElements);
         } else if (this.contentType === 'html') {
             this.contentConverter = new HTMLConverter();
         } else {
@@ -296,9 +296,9 @@ export class ProsemirrorAdapter {
     private initializeSchema() {
         let nodes = schema.spec.nodes;
 
-        this.plugins.forEach((plugin) => {
-            const newNodeSpec = createNodeSpec(plugin);
-            const nodeName = plugin.tagName;
+        this.customElements.forEach((customElement) => {
+            const newNodeSpec = createNodeSpec(customElement);
+            const nodeName = customElement.tagName;
 
             nodes = nodes.append({ [nodeName]: newNodeSpec });
         });

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -40,8 +40,10 @@ import {
 import { createImageRemoverPlugin } from './plugins/image-remover-plugin';
 import { createMenuStateTrackingPlugin } from './plugins/menu-state-tracking-plugin';
 import { createActionBarInteractionPlugin } from './plugins/menu-action-interaction-plugin';
-import { CustomElement } from '../../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../../global/shared-types/custom-element.types';
 import { createNodeSpec } from '../utils/plugin-factory';
+import { createTriggerPlugin } from './plugins/trigger/factory';
+import { TriggerCharacter } from '../text-editor.types';
 
 const DEBOUNCE_TIMEOUT = 300;
 
@@ -87,7 +89,16 @@ export class ProsemirrorAdapter {
      * @alpha
      */
     @Prop()
-    plugins: CustomElement[] = [];
+    plugins: CustomElementDefinition[] = [];
+
+    /**
+     * set to private to avoid usage while under development
+     *
+     * @private
+     * @alpha
+     */
+    @Prop()
+    triggerCharacters: TriggerCharacter[] = [];
 
     @Element()
     private host: HTMLLimelTextEditorElement;
@@ -324,6 +335,7 @@ export class ProsemirrorAdapter {
                 ...exampleSetup({ schema: this.schema, menuBar: false }),
                 keymap(this.menuCommandFactory.buildKeymap()),
                 createLinkPlugin(this.handleNewLinkSelection),
+                createTriggerPlugin(this.triggerCharacters),
                 createImageRemoverPlugin(),
                 createMenuStateTrackingPlugin(
                     editorMenuTypesArray,

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -99,13 +99,16 @@ export class TextEditor implements FormComponent<string> {
     public value: string;
 
     /**
-     * set to private to avoid usage while under development
+     * A list of custom elements
+     *
+     * Any `CustomElement` that should be used inside the text editor needs
+     * to be defined here.
      *
      * @private
      * @alpha
      */
     @Prop()
-    public plugins: CustomElementDefinition[] = [];
+    public customElements: CustomElementDefinition[] = [];
 
     /**
      * A set of trigger characters
@@ -235,7 +238,7 @@ export class TextEditor implements FormComponent<string> {
                 aria-placeholder={this.placeholder}
                 contentType={this.contentType}
                 onChange={this.handleChange}
-                plugins={this.plugins}
+                customElements={this.customElements}
                 value={this.value}
                 aria-controls={this.helperTextId}
                 id={this.editorId}

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -2,7 +2,8 @@ import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
 import { FormComponent } from '../form/form.types';
 import { Languages } from '../date-picker/date.types';
 import { createRandomString } from '../../util/random-string';
-import { CustomElement } from '../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
+import { TriggerCharacter, TriggerEventDetail } from './text-editor.types';
 
 /**
  * A rich text editor that offers a rich text editing experience with markdown support,
@@ -22,6 +23,7 @@ import { CustomElement } from '../../global/shared-types/custom-element.types';
  * @exampleComponent limel-example-text-editor-ui
  * @exampleComponent limel-example-text-editor-composite
  * @exampleComponent limel-example-text-editor-custom-element
+ * @exampleComponent limel-example-text-editor-triggers
  * @beta
  */
 @Component({
@@ -103,7 +105,19 @@ export class TextEditor implements FormComponent<string> {
      * @alpha
      */
     @Prop()
-    public plugins: CustomElement[] = [];
+    public plugins: CustomElementDefinition[] = [];
+
+    /**
+     * A set of trigger characters
+     *
+     * Defining a character here will enable trigger events to be sent if the
+     * character is detected in the editor.
+     *
+     * @private
+     * @alpha
+     */
+    @Prop()
+    public triggers: TriggerCharacter[] = [];
 
     /**
      * Set to `true` to indicate that the field is required.
@@ -141,6 +155,35 @@ export class TextEditor implements FormComponent<string> {
      */
     @Event()
     public change: EventEmitter<string>;
+
+    /**
+     * Dispatched if a trigger character is detected.
+     *
+     * @private
+     * @alpha
+     */
+    @Event()
+    public triggerStart: EventEmitter<TriggerEventDetail>;
+
+    /**
+     * Dispatched if a trigger session is ended. That is if the selection
+     * goes outside the trigger input or if something is inserted using the
+     * supplied `TextEditor` insert function.
+     *
+     * @private
+     * @alpha
+     */
+    @Event()
+    public triggerStop: EventEmitter<TriggerEventDetail>;
+
+    /**
+     * Dispatched if a input is changed during an active trigger.
+     *
+     * @private
+     * @alpha
+     */
+    @Event()
+    public triggerChange: EventEmitter<TriggerEventDetail>;
 
     private helperTextId: string;
     private editorId: string;
@@ -199,6 +242,7 @@ export class TextEditor implements FormComponent<string> {
                 tabindex={this.disabled ? -1 : undefined}
                 aria-disabled={this.disabled}
                 language={this.language}
+                triggerCharacters={this.triggers}
             />,
             this.renderPlaceholder(),
             this.renderHelperLine(),

--- a/src/components/text-editor/text-editor.types.ts
+++ b/src/components/text-editor/text-editor.types.ts
@@ -1,0 +1,83 @@
+import { CustomElement } from '../../global/shared-types/custom-element.types';
+
+/**
+ * @alpha
+ */
+export type TriggerCharacter =
+    | '@'
+    | '#'
+    | '$'
+    | '!'
+    | '?'
+    | '&'
+    | '*'
+    | '%'
+    | '+'
+    | '-'
+    | '='
+    | '/'
+    | '\\'
+    | '^'
+    | '~'
+    | '`'
+    | ':'
+    | ';'
+    | '|'
+    | '.'
+    | ','
+    | '<'
+    | '>'
+    | '['
+    | ']'
+    | '{'
+    | '}'
+    | '('
+    | ')'
+    | "'";
+
+/**
+ * @alpha
+ */
+export type TextEditorNode = {
+    /**
+     * The top node
+     */
+    node: CustomElement | string;
+
+    /**
+     * One more more children under the top node
+     */
+    children?: Array<TextEditorNode | string>;
+};
+
+/**
+ * @alpha
+ */
+export interface TextEditor {
+    /**
+     * Method to insert either text or a node at the cursor position
+     *
+     */
+    insert: (input: TextEditorNode | string) => void;
+}
+
+/**
+ * @alpha
+ */
+export interface TriggerEventDetail {
+    /**
+     * The trigger that triggered this event
+     *
+     */
+    trigger: TriggerCharacter;
+
+    /**
+     * The text editor
+     */
+    textEditor: TextEditor;
+
+    /**
+     * Current value of the trigger
+     */
+    value: string;
+}

--- a/src/components/text-editor/types.ts
+++ b/src/components/text-editor/types.ts
@@ -1,9 +1,9 @@
-import { CustomElement } from '../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 
 /**
  * @private
  * set to private to avoid usage while under development
  */
 export type TextEditorPlugin = {
-    node: CustomElement[];
+    node: CustomElementDefinition[];
 };

--- a/src/components/text-editor/utils/markdown-converter.ts
+++ b/src/components/text-editor/utils/markdown-converter.ts
@@ -7,7 +7,7 @@ import {
     defaultMarkdownSerializer,
 } from 'prosemirror-markdown';
 import { markdownToHTML } from '../../markdown/markdown-parser';
-import { CustomElement } from '../../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../../global/shared-types/custom-element.types';
 
 type MarkdownSerializerFunction = (
     state: MarkdownSerializerState,
@@ -15,7 +15,7 @@ type MarkdownSerializerFunction = (
 ) => void;
 
 const createMarkdownSerializerFunction = (
-    config: CustomElement,
+    config: CustomElementDefinition,
 ): MarkdownSerializerFunction => {
     return (state: MarkdownSerializerState, node: ProseMirrorNode) => {
         const tagOpen =
@@ -31,7 +31,7 @@ const createMarkdownSerializerFunction = (
 };
 
 const buildMarkdownSerializer = (
-    plugins: CustomElement[],
+    plugins: CustomElementDefinition[],
 ): MarkdownSerializer => {
     const customNodes = {};
 
@@ -62,15 +62,15 @@ const buildMarkdownSerializer = (
  */
 export class MarkdownConverter implements ContentTypeConverter {
     private markdownSerializer: MarkdownSerializer;
-    private customNodes: CustomElement[];
+    private customNodes: CustomElementDefinition[];
 
-    constructor(plugins: CustomElement[]) {
+    constructor(plugins: CustomElementDefinition[]) {
         this.markdownSerializer = buildMarkdownSerializer(plugins);
         this.customNodes = plugins;
     }
     public parseAsHTML = (text: string): Promise<string> => {
-        const whitelist: CustomElement[] = this.customNodes.map(
-            (nodeConfig: CustomElement) => ({
+        const whitelist: CustomElementDefinition[] = this.customNodes.map(
+            (nodeConfig: CustomElementDefinition) => ({
                 tagName: nodeConfig.tagName,
                 attributes: nodeConfig.attributes,
             }),

--- a/src/components/text-editor/utils/plugin-factory.ts
+++ b/src/components/text-editor/utils/plugin-factory.ts
@@ -1,10 +1,10 @@
 import { NodeSpec } from 'prosemirror-model';
-import { CustomElement } from '../../../global/shared-types/custom-element.types';
+import { CustomElementDefinition } from '../../../global/shared-types/custom-element.types';
 
-type NodeSpecFactory = (config: CustomElement) => NodeSpec;
+type NodeSpecFactory = (config: CustomElementDefinition) => NodeSpec;
 
 export const createNodeSpec: NodeSpecFactory = (
-    config: CustomElement,
+    config: CustomElementDefinition,
 ): NodeSpec => {
     const attributes = config.attributes.reduce((acc, attr) => {
         acc[attr] = {};

--- a/src/global/shared-types/custom-element.types.ts
+++ b/src/global/shared-types/custom-element.types.ts
@@ -9,3 +9,15 @@ export interface CustomElementDefinition {
     tagName: string;
     attributes: string[];
 }
+
+/**
+ * Custom Element
+ *
+ * @alpha
+ */
+export type CustomElement = Omit<CustomElementDefinition, 'attributes'> & {
+    /**
+     * Record of attributes and values to apply to the node
+     */
+    attributes: Record<string, any>;
+};

--- a/src/global/shared-types/custom-element.types.ts
+++ b/src/global/shared-types/custom-element.types.ts
@@ -1,9 +1,11 @@
 /**
- * Custom Element
+ * Custom Element definition
+ *
+ * Used to define a Custom Element
  *
  * @alpha
  */
-export interface CustomElement {
+export interface CustomElementDefinition {
     tagName: string;
     attributes: string[];
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -52,3 +52,4 @@ export * from './components/table/table.types';
 export * from './global/shared-types/separator.types';
 export * from './global/shared-types/icon.types';
 export * from './global/shared-types/image.types';
+export * from './components/text-editor/text-editor.types';


### PR DESCRIPTION
Adds triggers to be used when detecting a certain string and starting a trigger session. A trigger session begins when the magic string sequence is inserted, for instance an @ and will keep on sending user input back to the consumer until certain stop conditions occur.

fixes: Lundalogik/crm-feature#4430
Co-authored-by: John Traas <john.traas@lime.tech>

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
