### PR TITLE
Add `limel-3d-hover-effect-glow` as a `@private` internal component & use it

### DIFF
--- a/src/components/3d-hover-effect-glow/3d-hover-effect-glow.scss
+++ b/src/components/3d-hover-effect-glow/3d-hover-effect-glow.scss
@@ -1,0 +1,21 @@
+:host(limel-3d-hover-effect-glow) {
+    transition: background, opacity;
+    transition-timing-function: ease-out; // Must be the same as the 3D Element itself
+    transition-duration: 0.8s; // Must be the same as the 3D Element itself
+
+    display: block;
+    pointer-events: none;
+
+    position: absolute;
+    inset: 0;
+
+    opacity: 0.1;
+
+    background-image: radial-gradient(
+        circle at var(--limel-3d-hover-effect-glow-position, 50% -20%),
+        rgb(var(--color-white), 0.3),
+        rgb(var(--color-white), 0)
+    );
+
+    mix-blend-mode: plus-lighter;
+}

--- a/src/components/3d-hover-effect-glow/3d-hover-effect-glow.tsx
+++ b/src/components/3d-hover-effect-glow/3d-hover-effect-glow.tsx
@@ -1,0 +1,26 @@
+import { Component } from '@stencil/core';
+/**
+ * This component enhances the visual effects, when the `tiltFollowingTheCursor`
+ * utility function from `3d-tilt-hover-effect.ts` is implemented in a component.
+ *
+ * This component should be added to the HTML structure of the consumer component.
+ *
+ * This component carries its own styles which are needed to create a glow effect on the
+ * 3D element within the parent element, when the parent is hovered.
+ *
+ * The parent element must be using the `tiltFollowingTheCursor` utility function
+ * imported from `3d-tilt-hover-effect.ts`. This function will dynamically
+ * affect parts of the styles of this 3D glow effect.
+ *
+ * @private
+ */
+@Component({
+    tag: 'limel-3d-hover-effect-glow',
+    shadow: true,
+    styleUrl: '3d-hover-effect-glow.scss',
+})
+export class HoverEffectGlowComponent {
+    public render() {
+        return null;
+    }
+}

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -136,10 +136,9 @@ limel-action-bar {
 }
 
 // The 3D effect
-@include mixins.limel-3d-hover-effect-glow(
-    section,
-    var(--card-border-radius, $default-border-radius)
-);
+limel-3d-hover-effect-glow {
+    border-radius: var(--card-border-radius, $default-border-radius);
+}
 
 :host(limel-card) {
     @include mixins.parent-of-the-3d-element;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -124,7 +124,7 @@ export class Card {
                         {this.renderValue()}
                         {this.renderActionBar()}
                     </div>
-                    <div class="limel-3d-hover-effect-glow" />
+                    <limel-3d-hover-effect-glow />
                 </section>
             </Host>
         );

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -334,10 +334,9 @@ $l: 62.5rem; //1000px
 }
 
 // The 3D effect
-@include mixins.limel-3d-hover-effect-glow(
-    a,
-    var(--info-tile-border-radius, 1rem)
-);
+limel-3d-hover-effect-glow {
+    border-radius: var(--info-tile-border-radius, 1rem);
+}
 
 :host(limel-info-tile) {
     @include mixins.parent-of-the-3d-element;

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -165,7 +165,7 @@ export class InfoTile {
                     {this.renderLabel()}
                 </a>
                 {this.renderNotification()}
-                <div class="limel-3d-hover-effect-glow" />
+                <limel-3d-hover-effect-glow />
             </Host>
         );
     }

