### PR TITLE
chore(text editor): bump prosemirror-model to 1.22.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "prettier": "^3.3.3",
         "prosemirror-example-setup": "^1.2.3",
         "prosemirror-markdown": "^1.13.1",
+        "prosemirror-model": ">=1.22.1",
         "prosemirror-schema-basic": "^1.2.3",
         "puppeteer": "^19.11.1",
         "react": "^18.3.1",
@@ -13510,7 +13511,7 @@
       "dependencies": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.20.0"
+        "prosemirror-model": ">=1.22.1"
       }
     },
     "node_modules/prosemirror-menu": {
@@ -26648,7 +26649,7 @@
       "integrity": "sha512-hgLcPaakxH8tu6YvVAaILV2tXYsW3rAdDR8WNkeKGcgeMVQg3/TMhPdVoh7iAmfgVjZGtcOSjKiQaoeKjzd2mQ==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.0.0",
+        "prosemirror-model": ">=1.22.1",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
       }
@@ -26688,7 +26689,7 @@
       "dev": true,
       "requires": {
         "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
+        "prosemirror-model": ">=1.22.1",
         "prosemirror-state": "^1.0.0",
         "prosemirror-view": "^1.0.0"
       }
@@ -26733,7 +26734,7 @@
       "requires": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.20.0"
+        "prosemirror-model": ">=1.22.1"
       }
     },
     "prosemirror-menu": {
@@ -26763,7 +26764,7 @@
       "integrity": "sha512-h+H0OQwZVqMon1PNn0AG9cTfx513zgIG2DY00eJ00Yvgb3UD+GQ/VlWW5rcaxacpCGT1Yx8nuhwXk4+QbXUfJA==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.19.0"
+        "prosemirror-model": ">=1.22.1"
       }
     },
     "prosemirror-schema-list": {
@@ -26772,7 +26773,7 @@
       "integrity": "sha512-Hz/7gM4skaaYfRPNgr421CU4GSwotmEwBVvJh5ltGiffUJwm7C8GfN/Bc6DR1EKEp5pDKhODmdXXyi9uIsZl5A==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.0.0",
+        "prosemirror-model": ">=1.22.1",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.7.3"
       }
@@ -26783,7 +26784,7 @@
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.0.0",
+        "prosemirror-model": ">=1.22.1",
         "prosemirror-transform": "^1.0.0",
         "prosemirror-view": "^1.27.0"
       }
@@ -26794,7 +26795,7 @@
       "integrity": "sha512-BaSBsIMv52F1BVVMvOmp1yzD3u65uC3HTzCBQV1WDPqJRQ2LuHKcyfn0jwqodo8sR9vVzMzZyI+Dal5W9E6a9A==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.0.0"
+        "prosemirror-model": ">=1.22.1"
       }
     },
     "prosemirror-view": {
@@ -26803,7 +26804,7 @@
       "integrity": "sha512-62qkYgSJIkwIMMCpuGuPzc52DiK1Iod6TWoIMxP4ja6BTD4yO8kCUL64PZ/WhH/dJ9fW0CDO39FhH1EMyhUFEg==",
       "dev": true,
       "requires": {
-        "prosemirror-model": "^1.16.0",
+        "prosemirror-model": ">=1.22.1",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "prosemirror-example-setup": "^1.2.3",
     "prosemirror-markdown": "^1.13.1",
     "prosemirror-schema-basic": "^1.2.3",
+    "prosemirror-model": ">=1.22.1",
     "puppeteer": "^19.11.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -108,6 +109,9 @@
     "typescript": "^4.9.5",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0"
+  },
+  "overrides": {
+    "prosemirror-model": ">=1.22.1"
   },
   "keywords": [
     "lime elements",


### PR DESCRIPTION
As per this [post here](https://discuss.prosemirror.net/t/heads-up-xss-risk-in-domserializer/6572) we should update to prosemirror-model 1.22.1 as it contains a fix for a vulnerability to xss attacks in the DOMSerialiser.

