### PR TITLE
Refactor slider to use notched outline and add required and invalid props

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -663,6 +663,7 @@ export namespace Components {
         "disabled": boolean;
         "factor": number;
         "helperText": string;
+        "invalid": boolean;
         "label": string;
         "readonly": boolean;
         "step": number;
@@ -1784,6 +1785,7 @@ export namespace JSX {
         "disabled"?: boolean;
         "factor"?: number;
         "helperText"?: string;
+        "invalid"?: boolean;
         "label"?: string;
         "onChange"?: (event: LimelSliderCustomEvent<number>) => void;
         "readonly"?: boolean;

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -666,6 +666,7 @@ export namespace Components {
         "invalid": boolean;
         "label": string;
         "readonly": boolean;
+        "required": boolean;
         "step": number;
         "unit": string;
         "value": number;
@@ -1789,6 +1790,7 @@ export namespace JSX {
         "label"?: string;
         "onChange"?: (event: LimelSliderCustomEvent<number>) => void;
         "readonly"?: boolean;
+        "required"?: boolean;
         "step"?: number;
         "unit"?: string;
         "value"?: number;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -5,14 +5,30 @@
 @use '../../style/internal/lime-theme';
 
 @use '@material/slider/styles';
-@use '@material/floating-label/mdc-floating-label';
 
 :host(limel-slider) {
     isolation: isolate;
     position: relative;
-
     display: flex;
     flex-direction: column;
+}
+
+:host(limel-slider:not([invalid]):not([invalid='true'])),
+// We don't want the gray notched outlines around the slider by default
+:host(limel-slider[disabled]:not([disabled='false'])) {
+    .limel-notched-outline {
+        --limel-notched-outline-border-color: transparent;
+        --limel-notched-outline-background-color: transparent;
+    }
+    // and we don't want the `disabled` but `invalid` slider to show any
+    // red lines. Since users cannot do anything to fix a disabled but invalid slider
+}
+
+div[slot='content'] {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 0 0.25rem;
 }
 
 .mdc-slider {
@@ -20,7 +36,6 @@
     margin: 0 0.75rem;
 }
 
-.mdc-floating-label,
 .mdc-slider .mdc-slider__value-indicator-text {
     // As long as this component is depended on MDC,
     // we need to force it to be font-agnostic.
@@ -29,16 +44,6 @@
     // other font-related styles that might be set by MDC,
     // such as `letter-spacing` or `font-size`.
     font-family: inherit;
-}
-
-.slider__label {
-    padding-left: functions.pxToRem(20);
-    top: 0.75rem; // To place its label on the same height as other `floating-label`s in a form
-
-    color: shared_input-select-picker.$label-color;
-    :host(limel-slider.disabled:not(.readonly)) & {
-        color: shared_input-select-picker.$label-color-disabled;
-    }
 }
 
 .slider__content-range-container {

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -68,6 +68,12 @@ export class Slider {
     public helperText: string;
 
     /**
+     * Set to `true` to indicate that the slider is required.
+     */
+    @Prop({ reflect: true })
+    public required = false;
+
+    /**
      * Set to `true` to indicate that the current value of the slider is invalid.
      */
     @Prop({ reflect: true })

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -68,6 +68,12 @@ export class Slider {
     public helperText: string;
 
     /**
+     * Set to `true` to indicate that the current value of the slider is invalid.
+     */
+    @Prop({ reflect: true })
+    public invalid = false;
+
+    /**
      * Unit to display next to the value
      */
     @Prop({ reflect: true })
@@ -249,6 +255,7 @@ export class Slider {
             <limel-helper-line
                 helperText={this.helperText}
                 helperTextId={this.helperTextId}
+                invalid={this.invalid}
             />
         );
     };

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -162,60 +162,68 @@ export class Slider {
 
         return (
             <Host class={this.getContainerClassList()}>
-                <label
-                    class="slider__label mdc-floating-label mdc-floating-label--float-above"
-                    id={this.labelId}
+                <limel-notched-outline
+                    labelId={this.labelId}
+                    label={this.label}
+                    required={this.required}
+                    invalid={this.invalid}
+                    disabled={this.disabled}
+                    readonly={this.readonly}
+                    hasValue={!!this.value}
+                    hasFloatingLabel={true}
                 >
-                    {this.label}
-                </label>
-                <div class="slider__content-range-container">
-                    <span class="slider__content-min-label">
-                        {this.multiplyByFactor(this.valuemin)}
-                        {this.unit}
-                    </span>
-                    <span class="slider__content-max-label">
-                        {this.multiplyByFactor(this.valuemax)}
-                        {this.unit}
-                    </span>
-                </div>
-                <div
-                    class={{
-                        'mdc-slider': true,
-                        'mdc-slider--discrete': true,
-                        'mdc-slider--disabled': this.disabled || this.readonly,
-                    }}
-                >
-                    <input
-                        class="mdc-slider__input"
-                        type="range"
-                        min={this.multiplyByFactor(this.valuemin)}
-                        max={this.multiplyByFactor(this.valuemax)}
-                        value={this.multiplyByFactor(this.value)}
-                        name="volume"
-                        aria-labelledby={this.labelId}
-                        aria-controls={this.helperTextId}
-                        {...inputProps}
-                    />
-                    <div class="mdc-slider__track">
-                        <div class="mdc-slider__track--inactive"></div>
-                        <div class="mdc-slider__track--active">
-                            <div class="mdc-slider__track--active_fill"></div>
+                    <div slot="content">
+                        <div class="slider__content-range-container">
+                            <span class="slider__content-min-label">
+                                {this.multiplyByFactor(this.valuemin)}
+                                {this.unit}
+                            </span>
+                            <span class="slider__content-max-label">
+                                {this.multiplyByFactor(this.valuemax)}
+                                {this.unit}
+                            </span>
                         </div>
-                    </div>
-                    <div class="mdc-slider__thumb">
                         <div
-                            class="mdc-slider__value-indicator-container"
-                            aria-hidden="true"
+                            class={{
+                                'mdc-slider': true,
+                                'mdc-slider--discrete': true,
+                                'mdc-slider--disabled':
+                                    this.disabled || this.readonly,
+                            }}
                         >
-                            <div class="mdc-slider__value-indicator">
-                                <span class="mdc-slider__value-indicator-text">
-                                    {this.multiplyByFactor(this.value)}
-                                </span>
+                            <input
+                                class="mdc-slider__input"
+                                type="range"
+                                min={this.multiplyByFactor(this.valuemin)}
+                                max={this.multiplyByFactor(this.valuemax)}
+                                value={this.multiplyByFactor(this.value)}
+                                name="volume"
+                                aria-labelledby={this.labelId}
+                                aria-controls={this.helperTextId}
+                                {...inputProps}
+                            />
+                            <div class="mdc-slider__track">
+                                <div class="mdc-slider__track--inactive"></div>
+                                <div class="mdc-slider__track--active">
+                                    <div class="mdc-slider__track--active_fill"></div>
+                                </div>
+                            </div>
+                            <div class="mdc-slider__thumb">
+                                <div
+                                    class="mdc-slider__value-indicator-container"
+                                    aria-hidden="true"
+                                >
+                                    <div class="mdc-slider__value-indicator">
+                                        <span class="mdc-slider__value-indicator-text">
+                                            {this.multiplyByFactor(this.value)}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="mdc-slider__thumb-knob"></div>
                             </div>
                         </div>
-                        <div class="mdc-slider__thumb-knob"></div>
                     </div>
-                </div>
+                </limel-notched-outline>
                 {this.renderHelperLine()}
             </Host>
         );

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -173,55 +173,8 @@ export class Slider {
                     hasFloatingLabel={true}
                 >
                     <div slot="content">
-                        <div class="slider__content-range-container">
-                            <span class="slider__content-min-label">
-                                {this.multiplyByFactor(this.valuemin)}
-                                {this.unit}
-                            </span>
-                            <span class="slider__content-max-label">
-                                {this.multiplyByFactor(this.valuemax)}
-                                {this.unit}
-                            </span>
-                        </div>
-                        <div
-                            class={{
-                                'mdc-slider': true,
-                                'mdc-slider--discrete': true,
-                                'mdc-slider--disabled':
-                                    this.disabled || this.readonly,
-                            }}
-                        >
-                            <input
-                                class="mdc-slider__input"
-                                type="range"
-                                min={this.multiplyByFactor(this.valuemin)}
-                                max={this.multiplyByFactor(this.valuemax)}
-                                value={this.multiplyByFactor(this.value)}
-                                name="volume"
-                                aria-labelledby={this.labelId}
-                                aria-controls={this.helperTextId}
-                                {...inputProps}
-                            />
-                            <div class="mdc-slider__track">
-                                <div class="mdc-slider__track--inactive"></div>
-                                <div class="mdc-slider__track--active">
-                                    <div class="mdc-slider__track--active_fill"></div>
-                                </div>
-                            </div>
-                            <div class="mdc-slider__thumb">
-                                <div
-                                    class="mdc-slider__value-indicator-container"
-                                    aria-hidden="true"
-                                >
-                                    <div class="mdc-slider__value-indicator">
-                                        <span class="mdc-slider__value-indicator-text">
-                                            {this.multiplyByFactor(this.value)}
-                                        </span>
-                                    </div>
-                                </div>
-                                <div class="mdc-slider__thumb-knob"></div>
-                            </div>
-                        </div>
+                        {this.renderRangeContainer()}
+                        {this.renderSliderContainer(inputProps)}
                     </div>
                 </limel-notched-outline>
                 {this.renderHelperLine()}
@@ -259,6 +212,82 @@ export class Slider {
 
         this.reCreateSliderWithStep();
     }
+
+    private renderRangeContainer = () => {
+        return (
+            <div class="slider__content-range-container">
+                <span class="slider__content-min-label">
+                    {this.multiplyByFactor(this.valuemin)}
+                    {this.unit}
+                </span>
+                <span class="slider__content-max-label">
+                    {this.multiplyByFactor(this.valuemax)}
+                    {this.unit}
+                </span>
+            </div>
+        );
+    };
+
+    private renderSliderContainer = (inputProps: any) => {
+        return (
+            <div
+                class={{
+                    'mdc-slider': true,
+                    'mdc-slider--discrete': true,
+                    'mdc-slider--disabled': this.disabled || this.readonly,
+                }}
+            >
+                {this.renderSliderInput(inputProps)}
+                {this.renderTrack()}
+                {this.renderThumb()}
+            </div>
+        );
+    };
+
+    private renderSliderInput = (inputProps: any) => {
+        return (
+            <input
+                class="mdc-slider__input"
+                type="range"
+                min={this.multiplyByFactor(this.valuemin)}
+                max={this.multiplyByFactor(this.valuemax)}
+                value={this.multiplyByFactor(this.value)}
+                name="volume"
+                aria-labelledby={this.labelId}
+                aria-controls={this.helperTextId}
+                {...inputProps}
+            />
+        );
+    };
+
+    private renderTrack = () => {
+        return (
+            <div class="mdc-slider__track">
+                <div class="mdc-slider__track--inactive" />
+                <div class="mdc-slider__track--active">
+                    <div class="mdc-slider__track--active_fill" />
+                </div>
+            </div>
+        );
+    };
+
+    private renderThumb = () => {
+        return (
+            <div class="mdc-slider__thumb">
+                <div
+                    class="mdc-slider__value-indicator-container"
+                    aria-hidden="true"
+                >
+                    <div class="mdc-slider__value-indicator">
+                        <span class="mdc-slider__value-indicator-text">
+                            {this.multiplyByFactor(this.value)}
+                        </span>
+                    </div>
+                </div>
+                <div class="mdc-slider__thumb-knob" />
+            </div>
+        );
+    };
 
     private renderHelperLine = () => {
         if (!this.helperText) {


### PR DESCRIPTION
continuation of https://github.com/Lundalogik/lime-elements/pull/3518

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for marking the slider as required and indicating invalid states, with corresponding visual cues.

* **Style**
  * Improved the slider’s layout using flexbox and updated styling for the outline and helper line.
  * Simplified label styling and ensured consistent font usage for the value indicator.
  * Enhanced the appearance and conditional display of helper lines and outlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
