### PR TITLE
fix(text-editor): better support for nested custom elements

### DIFF
--- a/src/components/text-editor/examples/text-editor-custom-element.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-element.tsx
@@ -17,7 +17,7 @@ export class TextEditorCustomElementExample {
     @State()
     private value: string =
         "This chip doesn't fit " +
-        '<limel-chip text="Github" icon="github_copyrighted"/>';
+        '<limel-chip text="Github" icon="github_copyrighted">nested element</limel-chip>';
 
     public render() {
         return [

--- a/src/components/text-editor/examples/text-editor-custom-triggers.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-triggers.tsx
@@ -261,6 +261,7 @@ export class TextEditorCustomTriggersExample {
                     text: event.detail.text,
                 },
             },
+            children: ["I'm a teapot"],
         });
     };
 

--- a/src/components/text-editor/utils/markdown-converter.ts
+++ b/src/components/text-editor/utils/markdown-converter.ts
@@ -26,7 +26,9 @@ const createMarkdownSerializerFunction = (
             '>';
         const tagClose = `</${config.tagName}>`;
 
-        state.write(`${tagOpen}${tagClose}`);
+        state.write(tagOpen);
+        state.renderContent(node);
+        state.write(tagClose);
     };
 };
 

--- a/src/components/text-editor/utils/plugin-factory.ts
+++ b/src/components/text-editor/utils/plugin-factory.ts
@@ -1,41 +1,49 @@
-import { NodeSpec } from 'prosemirror-model';
+import {
+    AttributeSpec,
+    Attrs,
+    DOMOutputSpec,
+    NodeSpec,
+} from 'prosemirror-model';
 import { CustomElementDefinition } from '../../../global/shared-types/custom-element.types';
 
 type NodeSpecFactory = (config: CustomElementDefinition) => NodeSpec;
+type AttributeSpecs = {
+    [name: string]: AttributeSpec;
+};
+type MutableAttrs = {
+    [attr: string]: any;
+};
 
 export const createNodeSpec: NodeSpecFactory = (
     config: CustomElementDefinition,
 ): NodeSpec => {
-    const attributes = config.attributes.reduce((acc, attr) => {
-        acc[attr] = {};
+    const attributeSpecs: AttributeSpecs = {};
+    config.attributes.forEach((attribute) => (attributeSpecs[attribute] = {}));
 
-        return acc;
-    }, {});
+    const tag = `${config.tagName}[${config.attributes.map((attr) => attr).join('][')}]`;
 
     return {
         group: 'inline',
+        content: '(text* | inline*)',
         inline: true,
-        atom: false,
+        atom: true,
         selectable: true,
-        attrs: attributes,
+        attrs: attributeSpecs,
 
-        toDOM: (node) => [
-            config.tagName,
-            config.attributes.reduce((acc, attr) => {
-                acc[attr] = node.attrs[attr];
-
-                return acc;
-            }, {}),
-        ],
+        toDOM: (node): DOMOutputSpec => [config.tagName, node.attrs],
         parseDOM: [
             {
-                tag: `${config.tagName}[${config.attributes.map((attr) => attr).join('][')}]`,
-                getAttrs: (dom: Element) =>
-                    config.attributes.reduce((acc, attr) => {
-                        acc[attr] = dom.getAttribute(attr);
+                tag: tag,
+                getAttrs: (dom: Element): Attrs => {
+                    const attributes: MutableAttrs = {};
+                    config.attributes.forEach(
+                        (attribute: string) =>
+                            (attributes[attribute] =
+                                dom.getAttribute(attribute)),
+                    );
 
-                        return acc;
-                    }, {}),
+                    return attributes as Attrs;
+                },
             },
         ],
     };


### PR DESCRIPTION
Gives better support for nested custom elements. Previous implementation did not support nested contentent for custom nodes either in prosemirror nor in the markdown serializer.

This commit makes sure that any nested content will be serialized by the custom markdown serializer function as well as adding support for the custom node to support nested elements.

fixes: Lundalogik/crm-feature#4437



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
