### PR TITLE
fix(form): resolve warnings for disabled prop modification

### DIFF
--- a/src/components/form/templates/array-field-simple-item.ts
+++ b/src/components/form/templates/array-field-simple-item.ts
@@ -62,13 +62,11 @@ export class SimpleItemTemplate extends React.Component {
     private renderRemoveButton(item: ArrayFieldItem) {
         const props: any = {
             icon: 'trash',
+            disabled: !item.hasRemove,
             ref: (button: HTMLLimelButtonElement) => {
                 this.removeButton = button;
             },
         };
-        if (!item.hasRemove) {
-            props.disabled = true;
-        }
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }
@@ -76,13 +74,11 @@ export class SimpleItemTemplate extends React.Component {
     private renderMoveUpButton(item: ArrayFieldItem) {
         const props: any = {
             icon: 'up_arrow',
+            disabled: !item.hasMoveUp,
             ref: (button: HTMLLimelButtonElement) => {
                 this.moveUpButton = button;
             },
         };
-        if (!item.hasMoveUp) {
-            props.disabled = true;
-        }
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }
@@ -90,13 +86,11 @@ export class SimpleItemTemplate extends React.Component {
     private renderMoveDownButton(item: ArrayFieldItem) {
         const props: any = {
             icon: 'down_arrow',
+            disabled: !item.hasMoveDown,
             ref: (button: HTMLLimelButtonElement) => {
                 this.moveDownButton = button;
             },
         };
-        if (!item.hasMoveDown) {
-            props.disabled = true;
-        }
 
         return React.createElement(LIMEL_ICON_BUTTON, props);
     }


### PR DESCRIPTION
Since it looks like this issue was introduced in [this PR](https://github.com/Lundalogik/lime-elements/pull/3620). I will base this fix based on that branch. Even though it doesn't needs to be merged any specific order.

Fix: https://github.com/Lundalogik/crm-client/issues/193

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the logic controlling the enabled/disabled state of action buttons in array fields for improved maintainability. No visible changes to functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
