### PR TITLE
Update menu surface width CSS variable and adjust SCSS width calculation

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -876,7 +876,7 @@ export class InputField {
                     open={this.showCompletions}
                     allowClicksElement={this.limelInputField}
                     style={{
-                        '--mdc-menu-min-width': '100%',
+                        '--menu-surface-width': '100%',
                         'max-height': 'inherit',
                         display: 'flex',
                     }}

--- a/src/components/menu-surface/menu-surface.scss
+++ b/src/components/menu-surface/menu-surface.scss
@@ -21,10 +21,10 @@
     flex-direction: var(--limel-menu-surface-flex-direction, row);
     max-height: inherit;
     position: relative;
-    --mdc-menu-max-width: var(
-        --menu-surface-width,
-        min(calc(100vw - 2rem), 20rem)
-    );
+    --mdc-menu-max-width: calc(
+        100vw - 2rem
+    ); // just overriding MDC's pixel-based default (`calc(100vw - 32px)`) with a `rem` value
+    width: var(--menu-surface-width, auto);
     background-color: var(--lime-elevated-surface-background-color);
 }
 

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -234,7 +234,7 @@ export class Menu {
                         onDismiss={this.onClose}
                         style={{
                             ...cssProperties,
-                            '--mdc-menu-min-width': menuSurfaceWidth,
+                            '--menu-surface-width': menuSurfaceWidth,
                             '--limel-menu-surface-display': 'flex',
                             '--limel-menu-surface-flex-direction': 'column',
                         }}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -504,7 +504,7 @@ export class Picker {
                     open={content.length > 0}
                     allowClicksElement={this.host}
                     style={{
-                        '--mdc-menu-min-width': '100%',
+                        '--menu-surface-width': '100%',
                         'max-height': 'inherit',
                         display: 'flex',
                     }}

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -200,7 +200,7 @@ const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
                 open={props.isOpen}
                 onDismiss={props.close}
                 style={{
-                    '--mdc-menu-min-width': '100%',
+                    '--menu-surface-width': '100%',
                     'max-height': 'inherit',
                     display: 'flex',
                     'min-width': '100%',


### PR DESCRIPTION
There was a hidden `max-width` in the `min` function which
we were using to override the mdc's max width:
`min(calc(100vw - 2rem), 20rem)`, which was resulting in a
complicated spaghetti. Now we introduced our own `width`
to override the default `.mdc-menu-surface` styles.

fix https://github.com/Lundalogik/lime-elements/issues/3584

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the custom property used for menu surface width styling in dropdowns and menus, ensuring consistent and improved appearance across components.
  - Adjusted menu width calculations for better alignment with viewport and design guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