--- a/src/components/shortcut/shortcut.scss
+++ b/src/components/shortcut/shortcut.scss
@@ -40,19 +40,7 @@
 
 a {
     all: unset;
-    @include mixins.is-elevated-clickable(
-        $background-color:
-            var(
-                --shortcut-background-color,
-                var(--lime-elevated-surface-background-color)
-            ),
-        $background-color--hovered:
-            var(
-                --shortcut-background-color,
-                var(--lime-elevated-surface-background-color)
-            )
-    );
-    @include mixins.visualize-keyboard-focus;
+
     text-align: center;
 
     height: calc(100% - 1rem);
@@ -60,6 +48,10 @@ a {
     padding: 0.5rem;
 
     border-radius: var(--shortcut-border-radius, 1rem);
+    background-color: var(
+        --shortcut-background-color,
+        var(--lime-elevated-surface-background-color)
+    );
 }
 
 limel-icon {
@@ -83,4 +75,19 @@ limel-badge {
     position: absolute;
     top: -0.25rem;
     right: 0.125rem;
+}
+
+// The 3D effect
+limel-3d-hover-effect-glow {
+    border-radius: var(--shortcut-border-radius, 1rem);
+}
+
+:host(limel-shortcut) {
+    @include mixins.parent-of-the-3d-element;
+}
+
+a {
+    @include mixins.the-3d-element;
+
+    @include mixins.the-3d-element--clickable;
 }

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -1,5 +1,6 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Prop, h, Element, Host } from '@stencil/core';
 import { Link } from '../../global/shared-types/link.types';
+import { getMouseEventHandlers } from '../../util/3d-tilt-hover-effect';
 
 /**
  * This component can be used on places such as a start page or a dashboard.
@@ -53,21 +54,41 @@ export class Shortcut {
     @Prop()
     public link?: Link;
 
+    @Element()
+    private host: HTMLElement;
+
+    private handleMouseEnter: () => void;
+    private handleMouseLeave: () => void;
+
+    public componentWillLoad() {
+        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
+            this.host,
+        );
+        this.handleMouseEnter = handleMouseEnter;
+        this.handleMouseLeave = handleMouseLeave;
+    }
+
     public render() {
-        return [
-            <a
-                aria-disabled={this.disabled}
-                href={this.link?.href}
-                target={this.link?.target}
-                tabindex="0"
-                aria-label={this.getAriaLabel()}
-                title={this.link?.title}
+        return (
+            <Host
+                onMouseEnter={this.handleMouseEnter}
+                onMouseLeave={this.handleMouseLeave}
             >
-                <limel-icon name={this.icon} />
-            </a>,
-            this.renderLabel(),
-            this.renderNotification(),
-        ];
+                <a
+                    aria-disabled={this.disabled}
+                    href={this.link?.href}
+                    target={this.link?.target}
+                    tabindex="0"
+                    aria-label={this.getAriaLabel()}
+                    title={this.link?.title}
+                >
+                    <limel-icon name={this.icon} />
+                    <limel-3d-hover-effect-glow />
+                </a>
+                {this.renderLabel()}
+                {this.renderNotification()}
+            </Host>
+        );
     }
 
     private renderLabel = () => {

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -457,42 +457,6 @@ $clickable-normal-state-transitions: (
     white-space: nowrap;
 }
 
-// This mixin designed to enhance the visual effects,
-// when the `tiltFollowingTheCursor` utility function from `3d-tilt-hover-effect.ts`
-// is implemented in a component.
-// This adds styles to a `<div class"limel-3d-hover-effect-glow" />`, needed to create
-// a glow effect on a 3D element when the parent element is hovered.
-// when the `tiltFollowingTheCursor` utility function from `3d-tilt-hover-effect.ts`
-// Parts of these styles are controlled by the `titleFollowingTheCursor` function.
-@mixin limel-3d-hover-effect-glow($the3dElement, $border-radius) {
-    .limel-3d-hover-effect-glow {
-        transition:
-            background 0.4s ease,
-            opacity 0.4s ease;
-        pointer-events: none;
-
-        position: absolute;
-        inset: 0;
-        border-radius: $border-radius;
-
-        opacity: 0.1;
-        #{$the3dElement}:hover & {
-            opacity: 0.5;
-            @media (prefers-reduced-motion) {
-                opacity: 0.2;
-            }
-        }
-
-        background-image: radial-gradient(
-            circle at var(--limel-3d-hover-effect-glow-position, 50% -20%),
-            rgb(var(--color-white), 0.3),
-            rgb(var(--color-white), 0)
-        );
-
-        mix-blend-mode: plus-lighter;
-    }
-}
-
 // These mixins below are designed to apply the necessary visual effects,
 // when the `tiltFollowingTheCursor` utility function from `3d-tilt-hover-effect.ts`
 // is implemented in a component.

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -545,6 +545,15 @@ $clickable-normal-state-transitions: (
         outline: none;
         transform: scale3d(1.01, 1.01, 1.01);
     }
+
+    &:hover {
+        limel-3d-hover-effect-glow {
+            opacity: 0.5;
+            @media (prefers-reduced-motion) {
+                opacity: 0.2;
+            }
+        }
+    }
 }
 
 @mixin the-3d-element--clickable {


### PR DESCRIPTION
A `@private` component that is required for making
a 3D glow effect on some components. This
can be replaced by some internal elements and
styles, to further simplify things.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
