### PR TITLE
fix(table): apply new columns without a full init

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -200,10 +200,12 @@ export class Table {
     private firstRequest: boolean;
     private currentSorting: ColumnSorter[];
     private tableSelection: TableSelection;
+    private shouldSort: boolean = false;
 
     constructor() {
         this.handleDataSorting = this.handleDataSorting.bind(this);
         this.handlePageLoaded = this.handlePageLoaded.bind(this);
+        this.handleRenderComplete = this.handleRenderComplete.bind(this);
         this.handleAjaxRequesting = this.handleAjaxRequesting.bind(this);
         this.requestData = this.requestData.bind(this);
         this.onClickRow = this.onClickRow.bind(this);
@@ -305,9 +307,8 @@ export class Table {
             return;
         }
 
-        // Updating columns requires a reinitialization otherwise sorting will not work
-        // afterwards
-        this.init();
+        this.tabulator.setColumns(this.getColumnDefinitions());
+        this.shouldSort = true;
     }
 
     @Watch('aggregates')
@@ -495,6 +496,7 @@ export class Table {
             columns: this.getColumnDefinitions(),
             dataSorting: this.handleDataSorting,
             pageLoaded: this.handlePageLoaded,
+            renderComplete: this.handleRenderComplete,
             ...ajaxOptions,
             ...paginationOptions,
             rowClick: this.onClickRow,
@@ -682,6 +684,13 @@ export class Table {
         }
 
         this.changePage.emit(page);
+    }
+
+    private handleRenderComplete(): void {
+        if (this.tabulator && this.shouldSort) {
+            this.tabulator.setSort(this.getColumnSorter(this.sorting));
+            this.shouldSort = false;
+        }
     }
 
     private onClickRow(_ev, row: Tabulator.RowComponent): void {


### PR DESCRIPTION
Don't do a full initialization of the tabulator just because the column definition changed. Instead, set the columns and do a sorting when the rendering is complete.

fix: Lundalogik/crm-feature#4449

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
