### PR TITLE
fix(text-editor): don't animate the `padding` around the content

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -31,9 +31,6 @@
     limel-action-bar {
         will-change: opacity, padding;
     }
-    .ProseMirror {
-        will-change: padding;
-    }
 }
 
 .ProseMirror-menubar-wrapper {
@@ -101,13 +98,6 @@ limel-action-bar {
 }
 
 .ProseMirror {
-    transition-property: padding;
-    transition-duration: var(
-        --limel-prosemirror-adapter-toolbar-grid-template-rows-transition-duration
-    );
-    transition-timing-function: var(
-        --limel-prosemirror-adapter-toolbar-transition-timing-function
-    );
     position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -207,7 +207,7 @@ label {
 }
 
 .placeholder {
-    transition-property: top, padding;
+    transition-property: top;
     transition-duration: var(
         --limel-prosemirror-adapter-toolbar-grid-template-rows-transition-duration
     );


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/3406

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
