### PR TITLE
Autofix: Snackbar never shown when timeout is -1

### DIFF
--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -67,9 +67,9 @@ export class Snackbar {
 
     /**
      * The amount of time in milliseconds to show the snackbar.
-     * If set to `null`, the snackbar will be persistent.
+     * If set to `null` or any value less than or equal to 0, the snackbar will be persistent.
      * This means:
-     * - either the end user will need to close is manually,
+     * - either the end user will need to close it manually,
      * which requires the `dismissible` property to be set to `true`.
      * - or the snackbar needs to be closed programmatically.
      */
@@ -181,7 +181,7 @@ export class Snackbar {
         this.closing = false;
         container.add(this.host);
 
-        if (this.timeout) {
+        if (this.timeout && this.timeout > 0) {
             this.timeoutId = window.setTimeout(
                 this.handleClose,
                 Math.max(this.timeout - hideAnimationDuration, 0),
@@ -239,7 +239,7 @@ export class Snackbar {
             return undefined;
         }
 
-        if (!this.timeout) {
+        if (!this.timeout || this.timeout <= 0) {
             return 'alertdialog';
         }
 
@@ -294,7 +294,7 @@ export class Snackbar {
     }
 
     private renderTimeoutVisualization() {
-        if (!this.timeout) {
+        if (!this.timeout || this.timeout <= 0) {
             return;
         }
 


### PR DESCRIPTION
I have identified the issue in the `limel-snackbar` component where setting the `timeout` to -1 causes the snackbar to hide immediately. To fix this, I've updated the `handleOpen` method in the `Snackbar` class to treat negative timeout values as persistent (no timeout). Here's a summary of the changes:

1. Modified the `handleOpen` method to check if the timeout is greater than 0 before setting the timeout.
2. Updated the JSDoc comment for the `timeout` property to clarify the behavior with different values.

These changes ensure that setting `timeout` to -1 (or any negative value) will make the snackbar persistent, matching the expected behavior described in the problem statement. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission