### PR TITLE
fix(select): ensure label floats, when a labeled empty option is selected

### DIFF
--- a/src/components/select/examples/select-with-empty-option.tsx
+++ b/src/components/select/examples/select-with-empty-option.tsx
@@ -5,10 +5,43 @@ import { Component, h, State } from '@stencil/core';
  * With Empty Option
  *
  * Adding an empty option makes it possible for the user to "unset"
- * the value. Try selecting a value below, and then selecting the empty
- * option again.
+ * any chosen value.
  *
- * If the component is set as required, the empty option is removed.
+ * This example demonstrates two different approaches to empty options in select components:
+ *
+ * **1. Unlabeled empty option**:
+ * A select with a completely empty option (both `text` and `value` are empty).
+ *
+ * Provides a way to clear a selection without any visible text.
+ * This works well when the select's purpose is clear from context
+ * and "no selection" feels intuitive.
+ *
+ * **2. Labeled empty option**:
+ * A select with a labeled empty option (using a label as `text`,
+ * but with an empty `value`).
+ *
+ * This approach uses descriptive labels like "All", "None", while still
+ * having an empty `value`. When good labels are used in the right context,
+ * this improves clarity for users by explicitly communicating what an empty
+ * selection means in this specific context.
+ *
+ * Try selecting a value below, and then selecting the empty
+ * option again. Notice how the select's UI resets to an empty default state,
+ * if no `text` is provided to label the empty option.
+ *
+ * :::important
+ * If the component is set as `required`, and the empty option is unlabeled,
+ * it will be removed from the list.
+ * This is to ensure that if users open the required dropdown,
+ * and close it without selecting anything, the component can make set
+ * itself to `invalid`, forcing the user to choose a choice,
+ * before being able to continue.
+ *
+ * However, when the empty option is labeled, it will remain in the list,
+ * even if the component is set as `required`. This can be confusing for users,
+ * as they may not understand why the empty option is still available and selectable,
+ * but once selected, the component becomes `invalid`.
+ * :::
  */
 @Component({
     shadow: true,
@@ -16,28 +49,53 @@ import { Component, h, State } from '@stencil/core';
 })
 export class SelectWithEmptyOptionExample {
     @State()
-    public value: Option;
+    public value1: Option;
+
+    @State()
+    public value2: Option;
 
     @State()
     public required = false;
 
-    private options: Option[] = [
+    private optionsWithUnlabeledEmpty: Option[] = [
         { text: '', value: '' },
         { text: 'Luke Skywalker', value: 'luke' },
         { text: 'Han Solo', value: 'han' },
-        { text: 'Leia Organo', value: 'leia' },
+        { text: 'Leia Organa', value: 'leia' },
+        { text: 'Obi-Wan Kenobi', value: 'obi-wan' },
+    ];
+
+    private optionsWithLabeledEmpty: Option[] = [
+        { text: 'None', value: '' },
+        { text: 'Luke Skywalker', value: 'luke' },
+        { text: 'Han Solo', value: 'han' },
+        { text: 'Leia Organa', value: 'leia' },
+        { text: 'Obi-Wan Kenobi', value: 'obi-wan' },
     ];
 
     public render() {
         return (
             <section>
+                <h4>Unlabeled Empty Option</h4>
                 <limel-select
-                    label="Favorite hero"
-                    value={this.value}
-                    options={this.options}
+                    label="Select a character"
+                    value={this.value1}
+                    options={this.optionsWithUnlabeledEmpty}
                     required={this.required}
-                    onChange={this.handleChange}
+                    onChange={this.handleChange1}
                 />
+                <limel-example-value value={this.value1} />
+
+                <h4>Labeled Empty Option</h4>
+                <limel-select
+                    label="Select a character"
+                    value={this.value2}
+                    options={this.optionsWithLabeledEmpty}
+                    required={this.required}
+                    onChange={this.handleChange2}
+                />
+                <limel-example-value value={this.value2} />
+
                 <limel-example-controls>
                     <limel-checkbox
                         checked={this.required}
@@ -45,13 +103,16 @@ export class SelectWithEmptyOptionExample {
                         onChange={this.setRequired}
                     />
                 </limel-example-controls>
-                <limel-example-value value={this.value} />
             </section>
         );
     }
 
-    private handleChange = (event: LimelSelectCustomEvent<Option<string>>) => {
-        this.value = event.detail;
+    private handleChange1 = (event: LimelSelectCustomEvent<Option<string>>) => {
+        this.value1 = event.detail;
+    };
+
+    private handleChange2 = (event: LimelSelectCustomEvent<Option<string>>) => {
+        this.value2 = event.detail;
     };
 
     private setRequired = (event: CustomEvent<boolean>) => {

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -65,7 +65,7 @@ export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = (
             disabled={props.disabled}
             readonly={props.readonly}
             hasValue={hasValue}
-            hasFloatingLabel={props.isOpen}
+            hasFloatingLabel={floatLabelAbove(props)}
         >
             <SelectValue
                 {...props}
@@ -77,6 +77,23 @@ export const SelectTemplate: FunctionalComponent<SelectTemplateProps> = (
         <HelperText text={props.helperText} isValid={!props.invalid} />,
         <SelectDropdown {...props} />,
     ];
+};
+
+const floatLabelAbove = (props: SelectTemplateProps) => {
+    if (props.isOpen) {
+        return true;
+    }
+
+    const value = props.value;
+    if (value) {
+        if (isMultiple(value)) {
+            return value.length > 0;
+        } else {
+            return value.text !== '';
+        }
+    }
+
+    return false;
 };
 
 const SelectValue: FunctionalComponent<


### PR DESCRIPTION
… and that the label does not float,
when an unlabeled empty option is selected.
fix https://github.com/Lundalogik/lime-elements/issues/3537

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the select input example to showcase two methods for handling empty options: an unlabeled empty option and a labeled "None" option, each with its own state and options.
- **Documentation**
	- Expanded example documentation to clarify the approaches to empty options and their behavior when the select is required.
- **Style**
	- Improved label floating behavior in select inputs, ensuring the label floats based on both open state and whether a meaningful value is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
