### PR TITLE
fix(text-editor): ensure a tall `readonly` editor does not overflow its container

### DIFF
--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -11,6 +11,7 @@
 }
 
 $min-height: 5rem;
+$min-height-condensed: calc($min-height / 2);
 
 :host(limel-text-editor) {
     --limel-notched-outline-z-index: 2; // since `div.toolbar` has `z-index: 1;`
@@ -61,9 +62,9 @@ $min-height: 5rem;
     --limel-text-editor-padding: 0.75rem 1rem 0.75rem 1rem;
     --limel-text-editor-placeholder-top: 0;
 
-    min-height: calc($min-height / 2);
+    min-height: $min-height-condensed;
     limel-prosemirror-adapter {
-        min-height: calc($min-height / 2);
+        min-height: $min-height-condensed;
     }
 }
 

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -89,7 +89,9 @@ $min-height: 5rem;
         // displayed when `readonly` instead of the adapter
         display: block;
         padding: var(--limel-text-editor-padding);
+
         overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
         height: 100%;
 
         &:before,
@@ -155,6 +157,7 @@ limel-prosemirror-adapter {
     min-height: $min-height;
     height: 100%;
     overflow: hidden auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 @include mixins.hide-helper-line-when-not-needed(limel-text-editor);

--- a/src/components/text-editor/text-editor.scss
+++ b/src/components/text-editor/text-editor.scss
@@ -90,6 +90,7 @@ $min-height: 5rem;
         display: block;
         padding: var(--limel-text-editor-padding);
         overflow-y: auto;
+        height: 100%;
 
         &:before,
         &:after {


### PR DESCRIPTION
… and scrolls properly on Y axis instead.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved scrolling behavior and ensured full height usage in readonly mode for the text editor, especially on touch devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
