### PR TITLE
feat: menuitems to file chips

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -882,6 +882,7 @@ export interface FileInfo {
     iconColor?: Color;
     id: number | string;
     lastModified?: Date;
+    menuItems?: Array<MenuItem | ListSeparator>;
     size?: number;
 }
 

--- a/src/components/file/examples/file-menu-items.tsx
+++ b/src/components/file/examples/file-menu-items.tsx
@@ -1,0 +1,67 @@
+import {
+    FileInfo,
+    LimelMenuCustomEvent,
+    MenuItem,
+} from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+/**
+ * Custom menu items
+ *
+ * By providing custom menu items, you can add additional actions.
+ *
+ */
+@Component({
+    tag: 'limel-example-file-menu-items',
+    shadow: true,
+})
+export class FileMenuItemsExample {
+    @State()
+    private value: FileInfo = {
+        filename: 'deal.pdf',
+        id: 123,
+        menuItems: [
+            {
+                text: 'Download',
+                icon: 'download',
+                value: 1,
+                selected: false,
+            },
+            {
+                text: 'Share',
+                icon: 'share',
+                value: 2,
+                selected: false,
+            },
+        ],
+    };
+
+    @State()
+    private selectedValue: MenuItem = undefined;
+
+    public render() {
+        return (
+            <Host onMenuItemSelected={this.handleMenuItemSelected}>
+                <limel-file
+                    label="Attach a file"
+                    value={this.value}
+                    onChange={this.handleChange}
+                />
+                <limel-example-value value={this.selectedValue} />
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.value = event.detail;
+        console.log('onChange', this.value);
+    };
+
+    private handleMenuItemSelected = (
+        event: LimelMenuCustomEvent<MenuItem>
+    ) => {
+        event.stopPropagation();
+        console.log('onMenuItemSelected', event.detail);
+
+        this.selectedValue = event.detail;
+    };
+}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -47,6 +47,7 @@ const DEFAULT_FILE_CHIP: Chip = {
  *
  * @exampleComponent limel-example-file
  * @exampleComponent limel-example-file-custom-icon
+ * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
  * @exampleComponent limel-example-file-composite
  */
@@ -172,6 +173,7 @@ export class File {
                     backgroundColor: getFileBackgroundColor(this.value),
                 },
                 href: this.value.href,
+                menuItems: this.value.menuItems,
             },
         ];
     }

--- a/src/global/shared-types/file.types.ts
+++ b/src/global/shared-types/file.types.ts
@@ -1,5 +1,7 @@
+import { MenuItem } from '../../components';
 import { Icon } from '../../global/shared-types/icon.types';
 import { Color } from './color.types';
+import { ListSeparator } from './separator.types';
 
 /**
  * @public
@@ -81,4 +83,9 @@ export interface FileInfo {
      * be left undefined or set to `null`.
      */
     href?: string;
+
+    /**
+     * Custom menu items for the file.
+     */
+    menuItems?: Array<MenuItem | ListSeparator>;
 }


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

fix: #3583 

To be able to add commands in the file chips

![image](https://github.com/user-attachments/assets/b64464fb-5308-4e1c-bccc-64ff2c824338)



<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new example component demonstrating file input with custom menu items like "Download" and "Share".
  * Added support for displaying and interacting with custom menu items on file inputs.

* **Documentation**
  * Updated documentation examples to showcase the new file menu items feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
