### PR TITLE
UI improvements in dynamic-label, checkbox, and switch

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -19,6 +19,13 @@
 :host(limel-checkbox) {
     @include custom-checkbox-styles;
 }
+:host(limel-checkbox),
+limel-dynamic-label {
+    min-height: 2.5rem;
+}
+limel-dynamic-label {
+    margin-left: 0.25rem;
+}
 
 @include checkbox.core-styles;
 @include form-field.core-styles;

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -18,12 +18,11 @@
 
 :host(limel-checkbox) {
     @include custom-checkbox-styles;
-}
-:host(limel-checkbox),
-limel-dynamic-label {
     min-height: 2.5rem;
 }
+
 limel-dynamic-label {
+    margin-top: 0.375rem;
     margin-left: 0.25rem;
 }
 
@@ -42,6 +41,7 @@ limel-dynamic-label {
 
 .mdc-form-field {
     display: flex;
+    align-items: flex-start;
 
     .mdc-checkbox {
         .mdc-checkbox__native-control {
@@ -85,6 +85,7 @@ limel-dynamic-label {
     label {
         cursor: pointer;
         line-height: normal;
+        padding-top: 0.75rem;
         padding-left: 0;
 
         &.mdc-checkbox--required::after {

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -85,6 +85,8 @@ limel-dynamic-label {
     label {
         cursor: pointer;
         line-height: normal;
+        letter-spacing: normal;
+
         padding-top: 0.75rem;
         padding-left: 0;
 

--- a/src/components/dynamic-label/dynamic-label.scss
+++ b/src/components/dynamic-label/dynamic-label.scss
@@ -22,7 +22,7 @@ limel-icon {
     ); // The default `false` color. Will be overwritten by `Icon`
 }
 
-span {
+label {
     flex-grow: 1;
     font-size: 0.8125rem; // `13px`, Like Checkbox & Switch
     color: var(--mdc-theme-on-surface);

--- a/src/components/dynamic-label/dynamic-label.scss
+++ b/src/components/dynamic-label/dynamic-label.scss
@@ -1,5 +1,3 @@
-@use '../../style/mixins.scss';
-
 * {
     box-sizing: border-box;
     min-width: 0;
@@ -25,7 +23,6 @@ limel-icon {
 }
 
 span {
-    @include mixins.truncate-text;
     flex-grow: 1;
     font-size: 0.8125rem; // `13px`, Like Checkbox & Switch
     color: var(--mdc-theme-on-surface);

--- a/src/components/dynamic-label/dynamic-label.scss
+++ b/src/components/dynamic-label/dynamic-label.scss
@@ -7,7 +7,7 @@
     --limel-dynamic-label-min-height: 1.75rem;
     display: flex;
     gap: 0.5rem;
-    align-items: center;
+    align-items: flex-start;
     border-radius: 0.5rem;
     min-width: 0;
 }
@@ -26,4 +26,5 @@ span {
     flex-grow: 1;
     font-size: 0.8125rem; // `13px`, Like Checkbox & Switch
     color: var(--mdc-theme-on-surface);
+    padding-top: 0.375rem;
 }

--- a/src/components/dynamic-label/dynamic-label.scss
+++ b/src/components/dynamic-label/dynamic-label.scss
@@ -25,6 +25,7 @@ limel-icon {
 label {
     flex-grow: 1;
     font-size: 0.8125rem; // `13px`, Like Checkbox & Switch
+    line-height: normal;
     color: var(--mdc-theme-on-surface);
     padding-top: 0.375rem;
 }

--- a/src/components/dynamic-label/dynamic-label.tsx
+++ b/src/components/dynamic-label/dynamic-label.tsx
@@ -87,6 +87,6 @@ export class DynamicLabel {
     }
 
     private renderLabel(label: string = '') {
-        return <span>{label}</span>;
+        return <label>{label}</label>;
     }
 }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -81,6 +81,7 @@ label {
     color: var(--mdc-theme-on-surface);
     padding-top: 0.375rem;
     line-height: normal;
+    letter-spacing: normal;
 
     &:not(.disabled) {
         cursor: pointer;

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -10,9 +10,11 @@ $scale-factor: 0.8;
 :host(limel-switch) {
     isolation: isolate;
 
+    min-height: 1.75rem;
+
     display: flex;
-    align-items: center;
-    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 0.5rem;
 
     --mdc-switch-selected-icon-color: transparent;
     --mdc-switch-unselected-icon-color: transparent;
@@ -67,13 +69,8 @@ $scale-factor: 0.8;
     --mdc-switch-disabled-unselected-handle-color: rgb(var(--contrast-1000));
 }
 
-:host(limel-switch),
-limel-dynamic-label {
-    min-height: 1.625rem;
-}
-
 .mdc-switch {
-    margin-right: functions.pxToRem(8);
+    margin-top: 0.25rem;
     &:hover {
         --mdc-switch-handle-elevation: var(--button-shadow-hovered);
     }
@@ -82,6 +79,8 @@ limel-dynamic-label {
 label {
     @include lime-typography.typography(body2);
     color: var(--mdc-theme-on-surface);
+    padding-top: 0.375rem;
+    line-height: normal;
 
     &:not(.disabled) {
         cursor: pointer;

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -67,6 +67,11 @@ $scale-factor: 0.8;
     --mdc-switch-disabled-unselected-handle-color: rgb(var(--contrast-1000));
 }
 
+:host(limel-switch),
+limel-dynamic-label {
+    min-height: 1.625rem;
+}
+
 .mdc-switch {
     margin-right: functions.pxToRem(8);
     &:hover {


### PR DESCRIPTION
This is important specially because this component is
used to visualize the readonly state of the boolean elements
(checkbox and switch) which don't truncate their text by deafult
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
