### PR TITLE
feat(chip): add custom css prop for border in readonly mode

### DIFF
--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -3,6 +3,7 @@
 /**
 * @prop --chip-max-width: Maximum width of the chip. Defaults to `10rem`. Keep in mind that the chips should not appear too big.
 * @prop --chip-progress-color: Color of the progress bar. Defaults to `rgb(var(--contrast-700))`.
+* @prop --chip-readonly-border-color: Color of the border in readonly state. Defaults to `rgb(var(--contrast-800), 0.5)`.
 */
 
 :host(limel-chip) {
@@ -80,7 +81,8 @@
 
 :host(limel-chip[readonly]:not([readonly='false'])) {
     .chip {
-        box-shadow: 0 0 0 1px rgba(var(--contrast-800), 0.5);
+        box-shadow: 0 0 0 1px
+            var(--chip-readonly-border-color, rgb(var(--contrast-800), 0.5));
     }
 }
 

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -78,6 +78,7 @@ interface ChipInterface extends Omit<OldChipInterface, 'id' | 'badge'> {
  * @exampleComponent limel-example-chip-menu
  * @exampleComponent limel-example-chip-loading
  * @exampleComponent limel-example-chip-progress
+ * @exampleComponent limel-example-chip-readonly-border
  * @exampleComponent limel-example-chip-aria-role
  */
 @Component({

--- a/src/components/chip/examples/chip-readonly-border.scss
+++ b/src/components/chip/examples/chip-readonly-border.scss
@@ -1,0 +1,3 @@
+limel-chip {
+    --chip-readonly-border-color: rgb(var(--color-green-default));
+}

--- a/src/components/chip/examples/chip-readonly-border.tsx
+++ b/src/components/chip/examples/chip-readonly-border.tsx
@@ -1,0 +1,22 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Border color
+ * In readonly state, the border color of the chip can be customized,
+ * using `--chip-readonly-border-color`.
+ */
+@Component({
+    tag: 'limel-example-chip-readonly-border',
+    shadow: true,
+    styleUrl: 'chip-readonly-border.scss',
+})
+export class ChipReadonlyBorderExample {
+    public render() {
+        const icon = {
+            name: 'sent',
+            color: 'rgb(var(--color-green-default))',
+        };
+
+        return <limel-chip text="Delivered" icon={icon} readonly={true} />;
+    }
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3575
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the border color of readonly chips using a new CSS variable.
  - Introduced an example demonstrating how to set a custom border color for readonly chips.

- **Documentation**
  - Updated component documentation to reference the new example for readonly chip border color customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
