### PR TITLE
fix(text-editor): make sure trigger characters work on Android

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
@@ -142,17 +142,25 @@ export const createTriggerPlugin = (triggerCharacters: TriggerCharacter[]) => {
         activeTrigger = null;
     };
 
-    const handleKeyDown = (view: EditorView, event: any) => {
-        const { state } = view;
-
+    const handleKeyDown = (_: EditorView, event: any) => {
         if (event.key === 'Escape') {
             stopTrigger();
 
             return true;
         }
 
-        if (isTrigger(event.key, triggerCharacters) && shouldTrigger(state)) {
-            activeTrigger = event.key;
+        return false;
+    };
+
+    const handleInput = (view: EditorView, event: any) => {
+        const { state } = view;
+
+        if (
+            event.inputType === 'insertText' &&
+            isTrigger(event.data, triggerCharacters) &&
+            shouldTrigger(state)
+        ) {
+            activeTrigger = event.data;
             triggerText = '';
             triggerPosition = state.selection.$from.pos - triggerText.length;
             sendTriggerEvent('triggerStart', view, activeTrigger, triggerText);
@@ -221,6 +229,9 @@ export const createTriggerPlugin = (triggerCharacters: TriggerCharacter[]) => {
         },
         props: {
             handleKeyDown: handleKeyDown,
+            handleDOMEvents: {
+                input: handleInput,
+            },
         },
         appendTransaction: appendTransactions,
     });


### PR DESCRIPTION
fix: Lundalogik/crm-feature#4470

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
