### PR TITLE
fix(markdown/text-editor): properly handle internal vs external link targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-shadow-dom-retarget-events": "^1.1.0",
-        "rehype-external-links": "^3.0.0",
         "rehype-parse": "^9.0.1",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
@@ -7683,19 +7682,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "dev": true,
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
@@ -8381,18 +8367,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -13404,34 +13378,6 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
-      }
-    },
-    "node_modules/rehype-external-links": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
-      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
-      "dev": true,
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "is-absolute-url": "^4.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-external-links/node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/rehype-parse": {
@@ -21881,15 +21827,6 @@
         "xtend": "^4.0.1"
       }
     },
-    "hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "dev": true,
-      "requires": {
-        "@types/hast": "^3.0.0"
-      }
-    },
     "hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
@@ -22375,12 +22312,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
-    },
-    "is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
       "dev": true
     },
     "is-alphabetical": {
@@ -26136,28 +26067,6 @@
       "dev": true,
       "requires": {
         "jsesc": "~3.0.2"
-      }
-    },
-    "rehype-external-links": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
-      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
-      "dev": true,
-      "requires": {
-        "@types/hast": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "is-absolute-url": "^4.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "dependencies": {
-        "space-separated-tokens": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-          "dev": true
-        }
       }
     },
     "rehype-parse": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-shadow-dom-retarget-events": "^1.1.0",
-    "rehype-external-links": "^3.0.0",
     "rehype-parse": "^9.0.1",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",

--- a/src/components/markdown/link-markdown-plugin.ts
+++ b/src/components/markdown/link-markdown-plugin.ts
@@ -1,0 +1,35 @@
+import { visit } from 'unist-util-visit';
+import { Node } from 'unist';
+import { Plugin, Transformer } from 'unified';
+import { getLinkAttributes } from '../text-editor/prosemirror-adapter/plugins/link/utils';
+
+/**
+ * Creates a unified.js plugin that transforms link elements
+ * to add target, rel, and referrerpolicy attributes.
+ *
+ * @returns A unified.js plugin function
+ */
+export function createLinksPlugin(): Plugin {
+    return (): Transformer => {
+        return (tree: Node) => {
+            visit(tree, 'element', (node: any) => {
+                if (node.tagName === 'a') {
+                    const href = node.properties?.href;
+                    const title = node.properties?.title;
+
+                    if (!href) {
+                        return;
+                    }
+
+                    const attributes = getLinkAttributes(href, title);
+
+                    node.properties.target = attributes.target;
+                    node.properties.rel = attributes.rel;
+                    node.properties.referrerpolicy = attributes.referrerpolicy;
+                }
+            });
+
+            return tree;
+        };
+    };
+}

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -3,7 +3,6 @@ import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import remarkGfm from 'remark-gfm';
 import rehypeParse from 'rehype-parse';
-import rehypeExternalLinks from 'rehype-external-links';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 import rehypeRaw from 'rehype-raw';
@@ -13,6 +12,7 @@ import { Node } from 'unist';
 import { Schema } from 'rehype-sanitize/lib';
 import { createLazyLoadImagesPlugin } from './image-markdown-plugin';
 import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
