### PR TITLE
fix(prosemirror-adaptor): delegate focus

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -60,7 +60,7 @@ const DEBOUNCE_TIMEOUT = 300;
  */
 @Component({
     tag: 'limel-prosemirror-adapter',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'prosemirror-adapter.scss',
 })
 export class ProsemirrorAdapter {


### PR DESCRIPTION
Makes sure to delegate the focus so that the focus event chain will focus prosemirror.

fixes: Lundalogik/crm-feature#4528

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
