### PR TITLE
feat(list): add badge count

### DIFF
--- a/src/components/list/list-item.types.ts
+++ b/src/components/list/list-item.types.ts
@@ -63,6 +63,8 @@ export interface ListItem<T = any> {
      * Component used to render the list item.
      */
     primaryComponent?: ListComponent;
+
+    badgeCount?: number | string;
 }
 
 /**

--- a/src/components/list/list-renderer.tsx
+++ b/src/components/list/list-renderer.tsx
@@ -152,12 +152,21 @@ export class ListRenderer {
                 {...attributes}
             >
                 {this.renderIcon(this.config, item)}
+                {this.renderBadge(item)}
                 {this.getPrimaryComponent(item)}
                 {this.renderText(item)}
                 {this.twoLines && this.avatarList ? this.renderDivider() : null}
                 {this.renderActionMenu(item.actions)}
             </li>
         );
+    };
+
+    private renderBadge = (item: ListItem) => {
+        if (!item.badgeCount) {
+            return;
+        }
+
+        return <limel-badge label={item.badgeCount} />;
     };
 
     private renderTextForSeparator = (item: ListSeparator) => {

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -258,6 +258,15 @@ $list-mdc-list-item: 0;
     }
 }
 
+limel-badge {
+    position: absolute;
+    top: 0rem;
+    left: -0.0125rem;
+    /* color: red; */
+    --badge-background-color: rgb(var(--color-red-default));
+    --badge-text-color: rgb(var(--color-yellow-lighter));
+}
+
 @import '../checkbox/checkbox.scss';
 
 @import './radio-button/radio-button.scss';


### PR DESCRIPTION
Adds the possibility so supply a `badgeCount` to the list items. If added a badge will be shown in the list with either a number or string supplied by the consumer.

fixes: Lundalogik/hack-tuesday#376

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
