### PR TITLE
fix(action-bar): show expand button only when more than one action ex…

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -209,7 +209,7 @@ export class ActionBar {
     };
 
     private renderCollapseExpandButton() {
-        if (!this.collapsible) {
+        if (!this.collapsible || this.actions.length <= 1) {
             return;
         }
 


### PR DESCRIPTION
…ists
<img width="677" alt="Screenshot 2025-04-01 at 08 49 23" src="https://github.com/user-attachments/assets/58edc042-fcf3-4fd0-a3e0-9116b6911901" />



<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the Action Bar’s behavior so that the collapse/expand control now only appears when multiple actions are available. This change streamlines the interface by removing unnecessary controls when there’s one or no available actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
