### PR TITLE
feat(color): add autocomplete for defined colors

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -64,7 +64,7 @@ export type CalloutType = 'note' | 'important' | 'tip' | 'caution' | 'warning';
 // @beta
 export interface ChartItem<T extends number | [number, number] = number | [number, number]> {
     clickable?: boolean;
-    color?: string;
+    color?: Color;
     formattedValue?: string;
     text: string;
     value: T;
@@ -76,9 +76,9 @@ export interface Chip<T = any> {
     href?: string;
     icon?: string | Icon;
     // @deprecated
-    iconBackgroundColor?: string;
+    iconBackgroundColor?: Color;
     // @deprecated
-    iconFillColor?: string;
+    iconFillColor?: Color;
     // @deprecated
     iconTitle?: string;
     id: number | string;
@@ -104,6 +104,11 @@ export interface ClosingActions {
     // (undocumented)
     scrimClick: boolean;
 }
+
+// Warning: (ae-incompatible-release-tags) The symbol "Color" is marked as @public, but its signature references "_Internal" which is marked as @internal
+//
+// @public
+export type Color = `rgb(var(${_Internal.HueColor | _Internal.BlackColor | _Internal.WhiteColor | _Internal.ContrastColor | _Internal.BrandColor}))` | (string & {});
 
 // @public (undocumented)
 export type ColorScheme = 'dark' | 'light' | 'auto';
@@ -870,9 +875,9 @@ export interface FileInfo {
     href?: string;
     icon?: string | Icon;
     // @deprecated
-    iconBackgroundColor?: string;
+    iconBackgroundColor?: Color;
     // @deprecated
-    iconColor?: string;
+    iconColor?: Color;
     id: number | string;
     lastModified?: Date;
     size?: number;
@@ -890,10 +895,10 @@ export type FlexContainerJustify = 'start' | 'end' | 'center' | 'space-between' 
 // @public
 export interface FlowItem extends ListItem {
     // @deprecated
-    iconColor?: string;
+    iconColor?: Color;
     isOffProgress?: boolean;
-    passedColor?: string;
-    selectedColor?: string;
+    passedColor?: Color;
+    selectedColor?: Color;
 }
 
 // @public (undocumented)
@@ -993,8 +998,8 @@ export interface Help {
 
 // @public
 export interface Icon {
-    backgroundColor?: string;
-    color?: string;
+    backgroundColor?: Color;
+    color?: Color;
     name: string;
     title?: string;
 }
@@ -1030,6 +1035,28 @@ export interface InfoTileProgress {
 
 // @public (undocumented)
 export type InputType = 'date' | 'datetime-local' | 'email' | 'month' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'textarea' | 'time' | 'url' | 'urlAsText' | 'week';
+
+// @internal (undocumented)
+export namespace _Internal {
+    // (undocumented)
+    export type BlackColor = '--color-black';
+    // (undocumented)
+    export type BrandColor = `--lime-brand-color-${BrandHue}`;
+    // (undocumented)
+    export type BrandHue = 'lime-green' | 'ocean-teal' | 'aqua' | 'bubblegum' | 'sunny-orange' | 'cool-grey';
+    // (undocumented)
+    export type Brightness = 'lighter' | 'light' | 'default' | 'dark' | 'darker';
+    // (undocumented)
+    export type ContrastColor = `--contrast-${ContrastValue}`;
+    // (undocumented)
+    export type ContrastValue = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 1000 | 1100 | 1200 | 1300 | 1400 | 1500 | 1600 | 1700;
+    // (undocumented)
+    export type Hue = 'red' | 'pink' | 'magenta' | 'purple' | 'violet' | 'indigo' | 'blue' | 'cyan' | 'teal' | 'green' | 'lime' | 'yellow' | 'amber' | 'orange' | 'coral' | 'brown' | 'grey' | 'glaucous';
+    // (undocumented)
+    export type HueColor = `--color-${Hue}-${Brightness}`;
+    // (undocumented)
+    export type WhiteColor = '--color-white';
+}
 
 // Warning: (ae-missing-release-tag) "LocalJSX" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2393,7 +2420,7 @@ export interface ListItem<T = any> {
     disabled?: boolean;
     icon?: string | Icon;
     // @deprecated
-    iconColor?: string;
+    iconColor?: Color;
     image?: Image_2;
     primaryComponent?: ListComponent;
     secondaryText?: string;
@@ -2420,7 +2447,7 @@ interface MenuItem<T = any> {
     disabled?: boolean;
     icon?: string | Icon;
     // @deprecated
-    iconColor?: string;
+    iconColor?: Color;
     items?: Array<MenuItem<T> | ListSeparator> | MenuLoader;
     // @internal
     parentItem?: MenuItem;
@@ -2449,7 +2476,7 @@ interface Option_2<T extends string = string> {
     disabled?: boolean;
     icon?: string | Icon;
     // @deprecated
-    iconColor?: string;
+    iconColor?: Color;
     secondaryText?: string;
     text: string;
     value: T;
@@ -2490,7 +2517,7 @@ export interface Tab {
     badge?: number | string;
     icon?: string | Icon;
     // @deprecated
-    iconColor?: string;
+    iconColor?: Color;
     id: number | string;
     text?: string;
 }

--- a/src/components/chart/chart.types.ts
+++ b/src/components/chart/chart.types.ts
@@ -1,3 +1,5 @@
+import { Color } from '../../global/shared-types/color.types';
+
 /**
  * Chart component props.
  * @beta
@@ -25,7 +27,7 @@ export interface ChartItem<
      * It is recommended to use distinct colors for each item,
      * and make sure there is enough contrast between colors of adjacent items.
      */
-    color?: string;
+    color?: Color;
 
     /**
      * When set to `true`, the item will become clickable,

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -2,6 +2,7 @@ import { Image } from '../../global/shared-types/image.types';
 import { Icon } from '../../global/shared-types/icon.types';
 import { MenuItem } from '../menu/menu.types';
 import { ListSeparator } from '../list/list-item.types';
+import { Color } from '../../global/shared-types/color.types';
 
 /**
  * @public
@@ -40,7 +41,7 @@ export interface Chip<T = any> {
      * },
      * ```
      */
-    iconFillColor?: string;
+    iconFillColor?: Color;
 
     /**
      * `title` attribute of the icon
@@ -70,7 +71,7 @@ export interface Chip<T = any> {
      * },
      * ```
      */
-    iconBackgroundColor?: string;
+    iconBackgroundColor?: Color;
 
     /**
      * Whether the chip should be removable. Not valid for `choice`.

--- a/src/components/list/list-item.types.ts
+++ b/src/components/list/list-item.types.ts
@@ -2,6 +2,7 @@ import { ListSeparator } from '../../global/shared-types/separator.types';
 import { Icon } from '../../global/shared-types/icon.types';
 import { MenuItem } from '../menu/menu.types';
 import { Image } from '../../global/shared-types/image.types';
+import { Color } from '../../global/shared-types/color.types';
 
 export { ListSeparator };
 
@@ -43,7 +44,7 @@ export interface ListItem<T = any> {
      * },
      * ```
      */
-    iconColor?: string;
+    iconColor?: Color;
 
     /**
      * True if the list item should be selected.

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,5 +1,6 @@
 import { ListSeparator } from '../../global/shared-types/separator.types';
 import { Icon } from '../../global/shared-types/icon.types';
+import { Color } from '../../global/shared-types/color.types';
 
 /**
  * The direction in which the menu should open.
@@ -93,7 +94,7 @@ export interface MenuItem<T = any> {
      * },
      * ```
      */
-    iconColor?: string;
+    iconColor?: Color;
 
     /**
      * True if the menu item should be selected.

--- a/src/components/progress-flow/progress-flow.types.ts
+++ b/src/components/progress-flow/progress-flow.types.ts
@@ -1,3 +1,4 @@
+import { Color } from '../../global/shared-types/color.types';
 import { ListItem } from '../list/list-item.types';
 
 /**
@@ -14,12 +15,12 @@ export interface FlowItem extends ListItem {
     /**
      * Background color of selected step.
      */
-    selectedColor?: string;
+    selectedColor?: Color;
 
     /**
      * Background color of the step, when it is passed.
      */
-    passedColor?: string;
+    passedColor?: Color;
 
     /**
      * Fill color of the icon on the step,
@@ -35,5 +36,5 @@ export interface FlowItem extends ListItem {
      * },
      * ```
      */
-    iconColor?: string;
+    iconColor?: Color;
 }

--- a/src/components/select/option.types.ts
+++ b/src/components/select/option.types.ts
@@ -1,3 +1,4 @@
+import { Color } from '../../global/shared-types/color.types';
 import { Icon } from '../../global/shared-types/icon.types';
 /**
  * Describes an option for limel-select.
@@ -51,5 +52,5 @@ export interface Option<T extends string = string> {
      * },
      * ```
      */
-    iconColor?: string;
+    iconColor?: Color;
 }

--- a/src/components/tab-bar/tab.types.ts
+++ b/src/components/tab-bar/tab.types.ts
@@ -1,3 +1,4 @@
+import { Color } from '../../global/shared-types/color.types';
 import { Icon } from '../../global/shared-types/icon.types';
 
 /**
@@ -38,7 +39,7 @@ export interface Tab {
      * },
      * ```
      */
-    iconColor?: string;
+    iconColor?: Color;
 
     /**
      * Shows a badge within the tab with a specified label

--- a/src/global/shared-types/color.types.ts
+++ b/src/global/shared-types/color.types.ts
@@ -1,0 +1,110 @@
+/* eslint-disable no-magic-numbers */
+
+/**
+ * Defined colors and any color that can be used.
+ *
+ * Will auto-complete to any defined color from Lime Elements, while still
+ * allowing any valid CSS color value to be used.
+ *
+ * @public
+ */
+export type Color =
+    | `rgb(var(${_Internal.HueColor | _Internal.BlackColor | _Internal.WhiteColor | _Internal.ContrastColor | _Internal.BrandColor}))`
+    // eslint-disable-next-line sonarjs/no-useless-intersection
+    | (string & {});
+
+/**
+ * @internal
+ */
+export namespace _Internal {
+    /**
+     * @internal
+     */
+    export type Hue =
+        | 'red'
+        | 'pink'
+        | 'magenta'
+        | 'purple'
+        | 'violet'
+        | 'indigo'
+        | 'blue'
+        | 'cyan'
+        | 'teal'
+        | 'green'
+        | 'lime'
+        | 'yellow'
+        | 'amber'
+        | 'orange'
+        | 'coral'
+        | 'brown'
+        | 'grey'
+        | 'glaucous';
+
+    /**
+     * @internal
+     */
+    export type Brightness =
+        | 'lighter'
+        | 'light'
+        | 'default'
+        | 'dark'
+        | 'darker';
+
+    /**
+     * @internal
+     */
+    export type HueColor = `--color-${Hue}-${Brightness}`;
+
+    /**
+     * @internal
+     */
+    export type BlackColor = '--color-black';
+
+    /**
+     * @internal
+     */
+    export type WhiteColor = '--color-white';
+
+    /**
+     * @internal
+     */
+    export type ContrastValue =
+        | 100
+        | 200
+        | 300
+        | 400
+        | 500
+        | 600
+        | 700
+        | 800
+        | 900
+        | 1000
+        | 1100
+        | 1200
+        | 1300
+        | 1400
+        | 1500
+        | 1600
+        | 1700;
+
+    /**
+     * @internal
+     */
+    export type ContrastColor = `--contrast-${ContrastValue}`;
+
+    /**
+     * @internal
+     */
+    export type BrandHue =
+        | 'lime-green'
+        | 'ocean-teal'
+        | 'aqua'
+        | 'bubblegum'
+        | 'sunny-orange'
+        | 'cool-grey';
+
+    /**
+     * @internal
+     */
+    export type BrandColor = `--lime-brand-color-${BrandHue}`;
+}

--- a/src/global/shared-types/file.types.ts
+++ b/src/global/shared-types/file.types.ts
@@ -1,4 +1,5 @@
 import { Icon } from '../../global/shared-types/icon.types';
+import { Color } from './color.types';
 
 /**
  * @public
@@ -57,7 +58,7 @@ export interface FileInfo {
      * },
      * ```
      */
-    iconColor?: string;
+    iconColor?: Color;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.
@@ -72,7 +73,7 @@ export interface FileInfo {
      * },
      * ```
      */
-    iconBackgroundColor?: string;
+    iconBackgroundColor?: Color;
 
     /**
      * URL where the file can be downloaded. Note that this is optional. If the

--- a/src/global/shared-types/icon.types.ts
+++ b/src/global/shared-types/icon.types.ts
@@ -1,3 +1,5 @@
+import { Color } from './color.types';
+
 /**
  * This interface is used to specify which icon to use in many components,
  * along with related properties, like color.
@@ -12,12 +14,12 @@ export interface Icon {
     /**
      * Color of the icon.
      */
-    color?: string;
+    color?: Color;
 
     /**
      * Background color of the icon.
      */
-    backgroundColor?: string;
+    backgroundColor?: Color;
 
     /**
      * Used primarily to improve accessibility for users who

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -51,4 +51,5 @@ export * from './components/table/table.types';
 export * from './global/shared-types/separator.types';
 export * from './global/shared-types/icon.types';
 export * from './global/shared-types/image.types';
+export * from './global/shared-types/color.types';
 export * from './components/text-editor/text-editor.types';


### PR DESCRIPTION
Any color not defined by Lime Elements is still allowed to be used

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new, strongly-typed color system that supports both predefined CSS variable-based colors and any valid CSS color string.

* **Refactor**
  * Updated various components and shared interfaces to use the new color type for color-related properties, improving type safety and consistency across the application.

* **Chores**
  * Extended public exports to include the new color types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
