### PR TITLE
fix(text-editor): don't show placeholder when composer is active

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -72,6 +72,13 @@
     --limel-text-editor-outline-color: #{shared_input-select-picker.$lime-text-field-outline-color--focused};
 }
 
+:host(limel-text-editor:focus-within),
+:host(limel-text-editor:focus) {
+    .placeholder {
+        opacity: 0;
+    }
+}
+
 :host(limel-text-editor[disabled]:not([disabled='false'])) {
     @include shared_input-select-picker.looks-disabled;
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/4519

https://github.com/user-attachments/assets/4621d83a-f8cc-43b8-8429-ccd444e2a3df


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
