### PR TITLE
Add optional header icon support to collapsible section component

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -313,6 +313,7 @@ export namespace Components {
     export interface LimelCollapsibleSection {
         "actions": Action[];
         "header": string;
+        "icon"?: string | Icon;
         "invalid": boolean;
         "isOpen": boolean;
     }
@@ -1369,6 +1370,7 @@ export namespace JSX {
     export interface LimelCollapsibleSection {
         "actions"?: Action[];
         "header"?: string;
+        "icon"?: string | Icon;
         "invalid"?: boolean;
         "isOpen"?: boolean;
         "onAction"?: (event: LimelCollapsibleSectionCustomEvent<Action>) => void;

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -86,9 +86,14 @@ header {
     align-items: center;
     display: flex;
     justify-content: space-between;
+    gap: 0.5rem;
 
     padding-left: 0.5rem;
     height: shared_input-select-picker.$height-of-mdc-text-field;
+}
+
+limel-icon {
+    width: 1.5rem;
 }
 
 .title {
@@ -99,8 +104,6 @@ header {
     justify-self: flex-start;
 
     user-select: none; // mostly to improve experience on Android, where tapping on sections selects the text too
-
-    padding-right: 0.5rem;
 
     // Below tries to render text in two lines,
     // and then truncate if there is no more space
@@ -116,9 +119,9 @@ header {
     height: 0.125rem;
     border-radius: 1rem;
     background-color: var(--header-stroke-color, rgb(var(--contrast-900)));
-    margin-right: 0.5rem;
 
     opacity: 0;
+    margin-right: 0.5rem;
 
     section.open & {
         opacity: 0.16;

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -122,9 +122,7 @@ export class CollapsibleSection {
                         <div class="line" />
                         <div class="line" />
                     </div>
-                    <h2 class="title mdc-typography mdc-typography--headline2">
-                        {this.header}
-                    </h2>
+                    {this.renderHeading()}
                     <div class="divider-line" />
                     {this.renderHeaderSlot()}
                     {this.renderActions()}
@@ -154,6 +152,18 @@ export class CollapsibleSection {
         } else {
             this.close.emit();
         }
+    };
+
+    private renderHeading = () => {
+        if (!this.header) {
+            return;
+        }
+
+        return (
+            <h2 class="title mdc-typography mdc-typography--headline2">
+                {this.header}
+            </h2>
+        );
     };
 
     private renderActions = () => {

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -13,6 +13,12 @@ import {
     removeEnterClickable,
 } from '../../util/make-enter-clickable';
 import { createRandomString } from '../../util/random-string';
+import { Icon } from '../../global/shared-types/icon.types';
+import {
+    getIconColor,
+    getIconName,
+    getIconTitle,
+} from '../icon/get-icon-props';
 
 /**
  * A collapsible section can be used to group related content together
@@ -32,6 +38,7 @@ import { createRandomString } from '../../util/random-string';
  * @exampleComponent limel-example-collapsible-section-external-control
  * @exampleComponent limel-example-collapsible-section-with-slider
  * @exampleComponent limel-example-collapsible-section-invalid
+ * @exampleComponent limel-example-collapsible-section-icon
  * @exampleComponent limel-example-collapsible-section-css-props
  */
 @Component({
@@ -51,6 +58,12 @@ export class CollapsibleSection {
      */
     @Prop({ reflect: true })
     public header: string;
+
+    /**
+     * Icon to display in the header of the section
+     */
+    @Prop()
+    public icon?: string | Icon;
 
     /**
      * `true` if the section is invalid, `false` if valid.
@@ -124,6 +137,7 @@ export class CollapsibleSection {
                         <div class="line" />
                         <div class="line" />
                     </div>
+                    {this.renderIcon()}
                     {this.renderHeading()}
                     <div class="divider-line" role="presentation" />
                     {this.renderHeaderSlot()}
@@ -154,6 +168,27 @@ export class CollapsibleSection {
         } else {
             this.close.emit();
         }
+    };
+
+    private renderIcon = () => {
+        if (!this.icon) {
+            return;
+        }
+
+        const name = getIconName(this.icon);
+        const color = getIconColor(this.icon);
+        const title = getIconTitle(this.icon);
+
+        return (
+            <limel-icon
+                name={name}
+                aria-label={title}
+                aria-hidden={title ? null : 'true'}
+                style={{
+                    color: `${color}`,
+                }}
+            />
+        );
     };
 
     private renderHeading = () => {

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -87,6 +87,7 @@ export class CollapsibleSection {
     private host: HTMLElement;
 
     private bodyId = createRandomString();
+    private headingId = createRandomString();
 
     public componentDidRender() {
         const button = this.host.shadowRoot.querySelector(
@@ -109,6 +110,7 @@ export class CollapsibleSection {
             <section
                 class={`${this.isOpen ? 'open' : ''}`}
                 aria-invalid={this.invalid}
+                aria-labelledby={this.header ? this.headingId : null}
             >
                 <header>
                     <button
@@ -123,7 +125,7 @@ export class CollapsibleSection {
                         <div class="line" />
                     </div>
                     {this.renderHeading()}
-                    <div class="divider-line" />
+                    <div class="divider-line" role="presentation" />
                     {this.renderHeaderSlot()}
                     {this.renderActions()}
                 </header>
@@ -160,7 +162,10 @@ export class CollapsibleSection {
         }
 
         return (
-            <h2 class="title mdc-typography mdc-typography--headline2">
+            <h2
+                class="title mdc-typography mdc-typography--headline2"
+                id={this.headingId}
+            >
                 {this.header}
             </h2>
         );

--- a/src/components/collapsible-section/examples/collapsible-section-icon.tsx
+++ b/src/components/collapsible-section/examples/collapsible-section-icon.tsx
@@ -1,0 +1,24 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * Icon
+ */
+@Component({
+    tag: 'limel-example-collapsible-section-icon',
+    shadow: true,
+})
+export class CollapsibleSectionIconExample {
+    public render() {
+        const icon = {
+            name: 'ok',
+            title: 'Checkmark icon',
+            color: 'rgb(var(--color-green-default))',
+        };
+
+        return (
+            <limel-collapsible-section header="Header" icon={icon}>
+                <p>Body</p>
+            </limel-collapsible-section>
+        );
+    }
+}

--- a/src/components/collapsible-section/partial-styles/expand-icon.scss
+++ b/src/components/collapsible-section/partial-styles/expand-icon.scss
@@ -1,7 +1,7 @@
 .expand-icon {
     position: relative;
     height: 1.875rem;
-    margin: 0 1rem 0 0.5rem;
+    margin: 0 0 0 0.5rem;
     width: 0.75rem;
 
     flex-shrink: 0;


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/04c5d2f4-0412-48c5-a9b1-2a235f98dee4)
In Lime Go we have icons in our collapsible sections and we would like to replace our own collapsible sections to Lime Elements collapsible sections.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying an icon in the header of collapsible sections.
  - Introduced an example demonstrating the new icon feature in collapsible sections.

- **Style**
  - Improved spacing and alignment in the collapsible section header and icon.
  - Adjusted margins for the expand icon for better visual consistency.

- **Accessibility**
  - Enhanced accessibility by labeling the section header for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
