### PR TITLE
feat(popover): add new CSS variable for controlling surface's `box-shadow`

### DIFF
--- a/src/components/popover-surface/popover-surface.scss
+++ b/src/components/popover-surface/popover-surface.scss
@@ -18,7 +18,7 @@
     min-width: 0;
     min-height: 0;
     border-radius: var(--popover-border-radius, functions.pxToRem(12));
-    box-shadow: var(--shadow-depth-16);
+    box-shadow: var(--popover-box-shadow, var(--shadow-depth-16));
 
     backdrop-filter: blur(functions.pxToRem(5));
     -webkit-backdrop-filter: blur(functions.pxToRem(5));

--- a/src/components/popover/examples/popover-basic.scss
+++ b/src/components/popover/examples/popover-basic.scss
@@ -1,3 +1,0 @@
-:host(limel-example-popover) {
-    --popover-body-background-color: rgb(var(--contrast-200));
-}

--- a/src/components/popover/examples/popover-basic.tsx
+++ b/src/components/popover/examples/popover-basic.tsx
@@ -24,7 +24,6 @@ import { Component, h, State } from '@stencil/core';
 @Component({
     tag: 'limel-example-popover-basic',
     shadow: true,
-    styleUrl: 'popover-basic.scss',
 })
 export class PopoverBasicExample {
     @State()

--- a/src/components/popover/examples/popover-styling.scss
+++ b/src/components/popover/examples/popover-styling.scss
@@ -1,0 +1,5 @@
+limel-popover {
+    --popover-border-radius: 0.95rem;
+    --popover-body-background-color: transparent;
+    --popover-box-shadow: var(--shadow-depth-8);
+}

--- a/src/components/popover/examples/popover-styling.tsx
+++ b/src/components/popover/examples/popover-styling.tsx
@@ -1,0 +1,53 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Styling
+ * There are a few custom CSS properties that you can use to style the popover.
+ */
+
+@Component({
+    tag: 'limel-example-popover-styling',
+    shadow: true,
+    styleUrl: 'popover-styling.scss',
+})
+export class PopoverStylingExample {
+    @State()
+    private isOpen = false;
+
+    public render() {
+        const image = {
+            src: 'https://unsplash.it/800/800/?random',
+            alt: 'Some random image',
+        };
+
+        return [
+            <limel-popover open={this.isOpen} onClose={this.onPopoverClose}>
+                <limel-button
+                    slot="trigger"
+                    label="Click me!"
+                    onClick={this.openPopover}
+                />
+                <limel-card
+                    style={{ 'max-width': '20rem' }}
+                    orientation="landscape"
+                    image={image}
+                    heading="Heading"
+                    subheading="Subheading"
+                    value="This is the body of the card."
+                />
+            </limel-popover>,
+        ];
+    }
+
+    private openPopover = (event: MouseEvent) => {
+        event.stopPropagation();
+        console.log('opening');
+        this.isOpen = true;
+    };
+
+    private onPopoverClose = (event: CustomEvent) => {
+        event.stopPropagation();
+        console.log('closing');
+        this.isOpen = false;
+    };
+}

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -1,7 +1,7 @@
 /**
- * @prop --popover-surface-width: Width of the popover surface. defaults to `auto`
- * @prop --popover-body-background-color: Background color of popover body, defaults to `--lime-elevated-surface-background-color`.
- * @prop --popover-border-radius: Border radius of popover, defaults to `0.75rem`.
+ * @prop --popover-surface-width: Width of the popover surface. Defaults to `auto`
+ * @prop --popover-body-background-color: Background color of popover body. Defaults to `--lime-elevated-surface-background-color`.
+ * @prop --popover-border-radius: Border radius of popover. Defaults to `0.75rem`.
  * @prop --popover-z-index: z-index of the popover.
  * @prop --popover-box-shadow: Defines the shadow of the popover surface. Defaults to `--shadow-depth-16`.
  */

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -3,6 +3,7 @@
  * @prop --popover-body-background-color: Background color of popover body, defaults to `--lime-elevated-surface-background-color`.
  * @prop --popover-border-radius: Border radius of popover, defaults to `0.75rem`.
  * @prop --popover-z-index: z-index of the popover.
+ * @prop --popover-box-shadow: Defines the shadow of the popover surface. Defaults to `--shadow-depth-16`.
  */
 
 .trigger-anchor {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -56,6 +56,7 @@ import { OpenDirection } from '../menu/menu.types';
  * @slot - Content to put inside the surface
  * @exampleComponent limel-example-popover-basic
  * @exampleComponent limel-example-popover-trigger-interaction
+ * @exampleComponent limel-example-popover-styling
  */
 @Component({
     tag: 'limel-popover',

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -156,6 +156,7 @@ export class Popover {
             '--popover-surface-width',
             '--popover-body-background-color',
             '--popover-border-radius',
+            '--popover-box-shadow',
         ];
         const style = getComputedStyle(this.host);
         const values = propertyNames.map((property) => {


### PR DESCRIPTION
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
