### PR TITLE
chore(tab-bar): get rid of all functions.pxToRem() in styles

### DIFF
--- a/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
+++ b/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
@@ -1,4 +1,4 @@
-@use '../../style/functions';
+$tab-scroller-fade-width: 4rem;
 
 .scroll-fade,
 .scroll-button {
@@ -13,15 +13,11 @@
 .scroll-fade {
     top: 0;
     height: 100%;
-    width: functions.pxToRem($tab-scroller-fade-width);
+    width: $tab-scroller-fade-width;
     pointer-events: none;
 
     &.left {
-        transform: translate3d(
-            functions.pxToRem(0 - $tab-scroller-fade-width),
-            0,
-            0
-        );
+        transform: translate3d(-#{$tab-scroller-fade-width}, 0, 0);
         left: 0;
         background: linear-gradient(
             270deg,
@@ -32,11 +28,7 @@
     }
 
     &.right {
-        transform: translate3d(
-            functions.pxToRem($tab-scroller-fade-width),
-            0,
-            0
-        );
+        transform: translate3d($tab-scroller-fade-width, 0, 0);
         right: 0;
         background: linear-gradient(
             90deg,
@@ -55,21 +47,13 @@
     bottom: 0;
 
     &.left {
-        transform: translate3d(
-            functions.pxToRem(0 - $tab-scroller-fade-width),
-            0,
-            0
-        );
-        left: functions.pxToRem(4);
+        transform: translate3d(-#{$tab-scroller-fade-width}, 0, 0);
+        left: 0.25rem;
     }
 
     &.right {
-        transform: translate3d(
-            functions.pxToRem($tab-scroller-fade-width),
-            0,
-            0
-        );
-        right: functions.pxToRem(4);
+        transform: translate3d($tab-scroller-fade-width, 0, 0);
+        right: 0.25rem;
     }
 
     &:hover {

--- a/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
+++ b/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
@@ -1,4 +1,7 @@
+@use '../../../style/mixins';
+
 $tab-scroller-fade-width: 4rem;
+$space-around-buttons: 0.25rem;
 
 .scroll-fade,
 .scroll-button {
@@ -40,7 +43,6 @@ $tab-scroller-fade-width: 4rem;
 }
 
 .scroll-button {
-    --icon-background-color: rgb(var(--contrast-100));
     display: flex;
     align-items: center;
     top: 0;
@@ -48,16 +50,35 @@ $tab-scroller-fade-width: 4rem;
 
     &.left {
         transform: translate3d(-#{$tab-scroller-fade-width}, 0, 0);
-        left: 0.25rem;
+        left: $space-around-buttons;
     }
 
     &.right {
         transform: translate3d($tab-scroller-fade-width, 0, 0);
-        right: 0.25rem;
+        right: $space-around-buttons;
     }
 
     &:hover {
         transform: translate3d(0, 0, 0);
+    }
+
+    button {
+        all: unset;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        width: 1.25rem;
+        height: calc(100% - calc(#{$space-around-buttons} * 2));
+        border-radius: 0.25rem;
+
+        &:not(:disabled) {
+            @include mixins.is-elevated-clickable;
+        }
+    }
+
+    limel-icon {
+        width: 1rem;
     }
 }
 

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -64,11 +64,12 @@ $tab-separator-background-color: rgb(var(--contrast-600));
 
 .mdc-tab {
     border-radius: 0;
-    padding-right: 1.25rem;
-    padding-left: 1.25rem;
+    padding-right: 1rem;
+    padding-left: 1rem;
     min-width: 2.5rem;
     background-color: transparent;
     flex: 0 0 auto;
+    height: 2.5rem;
 
     &:not(.mdc-tab--active) {
         --badge-background-color: rgb(var(--contrast-600));
@@ -92,6 +93,14 @@ $tab-separator-background-color: rgb(var(--contrast-600));
                 display: none;
             }
         }
+    }
+
+    .mdc-tab__icon {
+        margin-left: -0.25rem;
+    }
+
+    limel-badge {
+        margin-right: -0.25rem;
     }
 }
 

--- a/src/components/tab-bar/tab-bar.scss
+++ b/src/components/tab-bar/tab-bar.scss
@@ -1,4 +1,3 @@
-@use '../../style/functions';
 @use '../../style/internal/lime-theme';
 @use '@material/tab-bar/mdc-tab-bar';
 @use '@material/tab-scroller/mdc-tab-scroller';
@@ -6,11 +5,10 @@
 @use '@material/tab/mdc-tab';
 
 $tab-background-color: var(--contrast-300);
-$tab-border-radius: functions.pxToRem(10);
-$tab-active-outer-edge-curve-size: functions.pxToRem(12);
-$tab-separator-width: functions.pxToRem(2);
+$tab-border-radius: 0.625rem;
+$tab-active-outer-edge-curve-size: 0.75rem;
+$tab-separator-width: 0.125rem;
 $tab-separator-background-color: rgb(var(--contrast-600));
-$tab-scroller-fade-width: 65;
 
 @import './partial-styles/tab-bar-scroller.scss';
 
@@ -54,7 +52,7 @@ $tab-scroller-fade-width: 65;
     border: {
         style: solid;
         color: transparent;
-        width: functions.pxToRem(4);
+        width: 0.25rem;
     }
     opacity: 0.7;
 
@@ -66,9 +64,9 @@ $tab-scroller-fade-width: 65;
 
 .mdc-tab {
     border-radius: 0;
-    padding-right: functions.pxToRem(20);
-    padding-left: functions.pxToRem(20);
-    min-width: functions.pxToRem(40);
+    padding-right: 1.25rem;
+    padding-left: 1.25rem;
+    min-width: 2.5rem;
     background-color: transparent;
     flex: 0 0 auto;
 
@@ -80,12 +78,12 @@ $tab-scroller-fade-width: 65;
             display: block;
             background-color: $tab-separator-background-color;
             width: $tab-separator-width;
-            height: functions.pxToRem(16);
+            height: 1rem;
             margin: auto;
             position: absolute;
             top: 0;
             bottom: 0;
-            border-radius: functions.pxToRem(16);
+            border-radius: 1rem;
             right: -$tab-separator-width;
         }
 
@@ -133,7 +131,7 @@ $tab-scroller-fade-width: 65;
 }
 
 .mdc-tab__content {
-    gap: functions.pxToRem(6);
+    gap: 0.375rem;
 }
 
 .mdc-tab {

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -19,6 +19,8 @@ import { getIconColor, getIconName } from '../icon/get-icon-props';
 const { TAB_ACTIVATED_EVENT } = strings;
 const SCROLL_DISTANCE_ON_CLICK_PX = 150;
 const HIDE_SCROLL_BUTTONS_WHEN_SCROLLED_LESS_THAN_PX = 40;
+const TOTAL_WIDTH_PERCENTAGE = 100;
+const OVERLAP_PERCENTAGE = 20;
 
 /**
  * Tabs are great to organize information hierarchically in the interface and divide it into distinct categories. Using tabs, you can create groups of content that are related and at the same level in the hierarchy.
@@ -250,17 +252,36 @@ export class TabBar {
     }
 
     private handleLeftScrollClick() {
+        const scrollDistance = this.getScrollDistance();
         this.scrollArea.scroll({
-            left: this.scrollArea.scrollLeft - SCROLL_DISTANCE_ON_CLICK_PX,
+            left: this.scrollArea.scrollLeft - scrollDistance,
             behavior: 'smooth',
         });
     }
 
     private handleRightScrollClick() {
+        const scrollDistance = this.getScrollDistance();
         this.scrollArea.scroll({
-            left: this.scrollArea.scrollLeft + SCROLL_DISTANCE_ON_CLICK_PX,
+            left: this.scrollArea.scrollLeft + scrollDistance,
             behavior: 'smooth',
         });
+    }
+
+    /**
+     * Calculates how far to scroll when navigation buttons are clicked.
+     * Returns the visible width minus an overlap percentage to maintain context.
+     * Falls back to the constant value if something goes wrong.
+     */
+    private getScrollDistance(): number {
+        if (!this.scrollArea) {
+            return SCROLL_DISTANCE_ON_CLICK_PX;
+        }
+
+        const containerWidth = this.scrollArea.getBoundingClientRect().width;
+        const scrollDistance =
+            containerWidth * (1 - OVERLAP_PERCENTAGE / TOTAL_WIDTH_PERCENTAGE);
+
+        return Math.max(scrollDistance, SCROLL_DISTANCE_ON_CLICK_PX);
     }
 
     private renderIcon(tab: Tab) {

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -119,25 +119,27 @@ export class TabBar {
                     </div>
                     <div class="scroll-fade left" />
                     <div class="scroll-button left">
-                        <limel-icon-button
-                            icon="angle_left"
-                            elevated={true}
+                        <button
+                            type="button"
                             tabindex="-1"
                             aria-hidden="true"
                             disabled={!this.canScrollLeft}
                             onClick={this.handleLeftScrollClick}
-                        />
+                        >
+                            <limel-icon name="angle_left" />
+                        </button>
                     </div>
                     <div class="scroll-fade right" />
                     <div class="scroll-button right">
-                        <limel-icon-button
-                            icon="angle_right"
-                            elevated={true}
+                        <button
+                            type="button"
                             tabindex="-1"
                             aria-hidden="true"
                             disabled={!this.canScrollRight}
                             onClick={this.handleRightScrollClick}
-                        />
+                        >
+                            <limel-icon name="angle_right" />
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

### Before:
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/9454a23a-f8a2-49b6-b510-a8ff0de1ed0a" />

### After
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/74651b9a-c15f-49b9-9cc1-0bfa1cc9fe9c" />

fix https://github.com/Lundalogik/lime-elements/issues/3541

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Scroll buttons in the tab bar now provide a smoother experience by adapting the scroll distance to the visible area, ensuring a partial tab remains visible after scrolling.
- **Style**
	- Updated tab bar and scroller styles to use consistent rem-based spacing and sizing.
	- Improved appearance and layout of scroll buttons and icons for better visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
