### PR TITLE
fix(card): avoid rendering an empty markdown

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -195,6 +195,10 @@ export class Card {
     }
 
     private renderValue() {
+        if (!this.value) {
+            return;
+        }
+
         return <limel-markdown value={this.value} />;
     }
 


### PR DESCRIPTION
Right now no matter if `value` is empty we still render it.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
<img width="335" alt="Screenshot 2025-06-04 at 11 06 40" src="https://github.com/user-attachments/assets/9206b532-417f-4267-ae65-fe8672c5d3be" />
<img width="353" alt="Screenshot 2025-06-04 at 11 06 36" src="https://github.com/user-attachments/assets/68d838b3-7c38-4ac8-8dbd-b65f20a425a0" />

after: 

<img width="350" alt="Screenshot 2025-06-04 at 11 08 17" src="https://github.com/user-attachments/assets/ded450c7-6089-4481-a24f-604bd3acf092" />
<img width="345" alt="Screenshot 2025-06-04 at 11 08 24" src="https://github.com/user-attachments/assets/9106130f-ddbc-41c7-bab7-bf591360394d" />


<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty or missing values to prevent unnecessary rendering in cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
