### PR TITLE
limel-picker: add default searcher function for simple client-side filtering

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -554,6 +554,7 @@ export namespace Components {
         "actionPosition": ActionPosition;
         "actions": Array<ListItem<Action>>;
         "actionScrollBehavior": ActionScrollBehavior;
+        "allItems"?: Array<ListItem<PickerValue>>;
         "badgeIcons": boolean;
         "delimiter": string;
         "disabled": boolean;
@@ -565,7 +566,7 @@ export namespace Components {
         "multiple": boolean;
         "readonly": boolean;
         "required": boolean;
-        "searcher": Searcher;
+        "searcher"?: Searcher;
         "searchLabel": string;
         "value": ListItem<PickerValue> | Array<ListItem<PickerValue>>;
     }
@@ -1582,6 +1583,7 @@ namespace JSX_2 {
         "actionPosition"?: ActionPosition;
         "actions"?: Array<ListItem<Action>>;
         "actionScrollBehavior"?: ActionScrollBehavior;
+        "allItems"?: Array<ListItem<PickerValue>>;
         "badgeIcons"?: boolean;
         "delimiter"?: string;
         "disabled"?: boolean;

--- a/src/components/picker/examples/picker-basic.tsx
+++ b/src/components/picker/examples/picker-basic.tsx
@@ -4,13 +4,22 @@ import { Component, h, State } from '@stencil/core';
 /**
  * Single value can be picked.
  *
- * - "Search" is done locally in the frontend.
+ * Since all items are already loaded from the server, we can use the
+ * `allItems` property to provide the picker with all the items at once.
+ * The picker uses a default search function that filters the items based on
+ * the `text` and `secondaryText` properties of the items.
+ *
+ * :::note
+ * For performance reasons, the default searcher will never return more
+ * than 20 items, but if there are more than 20 items, the rest can be
+ * found by typing more characters in the search field.
+ * :::
  */
 @Component({
-    tag: 'limel-example-picker-single',
+    tag: 'limel-example-picker-basic',
     shadow: true,
 })
-export class PickerSingleExample {
+export class PickerBasicExample {
     @State()
     private selectedItem: ListItem<number>;
 
@@ -35,27 +44,14 @@ export class PickerSingleExample {
             <limel-picker
                 label="Favorite awesomenaut"
                 value={this.selectedItem}
-                searcher={this.search}
+                allItems={this.allItems}
+                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItem} />,
         ];
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                return resolve(this.allItems);
-            }
-
-            const filteredItems = this.allItems.filter((item) => {
-                return item.text.toLowerCase().includes(query.toLowerCase());
-            });
-
-            return resolve(filteredItems);
-        });
-    };
 
     private onChange = (event: LimelPickerCustomEvent<ListItem<number>>) => {
         this.selectedItem = event.detail;

--- a/src/components/picker/examples/picker-composite.tsx
+++ b/src/components/picker/examples/picker-composite.tsx
@@ -24,7 +24,7 @@ export class PickerCompositeExample {
         helperText: 'My helper text',
         leadingIcon: 'search',
         emptyResultMessage: 'No matches found',
-        delimiter: null,
+        delimiter: '',
         value: [],
         required: false,
         disabled: false,

--- a/src/components/picker/examples/picker-composite.tsx
+++ b/src/components/picker/examples/picker-composite.tsx
@@ -66,6 +66,7 @@ export class PickerCompositeExample {
         delete schema.properties.actionPosition;
         delete schema.properties.actionScrollBehavior;
         delete schema.properties.actions;
+        delete schema.properties.allItems;
         delete schema.properties.searcher;
         this.schema = schema;
     }
@@ -74,7 +75,7 @@ export class PickerCompositeExample {
         return [
             <limel-picker
                 {...this.props}
-                searcher={this.search}
+                allItems={this.availableItems}
                 onChange={this.handleChange}
                 onInteract={this.handleEvent}
             />,
@@ -84,20 +85,6 @@ export class PickerCompositeExample {
             />,
         ];
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                return resolve(this.availableItems);
-            }
-
-            const filteredItems = this.availableItems.filter((item) => {
-                return item.text.toLowerCase().includes(query.toLowerCase());
-            });
-
-            return resolve(filteredItems);
-        });
-    };
 
     private handleChange = (
         event: CustomEvent<

--- a/src/components/picker/examples/picker-empty-suggestions.tsx
+++ b/src/components/picker/examples/picker-empty-suggestions.tsx
@@ -4,7 +4,10 @@ import { Component, h, State } from '@stencil/core';
 const NETWORK_DELAY = 500;
 
 /**
- * With no suggestions and a message for empty search results
+ * With a custom search function
+ *
+ * The custom search function returns two suggestions if the query is empty.
+ * Otherwise, it filters the items based on the query.
  *
  * :::important
  * This example simulates that searching is done on the server. Because these
@@ -51,25 +54,19 @@ export class PickerExample {
         ];
     }
 
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                // Simulate some network delay
-                setTimeout(() => {
-                    resolve([]);
-                }, NETWORK_DELAY);
-            }
+    private search = async (query: string): Promise<ListItem[]> => {
+        // Simulate network delay
+        await new Promise((resolve) => setTimeout(resolve, NETWORK_DELAY));
 
-            // Simulate some network delay
-            setTimeout(() => {
-                const filteredItems = this.allItems.filter((item) => {
-                    return item.text
-                        .toLowerCase()
-                        .includes(query.toLowerCase());
-                });
-                resolve(filteredItems);
-            }, NETWORK_DELAY);
+        if (query === '') {
+            return this.allItems.slice(8, 10);
+        }
+
+        const filteredItems = this.allItems.filter((item) => {
+            return item.text.toLowerCase().includes(query.toLowerCase());
         });
+
+        return filteredItems;
     };
 
     private onChange = (event: LimelPickerCustomEvent<ListItem<number>>) => {

--- a/src/components/picker/examples/picker-icons.tsx
+++ b/src/components/picker/examples/picker-icons.tsx
@@ -144,31 +144,14 @@ export class PickerIconsExample {
                 value={this.selectedItems}
                 searchLabel={'Search your awesomenaut'}
                 multiple={true}
-                searcher={this.search}
+                allItems={this.allItems}
+                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItems} />,
         ];
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                resolve([]);
-            }
-
-            const filteredItems = this.allItems.filter((item) => {
-                const searchText =
-                    item.text.toLowerCase() +
-                    ' ' +
-                    item.secondaryText.toLowerCase();
-
-                return searchText.includes(query.toLowerCase());
-            });
-            resolve(filteredItems);
-        });
-    };
 
     private onChange = (
         event: LimelPickerCustomEvent<Array<ListItem<number>>>,

--- a/src/components/picker/examples/picker-leading-icon-example.tsx
+++ b/src/components/picker/examples/picker-leading-icon-example.tsx
@@ -34,7 +34,8 @@ export class PickerLeadingIconExample {
                 label="Favorite awesomenaut"
                 leadingIcon="search"
                 value={this.selectedItem}
-                searcher={this.search}
+                allItems={this.allItems}
+                emptyResultMessage="No results"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,
@@ -43,19 +44,6 @@ export class PickerLeadingIconExample {
             </p>,
         ];
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                resolve(this.allItems);
-            }
-
-            const filteredItems = this.allItems.filter((item) => {
-                return item.text.toLowerCase().includes(query.toLowerCase());
-            });
-            resolve(filteredItems);
-        });
-    };
 
     private onChange = (event: LimelPickerCustomEvent<ListItem<number>>) => {
         this.selectedItem = event.detail;

--- a/src/components/picker/examples/picker-multiple.tsx
+++ b/src/components/picker/examples/picker-multiple.tsx
@@ -4,7 +4,6 @@ import { Component, h, State } from '@stencil/core';
 /**
  * Multiple values can be picked.
  *
- * - "Search" is done locally in the frontend.
  * - Already picked items are removed from the available options.
  */
 @Component({
@@ -39,27 +38,14 @@ export class PickerMultipleExample {
                 label="Favorite awesomenaut"
                 value={this.selectedItems}
                 multiple={true}
-                searcher={this.search}
+                allItems={this.availableItems}
+                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItems} />,
         ];
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                return resolve(this.availableItems);
-            }
-
-            const filteredItems = this.availableItems.filter((item) => {
-                return item.text.toLowerCase().includes(query.toLowerCase());
-            });
-
-            return resolve(filteredItems);
-        });
-    };
 
     private onChange = (
         event: LimelPickerCustomEvent<Array<ListItem<number>>>,

--- a/src/components/picker/examples/picker-static-action.tsx
+++ b/src/components/picker/examples/picker-static-action.tsx
@@ -86,7 +86,6 @@ export class PickerStaticActionsExample {
     private actionPosition: Option<ActionPosition> = this.actionPositions[0];
 
     constructor() {
-        this.search = this.search.bind(this);
         this.onChange = this.onChange.bind(this);
         this.onAction = this.onAction.bind(this);
         this.setBehavior = this.setBehavior.bind(this);
@@ -99,7 +98,7 @@ export class PickerStaticActionsExample {
                 label="Select your favorite pet"
                 value={this.selectedItem}
                 searchLabel={'Search your awesomenaut'}
-                searcher={this.search}
+                allItems={this.allItems}
                 onChange={this.onChange}
                 onInteract={this.onInteract}
                 onAction={this.onAction}
@@ -131,19 +130,6 @@ export class PickerStaticActionsExample {
                 value={this.lastUsedAction}
             />,
         ];
-    }
-
-    private search(query: string): Promise<ListItem[]> {
-        return new Promise((resolve) => {
-            if (query === '') {
-                resolve(this.allItems);
-            }
-
-            const filteredItems = this.allItems.filter((item) => {
-                return item.text.toLowerCase().includes(query.toLowerCase());
-            });
-            resolve(filteredItems);
-        });
     }
 
     private onChange(event: LimelPickerCustomEvent<ListItem<number>>) {

--- a/src/components/picker/examples/picker-value-as-object-with-actions.tsx
+++ b/src/components/picker/examples/picker-value-as-object-with-actions.tsx
@@ -71,8 +71,9 @@ export class PickerValueAsObjectWithActionsExample {
                     label="Favorite authors"
                     value={this.selectedItems}
                     searchLabel={'Find your favorite authors'}
+                    emptyResultMessage="No matching authors found"
                     multiple={true}
-                    searcher={this.search}
+                    allItems={this.allItems}
                     onChange={this.onChange}
                     onInteract={this.onInteract}
                 />
@@ -80,24 +81,6 @@ export class PickerValueAsObjectWithActionsExample {
             </Host>
         );
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                resolve([]);
-            }
-
-            const filteredItems = this.allItems.filter((item) => {
-                const searchText =
-                    item.text.toLowerCase() +
-                    ' ' +
-                    item.secondaryText.toLowerCase();
-
-                return searchText.includes(query.toLowerCase());
-            });
-            resolve(filteredItems);
-        });
-    };
 
     private onChange = (
         event: LimelPickerCustomEvent<

--- a/src/components/picker/examples/picker-value-as-object.tsx
+++ b/src/components/picker/examples/picker-value-as-object.tsx
@@ -22,33 +22,16 @@ export class PickerValueAsObjectExample {
             <limel-picker
                 label="Favorite authors"
                 value={this.selectedItems}
-                searchLabel={'Search your favorite authors'}
+                searchLabel="Search your favorite authors"
+                emptyResultMessage="No matching authors found"
                 multiple={true}
-                searcher={this.search}
+                allItems={this.allItems}
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,
             <limel-example-value value={this.selectedItems} />,
         ];
     }
-
-    private search = (query: string): Promise<ListItem[]> => {
-        return new Promise((resolve) => {
-            if (query === '') {
-                resolve([]);
-            }
-
-            const filteredItems = this.allItems.filter((item) => {
-                const searchText =
-                    item.text.toLowerCase() +
-                    ' ' +
-                    item.secondaryText.toLowerCase();
-
-                return searchText.includes(query.toLowerCase());
-            });
-            resolve(filteredItems);
-        });
-    };
 
     private onChange = (
         event: LimelPickerCustomEvent<


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
