### PR TITLE
better checks for triggers

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
@@ -124,7 +124,9 @@ const shouldTrigger = (
     }
 
     const prevChar = getPreviousCharacter($from);
-    const charBeforePrevChar = getPreviousCharacter(state.doc.resolve($from.pos - 1));
+    const charBeforePrevChar = getPreviousCharacter(
+        state.doc.resolve($from.pos - 1),
+    );
 
     return (
         prevChar === null ||

--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/inserter.ts
@@ -3,18 +3,25 @@ import { EditorView } from 'prosemirror-view';
 import {
     TextEditor,
     TextEditorNode,
+    TriggerCharacter,
 } from 'src/components/text-editor/text-editor.types';
 import { ContentTypeConverter } from '../../../utils/content-type-converter';
 import { createHtmlInserter } from './create-html-inserter';
+import { findTriggerPosition } from './factory';
+
+const getTriggerStartPosition = (view: EditorView): number => {
+    return view.state?.selection?.$from?.pos;
+};
 
 export const inserterFactory = (
     view: EditorView,
     contentConverter: ContentTypeConverter,
+    triggerCharacter: TriggerCharacter,
 ): TextEditor => {
     const startPos = getTriggerStartPosition(view);
 
     return {
-        insert: createNodeAndTextInserter(view, startPos),
+        insert: createNodeAndTextInserter(view, triggerCharacter),
         insertHtml: createHtmlInserter(
             view,
             contentConverter,
@@ -26,9 +33,10 @@ export const inserterFactory = (
 };
 
 const createNodeAndTextInserter =
-    (view: EditorView, startPos: number) =>
+    (view: EditorView, triggerCharacter: TriggerCharacter) =>
     (input: TextEditorNode | string): void => {
         const schema = view.state.schema;
+        const state = view.state;
         let node: Node;
 
         try {
@@ -40,11 +48,12 @@ const createNodeAndTextInserter =
             return;
         }
 
+        const foundTrigger = findTriggerPosition(state, triggerCharacter);
+        const position = foundTrigger?.position;
         const spaceNode = schema.text(' ');
-
         const fragment = schema.nodes.doc.create(null, [node, spaceNode]);
 
-        dispatchTransaction(view, startPos, fragment);
+        dispatchTransaction(view, position, fragment);
     };
 
 const stopTriggerTransaction = (view: EditorView): void => {
@@ -62,11 +71,12 @@ const dispatchTransaction = (
     fragment: Fragment | Node,
 ): void => {
     const state = view.state;
-    const dispatch = view.dispatch;
     const fromPos = state.selection.$from.pos;
-
+    const dispatch = view.dispatch;
     const transaction = state.tr.replaceWith(startPos, fromPos, fragment);
+
     transaction.setMeta('stopTrigger', true);
+
     dispatch(transaction);
 };
 
@@ -102,8 +112,4 @@ const getCustomNode = (name: string, schema: Schema): NodeType => {
     }
 
     return customNode;
-};
-
-const getTriggerStartPosition = (view: EditorView): number => {
-    return view.state?.selection?.$from?.pos;
 };

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -351,11 +351,11 @@ export class ProsemirrorAdapter {
             plugins: [
                 ...exampleSetup({ schema: this.schema, menuBar: false }),
                 keymap(this.menuCommandFactory.buildKeymap()),
-                createLinkPlugin(this.handleNewLinkSelection),
                 createTriggerPlugin(
                     this.triggerCharacters,
                     this.contentConverter,
                 ),
+                createLinkPlugin(this.handleNewLinkSelection),
                 createImageRemoverPlugin(),
                 createMenuStateTrackingPlugin(
                     editorMenuTypesArray,


### PR DESCRIPTION
I wanted to reduce reliance on any plugin-level state. While investigating the issues with triggering from a text-editor rendered within a form-field I found that we couldn't always be certain about the position of the trigger within the editor state. 

This PR introduces more single responsibility functions to get the trigger position dynamically, and check conditions that are required for managing the flow of events. 


Fixes: Lundalogik/crm-feature#4498
