### PR TITLE
fix(menu-list-render): show primary text on hover

### DIFF
--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -169,14 +169,19 @@ export class MenuListRenderer {
     private renderText = (item: MenuItem) => {
         if (this.isSimpleItem(item)) {
             return (
-                <span class="mdc-deprecated-list-item__text">{item.text}</span>
+                <span class="mdc-deprecated-list-item__text" title={item.text}>
+                    {item.text}
+                </span>
             );
         }
 
         return (
             <div class="mdc-deprecated-list-item__text">
                 <div class="mdc-deprecated-list-item__primary-command-text">
-                    <div class="mdc-deprecated-list-item__primary-text">
+                    <div
+                        class="mdc-deprecated-list-item__primary-text"
+                        title={item.text}
+                    >
                         {item.text}
                     </div>
                     {this.renderCommandText(item)}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

If a list item is too long and gets truncated, it's impossible to read the full text. 
We can use this variable ` --menu-surface-width`  to make list wider, but we never know how many actions could be used and what title of them. 
. 
before:
<img width="379" alt="Screenshot 2025-06-09 at 14 13 04" src="https://github.com/user-attachments/assets/0ba6b9b2-454b-4336-beff-79610e337a14" />
after:
<img width="416" alt="Screenshot 2025-06-09 at 14 13 11" src="https://github.com/user-attachments/assets/35552610-4571-47ed-a615-02659e607b8e" />



<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
