### PR TITLE
Remove `@beta` JSDoc tags from some components

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -91,7 +91,7 @@ export interface Chip<T = any> {
     value?: T;
 }
 
-// @beta
+// @public
 export type ChipType = 'default' | 'filter';
 
 // @public (undocumented)
@@ -271,7 +271,6 @@ export namespace Components {
         "selected": boolean;
         "size": 'small' | 'default';
         "text": string;
-        // @beta
         "type"?: ChipType;
     }
     export interface LimelChipSet {
@@ -1343,7 +1342,6 @@ export namespace JSX {
         "selected"?: boolean;
         "size"?: 'small' | 'default';
         "text"?: string;
-        // @beta
         "type"?: ChipType;
     }
     export interface LimelChipSet {

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -213,7 +213,6 @@ export namespace Components {
         "language": Languages;
         "type"?: CalloutType;
     }
-    // @beta
     export interface LimelCard {
         "actions"?: Array<ActionBarItem | ListSeparator>;
         "clickable": boolean;
@@ -1087,8 +1086,6 @@ export namespace JSX {
         "limel-button-group": LimelButtonGroup;
         // (undocumented)
         "limel-callout": LimelCallout;
-        // Warning: (ae-incompatible-release-tags) The symbol ""limel-card"" is marked as @public, but its signature references "JSX" which is marked as @beta
-        //
         // (undocumented)
         "limel-card": LimelCard;
         // Warning: (ae-incompatible-release-tags) The symbol ""limel-chart"" is marked as @public, but its signature references "JSX" which is marked as @beta
@@ -1283,7 +1280,6 @@ export namespace JSX {
         "language"?: Languages;
         "type"?: CalloutType;
     }
-    // @beta
     export interface LimelCard {
         "actions"?: Array<ActionBarItem | ListSeparator>;
         "clickable"?: boolean;

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -252,7 +252,6 @@ export namespace Components {
         "invalid": boolean;
         "label": string;
         "readonly": boolean;
-        // @beta
         "readonlyLabels"?: Array<Label<boolean>>;
         "required": boolean;
     }
@@ -378,7 +377,6 @@ export namespace Components {
         "item": DockItem;
         "useMobileLayout"?: boolean;
     }
-    // @beta
     export interface LimelDynamicLabel {
         "defaultLabel": Omit<Label, 'value'>;
         "labels": Label[];
@@ -707,7 +705,6 @@ export namespace Components {
         "invalid": boolean;
         "label": string;
         "readonly": boolean;
-        // @beta
         "readonlyLabels"?: Array<Label<boolean>>;
         "value": boolean;
     }
@@ -1124,8 +1121,6 @@ export namespace JSX {
         "limel-dock": LimelDock;
         // (undocumented)
         "limel-dock-button": LimelDockButton;
-        // Warning: (ae-incompatible-release-tags) The symbol ""limel-dynamic-label"" is marked as @public, but its signature references "JSX" which is marked as @beta
-        //
         // (undocumented)
         "limel-dynamic-label": LimelDynamicLabel;
         // (undocumented)
@@ -1330,7 +1325,6 @@ export namespace JSX {
         "label"?: string;
         "onChange"?: (event: LimelCheckboxCustomEvent<boolean>) => void;
         "readonly"?: boolean;
-        // @beta
         "readonlyLabels"?: Array<Label<boolean>>;
         "required"?: boolean;
     }
@@ -1476,7 +1470,6 @@ export namespace JSX {
         "onMenuOpen"?: (event: LimelDockButtonCustomEvent<DockItem>) => void;
         "useMobileLayout"?: boolean;
     }
-    // @beta
     export interface LimelDynamicLabel {
         "defaultLabel"?: Omit<Label, 'value'>;
         "labels"?: Label[];
@@ -1840,7 +1833,6 @@ export namespace JSX {
         "label"?: string;
         "onChange"?: (event: LimelSwitchCustomEvent<boolean>) => void;
         "readonly"?: boolean;
-        // @beta
         "readonlyLabels"?: Array<Label<boolean>>;
         "value"?: boolean;
     }
@@ -1932,7 +1924,7 @@ export namespace JSX {
     }
 }
 
-// @beta (undocumented)
+// @public
 export interface Label<T = LabelValue> {
     icon?: string | Icon;
     text?: string;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -27,7 +27,6 @@ import { getMouseEventHandlers } from '../../util/3d-tilt-hover-effect';
  * @exampleComponent limel-example-card-orientation
  * @exampleComponent limel-example-card-slot
  * @exampleComponent limel-example-card-styling
- * @beta
  */
 @Component({
     tag: 'limel-card',

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -23,7 +23,6 @@
 
 limel-dynamic-label {
     margin-top: 0.375rem;
-    margin-left: 0.25rem;
 }
 
 @include checkbox.core-styles;

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -99,7 +99,6 @@ export class Checkbox {
     /**
      * The labels to use to clarify what kind of data is being visualized,
      * when the component is `readonly`.
-     * @beta
      */
     @Prop()
     public readonlyLabels?: Array<Label<boolean>> = [];

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -112,7 +112,6 @@ export interface Chip<T = any> {
 
 /**
  * This type is used to determine the visual style and behavior of a Chip component.
- *
- * @beta
+ * @public
  */
 export type ChipType = 'default' | 'filter';

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -163,7 +163,6 @@ export class Chip implements ChipInterface {
      * Set to `filter` to render the chip with a distinct style
      * suitable for visualizing filters.
      *
-     * @beta
      */
     @Prop({ reflect: true })
     public type?: ChipType = 'default';

--- a/src/components/dynamic-label/dynamic-label.tsx
+++ b/src/components/dynamic-label/dynamic-label.tsx
@@ -18,7 +18,6 @@ import { Icon } from '../../interface';
  *
  * @exampleComponent limel-example-dynamic-label
  * @exampleComponent limel-example-dynamic-label-readonly-boolean
- * @beta
  */
 @Component({
     tag: 'limel-dynamic-label',

--- a/src/components/dynamic-label/label.types.ts
+++ b/src/components/dynamic-label/label.types.ts
@@ -3,7 +3,10 @@ import { Icon } from '../../interface';
 export type LabelValue = string | number | boolean | null | undefined;
 
 /**
- * @beta
+ * Represents a label that can be displayed in the `limel-dynamic-label` component.
+ * Each label has a value that is used to match with the current value of the component.
+ *
+ * @public
  */
 export interface Label<T = LabelValue> {
     /**

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -85,7 +85,6 @@ export class Switch {
     /**
      * The labels to use to clarify what kind of data is being visualized,
      * when the component is `readonly`.
-     * @beta
      */
     @Prop()
     public readonlyLabels?: Array<Label<boolean>> = [];


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated documentation by removing `@beta` tags from various components and properties.
  * Adjusted checkbox component styles by removing left margin from dynamic labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
