### PR TITLE
feat(badge): enable the consumer to control its `max-width`

### DIFF
--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -5,6 +5,7 @@
 /**
  * @prop --badge-background-color: badge background color
  * @prop --badge-text-color: badge text color
+ * @prop --badge-max-width: maximum width of the badge, before its text gets truncated
  */
 
 :host([hidden]) {
@@ -43,7 +44,7 @@ span {
         min-width: var(
             --limel-min-badge-size
         ); // ensures that a badge with only one character rendered as perfect circle
-        max-width: 2.75rem;
+        max-width: var(--badge-max-width, 2.75rem);
         padding: 0 functions.pxToRem(4.5);
     }
 }


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-feature/issues/4665
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable styling option for badge components, allowing the maximum display width to be set externally. This change enhances the flexibility of badge presentation while preserving the default appearance when custom settings are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
