### PR TITLE
fix(file): add missing translations for dropzone tips

### DIFF
--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'År',
     'chip-set.clear-all': 'Ryd alle',
     'snackbar.dismiss': 'Luk',
+    'file.drag-and-drop-tips':
+        'Træk & slip filen her, eller klik for at gennemse.',
     'file-viewer.message.unsupported-filetype': 'Denne fil kan ikke vises!',
     'file-viewer.download': 'Hent',
     'file-viewer.exit-fullscreen': 'Afslut fuldskærm',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'Jahr',
     'chip-set.clear-all': 'Alles löschen',
     'snackbar.dismiss': 'Schließen',
+    'file.drag-and-drop-tips':
+        'Ziehen Sie Ihre Datei hierher oder klicken Sie, um zu durchsuchen.',
     'file-viewer.message.unsupported-filetype':
         'Diese Datei kann nicht angezeigt werden!',
     'file-viewer.download': 'Herunterladen',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'Year',
     'chip-set.clear-all': 'Clear all',
     'snackbar.dismiss': 'Dismiss',
+    'file.drag-and-drop-tips':
+        'Drag & drop your file here, or click to browse.',
     'file-viewer.message.unsupported-filetype': 'Cannot display this file!',
     'file-viewer.download': 'Download',
     'file-viewer.exit-fullscreen': 'Exit fullscreen',

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'Vuosi',
     'chip-set.clear-all': 'Tyhjennä kaikki',
     'snackbar.dismiss': 'Sulje',
+    'file.drag-and-drop-tips':
+        'Vedä & pudota tiedostosi tähän, tai napsauta selataksesi.',
     'file-viewer.message.unsupported-filetype':
         'Tätä tiedostoa ei voi näyttää!',
     'file-viewer.download': 'Ladata',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'Année',
     'chip-set.clear-all': 'Tout effacer',
     'snackbar.dismiss': 'Fermer',
+    'file.drag-and-drop-tips':
+        'Glissez-déposez votre fichier ici, ou cliquez pour parcourir.',
     'file-viewer.message.unsupported-filetype':
         "Impossible d'afficher ce fichier!",
     'file-viewer.download': 'Télécharger',

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -19,7 +19,7 @@ export default {
     'chip-set.clear-all': 'Alles wissen',
     'snackbar.dismiss': 'Sluiten',
     'file.drag-and-drop-tips':
-        'Sleep & bestand en zet het hier neer of klik om te bladeren.',
+        'Sleep een bestand hierheen of klik om te bladeren.',
     'file-viewer.message.unsupported-filetype':
         'Kan dit bestand niet weergeven!',
     'file-viewer.download': 'Downloaden',

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'Jaar',
     'chip-set.clear-all': 'Alles wissen',
     'snackbar.dismiss': 'Sluiten',
+    'file.drag-and-drop-tips':
+        'Sleep & bestand en zet het hier neer of klik om te bladeren.',
     'file-viewer.message.unsupported-filetype':
         'Kan dit bestand niet weergeven!',
     'file-viewer.download': 'Downloaden',

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -17,6 +17,8 @@ export default {
     'date-picker.quarter.heading': 'Kvartal',
     'date-picker.year.heading': 'År',
     'chip-set.clear-all': 'Fjern alle',
+    'file.drag-and-drop-tips':
+        'Dra & slipp filen her, eller klikk for å bla gjennom.',
     'file-viewer.message.unsupported-filetype': 'Kan ikke vise denne filen!',
     'file-viewer.download': 'Nedlasting',
     'file-viewer.exit-fullscreen': 'Gå ut av fullskjerm',

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -18,6 +18,8 @@ export default {
     'date-picker.year.heading': 'År',
     'chip-set.clear-all': 'Rensa alla',
     'snackbar.dismiss': 'Stäng',
+    'file.drag-and-drop-tips':
+        'Dra & släpp filen här eller klicka om du vill bläddra.',
     'file-viewer.message.unsupported-filetype': 'Kan inte visa den här filen!',
     'file-viewer.download': 'Ladda ner',
     'file-viewer.exit-fullscreen': 'Avsluta fullskärmsläge',


### PR DESCRIPTION
fix: #3570

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added drag-and-drop file upload instructions to Danish, German, English, Finnish, French, Dutch, Norwegian, and Swedish translations. Users will now see localized tips for uploading files in these languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->