### PR TITLE
fix(input-field): make input value color respect dark mode again

### DIFF
--- a/src/components/chip-set/chip-set.scss
+++ b/src/components/chip-set/chip-set.scss
@@ -64,6 +64,15 @@ $leading-icon-space: 1.5rem;
     }
 }
 
+.mdc-text-field__input {
+    .mdc-text-field:not(.mdc-text-field--disabled) & {
+        color: shared_input-select-picker.$input-text-color;
+    }
+    .mdc-text-field.mdc-text-field--disabled & {
+        color: shared_input-select-picker.$input-text-color-disabled;
+    }
+}
+
 .mdc-text-field {
     height: auto;
     cursor: text;

--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -152,6 +152,15 @@ limel-notched-outline {
     cursor: pointer;
 }
 
+.mdc-text-field__input {
+    .mdc-text-field:not(.mdc-text-field--disabled) & {
+        color: shared_input-select-picker.$input-text-color;
+    }
+    .mdc-text-field.mdc-text-field--disabled & {
+        color: shared_input-select-picker.$input-text-color-disabled;
+    }
+}
+
 input.mdc-text-field__input {
     @include shared_input-select-picker.input-field-placeholder;
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -62,8 +62,13 @@ limel-notched-outline:not([invalid]:not([invalid='false'])) {
 
 .limel-select__selected-option__text {
     .mdc-select:not(.mdc-select--disabled) & {
-        @include shared_input-select-picker.looks-like-input-label;
+        color: shared_input-select-picker.$input-text-color;
     }
+
+    .mdc-select.mdc-select--disabled & {
+        color: shared_input-select-picker.$input-text-color-disabled;
+    }
+
     @include mixins.truncate-text;
 }
 


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated input field and select component styles to clearly differentiate text colors between enabled and disabled states, enhancing visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
