### PR TITLE
feat(text-editor): add a new `ui` type for rendering the component without a toolbar

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -626,6 +626,7 @@ export namespace Components {
         "language": Languages;
         // @alpha
         "triggerCharacters": TriggerCharacter[];
+        "ui": EditorUiType;
         "value": string;
     }
     // (undocumented)
@@ -822,7 +823,7 @@ export type EditorTextLink = {
 };
 
 // @beta (undocumented)
-export type EditorUiType = 'standard' | 'minimal';
+export type EditorUiType = 'standard' | 'minimal' | 'no-toolbar';
 
 // Warning: (ae-missing-release-tag) "EventEmitter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1713,6 +1714,7 @@ export namespace JSX {
         "onImageRemoved"?: (event: LimelProsemirrorAdapterCustomEvent<ImageInfo>) => void;
         // @alpha
         "triggerCharacters"?: TriggerCharacter[];
+        "ui"?: EditorUiType;
         "value"?: string;
     }
     // (undocumented)

--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -3,7 +3,7 @@ import {
     LimelSelectCustomEvent,
     Option,
 } from '@limetech/lime-elements';
-import { Component, h, State, Watch } from '@stencil/core';
+import { Component, h, Host, State, Watch } from '@stencil/core';
 
 /**
  * Composite example
@@ -46,82 +46,84 @@ export class TextEditorCompositeExample {
         value: 'standard',
     };
 
-    private availableUis: Array<Option<EditorUiType>> = [
+    private readonly availableUis: Array<Option<EditorUiType>> = [
         { text: 'standard', value: 'standard' },
         { text: 'minimal', value: 'minimal' },
         { text: 'no-toolbar', value: 'no-toolbar' },
     ];
 
     public render() {
-        return [
-            <limel-text-editor
-                label={this.label}
-                helperText={this.helperText}
-                value={this.value}
-                onChange={this.handleChange}
-                readonly={this.readonly}
-                required={this.required}
-                disabled={this.disabled}
-                invalid={this.invalid}
-                placeholder={this.placeholder}
-                allowResize={this.allowResize}
-                ui={this.selectedUi.value}
-            />,
-            <limel-example-controls>
-                <limel-checkbox
-                    checked={this.readonly}
-                    label="Readonly"
-                    onChange={this.setReadonly}
+        return (
+            <Host>
+                <limel-text-editor
+                    label={this.label}
+                    helperText={this.helperText}
+                    value={this.value}
+                    onChange={this.handleChange}
+                    readonly={this.readonly}
+                    required={this.required}
+                    disabled={this.disabled}
+                    invalid={this.invalid}
+                    placeholder={this.placeholder}
+                    allowResize={this.allowResize}
+                    ui={this.selectedUi.value}
                 />
-                <limel-checkbox
-                    checked={this.invalid}
-                    label="Invalid"
-                    onChange={this.setInvalid}
-                />
-                <limel-checkbox
-                    checked={this.required}
-                    label="Required"
-                    onChange={this.setRequired}
-                />
-                <limel-checkbox
-                    checked={this.disabled}
-                    label="Disabled"
-                    onChange={this.setDisabled}
-                />
-                <limel-checkbox
-                    checked={this.allowResize}
-                    label="Allow resize"
-                    onChange={this.setAllowResize}
-                />
-                <limel-select
-                    label="ui"
-                    options={this.availableUis}
-                    value={this.selectedUi}
-                    onChange={this.handleNewSelection}
-                />
-                <hr
-                    style={{
-                        'grid-column': '1/-1',
-                    }}
-                />
-                <limel-input-field
-                    label="label"
-                    value={this.label}
-                    onChange={this.handleLabelChange}
-                />
-                <limel-input-field
-                    label="helperText"
-                    value={this.helperText}
-                    onChange={this.handleHelperTextChange}
-                />
-                <limel-input-field
-                    label="placeholder"
-                    value={this.placeholder}
-                    onChange={this.handlePlaceholderChange}
-                />
-            </limel-example-controls>,
-            <limel-example-value value={this.value} />,
-        ];
+                <limel-example-controls>
+                    <limel-checkbox
+                        checked={this.readonly}
+                        label="Readonly"
+                        onChange={this.setReadonly}
+                    />
+                    <limel-checkbox
+                        checked={this.invalid}
+                        label="Invalid"
+                        onChange={this.setInvalid}
+                    />
+                    <limel-checkbox
+                        checked={this.required}
+                        label="Required"
+                        onChange={this.setRequired}
+                    />
+                    <limel-checkbox
+                        checked={this.disabled}
+                        label="Disabled"
+                        onChange={this.setDisabled}
+                    />
+                    <limel-checkbox
+                        checked={this.allowResize}
+                        label="Allow resize"
+                        onChange={this.setAllowResize}
+                    />
+                    <limel-select
+                        label="ui"
+                        options={this.availableUis}
+                        value={this.selectedUi}
+                        onChange={this.handleNewSelection}
+                    />
+                    <hr
+                        style={{
+                            'grid-column': '1/-1',
+                        }}
+                    />
+                    <limel-input-field
+                        label="label"
+                        value={this.label}
+                        onChange={this.handleLabelChange}
+                    />
+                    <limel-input-field
+                        label="helperText"
+                        value={this.helperText}
+                        onChange={this.handleHelperTextChange}
+                    />
+                    <limel-input-field
+                        label="placeholder"
+                        value={this.placeholder}
+                        onChange={this.handlePlaceholderChange}
+                    />
+                </limel-example-controls>
+                <limel-example-value value={this.value} />
+            </Host>
+        );
     }
 
     @Watch('required')
@@ -130,51 +132,51 @@ export class TextEditorCompositeExample {
         this.invalid = this.required && !this.value;
     }
 
-    private setReadonly = (event: CustomEvent<boolean>) => {
+    private readonly setReadonly = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.readonly = event.detail;
     };
 
-    private setRequired = (event: CustomEvent<boolean>) => {
+    private readonly setRequired = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.required = event.detail;
     };
 
-    private setInvalid = (event: CustomEvent<boolean>) => {
+    private readonly setInvalid = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.invalid = event.detail;
     };
 
-    private setDisabled = (event: CustomEvent<boolean>) => {
+    private readonly setDisabled = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.disabled = event.detail;
     };
 
-    private setAllowResize = (event: CustomEvent<boolean>) => {
+    private readonly setAllowResize = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.allowResize = event.detail;
     };
 
-    private handleLabelChange = (event: CustomEvent<string>) => {
+    private readonly handleLabelChange = (event: CustomEvent<string>) => {
         event.stopPropagation();
         this.label = event.detail;
     };
 
-    private handleHelperTextChange = (event: CustomEvent<string>) => {
+    private readonly handleHelperTextChange = (event: CustomEvent<string>) => {
         event.stopPropagation();
         this.helperText = event.detail;
     };
 
-    private handlePlaceholderChange = (event: CustomEvent<string>) => {
+    private readonly handlePlaceholderChange = (event: CustomEvent<string>) => {
         event.stopPropagation();
         this.placeholder = event.detail;
     };
 
-    private handleChange = (event: CustomEvent<string>) => {
+    private readonly handleChange = (event: CustomEvent<string>) => {
         this.value = event.detail;
     };
 
-    private handleNewSelection = (
+    private readonly handleNewSelection = (
         event: LimelSelectCustomEvent<Option<EditorUiType>>,
     ) => {
         this.selectedUi = event.detail;

--- a/src/components/text-editor/examples/text-editor-composite.tsx
+++ b/src/components/text-editor/examples/text-editor-composite.tsx
@@ -1,5 +1,10 @@
-import { Option, LimelSelectCustomEvent } from '@limetech/lime-elements';
+import {
+    EditorUiType,
+    LimelSelectCustomEvent,
+    Option,
+} from '@limetech/lime-elements';
 import { Component, h, State, Watch } from '@stencil/core';
+
 /**
  * Composite example
  */
