### PR TITLE
fix(popover): ensure content is added to portal container

### DIFF
--- a/src/components/popover-surface/__snapshots__/popover-surface.spec.tsx.snap
+++ b/src/components/popover-surface/__snapshots__/popover-surface.spec.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render component with one child 1`] = `
+<limel-popover-surface>
+  <mock:shadow-root>
+    <div class="limel-popover-surface" tabindex="0">
+      <div>
+        Child 1
+      </div>
+    </div>
+  </mock:shadow-root>
+</limel-popover-surface>
+`;
+
+exports[`render component with trigger element 1`] = `
+<limel-popover-surface>
+  <mock:shadow-root>
+    <div class="limel-popover-surface" tabindex="0"></div>
+  </mock:shadow-root>
+</limel-popover-surface>
+`;
+
+exports[`render component with two children 1`] = `
+<limel-popover-surface>
+  <mock:shadow-root>
+    <div class="limel-popover-surface" tabindex="0">
+      <div>
+        Child 1
+      </div>
+      <div>
+        Child 2
+      </div>
+    </div>
+  </mock:shadow-root>
+</limel-popover-surface>
+`;
+
+exports[`render component without children 1`] = `
+<limel-popover-surface>
+  <mock:shadow-root>
+    <div class="limel-popover-surface" tabindex="0"></div>
+  </mock:shadow-root>
+</limel-popover-surface>
+`;

--- a/src/components/popover-surface/popover-surface.spec.tsx
+++ b/src/components/popover-surface/popover-surface.spec.tsx
@@ -1,0 +1,58 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { h } from '@stencil/core';
+import { PopoverSurface } from './popover-surface';
+
+let page: SpecPage;
+
+test('render component without children', async () => {
+    await createComponent([]);
+
+    expect(page.root).toMatchSnapshot();
+});
+
+test('render component with one child', async () => {
+    const child1 = document.createElement('div');
+    child1.textContent = 'Child 1';
+
+    await createComponent([child1]);
+
+    expect(page.root).toMatchSnapshot();
+});
+
+test('render component with two children', async () => {
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+    child1.textContent = 'Child 1';
+    child2.textContent = 'Child 2';
+
+    await createComponent([child1, child2]);
+
+    expect(page.root).toMatchSnapshot();
+});
+
+test('render component with trigger element', async () => {
+    const child1 = document.createElement('div');
+    child1.textContent = 'Child 1';
+    child1.slot = 'trigger';
+
+    await createComponent([child1]);
+
+    expect(page.root).toMatchSnapshot();
+});
+
+async function createComponent(children: HTMLElement[]): Promise<void> {
+    const aside = document.createElement('aside');
+    document.body.append(aside);
+    for (const child of children) {
+        aside.append(child);
+    }
+
+    page = await newSpecPage({
+        components: [PopoverSurface],
+        template: () => (
+            <limel-popover-surface contentCollection={aside.children} />
+        ),
+    });
+
+    await page.waitForChanges();
+}

--- a/src/components/popover-surface/popover-surface.tsx
+++ b/src/components/popover-surface/popover-surface.tsx
@@ -33,7 +33,8 @@ export class PopoverSurface {
             '.limel-popover-surface'
         );
 
-        for (const child of this.contentCollection) {
+        const childElementsCopy = [...this.contentCollection];
+        for (const child of childElementsCopy) {
             if (child.slot === 'trigger') {
                 continue;
             }


### PR DESCRIPTION
When iterating over the HTMLCollection, elements were removed from the collection during iteration when appended to the portal container. This caused elements to be skipped and never added to the container

fix Lundalogik/crm-client#184

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for the PopoverSurface component to verify rendering with various child element configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
