### PR TITLE
fix(input-field): ensure `type` `textarea` stretches within given ver…

### DIFF
--- a/src/components/input-field/input-field.scss
+++ b/src/components/input-field/input-field.scss
@@ -15,9 +15,10 @@
  * @prop --textarea-height: Height of the field when type is set to `textarea`
  */
 
-:host {
+:host(limel-input-field) {
     position: relative;
-    display: block;
+    display: flex;
+    flex-direction: column;
 }
 
 :host([hidden]) {
@@ -26,6 +27,10 @@
 
 :host([type='textarea']) {
     height: var(--textarea-height, 100%);
+
+    limel-notched-outline {
+        flex-grow: 1;
+    }
 
     .mdc-text-field.mdc-text-field--textarea {
         height: var(--textarea-height, 100%);


### PR DESCRIPTION
…tical space

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/crm-client/issues/93
<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
