### PR TITLE
Change expand icon, add internationalization and accessibility to CollapsibleSection component

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -316,6 +316,7 @@ export namespace Components {
         "icon"?: string | Icon;
         "invalid": boolean;
         "isOpen": boolean;
+        "language": Languages;
     }
     export interface LimelColorPicker {
         "helperText": string;
@@ -1373,6 +1374,7 @@ export namespace JSX {
         "icon"?: string | Icon;
         "invalid"?: boolean;
         "isOpen"?: boolean;
+        "language"?: Languages;
         "onAction"?: (event: LimelCollapsibleSectionCustomEvent<Action>) => void;
         "onClose"?: (event: LimelCollapsibleSectionCustomEvent<void>) => void;
         "onOpen"?: (event: LimelCollapsibleSectionCustomEvent<void>) => void;

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -37,7 +37,8 @@
     );
     border-radius: var(--border-radius-of-header);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
         background-color: var(
             --open-header-background-color,
             rgb(var(--contrast-300))
@@ -51,7 +52,8 @@
         );
         border-radius: var(--border-radius-of-header)
             var(--border-radius-of-header) 0 0;
-        &:hover {
+        &:hover,
+        &:focus-visible {
             background-color: var(
                 --open-header-background-color,
                 rgb(var(--contrast-300))
@@ -180,7 +182,9 @@ section.open {
     }
 }
 
-header:hover {
+header:hover,
+header:has(.open-close-toggle:hover),
+header:has(.open-close-toggle:focus-visible) {
     + .body {
         will-change: grid-template-rows;
 

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -131,12 +131,7 @@ export class CollapsibleSection {
                         onClick={this.onClick}
                         aria-controls={this.bodyId}
                     />
-                    <div class="expand-icon">
-                        <div class="line" />
-                        <div class="line" />
-                        <div class="line" />
-                        <div class="line" />
-                    </div>
+                    {this.renderExpandCollapseSign()}
                     {this.renderIcon()}
                     {this.renderHeading()}
                     <div class="divider-line" role="presentation" />
@@ -168,6 +163,17 @@ export class CollapsibleSection {
         } else {
             this.close.emit();
         }
+    };
+
+    private renderExpandCollapseSign = () => {
+        return (
+            <div class="expand-icon">
+                <div class="line" />
+                <div class="line" />
+                <div class="line" />
+                <div class="line" />
+            </div>
+        );
     };
 
     private renderIcon = () => {

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -19,6 +19,8 @@ import {
     getIconName,
     getIconTitle,
 } from '../icon/get-icon-props';
+import translate from '../../global/translations';
+import { Languages } from '../date-picker/date.types';
 
 /**
  * A collapsible section can be used to group related content together
@@ -79,6 +81,13 @@ export class CollapsibleSection {
     public actions: Action[];
 
     /**
+     * Defines the language for translations.
+     * Will translate the translatable strings on the components.
+     */
+    @Prop({ reflect: true })
+    public language: Languages = 'en';
+
+    /**
      * Emitted when the section is expanded
      */
     @Event()
@@ -131,6 +140,7 @@ export class CollapsibleSection {
                         onClick={this.onClick}
                         aria-controls={this.bodyId}
                         aria-expanded={this.isOpen ? 'true' : 'false'}
+                        aria-label={this.getCollapsibleSectionAriaLabel()}
                         type="button"
                     />
                     {this.renderExpandCollapseSign()}
@@ -245,5 +255,19 @@ export class CollapsibleSection {
     private handleActionClick = (action: Action) => (event: MouseEvent) => {
         event.stopPropagation();
         this.action.emit(action);
+    };
+
+    private getCollapsibleSectionAriaLabel = (): string => {
+        const heading = this.header ? `"${this.header}"` : ' ';
+
+        if (!this.isOpen) {
+            return translate.get('collapsible-section.open', this.language, {
+                header: heading,
+            });
+        }
+
+        return translate.get('collapsible-section.close', this.language, {
+            header: heading,
+        });
     };
 }

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -130,6 +130,8 @@ export class CollapsibleSection {
                         class="open-close-toggle"
                         onClick={this.onClick}
                         aria-controls={this.bodyId}
+                        aria-expanded={this.isOpen ? 'true' : 'false'}
+                        type="button"
                     />
                     {this.renderExpandCollapseSign()}
                     {this.renderIcon()}
@@ -142,6 +144,7 @@ export class CollapsibleSection {
                     class="body"
                     aria-hidden={String(!this.isOpen)}
                     id={this.bodyId}
+                    role="region"
                 >
                     <slot />
                 </div>
@@ -167,7 +170,7 @@ export class CollapsibleSection {
 
     private renderExpandCollapseSign = () => {
         return (
-            <div class="expand-icon">
+            <div class="expand-icon" role="presentation" aria-hidden="true">
                 <div class="line" />
                 <div class="line" />
                 <div class="line" />

--- a/src/components/collapsible-section/partial-styles/expand-icon.scss
+++ b/src/components/collapsible-section/partial-styles/expand-icon.scss
@@ -68,39 +68,42 @@
     }
 }
 
-.open-close-toggle:hover + .expand-icon {
-    .line {
-        &:first-of-type,
-        &:last-of-type {
-            transition:
-                opacity 0.8s ease 0.4s,
-                transform 0.4s ease 0.3s;
-            opacity: 1;
-        }
+.open-close-toggle:hover,
+.open-close-toggle:focus-visible {
+    + .expand-icon {
+        .line {
+            &:first-of-type,
+            &:last-of-type {
+                transition:
+                    opacity 0.8s ease 0.4s,
+                    transform 0.4s ease 0.3s;
+                opacity: 1;
+            }
 
-        &:first-of-type {
-            transform: rotate3d(0, 0, 1, 0deg);
-        }
+            &:first-of-type {
+                transform: rotate3d(0, 0, 1, 0deg);
+            }
 
-        &:last-of-type {
-            transform: rotate3d(0, 0, 1, 0deg);
-        }
+            &:last-of-type {
+                transform: rotate3d(0, 0, 1, 0deg);
+            }
 
-        &:nth-of-type(2),
-        &:nth-of-type(3) {
-            transition:
-                opacity 0.5s ease 0.4s,
-                transform 0.7s cubic-bezier(0.85, 0.11, 0.14, 1.35) 0.2s;
-        }
+            &:nth-of-type(2),
+            &:nth-of-type(3) {
+                transition:
+                    opacity 0.5s ease 0.4s,
+                    transform 0.7s cubic-bezier(0.85, 0.11, 0.14, 1.35) 0.2s;
+            }
 
-        &:nth-of-type(2) {
-            transform: translate3d(0, 0.5rem, 0) rotate(90deg);
-            opacity: 0.4;
-        }
+            &:nth-of-type(2) {
+                transform: translate3d(0, 0.5rem, 0) rotate(90deg);
+                opacity: 0.4;
+            }
 
-        &:nth-of-type(3) {
-            transform: translate3d(0, -0.5rem, 0) rotate(-90deg);
-            opacity: 0.4;
+            &:nth-of-type(3) {
+                transform: translate3d(0, -0.5rem, 0) rotate(-90deg);
+                opacity: 0.4;
+            }
         }
     }
 }
@@ -141,31 +144,34 @@ section.open {
         }
     }
 
-    .open-close-toggle:hover + .expand-icon {
-        .line {
-            &:first-of-type,
-            &:last-of-type {
-                transition:
-                    opacity 0.2s ease 0.4s,
-                    transform 0.4s cubic-bezier(0.85, 0.11, 0.14, 1.35) 0.2s;
-            }
+    .open-close-toggle:hover,
+    .open-close-toggle:focus-visible {
+        + .expand-icon {
+            .line {
+                &:first-of-type,
+                &:last-of-type {
+                    transition:
+                        opacity 0.2s ease 0.4s,
+                        transform 0.4s cubic-bezier(0.85, 0.11, 0.14, 1.35) 0.2s;
+                }
 
-            &:first-of-type {
-                transform: rotate3d(0, 0, 1, 45deg);
-            }
+                &:first-of-type {
+                    transform: rotate3d(0, 0, 1, 45deg);
+                }
 
-            &:last-of-type {
-                transform: rotate3d(0, 0, 1, -45deg);
-            }
+                &:last-of-type {
+                    transform: rotate3d(0, 0, 1, -45deg);
+                }
 
-            &:nth-of-type(2) {
-                transform: translate3d(0, 1rem, 0) rotate(90deg);
-                opacity: 0;
-            }
+                &:nth-of-type(2) {
+                    transform: translate3d(0, 1rem, 0) rotate(90deg);
+                    opacity: 0;
+                }
 
-            &:nth-of-type(3) {
-                transform: translate3d(0, -1rem, 0) rotate(-90deg);
-                opacity: 0;
+                &:nth-of-type(3) {
+                    transform: translate3d(0, -1rem, 0) rotate(-90deg);
+                    opacity: 0;
+                }
             }
         }
     }

--- a/src/components/collapsible-section/partial-styles/expand-icon.scss
+++ b/src/components/collapsible-section/partial-styles/expand-icon.scss
@@ -1,5 +1,9 @@
 .expand-icon {
     position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     height: 1.875rem;
     margin: 0 0 0 0.5rem;
     width: 0.75rem;
@@ -9,10 +13,7 @@
 
 .line {
     position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    inset: auto;
     margin: auto;
 
     width: 100%;
@@ -40,39 +41,6 @@
         transition:
             opacity 0.2s ease,
             transform 0.18s ease;
-    }
-
-    section.open & {
-        &:first-of-type,
-        &:last-of-type {
-            transition:
-                opacity 0.2s ease 0.1s,
-                transform 0.4s ease 0.3s;
-        }
-        &:first-of-type {
-            transform: rotate3d(0, 0, 1, 0deg);
-        }
-
-        &:last-of-type {
-            transform: rotate3d(0, 0, 1, 0deg);
-        }
-
-        &:nth-of-type(2),
-        &:nth-of-type(3) {
-            transition:
-                opacity 1s ease,
-                transform 0.4s ease;
-        }
-
-        &:nth-of-type(2) {
-            transform: translate3d(0, -1rem, 0);
-            opacity: 0;
-        }
-
-        &:nth-of-type(3) {
-            transform: translate3d(0, 1rem, 0);
-            opacity: 0;
-        }
     }
 }
 
@@ -106,6 +74,40 @@
 }
 
 section.open {
+    .line {
+        &:first-of-type,
+        &:last-of-type {
+            transition:
+                opacity 0.2s ease 0.1s,
+                transform 0.4s ease 0.3s;
+        }
+
+        &:first-of-type {
+            transform: rotate3d(0, 0, 1, 0deg);
+        }
+
+        &:last-of-type {
+            transform: rotate3d(0, 0, 1, 0deg);
+        }
+
+        &:nth-of-type(2),
+        &:nth-of-type(3) {
+            transition:
+                opacity 1s ease,
+                transform 0.4s ease;
+        }
+
+        &:nth-of-type(2) {
+            transform: translate3d(0, -1rem, 0);
+            opacity: 0;
+        }
+
+        &:nth-of-type(3) {
+            transform: translate3d(0, 1rem, 0);
+            opacity: 0;
+        }
+    }
+
     .open-close-toggle:hover + .expand-icon {
         .line {
             &:first-of-type,

--- a/src/components/collapsible-section/partial-styles/expand-icon.scss
+++ b/src/components/collapsible-section/partial-styles/expand-icon.scss
@@ -15,25 +15,28 @@
     position: absolute;
     inset: auto;
     margin: auto;
-
     width: 100%;
     border-radius: 1rem;
     height: 0.125rem;
-    background-color: var(--header-stroke-color, rgb(var(--contrast-900)));
 
     &:first-of-type,
     &:last-of-type {
         transition:
             opacity 0.2s ease 0.1s,
             transform 0.4s ease 0.3s;
+
+        opacity: 0;
+        background-color: var(--header-stroke-color, rgb(var(--contrast-900)));
     }
 
-    &:first-of-type {
-        transform: rotate3d(0, 0, 1, 90deg);
+    &:nth-of-type(2) {
+        // 🔽 arrow down
+        transform: translate3d(0, 0.25rem, 0) rotate(90deg);
     }
 
-    &:last-of-type {
-        transform: rotate3d(0, 0, 1, -90deg);
+    &:nth-of-type(3) {
+        // 🔼 arrow up
+        transform: translate3d(0, -0.25rem, 0) rotate(-90deg);
     }
 
     &:nth-of-type(2),
@@ -41,11 +44,40 @@
         transition:
             opacity 0.2s ease,
             transform 0.18s ease;
+
+        &:before,
+        &:after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            margin: auto;
+            width: 50%;
+            height: 100%;
+            border-radius: inherit;
+            background-color: var(
+                --header-stroke-color,
+                rgb(var(--contrast-900))
+            );
+        }
+        &:before {
+            transform: translate3d(0, -0.1rem, 0) rotate(45deg);
+        }
+        &:after {
+            transform: translate3d(0, 0.1rem, 0) rotate(-45deg);
+        }
     }
 }
 
 .open-close-toggle:hover + .expand-icon {
     .line {
+        &:first-of-type,
+        &:last-of-type {
+            transition:
+                opacity 0.8s ease 0.4s,
+                transform 0.4s ease 0.3s;
+            opacity: 1;
+        }
+
         &:first-of-type {
             transform: rotate3d(0, 0, 1, 0deg);
         }
@@ -62,12 +94,12 @@
         }
 
         &:nth-of-type(2) {
-            transform: translate3d(0, -0.5rem, 0);
+            transform: translate3d(0, 0.5rem, 0) rotate(90deg);
             opacity: 0.4;
         }
 
         &:nth-of-type(3) {
-            transform: translate3d(0, 0.5rem, 0);
+            transform: translate3d(0, -0.5rem, 0) rotate(-90deg);
             opacity: 0.4;
         }
     }
@@ -80,6 +112,7 @@ section.open {
             transition:
                 opacity 0.2s ease 0.1s,
                 transform 0.4s ease 0.3s;
+            opacity: 1;
         }
 
         &:first-of-type {
@@ -98,12 +131,12 @@ section.open {
         }
 
         &:nth-of-type(2) {
-            transform: translate3d(0, -1rem, 0);
+            transform: translate3d(0, 1rem, 0) rotate(90deg);
             opacity: 0;
         }
 
         &:nth-of-type(3) {
-            transform: translate3d(0, 1rem, 0);
+            transform: translate3d(0, -1rem, 0) rotate(-90deg);
             opacity: 0;
         }
     }
@@ -126,12 +159,12 @@ section.open {
             }
 
             &:nth-of-type(2) {
-                transform: translate3d(0, -1rem, 0);
+                transform: translate3d(0, 1rem, 0) rotate(90deg);
                 opacity: 0;
             }
 
             &:nth-of-type(3) {
-                transform: translate3d(0, 1rem, 0);
+                transform: translate3d(0, -1rem, 0) rotate(-90deg);
                 opacity: 0;
             }
         }

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Tip',
     'callout.caution': 'Advarsel',
     'callout.warning': 'Advarsel',
+    'collapsible-section.open': 'Åbn { header } sektion',
+    'collapsible-section.close': 'Luk { header } sektion',
     'date-picker.today': 'Idag',
     'date-picker.month.heading': 'Måned',
     'date-picker.quarter.heading': 'Kvartal',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Tipp',
     'callout.caution': 'Vorsicht',
     'callout.warning': 'Warnung',
+    'collapsible-section.open': '{ header } Bereich öffnen',
+    'collapsible-section.close': '{ header } Bereich schließen',
     'date-picker.today': 'Heute',
     'date-picker.month.heading': 'Monat',
     'date-picker.quarter.heading': 'Quartal',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Tip',
     'callout.caution': 'Caution',
     'callout.warning': 'Warning',
+    'collapsible-section.open': 'Open { header } section',
+    'collapsible-section.close': 'Close { header } section',
     'date-picker.today': 'Today',
     'date-picker.month.heading': 'Month',
     'date-picker.quarter.heading': 'Quarter',

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Vinkki',
     'callout.caution': 'Varoitus',
     'callout.warning': 'Varoitus',
+    'collapsible-section.open': 'Avaa { header } osio',
+    'collapsible-section.close': 'Sulje { header } osio',
     'date-picker.today': 'Tänään',
     'date-picker.month.heading': 'Kuukausi',
     'date-picker.quarter.heading': 'Vuosineljännes',

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Conseil',
     'callout.caution': 'Prudence',
     'callout.warning': 'Avertissement',
+    'collapsible-section.open': 'Ouvrir la section { header }',
+    'collapsible-section.close': 'Fermer la section { header }',
     'date-picker.today': "Aujourd'hui",
     'date-picker.month.heading': 'Mois',
     'date-picker.quarter.heading': 'Trimestre',

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Tip',
     'callout.caution': 'Waarschuwing',
     'callout.warning': 'Waarschuwing',
+    'collapsible-section.open': 'Open { header } sectie',
+    'collapsible-section.close': 'Sluit { header } sectie',
     'date-picker.today': 'Vandaag',
     'date-picker.month.heading': 'Maand',
     'date-picker.quarter.heading': 'Kwartaal',

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Tip',
     'callout.caution': 'Advarsel',
     'callout.warning': 'Advarsel',
+    'collapsible-section.open': 'Åpne { header } seksjon',
+    'collapsible-section.close': 'Lukk { header } seksjon',
     'date-picker.today': 'I dag',
     'date-picker.month.heading': 'Måned',
     'date-picker.quarter.heading': 'Kvartal',

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -12,6 +12,8 @@ export default {
     'callout.tip': 'Tips',
     'callout.caution': 'Varning',
     'callout.warning': 'Varning',
+    'collapsible-section.open': 'Öppna { header }-sektion',
+    'collapsible-section.close': 'Stäng { header }-sektion',
     'date-picker.today': 'Idag',
     'date-picker.month.heading': 'Månad',
     'date-picker.quarter.heading': 'Kvartal',


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added internationalization support to the collapsible section component, allowing users to see accessible labels in their selected language.
  - Expanded language support for collapsible section actions (open/close) in Danish, German, English, Finnish, French, Dutch, Norwegian, and Swedish.

- **Style**
  - Improved the expand/collapse icon with enhanced animations, clearer arrow shapes, and smoother transitions for better visual feedback.
  - Extended hover and focus-visible styles for toggle and header elements to optimize animation performance and user interaction feedback.

- **Accessibility**
  - Enhanced screen reader support with dynamic, localized aria-labels and improved landmark roles for collapsible content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

**After:**
<img width="467" alt="image" src="https://github.com/user-attachments/assets/4fde9181-1ac6-4073-9442-4327a7b52004" />

https://github.com/user-attachments/assets/bee7755e-667b-489c-bf4b-483b9d7fa60d





**Before:**
<img width="462" alt="image" src="https://github.com/user-attachments/assets/1827d2e4-ff76-4242-b7f9-1e6ee686475e" />

https://github.com/user-attachments/assets/7d9fab47-5399-4e56-966d-1e43efb25b40



## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
