### PR TITLE
fix(input-field): ensure label is vertically center aligned, in dialog

### DIFF
--- a/src/components/notched-outline/notched-outline.scss
+++ b/src/components/notched-outline/notched-outline.scss
@@ -113,6 +113,7 @@ limel-notched-outline {
                 --mdc-typography-subtitle1-letter-spacing,
                 0.009375em
             );
+            line-height: normal;
 
             &:after {
                 position: absolute;


### PR DESCRIPTION
The label of `limel-input-field` (as well as `limel-select`, `limel-chip-set` & other similar form components) would inherit a `line-height` when the component was used in `limel-dialog`

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/465cca0b-aa04-4ee1-a0f1-9acbe3f2f8d6" />

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved label text alignment by setting line height to normal within notched outline components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
