### PR TITLE
fix(table): prevent row selections from ruining the layout

### DIFF
--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -4,7 +4,10 @@
 
 .select-all,
 .limel-table--row-selector {
-    --mdc-checkbox-touch-target-size: 1rem; // prevent the checkbox affecting the row height
+    --mdc-checkbox-touch-target-size: 1.125rem; // prevent the checkbox affecting the row height
+    limel-checkbox {
+        min-height: 1.125rem;
+    }
 }
 
 .select-all {


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/4446

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
