### PR TITLE
Add primary slot to info tile component for custom content support

### DIFF
--- a/src/components/info-tile/examples/info-tile-primary-slot.tsx
+++ b/src/components/info-tile/examples/info-tile-primary-slot.tsx
@@ -1,0 +1,53 @@
+import { Component, h } from '@stencil/core';
+import { InfoTileProgress } from '@limetech/lime-elements';
+import { chartItems } from '../../chart/examples/chart-items-stack';
+
+/**
+ * Using the primary slot
+ * The component offers a primary slot that can be used to display
+ * any custom content.
+ *
+ * :::important
+ * 1. If there is a component to be displayed in the primary slot,
+ * the info tile won't render the inbuilt progress bar.
+ * 1. The primary slot has an aspect ratio of 1:1, so the content
+ * will be displayed in a square area.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-info-tile-primary-slot',
+    shadow: true,
+    styleUrl: 'info-tile.scss',
+})
+export class InfoTilePrimarySlotExample {
+    public render() {
+        const link = {
+            href: '#',
+            title: 'Click to see further details',
+            target: '_blank',
+        };
+
+        const progress: InfoTileProgress = {
+            value: 76,
+        };
+
+        return (
+            <div>
+                <limel-info-tile
+                    icon="cloud_storage"
+                    label="Cloud storage usage"
+                    value="215"
+                    suffix="GB"
+                    link={link}
+                    progress={progress} // won't be rendered
+                >
+                    <limel-chart
+                        slot="primary"
+                        items={chartItems}
+                        type="doughnut"
+                    />
+                </limel-info-tile>
+            </div>
+        );
+    }
+}

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -93,6 +93,11 @@ a {
     );
 }
 
+:host ::slotted([slot='primary']) {
+    width: 100%;
+    height: 100%;
+}
+
 .icon {
     z-index: 1;
     position: absolute;
@@ -115,6 +120,7 @@ a {
         width: max(10%, 3rem);
     }
 
+    :host(.has-primary-slot-content) &,
     a:has(limel-circular-progress) & {
         top: unset;
         bottom: 0.5rem;
@@ -123,11 +129,20 @@ a {
     }
 }
 
-.progress {
+slot[name='primary'] {
+    display: block;
+    aspect-ratio: 1;
+    width: min(var(--icon-preferred-size), var(--icon-max-size));
+}
+
+.progress,
+slot[name='primary'] {
     position: absolute;
     top: 0.75rem;
     right: 0.75rem;
+}
 
+.progress {
     --circular-progress-size: min(
         var(--icon-preferred-size),
         var(--icon-max-size)
@@ -239,7 +254,8 @@ $m: 40.5rem; //648px
 $l: 62.5rem; //1000px
 
 @container (width < #{$xs}) {
-    .progress {
+    .progress,
+    slot[name='primary'] {
         top: 0.25rem;
         right: 0.25rem;
     }
@@ -250,14 +266,17 @@ $l: 62.5rem; //1000px
 }
 
 @container (width < #{$s}) {
-    .progress {
+    .progress,
+    slot[name='primary'] {
         top: 0.5rem;
         right: 0.5rem;
     }
     .icon {
         top: 0.25rem;
         right: 0.5rem;
-        .a:has(limel-circular-progress) & {
+
+        :host(.has-primary-slot-content) &,
+        a:has(limel-circular-progress) & {
             right: 0.25rem;
             bottom: 0.25rem;
         }
@@ -310,6 +329,7 @@ $l: 62.5rem; //1000px
 
 @container (height > #{$s}) {
     .progress,
+    slot[name='primary'],
     .icon {
         position: relative;
         top: unset;
@@ -324,6 +344,7 @@ $l: 62.5rem; //1000px
         // -webkit-line-clamp: 3;
     }
 
+    :host(.has-primary-slot-content),
     a:has(limel-circular-progress) {
         .icon {
             position: absolute;

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -115,7 +115,7 @@ a {
         width: max(10%, 3rem);
     }
 
-    .has-circular-progress & {
+    a:has(limel-circular-progress) & {
         top: unset;
         bottom: 0.5rem;
         --icon-min-size: 1.5rem;
@@ -257,7 +257,7 @@ $l: 62.5rem; //1000px
     .icon {
         top: 0.25rem;
         right: 0.5rem;
-        .has-circular-progress & {
+        .a:has(limel-circular-progress) & {
             right: 0.25rem;
             bottom: 0.25rem;
         }
@@ -323,7 +323,8 @@ $l: 62.5rem; //1000px
         text-align: center;
         // -webkit-line-clamp: 3;
     }
-    .has-circular-progress {
+
+    a:has(limel-circular-progress) {
         .icon {
             position: absolute;
             top: 0.5rem;

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -147,9 +147,6 @@ export class InfoTile {
                     aria-live="polite"
                     class={{
                         'is-clickable': !!this.link?.href && !this.disabled,
-                        'has-circular-progress':
-                            !!this.progress?.value ||
-                            this.progress?.value === 0,
                     }}
                 >
                     {this.renderIcon()}

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Element, Host } from '@stencil/core';
+import { Component, Prop, h, Element, Host, State } from '@stencil/core';
 import { InfoTileProgress } from '../info-tile/info-tile.types';
 import { Link } from '../../global/shared-types/link.types';
 import { getMouseEventHandlers } from '../../util/3d-tilt-hover-effect';
@@ -16,6 +16,7 @@ import { getMouseEventHandlers } from '../../util/3d-tilt-hover-effect';
  * @exampleComponent limel-example-info-tile-badge
  * @exampleComponent limel-example-info-tile-progress
  * @exampleComponent limel-example-info-tile-loading
+ * @exampleComponent limel-example-info-tile-primary-slot
  * @exampleComponent limel-example-info-tile-styling
  */
 @Component({
@@ -105,6 +106,12 @@ export class InfoTile {
     @Element()
     private host: HTMLElement;
 
+    /**
+     * `true` when something is assigned to the `primary` slot
+     */
+    @State()
+    private hasPrimarySlot = false;
+
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
 
@@ -114,6 +121,7 @@ export class InfoTile {
         );
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.updateHasPrimarySlotContent();
     }
 
     public render() {
@@ -135,6 +143,7 @@ export class InfoTile {
             <Host
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
+                class={{ 'has-primary-slot-content': this.hasPrimarySlot }}
             >
                 <a
                     title={this.link?.title}
@@ -151,6 +160,10 @@ export class InfoTile {
                 >
                     {this.renderIcon()}
                     {this.renderProgress()}
+                    <slot
+                        name="primary"
+                        onSlotchange={this.updateHasPrimarySlotContent}
+                    />
                     <div class="value-group">
                         {this.renderPrefix()}
                         <div class="value-and-suffix">
@@ -210,7 +223,18 @@ export class InfoTile {
         }
     };
 
+    private updateHasPrimarySlotContent = (e?: Event) => {
+        const slot =
+            (e?.target as HTMLSlotElement) ??
+            this.host.shadowRoot.querySelector('slot[name="primary"]');
+        this.hasPrimarySlot = slot && slot.assignedElements().length > 0;
+    };
+
     private renderProgress = () => {
+        if (this.hasPrimarySlot) {
+            return;
+        }
+
         if (!this.progress?.value && this.progress?.value !== 0) {
             return;
         }

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -211,20 +211,20 @@ export class InfoTile {
     };
 
     private renderProgress = () => {
-        if (this.progress?.value || this.progress?.value === 0) {
-            return (
-                <limel-circular-progress
-                    class="progress"
-                    prefix={this.progress.prefix}
-                    value={this.progress.value}
-                    suffix={this.progress.suffix}
-                    maxValue={this.progress.maxValue}
-                    displayPercentageColors={
-                        this.progress.displayPercentageColors
-                    }
-                />
-            );
+        if (!this.progress?.value && this.progress?.value !== 0) {
+            return;
         }
+
+        return (
+            <limel-circular-progress
+                class="progress"
+                prefix={this.progress.prefix}
+                value={this.progress.value}
+                suffix={this.progress.suffix}
+                maxValue={this.progress.maxValue}
+                displayPercentageColors={this.progress.displayPercentageColors}
+            />
+        );
     };
 
     private renderLabel = () => {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for a "primary" slot in the info tile component, allowing custom content (such as charts) to be displayed instead of the default progress bar.
	- Introduced an example demonstrating how to use the new primary slot with a doughnut chart.

- **Style**
	- Updated styling to ensure consistent layout and responsive adjustments when using the primary slot or progress indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
