### PR TITLE
fix(text-editor): send stop trigger when outside

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/trigger/factory.ts
@@ -206,6 +206,8 @@ export const createTriggerPlugin = (
                 triggerText.length,
             )
         ) {
+            stopTrigger();
+
             return;
         }
 


### PR DESCRIPTION
Sends a stopTrigger event when the cursor goes outside the trigger.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
