### PR TITLE
fix(card): ensure the surface is as big as the card

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -32,6 +32,8 @@ section {
         flex-direction: row;
     }
 
+    width: 100%;
+    height: 100%;
     border-radius: var(--card-border-radius, $default-border-radius);
     border: 1px solid rgb(var(--contrast-500));
 


### PR DESCRIPTION
If a consumer sets a `height` or `width` on the
card element, the surface of the card should
respect that specified size, and not just rely on
the size or amount of the content inside the card.

fix https://github.com/Lundalogik/crm-feature/issues/4582

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