+import { createLinksPlugin } from './link-markdown-plugin';
 
 /**
  * Takes a string as input and returns a new string
@@ -40,8 +40,8 @@ export async function markdownToHTML(
         .use(remarkParse)
         .use(remarkGfm)
         .use(remarkRehype, { allowDangerousHtml: true })
-        .use(rehypeExternalLinks, { target: '_blank' })
         .use(rehypeRaw)
+        .use(createLinksPlugin())
         .use(rehypeSanitize, {
             ...getWhiteList(options?.whitelist ?? []),
         })
@@ -107,6 +107,7 @@ function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
                 ...(defaultSchema.attributes.p ?? []),
                 ['className', 'MsoNormal'],
             ], // Allow the class 'MsoNormal' on <p> elements
+            a: [...(defaultSchema.attributes.a ?? []), 'referrerpolicy'], // Allow referrerpolicy on <a> elements
             '*': asteriskAttributeWhitelist,
         },
     };

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -3,6 +3,7 @@ import { Schema, MarkType, NodeType, Attrs } from 'prosemirror-model';
 import { findWrapping, liftTarget } from 'prosemirror-transform';
 import { Command, EditorState, TextSelection } from 'prosemirror-state';
 import { EditorMenuTypes, EditorTextLink, LevelMapping } from './types';
+import { getLinkAttributes } from '../plugins/link/utils';
 
 type CommandFunction = (
     schema: Schema,
@@ -82,23 +83,17 @@ const createInsertLinkCommand: CommandFunction = (
 ): CommandWithActive => {
     const command: Command = (state, dispatch) => {
         const { from, to } = state.selection;
+        const linkMark = schema.marks.link.create(
+            getLinkAttributes(link.href, link.href),
+        );
+
         if (from === to) {
             // If no text is selected, insert new text with link
-            const linkMark = schema.marks.link.create({
-                href: link.href,
-                title: link.href,
-                target: isExternalLink(link.href) ? '_blank' : null,
-            });
             const linkText = link.text || link.href;
             const newLink = schema.text(linkText, [linkMark]);
             dispatch(state.tr.insert(from, newLink));
         } else {
             // If text is selected, replace selected text with link text
-            const linkMark = schema.marks.link.create({
-                href: link.href,
-                title: link.href,
-                target: isExternalLink(link.href) ? '_blank' : null,
-            });
             const selectedText = state.doc.textBetween(from, to, ' ');
             const newLink = schema.text(link.text || selectedText, [linkMark]);
             dispatch(state.tr.replaceWith(from, to, newLink));

--- a/src/components/text-editor/prosemirror-adapter/plugins/link/link-mark-spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link/link-mark-spec.ts
@@ -1,0 +1,44 @@
+import { MarkSpec, DOMOutputSpec } from 'prosemirror-model';
+
+export interface LinkMarkAttrs {
+    href: string;
+    title: string | null;
+    target: string | null;
+    rel: string | null;
+    referrerpolicy: string | null;
+}
+
+export const linkMarkSpec: MarkSpec = {
+    attrs: {
+        href: { default: '' },
+        title: { default: null },
+        target: { default: null },
+        rel: { default: null },
+        referrerpolicy: { default: null },
+    },
+    inclusive: false,
+    parseDOM: [
+        {
+            tag: 'a[href]',
+            getAttrs: (dom: HTMLElement): LinkMarkAttrs => {
+                return {
+                    href: dom.getAttribute('href') || '',
+                    title: dom.getAttribute('title'),
+                    target: dom.getAttribute('target'),
+                    rel: dom.getAttribute('rel'),
+                    referrerpolicy: dom.getAttribute('referrerpolicy'),
+                };
+            },
+        },
+    ],
+    toDOM: (mark): DOMOutputSpec => {
+        const target = mark.attrs.target || null;
+
+        const securityAttrs = {
+            rel: target === '_blank' ? 'noopener noreferrer' : null,
+            referrerpolicy: target === '_blank' ? 'noreferrer' : null,
+        };
+
+        return ['a', { ...mark.attrs, ...securityAttrs }, 0];
+    },
+};

--- a/src/components/text-editor/prosemirror-adapter/plugins/link/link-plugin.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link/link-plugin.ts
@@ -1,9 +1,9 @@
 import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { Mark, Fragment, Node, Schema } from 'prosemirror-model';
-import { isExternalLink } from '../menu/menu-commands';
-import { EditorMenuTypes, MouseButtons } from '../menu/types';
-import { EditorLink } from '../../text-editor.types';
+import { EditorMenuTypes, MouseButtons } from '../../menu/types';
+import { EditorLink } from '../../../text-editor.types';
+import { getLinkAttributes } from './utils';
 
 export const linkPluginKey = new PluginKey('linkPlugin');
 
@@ -198,12 +198,7 @@ const createTextNode = (schema: Schema, content: string): Node => {
  * Creates a link node with the provided URL
  */
 const createLinkNode = (schema: Schema, url: string): Node => {
-    const linkMark = schema.marks.link.create({
-        href: url,
-        title: url,
-        // Only set _blank for http/https links, not for mailto/tel
-        target: url.startsWith('http') && isExternalLink(url) ? '_blank' : null,
-    });
+    const linkMark = schema.marks.link.create(getLinkAttributes(url, url));
 
     return schema.text(url, [linkMark]);
 };

