### PR TITLE
Clicked item event in list

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1532,6 +1532,7 @@ namespace JSX_2 {
         "items"?: Array<ListItem | ListSeparator>;
         "maxLinesSecondaryText"?: number;
         "onChange"?: (event: LimelListCustomEvent<ListItem | ListItem[]>) => void;
+        "onInteract"?: (event: LimelListCustomEvent<ListItem>) => void;
         "onSelect"?: (event: LimelListCustomEvent<ListItem | ListItem[]>) => void;
         "type"?: ListType;
     }
@@ -1562,6 +1563,7 @@ namespace JSX_2 {
         "iconSize"?: IconSize;
         "items"?: Array<MenuItem | ListSeparator>;
         "maxLinesSecondaryText"?: number;
+        "onInteract"?: (event: LimelMenuListCustomEvent<MenuItem>) => void;
         "onSelect"?: (event: LimelMenuListCustomEvent<MenuItem>) => void;
         "type"?: MenuListType;
     }

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -99,6 +99,13 @@ export class List {
     @Event()
     protected select: EventEmitter<ListItem | ListItem[]>;
 
+    /**
+     * Fires when a user interacts with an item in the list (e.g., click,
+     * keyboard select).
+     */
+    @Event()
+    interact: EventEmitter<ListItem>;
+
     public connectedCallback() {
         this.setup();
     }
@@ -238,17 +245,23 @@ export class List {
             return !!item.selected;
         });
 
+        let interactedItem: ListItem;
+
         if (selectedItem) {
             if (this.type !== 'radio') {
                 this.mdcList.selectedIndex = -1;
             }
 
-            this.change.emit({ ...selectedItem, selected: false });
+            interactedItem = { ...selectedItem, selected: false };
+            this.change.emit(interactedItem);
         }
 
         if (listItems[index] !== selectedItem) {
-            this.change.emit({ ...listItems[index], selected: true });
+            interactedItem = { ...listItems[index], selected: true };
+            this.change.emit(interactedItem);
         }
+
+        this.interact.emit(interactedItem);
     };
 
     private handleMultiSelect = (index: number) => {
@@ -273,6 +286,7 @@ export class List {
             });
 
         this.change.emit(selectedItems);
+        this.interact.emit({ ...selectedItems[index] });
     };
 
     private isListItem = (item: ListItem): boolean => {

--- a/src/components/menu-list/menu-list.tsx
+++ b/src/components/menu-list/menu-list.tsx
@@ -76,6 +76,13 @@ export class MenuList {
     @Event()
     private select: EventEmitter<MenuItem>;
 
+    /**
+     * Fires when a user interacts with an item in the list (e.g., click,
+     * keyboard select).
+     */
+    @Event()
+    interact: EventEmitter<MenuItem>;
+
     public connectedCallback() {
         this.setup();
     }
@@ -163,13 +170,18 @@ export class MenuList {
             return !!item.selected;
         });
 
+        let interactedItem: MenuItem;
         if (selectedItem) {
-            this.select.emit({ ...selectedItem, selected: false });
+            interactedItem = { ...selectedItem, selected: false };
+            this.select.emit(interactedItem);
         }
 
         if (MenuItems[index] !== selectedItem) {
-            this.select.emit({ ...MenuItems[index], selected: false });
+            interactedItem = { ...MenuItems[index], selected: false };
+            this.select.emit(interactedItem);
         }
+
+        this.interact.emit(interactedItem);
     };
 
     private isMenuItem = (item: MenuItem): boolean => {

--- a/src/components/text-editor/examples/text-editor-custom-triggers.tsx
+++ b/src/components/text-editor/examples/text-editor-custom-triggers.tsx
@@ -1,7 +1,7 @@
 import {
     Button,
-    LimelListCustomEvent,
-    ListItem,
+    LimelMenuListCustomEvent,
+    MenuItem,
 } from '@limetech/lime-elements';
 import { Component, h, State, Element, Watch } from '@stencil/core';
 import {
@@ -52,7 +52,7 @@ export class TextEditorCustomTriggersExample {
     private insertMode: 'text' | 'chip' = 'text';
 
     @State()
-    private items: Array<ListItem<number>> = [
+    private items: Array<MenuItem<number>> = [
         { text: 'Wolverine', value: 1, icon: 'wolf', selected: true },
         { text: 'Captain America', value: 2, icon: 'captain_america' },
         { text: 'Superman', value: 3, icon: 'superman' },
@@ -61,7 +61,7 @@ export class TextEditorCustomTriggersExample {
     ];
 
     @State()
-    private visibleItems: Array<ListItem<number>>;
+    private visibleItems: Array<MenuItem<number>>;
 
     @Element()
     private host: HTMLLimelPopoverElement;
@@ -88,7 +88,7 @@ export class TextEditorCustomTriggersExample {
     @Watch('inputText')
     protected watchInputText() {
         if (this.isPickerOpen) {
-            this.visibleItems = this.items.filter((item: ListItem<number>) =>
+            this.visibleItems = this.items.filter((item: MenuItem<number>) =>
                 item.text.toLowerCase().includes(this.inputText),
             );
         }
@@ -122,7 +122,7 @@ export class TextEditorCustomTriggersExample {
         }
 
         if (event.key === ENTER || event.key === TAB) {
-            const selectedItem: ListItem | undefined = this.visibleItems.find(
+            const selectedItem: MenuItem | undefined = this.visibleItems.find(
                 (item) => item.selected,
             );
 
@@ -227,7 +227,7 @@ export class TextEditorCustomTriggersExample {
         );
     };
 
-    private renderList = (items: Array<ListItem<number>>) => {
+    private renderList = (items: Array<MenuItem<number>>) => {
         if (items.length === 0) {
             return (
                 <div style={{ padding: '0.5rem' }}>
@@ -237,10 +237,9 @@ export class TextEditorCustomTriggersExample {
         }
 
         return (
-            <limel-list
+            <limel-menu-list
                 items={items}
-                onChange={this.handleListChange}
-                type="selectable"
+                onInteract={this.handleListInteraction}
             />
         );
     };
@@ -265,19 +264,17 @@ export class TextEditorCustomTriggersExample {
         this.value = event.detail;
     };
 
-    private handleListChange = (
-        event: LimelListCustomEvent<ListItem<number>>,
+    private handleListInteraction = (
+        event: LimelMenuListCustomEvent<MenuItem<number>>,
     ) => {
-        if (event.detail.selected) {
-            this.insertItem(event.detail);
-        }
+        this.insertItem(event.detail);
     };
 
     private handleInsertModeChange = (event: CustomEvent<Button>) => {
         this.insertMode = event.detail.title as any;
     };
 
-    private insertItem = (item: ListItem) => {
+    private insertItem = (item: MenuItem) => {
         this.removeAllSelections();
         this.visibleItems = this.items;
         if (this.insertMode === 'text') {


### PR DESCRIPTION
Adds a specific event for interaction in `limel-list`. With the current change event it can be hard to sort out which element was actually interacted with.

If one item is already selected and a new one is clicked then one could see which one is selected to know the interaction. But if the same selected item is clicked it's not possible to know that that element was interacted with since the events come one by one by design.

With the new interaction event it's easy to know which item was either clicked or selected by other means.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
