### PR TITLE
chore(mixins): enable passing extra transitionable props to some mixins

### DIFF
--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -68,7 +68,14 @@ $clickable-normal-state-transitions: (
     background-color var(--limel-clickable-transition-speed, 0.4s) ease,
     box-shadow var(--limel-clickable-transform-speed, 0.4s) ease,
     transform var(--limel-clickable-transform-speed, 0.4s)
-        var(--limel-clickable-transform-timing-function, ease)
+        var(--limel-clickable-transform-timing-function, ease),
+    // the property below can be used by consumer to pass
+    // one or more extra transition properties to the mixin,
+    // instead of overriding (or repeating) the whole transition rule
+    // which is applied by the mixin
+    // an example could be:
+    // `--limel-additional-clickable-transition-properties: opacity 0.2s ease, width 0.3s ease-out;`
+    var(--limel-additional-clickable-transition-properties)
 );
 
 @mixin is-elevated-clickable(


### PR DESCRIPTION
Some of our mixins have inbuilt transitions.
Sometimes the consumer has to override everything, which will either 
- result in a really poor animation
- or a lot of repeated code

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
