### PR TITLE
refactor(table): use an SCSS variable for the height of aggregations row

### DIFF
--- a/src/components/table/partial-styles/_tabulator-footer.scss
+++ b/src/components/table/partial-styles/_tabulator-footer.scss
@@ -17,6 +17,7 @@
             margin-bottom: 0;
 
             .tabulator-row {
+                height: $height-of-aggregations-row;
                 background: transparent !important;
             }
 
@@ -25,8 +26,9 @@
             }
 
             .tabulator-cell {
-                padding-top: functions.pxToRem(3);
-                padding-bottom: functions.pxToRem(3);
+                height: $height-of-aggregations-row !important;
+                padding-top: 0.25rem;
+                padding-bottom: 0;
             }
         }
     }

--- a/src/components/table/partial-styles/tabulator-custom-styles.scss
+++ b/src/components/table/partial-styles/tabulator-custom-styles.scss
@@ -163,9 +163,9 @@
 
     .has-aggregation {
         .tabulator-tableHolder {
-            margin-bottom: functions.pxToRem(
-                24
-            ); // makes sure aggregations row doesn't cover the last table row, and horizontal scroll bar is shown on windows
+            // makes sure aggregations row doesn't cover the last table row,
+            // and the horizontal scroll bar which is shown on windows
+            margin-bottom: $height-of-aggregations-row;
         }
     }
 

--- a/src/components/table/partial-styles/tabulator-custom-styles.scss
+++ b/src/components/table/partial-styles/tabulator-custom-styles.scss
@@ -161,7 +161,7 @@
         }
     }
 
-    .has-aggregation {
+    &:has(.tabulator-calcs-holder) {
         .tabulator-tableHolder {
             // makes sure aggregations row doesn't cover the last table row,
             // and the horizontal scroll bar which is shown on windows

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -10,6 +10,7 @@ $width-of-sorter-arrow: 0.5rem;
 $cell-padding: 0.5rem;
 $table--has-interactive-rows--selectable-row--hover: 2;
 $table--limel-table--row-selector: 1;
+$height-of-aggregations-row: 1.5rem;
 
 :host(limel-table) {
     isolation: isolate;


### PR DESCRIPTION
fix https://product.lime-crm.com/client/object/bug/7808?tab=_overview

The summary/aggregation of the column is not shown correctly. The number is being cut, not being readable.A lot of costumers reaching out about this., see example pic

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
