### PR TITLE
fix(form): set collapsible item initial state correctly

### DIFF
--- a/src/components/form/templates/array-field-collapsible-item.ts
+++ b/src/components/form/templates/array-field-collapsible-item.ts
@@ -43,9 +43,9 @@ export class CollapsibleItemTemplate extends React.Component {
         this.handleAction = this.handleAction.bind(this);
         this.isDeepEmpty = this.isDeepEmpty.bind(this);
 
-        this.setState({
+        this.state = {
             isOpen: this.isDeepEmpty(props.data),
-        });
+        };
     }
 
     public componentDidMount() {


### PR DESCRIPTION
Sets the initial state `isOpen` of a collapsible item in a form correctly.

State shouldn't be updated in the constructor of a React component using `this.setState`. It should just be assigned an initial value.

fix: #3288

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
