### PR TITLE
feat(table): introduce recent active markers

### DIFF
--- a/src/components/table/partial-styles/tabulator-custom-styles.scss
+++ b/src/components/table/partial-styles/tabulator-custom-styles.scss
@@ -1,6 +1,22 @@
 @use '../../../style/mixins';
 @use '../../../style/functions';
+@use '../../../style/theme-color-variables';
+@use '../../../style/color-palette-extended';
 
+@mixin table-row-selected-indicator($border-color, $z-index) {
+    &:before {
+        $width-of-selected-row-indicator: 0.2rem;
+        content: '';
+        display: inline-block;
+        box-sizing: border-box;
+        position: sticky;
+        z-index: $z-index;
+        inset: 0 0 auto 0;
+        border: $width-of-selected-row-indicator solid $border-color;
+        border-radius: 1rem;
+        margin-right: -$width-of-selected-row-indicator * 2;
+    }
+}
 .interactive-feedback {
     // This is a div, injected by us into all rows.
     // We use it to visualize interactive feedback.
@@ -45,19 +61,10 @@
                 box-shadow: var(--button-shadow-inset-pressed);
             }
 
-            &:before {
-                $width-of-selected-row-indicator: 0.2rem;
-                content: '';
-                display: inline-block;
-                box-sizing: border-box;
-                position: sticky;
-                z-index: $table--has-interactive-rows--selectable-row--hover + 1;
-                inset: 0 0 auto 0;
-                border: $width-of-selected-row-indicator solid
-                    var(--mdc-theme-primary);
-                border-radius: 1rem;
-                margin-right: -$width-of-selected-row-indicator * 2;
-            }
+            @include table-row-selected-indicator(
+                var(--mdc-theme-primary),
+                $table--has-interactive-rows--selectable-row--hover + 1
+            );
         }
     }
 }
@@ -88,6 +95,12 @@
                 }
             }
         }
+    }
+    .recent-active {
+        @include table-row-selected-indicator(
+            rgb(var(--contrast-700)),
+            $table--has-interactive-rows--selectable-row--hover + 1
+        );
     }
 }
 


### PR DESCRIPTION
fix: https://github.com/Lundalogik/crm-feature/issues/1294

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recently active table rows are now visually indicated, allowing users to see not only the currently selected row but also the previous one.  
- **Style**
  - Enhanced table row styling with a consistent left border indicator for selected and recently active rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