@@ -36,14 +41,15 @@ export class TextEditorCompositeExample {
     private helperText: string;
 
     @State()
-    private selectedUi: Option<'standard' | 'minimal'> = {
+    private selectedUi: Option<EditorUiType> = {
         text: 'standard',
         value: 'standard',
     };
 
-    private availableUis: Array<Option<'standard' | 'minimal'>> = [
+    private availableUis: Array<Option<EditorUiType>> = [
         { text: 'standard', value: 'standard' },
         { text: 'minimal', value: 'minimal' },
+        { text: 'no-toolbar', value: 'no-toolbar' },
     ];
 
     public render() {
@@ -169,7 +175,7 @@ export class TextEditorCompositeExample {
     };
 
     private handleNewSelection = (
-        event: LimelSelectCustomEvent<Option<'standard' | 'minimal'>>,
+        event: LimelSelectCustomEvent<Option<EditorUiType>>,
     ) => {
         this.selectedUi = event.detail;
     };

--- a/src/components/text-editor/examples/text-editor-ui.tsx
+++ b/src/components/text-editor/examples/text-editor-ui.tsx
@@ -1,5 +1,9 @@
-import { Option, LimelSelectCustomEvent } from '@limetech/lime-elements';
-import { Component, h, State } from '@stencil/core';
+import {
+    EditorUiType,
+    LimelSelectCustomEvent,
+    Option,
+} from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
 
 /**
  * UI
@@ -10,10 +14,14 @@ import { Component, h, State } from '@stencil/core';
  * - `minimal`: A compact editor appearance, ideal for limited space
  *    scenarios such as mobile devices. In this mode, the toolbar is hidden
  *    until the editor is focused.
+ * - `no-toolbar`: A basic textarea appearance without any text styling toolbar.
+ *    This mode is suitable for scenarios where you want to provide a simple
+ *    text input without any visible formatting options; but still provide
+ *    support for markdown syntax and rich text, using hotkeys or when pasting.
  *
  * :::important
  * It's very important to add a `placeholder` or `label` when using
- * the `minimal` UI. The reason is that without a placeholder or a label,
+ * the `minimal` or `no-toolbar` UI. The reason is that without a placeholder or a label,
  * there is no visual clue for the user to realize that the grey box is
  * actually an input field that they can type in,
  * since the toolbar would not be shown unless the input filed is focused.
@@ -25,14 +33,15 @@ import { Component, h, State } from '@stencil/core';
 })
 export class TextEditorUiExample {
     @State()
-    private selectedUi: Option<'standard' | 'minimal'> = {
+    private selectedUi: Option<EditorUiType> = {
         text: 'standard',
         value: 'standard',
     };
 
-    private availableUis: Array<Option<'standard' | 'minimal'>> = [
+    private readonly availableUis: Array<Option<EditorUiType>> = [
         { text: 'standard', value: 'standard' },
         { text: 'minimal', value: 'minimal' },
+        { text: 'no-toolbar', value: 'no-toolbar' },
     ];
 
     @State()
@@ -40,35 +49,37 @@ export class TextEditorUiExample {
 
     public render() {
         const placeholderText =
-            this.selectedUi.value === 'minimal' ? 'Write a comment…' : '';
+            this.selectedUi.value !== 'standard' ? 'Write a comment…' : '';
 
-        return [
-            <limel-text-editor
-                value={this.value}
-                onChange={this.handleChange}
-                ui={this.selectedUi.value}
-                placeholder={placeholderText}
-            />,
-            <limel-example-controls
-                style={{ '--example-controls-column-layout': 'auto-fit' }}
-            >
-                <limel-example-value value={this.value} />
-                <limel-select
-                    label="ui"
-                    options={this.availableUis}
-                    value={this.selectedUi}
-                    onChange={this.handleNewSelection}
+        return (
+            <Host>
+                <limel-text-editor
+                    value={this.value}
+                    onChange={this.handleChange}
+                    ui={this.selectedUi.value}
+                    placeholder={placeholderText}
                 />
-            </limel-example-controls>,
-        ];
+                <limel-example-controls
+                    style={{ '--example-controls-column-layout': 'auto-fit' }}
+                >
+                    <limel-example-value value={this.value} />
+                    <limel-select
+                        label="ui"
+                        options={this.availableUis}
+                        value={this.selectedUi}
+                        onChange={this.handleNewSelection}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
     }
 
-    private handleChange = (event: CustomEvent<string>) => {
+    private readonly handleChange = (event: CustomEvent<string>) => {
         this.value = event.detail;
     };
 
-    private handleNewSelection = (
-        event: LimelSelectCustomEvent<Option<'standard' | 'minimal'>>,
+    private readonly handleNewSelection = (
+        event: LimelSelectCustomEvent<Option<EditorUiType>>,
     ) => {
         this.selectedUi = event.detail;
     };

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -52,6 +52,7 @@ import {
 } from '../text-editor.types';
 import { getTableNodes, getTableEditingPlugins } from './plugins/table-plugin';
 import { getImageNode, imageCache } from './plugins/image/node';
+import { EditorUiType } from '../types';
 
 const DEBOUNCE_TIMEOUT = 300;
 
@@ -116,6 +117,12 @@ export class ProsemirrorAdapter {
      */
     @Prop()
     triggerCharacters: TriggerCharacter[] = [];
+
+    /**
+     * Specifies the visual appearance of the editor.
+     */
+    @Prop()
+    public ui: EditorUiType = 'standard';
 
     @Element()
     private host: HTMLLimelTextEditorElement;
@@ -244,16 +251,26 @@ export class ProsemirrorAdapter {
         return (
             <Host onFocus={this.handleFocus}>
                 <div id="editor" />
-                <div class="toolbar">
-                    <limel-action-bar
-                        ref={(el) => (this.actionBarElement = el)}
-                        accessibleLabel="Toolbar"
-                        actions={this.actionBarItems}
-                        onItemSelected={this.handleActionBarItem}
-                    />
-                </div>
+                {this.renderToolbar()}
                 {this.renderLinkMenu()}
             </Host>
+        );
+    }
+
+    renderToolbar() {
+        if (!this.actionBarItems.length || this.ui === 'no-toolbar') {
+            return;
+        }
+
+        return (
+            <div class="toolbar">
+                <limel-action-bar
+                    ref={(el) => (this.actionBarElement = el)}
+                    accessibleLabel="Toolbar"
+                    actions={this.actionBarItems}
+                    onItemSelected={this.handleActionBarItem}
+                />
+            </div>
         );
     }
 

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -50,11 +50,15 @@ $min-height: 5rem;
 }
 
 :host(limel-text-editor[ui='minimal']:not(:focus-within)) {
-    --limel-text-editor-padding: 0.75rem 1rem 0.75rem 1rem;
     --limel-prosemirror-adapter-toolbar-grid-template-rows: 0fr;
     --limel-prosemirror-adapter-toolbar-grid-template-rows-transition-duration: 0.46s;
     --limel-prosemirror-adapter-action-bar-padding-top-bottom: 0;
     --limel-prosemirror-adapter-toolbar-opacity: 0;
+}
+
+:host(limel-text-editor[ui='minimal']:not(:focus-within)),
+:host(limel-text-editor[ui='no-toolbar']) {
+    --limel-text-editor-padding: 0.75rem 1rem 0.75rem 1rem;
     --limel-text-editor-placeholder-top: 0;
 
     min-height: calc($min-height / 2);

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
 import { FormComponent } from '../form/form.types';
 import { Languages } from '../date-picker/date.types';
 import { createRandomString } from '../../util/random-string';
@@ -179,7 +179,7 @@ export class TextEditor implements FormComponent<string> {
      * @alpha
      */
     @Event()
-    private imagePasted: EventEmitter<ImageInserter>;
+    private readonly imagePasted: EventEmitter<ImageInserter>;
 
     /**
      * Dispatched when a image is removed from the editor
@@ -188,7 +188,7 @@ export class TextEditor implements FormComponent<string> {
      * @alpha
      */
     @Event()
-    private imageRemoved: EventEmitter<ImageInfo>;
+    private readonly imageRemoved: EventEmitter<ImageInfo>;
 
     /**
      * Dispatched if a trigger character is detected.
@@ -219,8 +219,8 @@ export class TextEditor implements FormComponent<string> {
     @Event()
     public triggerChange: EventEmitter<TriggerEventDetail>;
 
-    private helperTextId: string;
-    private editorId: string;
+    private readonly helperTextId: string;
+    private readonly editorId: string;
 
     public constructor() {
         this.helperTextId = createRandomString();
@@ -228,22 +228,24 @@ export class TextEditor implements FormComponent<string> {
     }
 
     public render() {
-        return [
-            <limel-notched-outline
-                labelId={this.editorId}
-                label={this.label}
-                required={this.required}
-                invalid={this.invalid}
-                disabled={this.disabled}
-                readonly={this.readonly}
-                hasValue={!!this.value}
-                hasFloatingLabel={true}
-            >
-                {this.renderEditor()}
-                {this.renderPlaceholder()}
-            </limel-notched-outline>,
-            this.renderHelperLine(),
-        ];
+        return (
+            <Host>
+                <limel-notched-outline
+                    labelId={this.editorId}
+                    label={this.label}
+                    required={this.required}
+                    invalid={this.invalid}
+                    disabled={this.disabled}
+                    readonly={this.readonly}
+                    hasValue={!!this.value}
+                    hasFloatingLabel={true}
+                >
+                    {this.renderEditor()}
+                    {this.renderPlaceholder()}
+                </limel-notched-outline>
+                {this.renderHelperLine()}
+            </Host>
+        );
     }
 
     private renderEditor() {

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -158,6 +158,10 @@ export class TextEditor implements FormComponent<string> {
      * - `minimal`: A compact editor appearance, ideal for limited space
      *    scenarios such as mobile devices. In this mode, the toolbar is hidden
      *    until the editor is focused.
+     * - `no-toolbar`: A basic textarea appearance without any text styling toolbar.
+     *    This mode is suitable for scenarios where you want to provide a simple
+     *    text input without any visible formatting options; but still provide
+     *    support for markdown syntax and rich text, using hotkeys or when pasting.
      */
     @Prop({ reflect: true })
     public ui?: EditorUiType = 'standard';
@@ -272,6 +276,7 @@ export class TextEditor implements FormComponent<string> {
                 language={this.language}
                 triggerCharacters={this.triggers}
                 disabled={this.disabled}
+                ui={this.ui}
             />
         );
     }

--- a/src/components/text-editor/types.ts
+++ b/src/components/text-editor/types.ts
@@ -11,4 +11,4 @@ export type TextEditorPlugin = {
 /**
  * @beta
  */
-export type EditorUiType = 'standard' | 'minimal';
+export type EditorUiType = 'standard' | 'minimal' | 'no-toolbar';


### PR DESCRIPTION

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "no-toolbar" mode for the text editor, offering a simplified textarea interface without a visible toolbar, while still supporting markdown and rich text input via hotkeys or pasting.
- **Documentation**
  - Updated descriptions and examples to include the new "no-toolbar" mode and its placeholder requirements.
- **Style**
  - Adjusted editor styles to apply consistent padding for both "minimal" and "no-toolbar" UI modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
