### PR TITLE
fix(form): array item reordering now works correctly

### DIFF
--- a/src/components/form/templates/array-field-simple-item.ts
+++ b/src/components/form/templates/array-field-simple-item.ts
@@ -47,13 +47,11 @@ export class SimpleItemTemplate extends React.Component {
     private renderRemoveButton(item: ArrayFieldItem) {
         const props: any = {
             icon: 'trash',
+            disabled: !item.hasRemove,
             ref: (button: HTMLLimelButtonElement) => {
                 this.removeButton = button;
             },
         };
-        if (!item.hasRemove) {
-            props.disabled = true;
-        }
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }
@@ -61,13 +59,11 @@ export class SimpleItemTemplate extends React.Component {
     private renderMoveUpButton(item: ArrayFieldItem) {
         const props: any = {
             icon: 'up_arrow',
+            disabled: !item.hasMoveUp,
             ref: (button: HTMLLimelButtonElement) => {
                 this.moveUpButton = button;
             },
         };
-        if (!item.hasMoveUp) {
-            props.disabled = true;
-        }
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }
@@ -75,13 +71,11 @@ export class SimpleItemTemplate extends React.Component {
     private renderMoveDownButton(item: ArrayFieldItem) {
         const props: any = {
             icon: 'down_arrow',
+            disabled: !item.hasMoveDown,
             ref: (button: HTMLLimelButtonElement) => {
                 this.moveDownButton = button;
             },
         };
-        if (!item.hasMoveDown) {
-            props.disabled = true;
-        }
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }

--- a/src/components/form/templates/array-field-simple-item.ts
+++ b/src/components/form/templates/array-field-simple-item.ts
@@ -17,31 +17,16 @@ export class SimpleItemTemplate extends React.Component {
     private moveUpButton: HTMLLimelButtonElement;
     private moveDownButton: HTMLLimelButtonElement;
 
-    private removeHandler: (event: any) => void;
-    private moveUpHandler: (event: any) => void;
-    private moveDownHandler: (event: any) => void;
-
     public componentDidMount() {
-        const { item, index } = this.props;
-        const removeButton = this.removeButton;
-        this.removeHandler = item.onDropIndexClick(index);
-        removeButton.addEventListener('click', this.removeHandler);
-
-        const upButton = this.moveUpButton;
-        this.moveUpHandler = item.onReorderClick(index, index - 1);
-        upButton.addEventListener('click', this.moveUpHandler);
-
-        const downButton = this.moveDownButton;
-        this.moveDownHandler = item.onReorderClick(index, index + 1);
-        downButton.addEventListener('click', this.moveDownHandler);
+        this.removeButton.addEventListener('click', this.handleRemove);
+        this.moveUpButton.addEventListener('click', this.handleMoveUp);
+        this.moveDownButton.addEventListener('click', this.handleMoveDown);
     }
 
     public componentWillUnmount() {
-        this.removeButton.removeEventListener('click', this.removeHandler);
-
-        this.moveUpButton.removeEventListener('click', this.moveUpHandler);
-
-        this.moveDownButton.removeEventListener('click', this.moveDownHandler);
+        this.removeButton.removeEventListener('click', this.handleRemove);
+        this.moveUpButton.removeEventListener('click', this.handleMoveUp);
+        this.moveDownButton.removeEventListener('click', this.handleMoveDown);
     }
 
     public render() {
@@ -100,4 +85,19 @@ export class SimpleItemTemplate extends React.Component {
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }
+
+    private handleRemove = (event: PointerEvent): void => {
+        const { item, index } = this.props;
+        item.onDropIndexClick(index)(event);
+    };
+
+    private handleMoveUp = (event: PointerEvent): void => {
+        const { item, index } = this.props;
+        item.onReorderClick(index, index - 1)(event);
+    };
+
+    private handleMoveDown = (event: PointerEvent): void => {
+        const { item, index } = this.props;
+        item.onReorderClick(index, index + 1)(event);
+    };
 }


### PR DESCRIPTION
Item handlers now use the correct positions.
Previously, wrong positions was referenced when an item was moved multiple times.

Fix https://github.com/Lundalogik/lime-webclient/issues/6222
Fix https://github.com/Lundalogik/crm-client/issues/193

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of button events for removing and reordering items in array fields, resulting in more streamlined and maintainable event management. No changes to visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
