### PR TITLE
Replace hardcoded small font sizes with theme variable in SCSS files 

### DIFF
--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -123,7 +123,7 @@
 }
 
 .mdc-chip__text {
-    font-size: functions.pxToRem(13);
+    font-size: var(--limel-theme-default-small-font-size);
     overflow: hidden;
     text-overflow: ellipsis;
     display: block;

--- a/src/components/dynamic-label/dynamic-label.scss
+++ b/src/components/dynamic-label/dynamic-label.scss
@@ -24,7 +24,9 @@ limel-icon {
 
 label {
     flex-grow: 1;
-    font-size: 0.8125rem; // `13px`, Like Checkbox & Switch
+    font-size: var(
+        --limel-theme-default-small-font-size
+    ); // `13px`, Like Checkbox & Switch
     line-height: normal;
     color: var(--limel-theme-on-surface-color);
     padding-top: 0.375rem;

--- a/src/components/form/row/row.scss
+++ b/src/components/form/row/row.scss
@@ -81,7 +81,7 @@
     .description {
         margin: 0;
         color: var(--limel-theme-text-secondary-on-background-color);
-        font-size: 0.8125rem;
+        font-size: var(--limel-theme-default-small-font-size);
         line-height: 1.5;
     }
 

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -66,7 +66,7 @@
 
 .subheading {
     color: var(--header-subheading-color, rgb(var(--contrast-900)));
-    font-size: functions.pxToRem(13);
+    font-size: var(--limel-theme-default-small-font-size);
     font-weight: 400;
 }
 

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -53,7 +53,7 @@ $list-mdc-list-item: 0;
 
 .mdc-deprecated-list-item__secondary-text {
     opacity: 0.6;
-    font-size: 0.8125rem; //13px
+    font-size: var(--limel-theme-default-small-font-size); //13px
 }
 
 .mdc-deprecated-list-item--disabled {
@@ -97,7 +97,7 @@ $list-mdc-list-item: 0;
         all: unset;
         @include mixins.truncate-text;
         color: rgb(var(--contrast-900));
-        font-size: 0.8125rem; // 13px
+        font-size: var(--limel-theme-default-small-font-size); // 13px
     }
 
     .mdc-deprecated-list-item {

--- a/src/components/markdown/partial-styles/_pre-code.scss
+++ b/src/components/markdown/partial-styles/_pre-code.scss
@@ -3,7 +3,7 @@
 
 code {
     @include mixins.font-family(monospace);
-    font-size: functions.pxToRem(13);
+    font-size: var(--limel-theme-default-small-font-size);
     letter-spacing: functions.pxToRem(-0.2);
     color: rgb(var(--contrast-1300));
 

--- a/src/components/menu-list/menu-list.scss
+++ b/src/components/menu-list/menu-list.scss
@@ -22,7 +22,7 @@
     margin: functions.pxToRem(4);
     // added space to visualize keyboard-focused items
     .mdc-deprecated-list-item[role='menuitem'] {
-        font-size: functions.pxToRem(13);
+        font-size: var(--limel-theme-default-small-font-size);
 
         .mdc-deprecated-list-item__graphic {
             margin-right: 0;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -59,7 +59,7 @@ div[slot='content'] {
     }
 
     .mdc-slider__value-indicator-text {
-        font-size: 0.8125rem; //13px
+        font-size: var(--limel-theme-default-small-font-size); //13px
     }
 }
 

--- a/src/components/snackbar/snackbar.scss
+++ b/src/components/snackbar/snackbar.scss
@@ -51,7 +51,7 @@ aside {
     color: rgb(var(--contrast-100));
 
     -webkit-font-smoothing: antialiased;
-    font-size: 0.8125rem;
+    font-size: var(--limel-theme-default-small-font-size);
     font-weight: 400;
     padding: 0 0.25rem;
 

--- a/src/global/core-styles.scss
+++ b/src/global/core-styles.scss
@@ -27,6 +27,7 @@
 
     // The default font size for Lime Elements components.
     --limel-theme-default-font-size: 0.875rem; //14px
+    --limel-theme-default-small-font-size: 0.8125rem; //13px
 }
 
 // ⚠️ This section below is commented out.


### PR DESCRIPTION
We now have an internal CSS variable called
`--limel-theme-default-small-font-size`, that can unify all font sizes that
are `0.8125rem` (`13px`) across all components.<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated various components to use a theme-based variable for small font sizes, replacing hardcoded values for improved consistency and easier theming.
  * Introduced a new CSS custom property for the default small font size, enabling better customization across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
