### PR TITLE
fix(markdown): better render the `<kbd>` element

### DIFF
--- a/src/components/markdown/examples/markdown-keys.tsx
+++ b/src/components/markdown/examples/markdown-keys.tsx
@@ -1,0 +1,20 @@
+import { Component, h } from '@stencil/core';
+
+const markdown = `
+To render physical keyboard keys within your text, you can use the \`<kbd>\` HTML element. This represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device.
+
+For example: <kbd>⌘ cmd</kbd> + <kbd>⌥ alt</kbd> + <kbd>R</kbd>
+`;
+
+/**
+ * Keys
+ */
+@Component({
+    tag: 'limel-example-markdown-keys',
+    shadow: true,
+})
+export class MarkdownFootnotesExample {
+    public render() {
+        return <limel-markdown value={markdown} />;
+    }
+}

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -11,6 +11,7 @@
 @import './partial-styles/blockquotes';
 @import './partial-styles/definition-lists';
 @import './partial-styles/img';
+@import './partial-styles/kbd';
 @import './partial-styles/_adjust-for-table-cell';
 
 // body-text

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -16,6 +16,7 @@ import { CustomElementDefinition } from '../../global/shared-types/custom-elemen
  * @exampleComponent limel-example-markdown-footnotes
  * @exampleComponent limel-example-markdown-tables
  * @exampleComponent limel-example-markdown-html
+ * @exampleComponent limel-example-markdown-keys
  * @exampleComponent limel-example-markdown-blockquotes
  * @exampleComponent limel-example-markdown-horizontal-rule
  * @exampleComponent limel-example-markdown-composite

--- a/src/components/markdown/partial-styles/_kbd.scss
+++ b/src/components/markdown/partial-styles/_kbd.scss
@@ -1,0 +1,27 @@
+@use '../../../style/mixins';
+
+kbd {
+    @include mixins.font-family('monospace');
+    font-weight: 600;
+    color: rgb(var(--contrast-1100));
+    background-color: rgb(var(--contrast-200));
+
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: normal;
+
+    padding: 0.125rem 0.5rem;
+    margin: 0 0.25rem;
+    box-shadow:
+        var(--button-shadow-normal),
+        0 0.03125rem 0.21875rem 0 rgba(var(--contrast-100), 0.5) inset;
+
+    border: {
+        radius: 0.125rem;
+        style: solid;
+        color: rgba(var(--contrast-600), 0.8);
+        width: 0 1px 0.125rem 1px;
+    }
+}

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -168,3 +168,4 @@ limel-portal {
 @import '../../markdown/partial-styles/pre-code';
 @import '../../markdown/partial-styles/tables';
 @import '../../markdown/partial-styles/kbd';
+@import '../../markdown/partial-styles/img';

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -167,3 +167,4 @@ limel-portal {
 @import '../../markdown/partial-styles/lists';
 @import '../../markdown/partial-styles/pre-code';
 @import '../../markdown/partial-styles/tables';
+@import '../../markdown/partial-styles/kbd';


### PR DESCRIPTION

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
