### PR TITLE
feat(text-editor): add insertHtml function to properly parse html string

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -2417,6 +2417,7 @@ export interface TabPanelComponent {
 // @alpha (undocumented)
 export interface TextEditor {
     insert: (input: TextEditorNode | string) => void;
+    insertHtml: (input: string) => Promise<void>;
     // (undocumented)
     stopTrigger: () => void;
 }

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/create-html-inserter.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/create-html-inserter.spec.ts
@@ -1,0 +1,98 @@
+import { Schema } from 'prosemirror-model';
+import { createHtmlInserter } from './create-html-inserter';
+
+describe('createHtmlInserter', () => {
+    let mockContentConverter: any;
+    let mockDispatchTransaction: jest.Mock;
+    let schema: Schema;
+
+    beforeEach(() => {
+        mockContentConverter = {
+            parseAsHTML: jest.fn((input) => Promise.resolve(`<p>${input}</p>`)),
+        };
+
+        mockDispatchTransaction = jest.fn();
+
+        schema = new Schema({
+            nodes: {
+                doc: { content: 'block+' },
+                paragraph: { group: 'block', content: 'inline*' },
+                text: { group: 'inline' },
+            },
+            marks: {},
+        });
+    });
+
+    it('resolves after inserting valid HTML into the editor', async () => {
+        const inserter = await createHtmlInserter(
+            { state: { schema: schema } } as any, // Mock EditorView
+            mockContentConverter,
+            0, // startPos
+            mockDispatchTransaction,
+        );
+
+        const inputHtml = '<strong>Test</strong>';
+        await inserter(inputHtml);
+
+        expect(mockContentConverter.parseAsHTML).toHaveBeenCalledWith(
+            inputHtml,
+            schema,
+        );
+        expect(mockDispatchTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves after handling invalid HTML gracefully', async () => {
+        const inserter = await createHtmlInserter(
+            { state: { schema: schema } } as any,
+            mockContentConverter,
+            0,
+            mockDispatchTransaction,
+        );
+
+        const inputHtml = '<div><p>Unclosed tag';
+        await inserter(inputHtml);
+
+        expect(mockContentConverter.parseAsHTML).toHaveBeenCalledWith(
+            inputHtml,
+            schema,
+        );
+        expect(mockDispatchTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches the correct fragment for nested HTML', async () => {
+        const inserter = await createHtmlInserter(
+            { state: { schema: schema } } as any,
+            mockContentConverter,
+            0,
+            mockDispatchTransaction,
+        );
+
+        const inputHtml = '<div><span color="#FF0000">Nested</span></div>';
+        await inserter(inputHtml);
+
+        expect(mockDispatchTransaction).toHaveBeenCalledTimes(1);
+
+        // Convert the fragment to an array for easier testing
+        const dispatchedArgs = mockDispatchTransaction.mock.calls[0];
+        const dispatchedFragment = dispatchedArgs[2];
+        const fragmentArray = dispatchedFragment.content.map((node) =>
+            node.toJSON(),
+        );
+
+        // Check the structure and content of the fragment
+        // The reason that the structure doesn't completely match the input is
+        // that ProseMirror will transform the input based on what the schema
+        // allows. (At least I think that's why… /Ads)
+        expect(fragmentArray).toEqual([
+            {
+                type: 'paragraph',
+                content: [
+                    {
+                        type: 'text',
+                        text: 'Nested',
+                    },
+                ],
+            },
+        ]);
+    });
+});

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/create-html-inserter.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/create-html-inserter.ts
@@ -1,0 +1,25 @@
+import { Node, DOMParser, Fragment } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
+import { ContentTypeConverter } from '../../../utils/content-type-converter';
+
+export const createHtmlInserter = (
+    view: EditorView,
+    contentConverter: ContentTypeConverter,
+    startPos: number,
+    dispatchTransaction: (
+        view: EditorView,
+        startPos: number,
+        fragment: Fragment | Node,
+    ) => void,
+): ((input: string) => Promise<void>) => {
+    const schema = view.state.schema;
+
+    return async (input: string): Promise<void> => {
+        const container = document.createElement('span');
+        container.innerHTML = await contentConverter.parseAsHTML(input, schema);
+
+        const fragment = DOMParser.fromSchema(schema).parse(container).content;
+
+        dispatchTransaction(view, startPos, fragment);
+    };
+};

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
@@ -1,52 +1,73 @@
-import { Node, NodeType, Schema } from 'prosemirror-model';
+import { Node, NodeType, Schema, Fragment } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
 import {
     TextEditor,
     TextEditorNode,
 } from 'src/components/text-editor/text-editor.types';
+import { ContentTypeConverter } from '../../../utils/content-type-converter';
+import { createHtmlInserter } from './create-html-inserter';
 
-export const inserterFactory = (view: EditorView): TextEditor => {
+export const inserterFactory = (
+    view: EditorView,
+    contentConverter: ContentTypeConverter,
+): TextEditor => {
     const startPos = getTriggerStartPosition(view);
 
     return {
-        insert: (input: TextEditorNode | string) => {
-            const { state, dispatch } = view;
-            const { schema, selection } = state;
-            const { $from } = selection;
-
-            let node: Node;
-
-            try {
-                node = createNode(input, schema);
-            } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error(error.message);
-
-                return;
-            }
-
-            const spaceNode = schema.text(' ');
-
-            const fragment = schema.nodes.doc.create(null, [node, spaceNode]);
-
-            const transaction = state.tr.replaceWith(
-                startPos,
-                $from.pos,
-                fragment,
-            );
-
-            transaction.setMeta('stopTrigger', true);
-            dispatch(transaction);
-        },
-        stopTrigger: () => {
-            const { state, dispatch } = view;
-
-            const transaction = state.tr;
-            transaction.setMeta('stopTrigger', true);
-
-            dispatch(transaction);
-        },
+        insert: createNodeAndTextInserter(view, startPos),
+        insertHtml: createHtmlInserter(
+            view,
+            contentConverter,
+            startPos,
+            dispatchTransaction,
+        ),
+        stopTrigger: () => stopTriggerTransaction(view),
     };
+};
+
+const createNodeAndTextInserter =
+    (view: EditorView, startPos: number) =>
+    (input: TextEditorNode | string): void => {
+        const schema = view.state.schema;
+        let node: Node;
+
+        try {
+            node = createNode(input, schema);
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(error.message);
+
+            return;
+        }
+
+        const spaceNode = schema.text(' ');
+
+        const fragment = schema.nodes.doc.create(null, [node, spaceNode]);
+
+        dispatchTransaction(view, startPos, fragment);
+    };
+
+const stopTriggerTransaction = (view: EditorView): void => {
+    const { state, dispatch } = view;
+
+    const transaction = state.tr;
+    transaction.setMeta('stopTrigger', true);
+
+    dispatch(transaction);
+};
+
+const dispatchTransaction = (
+    view: EditorView,
+    startPos: number,
+    fragment: Fragment | Node,
+): void => {
+    const state = view.state;
+    const dispatch = view.dispatch;
+    const fromPos = state.selection.$from.pos;
+
+    const transaction = state.tr.replaceWith(startPos, fromPos, fragment);
+    transaction.setMeta('stopTrigger', true);
+    dispatch(transaction);
 };
 
 const createNode = (input: TextEditorNode | string, schema: Schema): Node => {

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
@@ -97,7 +97,7 @@ const getCustomNode = (name: string, schema: Schema): NodeType => {
 
     if (!customNode) {
         throw new Error(
-            `A custom element hasn't been registered for node ${name}`,
+            `No custom element has been registered for node ${name}`,
         );
     }
 

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -352,7 +352,10 @@ export class ProsemirrorAdapter {
                 ...exampleSetup({ schema: this.schema, menuBar: false }),
                 keymap(this.menuCommandFactory.buildKeymap()),
                 createLinkPlugin(this.handleNewLinkSelection),
-                createTriggerPlugin(this.triggerCharacters),
+                createTriggerPlugin(
+                    this.triggerCharacters,
+                    this.contentConverter,
+                ),
                 createImageRemoverPlugin(),
                 createMenuStateTrackingPlugin(
                     editorMenuTypesArray,

--- a/src/components/text-editor/text-editor.types.ts
+++ b/src/components/text-editor/text-editor.types.ts
@@ -56,9 +56,14 @@ export type TextEditorNode = {
 export interface TextEditor {
     /**
      * Method to insert either text or a node at the cursor position
-     *
      */
     insert: (input: TextEditorNode | string) => void;
+
+    /**
+     * Method to insert an HTML string at the cursor position
+     */
+    insertHtml: (input: string) => Promise<void>;
+
     stopTrigger: () => void;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Lundalogik/limepkg-email/issues/1210

I would be delighted to write some tests, but the overall test coverage for the trigger factory appears to be rather limited.
I presume that mocking ProseMirror is a prerequisite for writing tests for this component, which I am not entirely comfortable with.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
