### PR TITLE
update notched outline height to fit-content

### DIFF
--- a/src/components/notched-outline/notched-outline.scss
+++ b/src/components/notched-outline/notched-outline.scss
@@ -19,13 +19,12 @@ limel-notched-outline {
 
     display: block;
     width: 100%;
-    height: 100%;
+    height: fit-content;
 }
 
 .limel-notched-outline {
     position: relative;
     width: 100%;
-    height: 100%;
 
     [slot='content'] {
         background-color: var(--limel-notched-outline-background-color);

--- a/src/components/notched-outline/notched-outline.scss
+++ b/src/components/notched-outline/notched-outline.scss
@@ -7,6 +7,12 @@
 $border-radius: 0.25rem;
 $value-top: 0.62rem;
 
+*,
+*:before,
+*:after {
+    box-sizing: border-box;
+}
+
 limel-notched-outline {
     --limel-notched-outline-border-color: #{shared_input-select-picker.$lime-text-field-outline-color};
     --limel-notched-outline-background-color: #{shared_input-select-picker.$background-color-normal};
@@ -14,12 +20,6 @@ limel-notched-outline {
     display: block;
     width: 100%;
     height: 100%;
-
-    *,
-    *:before,
-    *:after {
-        box-sizing: border-box;
-    }
 }
 
 .limel-notched-outline {


### PR DESCRIPTION
### How to test this PR
1. Add this code snippet 👇 to an example in the docs
2. Click on the required fields, and **_without this PR_**, it should be rendered outside of the bounding box of `limel-input-field`.
```tsx
<div style={{ display: 'flex', flexDirection: 'column', gap: '8px', }}>
      <limel-input-field style={{ background: 'cyan', }}
          label="Something"
          required={true}
          type="text"
          format-number=""
          step="any"
          value=""
      />
      <limel-select
          required={true}
          label="Something else"
      />
</div>
```
This rendering error happens when input fields are inside `flex` or `grid` containers.

fix https://github.com/Lundalogik/lime-elements/issues/3550
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the box-sizing model to apply globally across all elements for more consistent layout behavior.
  - Adjusted the height of the notched outline component to use fit-content, improving its adaptability to content size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
