### PR TITLE
Text Editor: trailing * is added to label even if required=false

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -199,7 +199,7 @@ label {
     font-size: 0.65rem; // `10.4px` similar to MDC's floating label
     letter-spacing: var(--mdc-typography-subtitle1-letter-spacing, 0.009375em);
 
-    :host(limel-text-editor[required]) & {
+    :host(limel-text-editor[required]:not([required='false'])) & {
         &::after {
             content: '*';
         }


### PR DESCRIPTION
Fixes #3390 


| Before fix |  |
|--------|--------|
| Required | ![image](https://github.com/user-attachments/assets/224700ca-588a-428e-bc7c-5ddca1f99495) |
| Non-required | ![image](https://github.com/user-attachments/assets/f7c00510-7d0d-4e8e-bfe6-53b35fe7a0a4) | 



| After fix |  |
|--------|--------|
| Required | ![image](https://github.com/user-attachments/assets/6367b5c4-616b-4e6a-b407-42d5504842ef) |
| Non-required | ![image](https://github.com/user-attachments/assets/d75d9be1-2121-450b-9502-688f28cbbc5f) | 




## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
