### PR TITLE
Add function to inserter to stopTrigger

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -2413,6 +2413,8 @@ export interface TabPanelComponent {
 // @alpha (undocumented)
 export interface TextEditor {
     insert: (input: TextEditorNode | string) => void;
+    // (undocumented)
+    stopTrigger: () => void;
 }
 
 // @alpha (undocumented)

--- a/src/components/text-editor/examples/text-editor-custom-triggers.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-triggers.tsx
@@ -133,6 +133,7 @@ export class TextEditorCustomTriggersExample {
 
         if (event.key === ESCAPE) {
             this.isPickerOpen = false;
+            this.triggerFunction?.stopTrigger();
         }
     };
 

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
@@ -38,6 +38,14 @@ export const inserterFactory = (view: EditorView): TextEditor => {
             transaction.setMeta('stopTrigger', true);
             dispatch(transaction);
         },
+        stopTrigger: () => {
+            const { state, dispatch } = view;
+
+            const transaction = state.tr;
+            transaction.setMeta('stopTrigger', true);
+
+            dispatch(transaction);
+        },
     };
 };
 

--- a/src/components/text-editor/text-editor.types.ts
+++ b/src/components/text-editor/text-editor.types.ts
@@ -59,6 +59,7 @@ export interface TextEditor {
      *
      */
     insert: (input: TextEditorNode | string) => void;
+    stopTrigger: () => void;
 }
 
 /**


### PR DESCRIPTION
Add's a function to the `inserterFactory` called `stopTrigger` which the consumer can access via the `TextEditor (TriggerFunction)` interface.

Fixes: https://github.com/Lundalogik/crm-feature/issues/4474