### PR TITLE
fix(text-editor): correctly animate the padding property

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -101,7 +101,7 @@ limel-action-bar {
 }
 
 .ProseMirror {
-    transition-duration: padding;
+    transition-property: padding;
     transition-duration: var(
         --limel-prosemirror-adapter-toolbar-grid-template-rows-transition-duration
     );


### PR DESCRIPTION

<img width="245" alt="Screenshot 2024-10-17 at 09 29 56" src="https://github.com/user-attachments/assets/c169d613-120e-4ff6-9de2-67fa64fa7123">

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
