### PR TITLE
fix(input-field): be able to focus on the input field

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -21,7 +21,7 @@ import {
 import { InputType } from '../input-field/input-field.types';
 import { ListItem } from '../list/list-item.types';
 import { getHref, getTarget, getRel } from '../../util/link-helper';
-import { JSXBase } from '@stencil/core/internal';
+import { JSXBase, Method } from '@stencil/core/internal';
 import { createRandomString } from '../../util/random-string';
 import { LimelListCustomEvent } from '../../components';
 import { globalConfig } from '../../global/config';
@@ -55,7 +55,7 @@ const RESIZE_HANDLER_DEBOUNCE_TIMEOUT = 100;
  */
 @Component({
     tag: 'limel-input-field',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'input-field.scss',
 })
 export class InputField {
@@ -247,6 +247,11 @@ export class InputField {
 
     @State()
     public showCompletions: boolean = false;
+
+    @Method()
+    public async focus() {
+        this.mdcTextField?.focus();
+    }
 
     private inputElement?: HTMLInputElement | HTMLTextAreaElement;
     private mdcTextField: MDCTextField;


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

fixes Lundalogik/limepkg-marketing#24

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
