### PR TITLE
fix(text-editor): avoid occasional null reference error

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
@@ -106,7 +106,7 @@ const findEnd = (doc, pos, href) => {
  */
 const getLinkDataAtPosition = (view: EditorView, event: MouseEvent) => {
     const pos = view.posAtCoords({ left: event.clientX, top: event.clientY });
-    const node = view.state.doc.nodeAt(pos.pos);
+    const node = view.state.doc.nodeAt(pos?.pos);
     if (!node) {
         return null;
     }


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
