### PR TITLE
feat(chip): add missing `loading` property to `Chip` interface

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -83,6 +83,7 @@ export interface Chip<T = any> {
     iconTitle?: string;
     id: number | string;
     image?: Image_2;
+    loading?: boolean;
     menuItems?: Array<MenuItem | ListSeparator>;
     removable?: boolean;
     selected?: boolean;

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -646,6 +646,7 @@ export class ChipSet {
             badge: chip.badge,
             selected: chip.selected,
             disabled: this.disabled,
+            loading: chip.loading,
             readonly: readonly,
             type: chipType,
             removable: removable,

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -101,6 +101,12 @@ export interface Chip<T = any> {
      * List of the items to display as in a menu, on the chip.
      */
     menuItems?: Array<MenuItem | ListSeparator>;
+
+    /**
+     * Set to `true` to put the chip in the `loading` state, and render an
+     * indeterminate progress indicator inside the chip.
+     */
+    loading?: boolean;
 }
 
 /**


### PR DESCRIPTION
fix Lundalogik/crm-feature#4676

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chips now support a loading state, allowing them to display a visual indicator during active operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->