### PR TITLE
fix(table): add empty space after the last row

### DIFF
--- a/src/components/table/partial-styles/_table-main-layout.scss
+++ b/src/components/table/partial-styles/_table-main-layout.scss
@@ -23,6 +23,7 @@
         height: $unset-tabulators-calculated-and-hardcoded-height;
         max-height: $unset-tabulators-calculated-and-hardcoded-height;
         min-height: $unset-tabulators-calculated-and-hardcoded-height;
+        padding-bottom: 5rem;
     }
 
     .tabulator-footer {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Increased bottom padding in the table's scrollable area for improved spacing and visual comfort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->
fix https://github.com/Lundalogik/crm-feature/issues/4390
fix https://github.com/Lundalogik/crm-client/issues/26


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
