### PR TITLE
fix(text editor): preserve whitespace when toggling block types

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -183,59 +183,96 @@ const toggleNodeType = (
     const paragraphType = schema.nodes.paragraph;
 
     return (state, dispatch) => {
-        const { $from, $to } = state.selection;
+        const { $from } = state.selection;
 
-        const hasActiveWrap = $from.node($from.depth - 1).type === nodeType;
-
-        if (
-            state.selection instanceof TextSelection &&
-            // Ensure selection is within the same parent block
-            // We don't want toggling block types across multiple blocks
-            $from.sameParent($from.doc.resolve($to.pos))
-        ) {
-            if ($from.parent.type === nodeType) {
-                let tr = state.tr
-                    .setBlockType($from.pos, $to.pos, paragraphType)
-                    .setMeta('preserveWhitespace', true);
-                tr.replaceSelectionWith(schema.text($from.parent.textContent));
-
-                tr = preserveSelection(state, tr);
-
-                if (dispatch) {
-                    dispatch(tr);
-                }
-
-                return true;
-            } else {
-                if (hasActiveWrap) {
-                    return lift(state, dispatch);
-                }
-
-                if (shouldWrap) {
-                    return wrapIn(nodeType, attrs)(state, dispatch);
-                } else {
-                    let tr = state.tr
-                        .setBlockType($from.pos, $to.pos, nodeType, attrs)
-                        .setMeta('preserveWhitespace', true);
-                    if (nodeType === paragraphType) {
-                        tr.replaceSelectionWith(
-                            schema.text($from.parent.textContent),
-                        );
-                    }
-
-                    tr = preserveSelection(state, tr);
-
-                    if (dispatch) {
-                        dispatch(tr);
-                    }
-
-                    return true;
-                }
-            }
+        if (!isSameParentBlock(state)) {
+            return false;
         }
 
-        return false;
+        if ($from.parent.type === nodeType) {
+            return handleSameNodeType(state, dispatch, schema, paragraphType);
+        } else {
+            return handleDifferentNodeType(
+                state,
+                dispatch,
+                nodeType,
+                attrs,
+                shouldWrap,
+                schema,
+                paragraphType,
+            );
+        }
     };
+};
+
+const isSameParentBlock = (state: EditorState): boolean => {
+    const { $from, $to } = state.selection;
+
+    return (
+        state.selection instanceof TextSelection &&
+        $from.sameParent($from.doc.resolve($to.pos))
+    );
+};
+
+const handleSameNodeType = (
+    state: EditorState,
+    dispatch: (tr: Transaction) => void,
+    schema: Schema,
+    paragraphType: NodeType,
+): boolean => {
+    let tr = state.tr
+        .setBlockType(
+            state.selection.$from.pos,
+            state.selection.$to.pos,
+            paragraphType,
+        )
+        .setMeta('preserveWhitespace', true);
+    tr.replaceSelectionWith(
+        schema.text(state.selection.$from.parent.textContent),
+    );
+    tr = preserveSelection(state, tr);
+
+    if (dispatch) {
+        dispatch(tr);
+    }
+
+    return true;
+};
+
+const handleDifferentNodeType = (
+    state: EditorState,
+    dispatch: (tr: Transaction) => void,
+    nodeType: NodeType,
+    attrs: Attrs,
+    shouldWrap: boolean,
+    schema: Schema,
+    paragraphType: NodeType,
+): boolean => {
+    const { $from, $to } = state.selection;
+    const hasActiveWrap = $from.node($from.depth - 1).type === nodeType;
+
+    if (hasActiveWrap) {
+        return lift(state, dispatch);
+    }
+
+    if (shouldWrap) {
+        return wrapIn(nodeType, attrs)(state, dispatch);
+    } else {
+        let tr = state.tr
+            .setBlockType($from.pos, $to.pos, nodeType, attrs)
+            .setMeta('preserveWhitespace', true);
+        if (nodeType === paragraphType) {
+            tr.replaceSelectionWith(schema.text($from.parent.textContent));
+        }
+
+        tr = preserveSelection(state, tr);
+
+        if (dispatch) {
+            dispatch(tr);
+        }
+
+        return true;
+    }
 };
 
 export const isValidUrl = (text: string): boolean => {

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -262,7 +262,8 @@ const handleDifferentNodeType = (
             .setBlockType($from.pos, $to.pos, nodeType, attrs)
             .setMeta('preserveWhitespace', true);
         if (nodeType === paragraphType) {
-            tr.replaceSelectionWith(schema.text($from.parent.textContent));
+            const selectedText = state.doc.textBetween($from.pos, $to.pos, '');
+            tr.replaceSelectionWith(schema.text(selectedText));
         }
 
         tr = preserveSelection(state, tr);


### PR DESCRIPTION
Fixes: https://github.com/Lundalogik/lime-elements/issues/3314
Fixes: https://github.com/Lundalogik/lime-elements/issues/3179