### PR TITLE
fix(input-field): render empty fields with correct height on Safari

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -65,6 +65,15 @@ limel-notched-outline {
     }
 }
 
+:host(limel-input-field:not([type='textarea'])) {
+    .limel-notched-outline {
+        // Needed only for Safari,
+        // to ensure that the outlines are not rendered
+        // larger than the input element.
+        height: shared_input-select-picker.$height-of-mdc-text-field;
+    }
+}
+
 .mdc-text-field {
     width: 100%;
 


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/crm-client/issues/29
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input field appearance in Safari by ensuring the outline height matches the input element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
