### PR TITLE
fix(info-tile): render the 3d glow effect with the right intensity

### DIFF
--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -163,9 +163,9 @@ export class InfoTile {
                         {this.renderSpinner()}
                     </div>
                     {this.renderLabel()}
+                    <limel-3d-hover-effect-glow />
                 </a>
                 {this.renderNotification()}
-                <limel-3d-hover-effect-glow />
             </Host>
         );
     }


### PR DESCRIPTION
The 3D hover glow effect was not correctly being rendered, due to its location in the dom.

# before

https://github.com/user-attachments/assets/9d6f0517-dc7f-4a07-9122-30b156984263


# after


https://github.com/user-attachments/assets/b4ca9430-66d4-47e3-a23d-772c19069401



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
