### PR TITLE
docs(markdown): ensure markdown component in composite example doesn't overflow

### DIFF
--- a/src/components/markdown/examples/markdown-composite.scss
+++ b/src/components/markdown/examples/markdown-composite.scss
@@ -3,6 +3,10 @@
     flex-direction: column;
     gap: 1rem;
 
+    * {
+        min-width: 0;
+    }
+
     limel-input-field {
         height: 10rem;
     }


### PR DESCRIPTION
`limel-markdown` with large content would grow lager than its own container. This would make testing hard sometimes.

Paste this MD code in the Composite example:
```md
| Column 1 | Column 2 | Column 3 | Column 4 | Column 5 | Column 6 | Column 7 | Column 8 | Column 9 | Column 10 |
|----------|----------|----------|----------|----------|----------|----------|----------|----------|-----------|
| Data 1   | Data 2   | Data 3   | Data 4   | Data 5   | Data 6   | Data 7   | Data 8   | Data 9   | Data 10   |
| Info A   | Info B   | Info C   | Info D   | Info E   | Info F   | Info G   | Info H   | Info I   | Info J    |
| Test 1   | Test 2   | Test 3   | Test 4   | Test 5   | Test 6   | Test 7   | Test 8   | Test 9   | Test 10   |
```

The entire table should be rendered in the example and become scrollable.


## without this fix:
![image](https://github.com/user-attachments/assets/ae7bb0f5-be25-4f54-8932-2b1ca441a189)

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the visual styling for an example component to allow nested elements to shrink more flexibly, enhancing responsiveness and layout adaptability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
