### PR TITLE
chore(spinner): do not set `limeBranded` to `true` by default

### DIFF
--- a/src/components/spinner/examples/spinner.tsx
+++ b/src/components/spinner/examples/spinner.tsx
@@ -4,12 +4,9 @@ import { Component, State, h } from '@stencil/core';
  * The `limel-spinner` makes the boring waiting times slightly more cheerful by
  * cycling through nine delightful colors.
  *
- * By default spinner's shape represents Lime Technologies' logo, as it is used
- * primarily in our own products.
- *
- * However, it is easy render the spinner as a generic circle by specifying
- * `limeBranded={false}`, which may be useful for instance when the
- * spinner is used on a small component like a button.
+ * By default, the spinner is rendered as a circle.
+ * However, it is possible to set `limeBranded={true}`,
+ * which renders the spinner's shape as Lime Technologies' logo.
  */
 @Component({
     tag: 'limel-example-spinner',
@@ -27,7 +24,7 @@ export class SpinnerExample {
             >
                 <limel-checkbox
                     checked={this.limeBranded}
-                    label="Lime branded (default design)"
+                    label="Lime branded"
                     onChange={this.renderBranded}
                 />
             </limel-example-controls>,

--- a/src/components/spinner/spinner.tsx
+++ b/src/components/spinner/spinner.tsx
@@ -22,7 +22,7 @@ export class Spinner {
      * Gives the spinner the shape of Lime Technologies' logo
      */
     @Prop()
-    public limeBranded: boolean = true;
+    public limeBranded: boolean = false;
 
     public render() {
         return [


### PR DESCRIPTION
There is lime's logo everywhere the spinner is being used. In a public library, it is better that this specific design is not default.
In Lime's products, there is no point of repeating this logo everywhere in the UI, and a better approach is to
more purposefully set it to `true`, where appropriate in the ui.



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
