### PR TITLE
input-field: do not close completions dropdown when onscreen keyboard opens

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -37,7 +37,8 @@ interface LinkProperties {
     target?: string;
 }
 
-const DEBOUNCE_TIMEOUT = 300;
+const CHANGE_EVENT_DEBOUNCE_TIMEOUT = 300;
+const RESIZE_HANDLER_DEBOUNCE_TIMEOUT = 100;
 
 /**
  * @exampleComponent limel-example-input-field-text
@@ -280,6 +281,7 @@ export class InputField {
             this.mdcTextField.destroy();
         }
 
+        this.restyleCompletionsDropDown.cancel();
         window.removeEventListener('resize', this.layout);
         this.limelInputField.removeEventListener('focus', this.setFocus);
     }
@@ -492,7 +494,16 @@ export class InputField {
 
     private layout = () => {
         this.mdcTextField?.layout();
+        this.restyleCompletionsDropDown();
     };
+
+    private restyleCompletionsDropDown = debounce(() => {
+        const stateOfShowCompletions = this.showCompletions;
+        this.showCompletions = false;
+        requestAnimationFrame(() => {
+            this.showCompletions = stateOfShowCompletions;
+        });
+    }, RESIZE_HANDLER_DEBOUNCE_TIMEOUT);
 
     private getAdditionalProps = () => {
         const props: any = {};
@@ -974,7 +985,7 @@ export class InputField {
     private changeEmitter = debounce((value: string) => {
         this.change.emit(value);
         this.changeWaiting = false;
-    }, DEBOUNCE_TIMEOUT);
+    }, CHANGE_EVENT_DEBOUNCE_TIMEOUT);
 
     private handleChange = (event: Event) => {
         event.stopPropagation();

--- a/src/components/menu-surface/menu-surface.tsx
+++ b/src/components/menu-surface/menu-surface.tsx
@@ -90,9 +90,6 @@ export class MenuSurface {
             capture: true,
         });
         this.host.addEventListener('keydown', this.handleKeyDown);
-        window.addEventListener('resize', this.handleResize, {
-            passive: true,
-        });
     };
 
     private teardown = () => {
@@ -101,7 +98,6 @@ export class MenuSurface {
             capture: true,
         });
         this.host.removeEventListener('keydown', this.handleKeyDown);
-        window.removeEventListener('resize', this.handleResize);
     };
 
     private handleDocumentClick = (event) => {
@@ -127,12 +123,6 @@ export class MenuSurface {
 
         this.dismiss.emit();
         this.preventClickEventPropagation();
-    };
-
-    private handleResize = () => {
-        if (this.open) {
-            this.dismiss.emit();
-        }
     };
 
     private preventClickEventPropagation = () => {


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/4408

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
