### PR TITLE
feat(text editor): conditionally allow commands

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -21,6 +21,7 @@ interface CommandMapping {
 
 export interface CommandWithActive extends Command {
     active?: (state: EditorState) => boolean;
+    allowed?: (state: EditorState) => boolean;
 }
 
 const setActiveMethodForMark = (

--- a/src/components/text-editor/prosemirror-adapter/plugins/menu-state-tracking-plugin.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/menu-state-tracking-plugin.spec.ts
@@ -1,0 +1,182 @@
+import {
+    createMenuStateTrackingPlugin,
+    getMenuItemStates,
+} from './menu-state-tracking-plugin';
+import { EditorState, Plugin, Transaction } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { EditorMenuTypes } from '../menu/types';
+import { MenuCommandFactory } from '../menu/menu-commands';
+
+// Mock EditorMenuTypes enum for testing
+const mockMenuTypes: EditorMenuTypes[] = [
+    'bold' as EditorMenuTypes,
+    'italic' as EditorMenuTypes,
+    'link' as EditorMenuTypes,
+];
+
+describe('menu-state-tracking-plugin', () => {
+    let menuCommandFactory: MenuCommandFactory;
+    let updateCallback: jest.Mock;
+    let view: Partial<EditorView>;
+    let state: Partial<EditorState>;
+    let dispatch: jest.Mock;
+
+    beforeEach(() => {
+        menuCommandFactory = {
+            getCommand: jest.fn(),
+        } as any;
+
+        updateCallback = jest.fn();
+        dispatch = jest.fn();
+
+        state = {
+            tr: {
+                setMeta: jest.fn().mockReturnThis(),
+            } as any,
+        };
+
+        view = {
+            state: state as EditorState,
+            dispatch: dispatch,
+        };
+    });
+
+    describe('getMenuItemStates', () => {
+        it('should return active and allowed states for menu items', () => {
+            const mockCommands = {
+                bold: {
+                    active: jest.fn().mockReturnValue(true),
+                    allowed: jest.fn().mockReturnValue(true),
+                },
+                italic: {
+                    active: jest.fn().mockReturnValue(false),
+                    allowed: jest.fn().mockReturnValue(true),
+                },
+                link: {
+                    active: jest.fn().mockReturnValue(false),
+                    allowed: jest.fn().mockReturnValue(false),
+                },
+            };
+
+            menuCommandFactory.getCommand = jest.fn(
+                (type) => mockCommands[type],
+            );
+
+            const result = getMenuItemStates(
+                mockMenuTypes,
+                menuCommandFactory,
+                view as EditorView,
+            );
+
+            expect(result).toEqual({
+                active: {
+                    bold: true,
+                    italic: false,
+                    link: false,
+                },
+                allowed: {
+                    bold: true,
+                    italic: true,
+                    link: false,
+                },
+            });
+
+            expect(menuCommandFactory.getCommand).toHaveBeenCalledTimes(3);
+            expect(mockCommands.bold.active).toHaveBeenCalledWith(state);
+            expect(mockCommands.bold.allowed).toHaveBeenCalledWith(state);
+        });
+
+        it('should handle missing active or allowed methods', () => {
+            const commands = {
+                bold: {
+                    active: jest.fn().mockReturnValue(true),
+                    // No allowed method
+                },
+                italic: {
+                    // No active method
+                    allowed: jest.fn().mockReturnValue(true),
+                },
+                link: {},
+            };
+
+            menuCommandFactory.getCommand = jest.fn((type) => commands[type]);
+
+            const result = getMenuItemStates(
+                mockMenuTypes,
+                menuCommandFactory,
+                view as EditorView,
+            );
+
+            expect(result).toEqual({
+                active: {
+                    bold: true,
+                    italic: false,
+                    link: false,
+                },
+                allowed: {
+                    bold: true, // Default to true when missing
+                    italic: true,
+                    link: true, // Default to true when missing
+                },
+            });
+        });
+    });
+
+    describe('createMenuStateTrackingPlugin', () => {
+        it('should create a plugin with the correct key', () => {
+            const plugin: Plugin = createMenuStateTrackingPlugin(
+                mockMenuTypes,
+                menuCommandFactory,
+                updateCallback,
+            );
+
+            expect(plugin).toBeInstanceOf(Plugin);
+            expect(plugin.key).toBe('actionBarPlugin$');
+        });
+
+        it('should update plugin state when meta is set', () => {
+            const plugin = createMenuStateTrackingPlugin(
+                mockMenuTypes,
+                menuCommandFactory,
+                updateCallback,
+            );
+
+            const mockTransaction = {
+                getMeta: jest.fn().mockReturnValue({
+                    active: { bold: true },
+                    allowed: { bold: true },
+                }),
+            } as unknown as Transaction;
+
+            const newState = plugin.spec.state.apply(mockTransaction, {
+                active: {},
+                allowed: {},
+            });
+
+            expect(newState).toEqual({
+                active: { bold: true },
+                allowed: { bold: true },
+            });
+        });
+
+        it('should not update plugin state when no meta is set', () => {
+            const plugin = createMenuStateTrackingPlugin(
+                mockMenuTypes,
+                menuCommandFactory,
+                updateCallback,
+            );
+
+            const mockTransaction = {
+                getMeta: jest.fn().mockReturnValue(null),
+            } as unknown as Transaction;
+
+            const oldState = {
+                active: { bold: true },
+                allowed: { bold: true },
+            };
+            const newState = plugin.spec.state.apply(mockTransaction, oldState);
+
+            expect(newState).toBe(oldState);
+        });
+    });
+});

--- a/src/components/text-editor/prosemirror-adapter/plugins/menu-state-tracking-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/menu-state-tracking-plugin.ts
@@ -17,7 +17,7 @@ export type UpdateMenuItemsCallBack = (
     allowedTypes: Record<EditorMenuTypes, boolean>,
 ) => void;
 
-const getMenuItemStates = (
+export const getMenuItemStates = (
     menuTypes: EditorMenuTypes[],
     menuCommandFactory: MenuCommandFactory,
     view: EditorView,

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -405,19 +405,23 @@ export class ProsemirrorAdapter {
 
     private updateActiveActionBarItems = (
         activeTypes: Record<EditorMenuTypes, boolean>,
+        allowedTypes: Record<EditorMenuTypes, boolean>,
     ) => {
         const newItems = getTextEditorMenuItems().map((item) => {
             if (isItem(item)) {
                 return {
                     ...item,
                     selected: activeTypes[item.value],
+                    allowed: allowedTypes[item.value],
                 };
             }
 
             return item;
         });
 
-        this.actionBarItems = newItems;
+        this.actionBarItems = newItems.filter((item) =>
+            isItem(item) ? item.allowed : true,
+        );
     };
 
     private async updateView(content: string) {


### PR DESCRIPTION
This changes the `ActiveMenuItems` from a type to an interface.

Rather than handling some extremely complex actions that may or may not be part of a good UX, we should instead disable certain commands based on certain conditions. 

This change will allow us to do that both visually (not show the button in the menu) and within the command factory (ensure key bindings aren't used to trigger a command that's not allowed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- The text editor’s toolbar now displays only the actions permitted by the current context, ensuring a more relevant and streamlined interface.
- **Refactor**
	- Underlying menu state handling has been improved to differentiate between active and permissible commands, further enhancing the consistency of available actions.
	- Action bar items are now filtered based on their allowed status, improving control over visibility.
- **Tests**
	- Introduced unit tests for the menu state tracking functionality to ensure robustness and correctness in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->