### PR TITLE
fix(select): improve visualisation of the `readOnly` state

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -109,7 +109,7 @@
         margin-left: 0.25rem;
     }
 
-    &.mdc-select--disabled {
+    &.mdc-select--disabled:not(.limel-select--readonly) {
         .limel-select-trigger {
             @include shared_input-select-picker.looks-disabled;
             box-shadow: var(--button-shadow-normal);
@@ -155,6 +155,11 @@
                 box-shadow: var(--button-shadow-inset-pressed);
             }
         }
+    }
+
+    .readonly-option {
+        position: absolute;
+        top: 1.145rem;
     }
 
     &.limel-select--required {

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -323,16 +323,19 @@ function getMenuOptionFilter(selectIsRequired: boolean) {
 }
 
 function getSelectedText(value: Option | Option[], readonly: boolean): string {
-    if ((!value || (isMultiple(value) && !value.length)) && readonly) {
-        return '–';
-    }
+    const emptyReadOnlyOption = <span class="readonly-option">–</span>;
 
-    if (!value) {
-        return '';
+    const isEmptyValue = !value || (isMultiple(value) && !value.length);
+    if (isEmptyValue) {
+        return readonly ? emptyReadOnlyOption : '';
     }
 
     if (isMultiple(value)) {
         return value.map((option) => option.text).join(', ');
+    }
+
+    if (readonly && (value.value === 'empty' || value.text === '')) {
+        return emptyReadOnlyOption;
     }
 
     return value.text;


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/4462#issuecomment-2604960741
## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