--- a/src/components/text-editor/prosemirror-adapter/plugins/link/utils.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link/utils.spec.ts
@@ -1,0 +1,132 @@
+import { getLinkAttributes } from './utils';
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+            hostname: 'internal.com',
+            protocol: 'https:',
+            origin: 'https://internal.com',
+        },
+    });
+});
+
+afterEach(() => {
+    // Restore original window.location
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+    });
+});
+
+test.each([
+    {
+        description: 'relative URL as internal link',
+        url: '/path/to/page',
+        title: 'Title',
+        expected: {
+            isExternal: false,
+            href: '/path/to/page',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'fragment URL as internal link',
+        url: '#section-1',
+        title: 'Title',
+        expected: {
+            isExternal: false,
+            href: '#section-1',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'protocol-relative URL to same domain as internal link',
+        url: '//internal.com/path',
+        title: 'Title',
+        expected: {
+            isExternal: false,
+            href: '//internal.com/path',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'absolute URL to same domain as internal link',
+        url: 'https://internal.com/page',
+        title: 'Title',
+        expected: {
+            isExternal: false,
+            href: 'https://internal.com/page',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'relative URL with query parameters as internal link',
+        url: '/search?q=test&page=1',
+        title: 'Title',
+        expected: {
+            isExternal: false,
+            href: '/search?q=test&page=1',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'malformed URL as internal link',
+        url: 'not-a-valid-url',
+        title: 'Title',
+        expected: {
+            isExternal: false,
+            href: 'not-a-valid-url',
+            title: 'Title',
+        },
+    },
+    {
+        description:
+            'protocol-relative URL to different domain as external link',
+        url: '//external.com/path',
+        title: 'Title',
+        expected: {
+            isExternal: true,
+            href: '//external.com/path',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'absolute URL to different domain as external link',
+        url: 'https://external.com/page',
+        title: 'Title',
+        expected: {
+            isExternal: true,
+            href: 'https://external.com/page',
+            title: 'Title',
+        },
+    },
+    {
+        description: 'external link with null title preserves null title',
+        url: 'https://external.com/page',
+        title: null,
+        expected: {
+            isExternal: true,
+            href: 'https://external.com/page',
+            title: null,
+        },
+    },
+])('getLinkAttributes handles $description', ({ url, title, expected }) => {
+    const attributes = getLinkAttributes(url, title);
+
+    expect(attributes.href).toBe(expected.href);
+    expect(attributes.title).toBe(expected.title);
+
+    if (expected.isExternal) {
+        expect(attributes.target).toBe('_blank');
+        expect(attributes.rel).toBe('noopener noreferrer');
+        expect(attributes.referrerpolicy).toBe('noreferrer');
+    } else {
+        expect(attributes.target).toBeNull();
+        expect(attributes.rel).toBeNull();
+        expect(attributes.referrerpolicy).toBeNull();
+    }
+});

--- a/src/components/text-editor/prosemirror-adapter/plugins/link/utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/link/utils.ts
@@ -1,0 +1,48 @@
+import { LinkMarkAttrs } from './link-mark-spec';
+
+export function getLinkAttributes(
+    url: string,
+    title: string | null,
+): LinkMarkAttrs {
+    if (isExternalUrl(url)) {
+        return {
+            href: url,
+            title: title,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            referrerpolicy: 'noreferrer',
+        };
+    }
+
+    return {
+        href: url,
+        title: title,
+        target: null,
+        rel: null,
+        referrerpolicy: null,
+    };
+}
+
+function isExternalUrl(url: string): boolean {
+    try {
+        let urlObj: URL;
+
+        if (isProtocolRelativeUrl(url)) {
+            urlObj = new URL(window.location.protocol + url);
+        } else {
+            urlObj = new URL(url, window.location.origin);
+        }
+
+        return (
+            urlObj.protocol.startsWith('http') &&
+            urlObj.hostname !== window.location.hostname
+        );
+    } catch {
+        // Malformed URLs → internal
+        return false;
+    }
+}
+
+function isProtocolRelativeUrl(url: string) {
+    return url.startsWith('//');
+}

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -34,7 +34,8 @@ import { isItem } from '../../../components/action-bar/isItem';
 import { cloneDeep, debounce } from 'lodash-es';
 import { Languages } from '../../date-picker/date.types';
 import { strikethrough } from './menu/menu-schema-extender';
-import { createLinkPlugin } from './plugins/link-plugin';
+import { createLinkPlugin } from './plugins/link/link-plugin';
+import { linkMarkSpec } from './plugins/link/link-mark-spec';
 import { createImageInserterPlugin } from './plugins/image/inserter';
 import { createImageViewPlugin } from './plugins/image/view';
 import { createMenuStateTrackingPlugin } from './plugins/menu-state-tracking-plugin';
@@ -390,6 +391,7 @@ export class ProsemirrorAdapter {
             nodes: nodes,
             marks: schema.spec.marks.append({
                 strikethrough: strikethrough,
+                link: linkMarkSpec,
             }),
         });
     }

--- a/src/design-guidelines/text-editor/menu-command.md
+++ b/src/design-guidelines/text-editor/menu-command.md
@@ -96,6 +96,7 @@ We iterate through each position within the selection range and check if any anc
     ```
 
 **Code**:
+
 ```typescript
 const createInsertLinkCommand: CommandFunction = (
     schema: Schema,
@@ -104,29 +105,27 @@ const createInsertLinkCommand: CommandFunction = (
 ): CommandWithActive => {
     const command: Command = (state, dispatch) => {
         const { from, to } = state.selection;
+        const linkMark = schema.marks.link.create(
+            getLinkAttributes(link.href, link.href),
+        );
+
         if (from === to) {
-            const linkMark = schema.marks.link.create({
-                href: link.href,
-                title: link.href,
-                target: isExternalLink(link.href) ? '_blank' : null,
-            });
+            // If no text is selected, insert new text with link
             const linkText = link.text || link.href;
             const newLink = schema.text(linkText, [linkMark]);
             dispatch(state.tr.insert(from, newLink));
         } else {
-            const linkMark = schema.marks.link.create({
-                href: link.href,
-                title: link.href,
-                target: isExternalLink(link.href) ? '_blank' : null,
-            });
+            // If text is selected, replace selected text with link text
             const selectedText = state.doc.textBetween(from, to, ' ');
             const newLink = schema.text(link.text || selectedText, [linkMark]);
             dispatch(state.tr.replaceWith(from, to, newLink));
         }
+
         return true;
     };
 
     setActiveMethodForMark(command, schema.marks.link);
+
     return command;
 };
 ```


### PR DESCRIPTION
Fixes https://github.com/Lundalogik/crm-feature/issues/4397

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->


## How to Test

1. Open the Rich Text Editor
   * Create internal links (same domain/relative urls)
   * Create external links (different domains)
   * Verify internal links don't have target="_blank"
   * Verify external links have target="_blank" and security attributes

2. Check Markdown Component
   * Add markdown with internal links
   * Add markdown with external links
   * Verify the same behavior as in Rich Text Editor

### Expected Results
   * Internal links stay in the same tab (no target="_blank")
   * External links open in new tabs (with target="_blank")
   * Security attributes (rel="noopener noreferrer", referrerpolicy="noreferrer") are present on external links
   * No regressions in link functionality or appearance should be observed.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
