### PR TITLE
fix(action-bar): restrict collapse button to floating layout only

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -209,7 +209,11 @@ export class ActionBar {
     };
 
     private renderCollapseExpandButton() {
-        if (!this.collapsible || this.actions.length <= 1) {
+        if (
+            !this.collapsible ||
+            this.actions.length <= 1 ||
+            this.layout !== 'floating'
+        ) {
             return;
         }
 

--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -39,7 +39,7 @@ import { Icon } from '../../global/shared-types/icon.types';
  * @exampleComponent limel-example-action-bar-selected-item
  * @exampleComponent limel-example-action-bar-colors
  * @exampleComponent limel-example-action-bar-floating
- * @exampleComponent limel-example-action-bar-floating-expand
+ * @exampleComponent limel-example-action-bar-floating-collapsible
  * @exampleComponent limel-example-action-bar-styling
  * @exampleComponent limel-example-action-bar-as-primary-component
  * @exampleComponent limel-example-action-bar-icon-title

--- a/src/components/action-bar/examples/action-bar-floating-with-collaps-button.tsx
+++ b/src/components/action-bar/examples/action-bar-floating-with-collaps-button.tsx
@@ -2,19 +2,19 @@ import { Component, h } from '@stencil/core';
 import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
 
 /**
- * Floating action bar with expand button
+ * Floating action bar with collapse button
  *
- * Some designs may require a floating action bar with an expand button.
- * It can be useful if action bar is covering important content.
- * To make the action bar expandable, set the `collapsible` prop to `true`.
+ * Some designs may require a floating action bar with a collapse button.
+ * This feature is useful when the action bar is covering important content.
+ * To make the action bar collapsible, set the `collapsible` prop to `true`.
  *
  */
 @Component({
-    tag: 'limel-example-action-bar-floating-expand',
+    tag: 'limel-example-action-bar-floating-collapsible',
     shadow: true,
     styleUrl: 'action-bar-floating.scss',
 })
-export class ActionBarFloatingExpandExample {
+export class ActionBarFloatingCollapsibleExample {
     private actionBarItems: Array<ActionBarItem | ListSeparator> = [
         {
             text: 'Add',


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the action bar so that the collapse/expand control will no longer appear when using a floating layout. This change refines the interface, ensuring the control only displays when applicable based on the current design configuration.
  
- **New Features**
	- Updated documentation to reflect changes in component functionality from "expand" to "collapse" for the action bar, enhancing clarity on usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
