### PR TITLE
Add a Type definition for uiType used in the text-editor

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -677,7 +677,7 @@ export namespace Components {
         "required"?: boolean;
         // @alpha
         "triggers": TriggerCharacter[];
-        "ui"?: 'standard' | 'minimal';
+        "ui"?: EditorUiType;
         "value": string;
     }
     // @beta
@@ -760,6 +760,9 @@ export type EditorTextLink = {
     text?: string;
     href: string;
 };
+
+// @beta (undocumented)
+export type EditorUiType = 'standard' | 'minimal';
 
 // Warning: (ae-missing-release-tag) "EventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1683,7 +1686,7 @@ namespace JSX_2 {
         "required"?: boolean;
         // @alpha
         "triggers"?: TriggerCharacter[];
-        "ui"?: 'standard' | 'minimal';
+        "ui"?: EditorUiType;
         "value"?: string;
     }
     // @beta

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -4,6 +4,7 @@ import { Languages } from '../date-picker/date.types';
 import { createRandomString } from '../../util/random-string';
 import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 import { TriggerCharacter, TriggerEventDetail } from './text-editor.types';
+import { EditorUiType } from './types';
 
 /**
  * A rich text editor that offers a rich text editing experience with markdown support,
@@ -151,7 +152,7 @@ export class TextEditor implements FormComponent<string> {
      *    until the editor is focused.
      */
     @Prop({ reflect: true })
-    public ui?: 'standard' | 'minimal' = 'standard';
+    public ui?: EditorUiType = 'standard';
 
     /**
      * Dispatched when a change is made to the editor

--- a/src/components/text-editor/types.ts
+++ b/src/components/text-editor/types.ts
@@ -7,3 +7,8 @@ import { CustomElementDefinition } from '../../global/shared-types/custom-elemen
 export type TextEditorPlugin = {
     node: CustomElementDefinition[];
 };
+
+/**
+ * @beta
+ */
+export type EditorUiType = 'standard' | 'minimal';


### PR DESCRIPTION
Fixes https://github.com/Lundalogik/crm-feature/issues/4455

May need separate PR's in both building blocks and lime-crm-components to then import and use the Type definition. 