### PR TITLE
feat(text-editor): add metadata event for notifying about metadata changes (images and links)

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -820,6 +820,28 @@ export interface DockMenu {
     };
 }
 
+// @alpha (undocumented)
+export interface EditorImage {
+    fileInfoId: string;
+    src: string;
+    state: EditorImageState;
+}
+
+// @alpha (undocumented)
+export type EditorImageState = 'loading' | 'failed' | 'success';
+
+// @alpha (undocumented)
+export interface EditorLink {
+    href: string;
+    text: string;
+}
+
+// @alpha
+export interface EditorMetadata {
+    images: EditorImage[];
+    links: EditorLink[];
+}
+
 // @beta
 export type EditorTextLink = {
     text?: string;
@@ -987,29 +1009,12 @@ interface Image_2 {
 export { Image_2 as Image }
 
 // @alpha (undocumented)
-export interface ImageInfo {
-    fileInfoId: string;
-    src: string;
-    state: ImageState;
-}
-
-// @alpha (undocumented)
 export interface ImageInserter {
     // (undocumented)
     fileInfo: FileInfo;
     insertFailedThumbnail: () => void;
     insertImage: (src?: string) => void;
     insertThumbnail: () => void;
-}
-
-// @alpha (undocumented)
-export enum ImageState {
-    // (undocumented)
-    FAILED = "failed",
-    // (undocumented)
-    LOADING = "loading",
-    // (undocumented)
-    SUCCESS = "success"
 }
 
 // @public (undocumented)
@@ -1721,7 +1726,9 @@ export namespace JSX {
         // @alpha
         "onImagePasted"?: (event: LimelProsemirrorAdapterCustomEvent<ImageInserter>) => void;
         // @alpha
-        "onImageRemoved"?: (event: LimelProsemirrorAdapterCustomEvent<ImageInfo>) => void;
+        "onImageRemoved"?: (event: LimelProsemirrorAdapterCustomEvent<EditorImage>) => void;
+        // @alpha
+        "onMetadataChange"?: (event: LimelProsemirrorAdapterCustomEvent<EditorMetadata>) => void;
         // @alpha
         "triggerCharacters"?: TriggerCharacter[];
         "ui"?: EditorUiType;
@@ -1846,8 +1853,10 @@ export namespace JSX {
         "onChange"?: (event: LimelTextEditorCustomEvent<string>) => void;
         // @alpha
         "onImagePasted"?: (event: LimelTextEditorCustomEvent<ImageInserter>) => void;
+        // @alpha @deprecated
+        "onImageRemoved"?: (event: LimelTextEditorCustomEvent<EditorImage>) => void;
         // @alpha
-        "onImageRemoved"?: (event: LimelTextEditorCustomEvent<ImageInfo>) => void;
+        "onMetadataChange"?: (event: LimelTextEditorCustomEvent<EditorMetadata>) => void;
         // @alpha
         "onTriggerChange"?: (event: LimelTextEditorCustomEvent<TriggerEventDetail>) => void;
         // @alpha

--- a/src/components/text-editor/examples/text-editor-with-inline-images-file-storage.tsx
+++ b/src/components/text-editor/examples/text-editor-with-inline-images-file-storage.tsx
@@ -2,9 +2,10 @@ import { Component, h, State, Host } from '@stencil/core';
 import {
     ImageInserter,
     FileInfo,
-    ImageInfo,
+    EditorImage,
     LimelTextEditorCustomEvent,
     LimelCheckboxCustomEvent,
+    EditorMetadata,
 } from '@limetech/lime-elements';
 /**
  * Handling inline images (with external file storage)
@@ -41,6 +42,8 @@ export class TextEditorWithInlineImagesExample {
     @State()
     private uploadImageFails = false;
 
+    private metadata: EditorMetadata = { links: [], images: [] };
+
     public render() {
         return (
             <Host>
@@ -48,7 +51,7 @@ export class TextEditorWithInlineImagesExample {
                     value={this.value}
                     onChange={this.handleChange}
                     onImagePasted={this.handleImagePasted}
-                    onImageRemoved={this.handleImageRemoved}
+                    onMetadataChange={this.handleMetadataChange}
                 />
                 <limel-checkbox
                     label="Upload image fails - insert failed thumbnail"
@@ -109,19 +112,38 @@ export class TextEditorWithInlineImagesExample {
         }
     };
 
-    private handleImageRemoved = (
-        event: LimelTextEditorCustomEvent<ImageInfo>,
+    private handleMetadataChange = (
+        event: LimelTextEditorCustomEvent<EditorMetadata>,
     ) => {
-        const imageInfo = event.detail;
-        console.log(`Image deleted: ${imageInfo.fileInfoId}`);
+        const removedImages = this.getRemovedImages(
+            this.metadata,
+            event.detail,
+        );
 
-        try {
-            throw new Error('Not implemented.');
-        } catch (error) {
-            console.error(
-                `Failed to delete image ${imageInfo.fileInfoId}`,
-                error,
-            );
-        }
+        removedImages.forEach((image) => {
+            if (image.state === 'success') {
+                this.removeImage(image);
+            }
+        });
+
+        this.metadata = event.detail;
     };
+
+    private getRemovedImages(
+        oldMetadata: EditorMetadata,
+        newMetadata: EditorMetadata,
+    ): EditorImage[] {
+        const newImageIds = new Set(
+            newMetadata.images.map((image) => image.fileInfoId),
+        );
+
+        return oldMetadata.images.filter(
+            (image) => !newImageIds.has(image.fileInfoId),
+        );
+    }
+
+    private removeImage(image: EditorImage) {
+        // Remove image from external file storage if desired.
+        console.log(`Image removed: ${image.fileInfoId}`);
+    }
 }

--- a/src/components/text-editor/prosemirror-adapter/plugins/image/view.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/image/view.ts
@@ -1,7 +1,7 @@
 import { EditorView, NodeView } from 'prosemirror-view';
 import { Node } from 'prosemirror-model';
 import { Plugin } from 'prosemirror-state';
-import { ImageState } from '../../../text-editor.types';
+import { EditorImageState } from '../../../text-editor.types';
 import translate from '../../../../../global/translations';
 import { Languages } from '../../../../date-picker/date.types';
 
@@ -174,19 +174,20 @@ class ImageView implements NodeView {
         this.cleanUpPreviousState();
         this.dom.className = `image-wrapper state-${this.node.attrs.state}`;
 
-        if (this.node.attrs.state === ImageState.LOADING) {
-            this.createLoadingState();
-        } else if (this.node.attrs.state === ImageState.SUCCESS) {
-            this.createSuccessState();
-        } else if (this.node.attrs.state === ImageState.FAILED) {
-            this.createFailedState();
-        }
+        const stateHandlers: Record<EditorImageState, () => void> = {
+            loading: this.createLoadingState,
+            success: this.createSuccessState,
+            failed: this.createFailedState,
+        };
+
+        const state: EditorImageState = this.node.attrs.state;
+        stateHandlers[state]?.();
     };
 
     private transitioningBetweenSuccessStates = (newNode: Node): boolean => {
         return (
-            this.node.attrs.state === ImageState.SUCCESS &&
-            newNode.attrs.state === ImageState.SUCCESS
+            this.node.attrs.state === 'success' &&
+            newNode.attrs.state === 'success'
         );
     };
 

--- a/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link-plugin.ts
@@ -4,15 +4,11 @@ import { schema } from 'prosemirror-schema-basic';
 import { Mark } from 'prosemirror-model';
 import { isExternalLink, isValidUrl } from '../menu/menu-commands';
 import { EditorMenuTypes, MouseButtons } from '../menu/types';
+import { EditorLink } from '../../text-editor.types';
 
 export const linkPluginKey = new PluginKey('linkPlugin');
 
 export type UpdateLinkCallback = (text: string, href: string) => void;
-
-export interface EditorLinkMenuEventDetail {
-    href: string;
-    text: string;
-}
 
 const updateLink = (
     view: EditorView,
@@ -138,14 +134,11 @@ const processModClickEvent = (view: EditorView, event: MouseEvent): boolean => {
 };
 
 const openLinkMenu = (view: EditorView, href: string, text: string) => {
-    const event = new CustomEvent<EditorLinkMenuEventDetail>(
-        'open-editor-link-menu',
-        {
-            detail: { href: href, text: text },
-            bubbles: true,
-            composed: true,
-        },
-    );
+    const event = new CustomEvent<EditorLink>('open-editor-link-menu', {
+        detail: { href: href, text: text },
+        bubbles: true,
+        composed: true,
+    });
     view.dom.dispatchEvent(event);
 };
 

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -7,7 +7,8 @@ import {
     TriggerCharacter,
     TriggerEventDetail,
     ImageInserter,
-    ImageInfo,
+    EditorImage,
+    EditorMetadata,
 } from './text-editor.types';
 import { EditorUiType } from './types';
 
@@ -186,9 +187,20 @@ export class TextEditor implements FormComponent<string> {
      *
      * @private
      * @alpha
+     * @deprecated - This event is deprecated and will be removed in a future version.
+     * Use the `metadataChange` event instead to track image removals.
      */
     @Event()
-    private readonly imageRemoved: EventEmitter<ImageInfo>;
+    private readonly imageRemoved: EventEmitter<EditorImage>;
+
+    /**
+     * Dispatched when the metadata of the editor changes
+     *
+     * @private
+     * @alpha
+     */
+    @Event()
+    private readonly metadataChange: EventEmitter<EditorMetadata>;
 
     /**
      * Dispatched if a trigger character is detected.
@@ -268,6 +280,7 @@ export class TextEditor implements FormComponent<string> {
                 onChange={this.handleChange}
                 onImagePasted={this.handleImagePasted}
                 onImageRemoved={this.handleImageRemoved}
+                onMetadataChange={this.handleMetadataChange}
                 customElements={this.customElements}
                 value={this.value}
                 aria-controls={this.helperTextId}
@@ -330,8 +343,14 @@ export class TextEditor implements FormComponent<string> {
         this.imagePasted.emit(event.detail);
     };
 
-    private handleImageRemoved = (event: CustomEvent<ImageInfo>) => {
+    private handleMetadataChange = (event: CustomEvent<EditorMetadata>) => {
         event.stopPropagation();
+        this.metadataChange.emit(event.detail);
+    };
+
+    private handleImageRemoved = (event: CustomEvent<EditorImage>) => {
+        event.stopPropagation();
+        // eslint-disable-next-line sonarjs/deprecation
         this.imageRemoved.emit(event.detail);
     };
 }

--- a/src/components/text-editor/text-editor.types.ts
+++ b/src/components/text-editor/text-editor.types.ts
@@ -94,16 +94,12 @@ export interface ImageInserter {
 /**
  * @alpha
  */
-export enum ImageState {
-    LOADING = 'loading',
-    FAILED = 'failed',
-    SUCCESS = 'success',
-}
+export type EditorImageState = 'loading' | 'failed' | 'success';
 
 /**
  * @alpha
  */
-export interface ImageInfo {
+export interface EditorImage {
     /**
      * Unique ID of the image file.
      */
@@ -116,7 +112,22 @@ export interface ImageInfo {
     /**
      * The current state of the image.
      */
-    state: ImageState;
+    state: EditorImageState;
+}
+
+/**
+ * @alpha
+ */
+export interface EditorLink {
+    /**
+     * The URL of the link.
+     */
+    href: string;
+
+    /**
+     * The text associated with the link.
+     */
+    text: string;
 }
 
 /**
@@ -155,4 +166,22 @@ export interface TriggerEventDetail {
      * Current value of the trigger
      */
     value: string;
+}
+
+/**
+ *
+ * @alpha
+ *
+ * Interface representing metadata extracted from the editor document
+ */
+export interface EditorMetadata {
+    /**
+     * Collection of image elements found in the document
+     */
+    images: EditorImage[];
+
+    /**
+     * Collection of link elements found in the document
+     */
+    links: EditorLink[];
 }

--- a/src/components/text-editor/utils/metadata-utils.spec.ts
+++ b/src/components/text-editor/utils/metadata-utils.spec.ts
@@ -1,0 +1,295 @@
+import { Node, Schema } from 'prosemirror-model';
+import { getMetadataFromDoc, hasMetadataChanged } from './metadata-utils';
+import { EditorMetadata } from '../text-editor.types';
+
+function createTestSchema() {
+    return new Schema({
+        nodes: {
+            doc: { content: 'block+' },
+            paragraph: { group: 'block', content: 'inline*' },
+            text: { group: 'inline' },
+            image: {
+                group: 'inline',
+                inline: true,
+                attrs: {
+                    src: { default: '' },
+                    alt: { default: '' },
+                    fileInfoId: { default: '' },
+                    state: { default: '' },
+                },
+            },
+        },
+        marks: {
+            link: {
+                attrs: {
+                    href: { default: '' },
+                    title: { default: '' },
+                },
+            },
+        },
+    });
+}
+
+function createTestDoc(schema: Schema, content: any): Node {
+    return schema.nodeFromJSON(content);
+}
+
+test('getMetadataFromDoc should extract images correctly', () => {
+    const schema = createTestSchema();
+    const doc = createTestDoc(schema, {
+        type: 'doc',
+        content: [
+            {
+                type: 'paragraph',
+                content: [
+                    {
+                        type: 'image',
+                        attrs: {
+                            src: 'image1.jpg',
+                            fileInfoId: 'id1',
+                            state: 'success',
+                        },
+                    },
+                    {
+                        type: 'image',
+                        attrs: {
+                            src: 'image2.jpg',
+                            fileInfoId: 'id2',
+                            state: 'success',
+                        },
+                    },
+                ],
+            },
+        ],
+    });
+
+    const metadata = getMetadataFromDoc(doc);
+
+    expect(metadata.images.length).toBe(2);
+    expect(metadata.images[0].src).toBe('image1.jpg');
+    expect(metadata.images[0].fileInfoId).toBe('id1');
+    expect(metadata.images[1].src).toBe('image2.jpg');
+    expect(metadata.images[1].fileInfoId).toBe('id2');
+    expect(metadata.links.length).toBe(0);
+});
+
+test('getMetadataFromDoc should extract links correctly', () => {
+    const schema = createTestSchema();
+    const doc = createTestDoc(schema, {
+        type: 'doc',
+        content: [
+            {
+                type: 'paragraph',
+                content: [
+                    {
+                        type: 'text',
+                        text: 'Link 1',
+                        marks: [
+                            {
+                                type: 'link',
+                                attrs: {
+                                    href: 'https://example.com',
+                                },
+                            },
+                        ],
+                    },
+                    { type: 'text', text: ' and ' },
+                    {
+                        type: 'text',
+                        text: 'Link 2',
+                        marks: [
+                            {
+                                type: 'link',
+                                attrs: {
+                                    href: 'https://test.com',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    });
+
+    const metadata = getMetadataFromDoc(doc);
+
+    expect(metadata.links.length).toBe(2);
+    expect(metadata.links[0].href).toBe('https://example.com');
+    expect(metadata.links[0].text).toBe('Link 1');
+    expect(metadata.links[1].href).toBe('https://test.com');
+    expect(metadata.links[1].text).toBe('Link 2');
+    expect(metadata.images.length).toBe(0);
+});
+
+test('getMetadataFromDoc should handle complex documents with both images and links', () => {
+    const schema = createTestSchema();
+    const doc = createTestDoc(schema, {
+        type: 'doc',
+        content: [
+            {
+                type: 'paragraph',
+                content: [
+                    {
+                        type: 'text',
+                        text: 'Text with ',
+                    },
+                    {
+                        type: 'text',
+                        text: 'link',
+                        marks: [
+                            {
+                                type: 'link',
+                                attrs: {
+                                    href: 'https://example.com',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        type: 'image',
+                        attrs: {
+                            src: 'image.jpg',
+                            fileInfoId: 'id123',
+                            state: 'success',
+                        },
+                    },
+                ],
+            },
+        ],
+    });
+
+    const metadata = getMetadataFromDoc(doc);
+
+    expect(metadata.images.length).toBe(1);
+    expect(metadata.links.length).toBe(1);
+    expect(metadata.images[0].src).toBe('image.jpg');
+    expect(metadata.links[0].href).toBe('https://example.com');
+});
+
+test('hasMetadataChanged should return true when image counts differ', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+            { src: 'img2.jpg', fileInfoId: 'id2', state: 'success' },
+        ],
+        links: [],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [{ src: 'img1.jpg', fileInfoId: 'id1', state: 'success' }],
+        links: [],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(true);
+});
+
+test('hasMetadataChanged should return true when link counts differ', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [],
+        links: [
+            { href: 'https://example.com', text: 'Example' },
+            { href: 'https://test.com', text: 'Test' },
+        ],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [],
+        links: [{ href: 'https://example.com', text: 'Example' }],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(true);
+});
+
+test('hasMetadataChanged should return true when image content differs', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [{ src: 'img1.jpg', fileInfoId: 'id1', state: 'success' }],
+        links: [],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [{ src: 'img2.jpg', fileInfoId: 'id1', state: 'success' }],
+        links: [],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(true);
+});
+
+test('hasMetadataChanged should return true when link content differs', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [],
+        links: [{ href: 'https://example.com', text: 'Example' }],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [],
+        links: [{ href: 'https://example.com', text: 'Changed Text' }],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(true);
+});
+
+test('hasMetadataChanged should handle duplicate elements correctly', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+        ],
+        links: [
+            { href: 'https://example.com', text: 'Example' },
+            { href: 'https://example.com', text: 'Example' },
+        ],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+        ],
+        links: [
+            { href: 'https://example.com', text: 'Example' },
+            { href: 'https://example.com', text: 'Example' },
+        ],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(false);
+});
+
+test('hasMetadataChanged should ignore order changes', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+            { src: 'img2.jpg', fileInfoId: 'id2', state: 'success' },
+        ],
+        links: [
+            { href: 'https://example.com', text: 'Example' },
+            { href: 'https://test.com', text: 'Test' },
+        ],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [
+            { src: 'img2.jpg', fileInfoId: 'id2', state: 'success' },
+            { src: 'img1.jpg', fileInfoId: 'id1', state: 'success' },
+        ],
+        links: [
+            { href: 'https://test.com', text: 'Test' },
+            { href: 'https://example.com', text: 'Example' },
+        ],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(false);
+});
+
+test('hasMetadataChanged should return false when metadata is identical', () => {
+    const oldMetadata: EditorMetadata = {
+        images: [{ src: 'img1.jpg', fileInfoId: 'id1', state: 'success' }],
+        links: [{ href: 'https://example.com', text: 'Example' }],
+    };
+
+    const newMetadata: EditorMetadata = {
+        images: [{ src: 'img1.jpg', fileInfoId: 'id1', state: 'success' }],
+        links: [{ href: 'https://example.com', text: 'Example' }],
+    };
+
+    expect(hasMetadataChanged(oldMetadata, newMetadata)).toBe(false);
+});

--- a/src/components/text-editor/utils/metadata-utils.ts
+++ b/src/components/text-editor/utils/metadata-utils.ts
@@ -1,0 +1,153 @@
+import { EditorImage, EditorLink, EditorMetadata } from '../text-editor.types';
+import { Node } from 'prosemirror-model';
+
+/**
+ * Extracts metadata from a ProseMirror document node
+ *
+ * This function traverses the entire document tree and collects information about
+ * special elements like images and links.
+ *
+ * @param doc - The ProseMirror document node to extract metadata from
+ * @returns A metadata object containing arrays of images and links found in the document
+ */
+export function getMetadataFromDoc(doc: Node): EditorMetadata {
+    const metadata: EditorMetadata = { images: [], links: [] };
+
+    doc.descendants((node) => {
+        if (isImageNode(node)) {
+            metadata.images.push(extractImageMetadata(node));
+        } else if (isTextNodeWithMarks(node)) {
+            extractLinkMetadata(node).forEach((link) =>
+                metadata.links.push(link),
+            );
+        }
+
+        return true;
+    });
+
+    return metadata;
+}
+
+function isImageNode(node: Node): boolean {
+    return node.type.name === 'image' && !!node.attrs;
+}
+
+function extractImageMetadata(node: Node): EditorImage {
+    return {
+        src: node.attrs.src,
+        state: node.attrs.state,
+        fileInfoId: node.attrs.fileInfoId,
+    };
+}
+
+function isTextNodeWithMarks(node: Node): boolean {
+    return node.isText && node.marks?.length > 0;
+}
+
+function extractLinkMetadata(node: Node): EditorLink[] {
+    return node.marks
+        .filter((mark) => mark.type.name === 'link' && mark.attrs)
+        .map((mark) => ({
+            href: mark.attrs.href,
+            text: node.text,
+        }));
+}
+
+/**
+ * Determines if metadata has changed between two states
+ * Handles duplicates correctly but is order-insensitive
+ *
+ * @param oldMetadata - The previous metadata state to compare against
+ * @param newMetadata - The current metadata state
+ * @returns True if there are any differences between the metadata objects, false otherwise
+ */
+export function hasMetadataChanged(
+    oldMetadata: EditorMetadata,
+    newMetadata: EditorMetadata,
+): boolean {
+    return (
+        hasDifferentLengths(oldMetadata, newMetadata) ||
+        hasDifferentLinks(oldMetadata.links, newMetadata.links) ||
+        hasDifferentImages(oldMetadata.images, newMetadata.images)
+    );
+}
+
+function hasDifferentLengths(
+    oldMetadata: EditorMetadata,
+    newMetadata: EditorMetadata,
+): boolean {
+    return (
+        oldMetadata.images.length !== newMetadata.images.length ||
+        oldMetadata.links.length !== newMetadata.links.length
+    );
+}
+
+function hasDifferentLinks(
+    oldLinks: EditorLink[],
+    newLinks: EditorLink[],
+): boolean {
+    const oldLinkCounts = getLinkFrequencyMap(oldLinks);
+    const newLinkCounts = getLinkFrequencyMap(newLinks);
+
+    return !areFrequencyMapsEqual(oldLinkCounts, newLinkCounts);
+}
+
+function hasDifferentImages(
+    oldImages: EditorImage[],
+    newImages: EditorImage[],
+): boolean {
+    const oldImageCounts = getImageFrequencyMap(oldImages);
+    const newImageCounts = getImageFrequencyMap(newImages);
+
+    return !areFrequencyMapsEqual(oldImageCounts, newImageCounts);
+}
+
+/**
+ * Creates a frequency map for images based on their key properties
+ */
+function getImageFrequencyMap(images: EditorImage[]): Map<string, number> {
+    const countMap = new Map<string, number>();
+
+    images.forEach((image) => {
+        const key = `${image.fileInfoId}|${image.state}|${image.src}`;
+
+        countMap.set(key, (countMap.get(key) || 0) + 1);
+    });
+
+    return countMap;
+}
+
+/**
+ * Creates a frequency map for links based on their key properties
+ */
+function getLinkFrequencyMap(links: EditorLink[]): Map<string, number> {
+    const countMap = new Map<string, number>();
+
+    links.forEach((link) => {
+        const key = `${link.href}|${link.text}`;
+
+        countMap.set(key, (countMap.get(key) || 0) + 1);
+    });
+
+    return countMap;
+}
+
+/**
+ * Compares two frequency maps for equality
+ */
+function areFrequencyMapsEqual(
+    map1: Map<string, number>,
+    map2: Map<string, number>,
+): boolean {
+    if (map1.size !== map2.size) {
+        return false;
+    }
+
+    for (const [key, count] of map1.entries()) {
+        if (map2.get(key) !== count) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced unified metadata tracking for images and links in the text editor, enabling detection of changes to both.
  - Added a new event for notifying about metadata changes, including image and link updates.
  - Added support for extracting and comparing image and link metadata from editor content.
  - Enhanced image state handling with string-based states for clearer status representation.

- **Deprecations**
  - Deprecated the previous image removal event in favor of the new metadata change event.

- **Bug Fixes**
  - Improved detection and cleanup of removed images when editor content changes.

- **Tests**
  - Added comprehensive tests for metadata extraction and change detection utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

Connected: https://github.com/Lundalogik/crm-client/issues/38

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
