### PR TITLE
chore(radio-button): remove last MDC leftover

### DIFF
--- a/src/components/list/radio-button/radio-button.template.tsx
+++ b/src/components/list/radio-button/radio-button.template.tsx
@@ -12,27 +12,25 @@ export const RadioButtonTemplate: FunctionalComponent<
     RadioButtonTemplateProps
 > = (props) => {
     return (
-        <div class="mdc-form-field">
-            <div
-                class={{
-                    'boolean-input': true,
-                    'radio-button': true,
-                    checked: props.checked,
-                    disabled: props.disabled,
-                }}
-            >
-                <input
-                    type="radio"
-                    id={props.id}
-                    checked={props.checked}
-                    disabled={props.disabled}
-                    onChange={props.onChange}
-                />
-                <div class="box" />
-                <label class="boolean-input-label" htmlFor={props.id}>
-                    {props.label}
-                </label>
-            </div>
+        <div
+            class={{
+                'boolean-input': true,
+                'radio-button': true,
+                checked: props.checked,
+                disabled: props.disabled,
+            }}
+        >
+            <input
+                type="radio"
+                id={props.id}
+                checked={props.checked}
+                disabled={props.disabled}
+                onChange={props.onChange}
+            />
+            <div class="box" />
+            <label class="boolean-input-label" htmlFor={props.id}>
+                {props.label}
+            </label>
         </div>
     );
 };


### PR DESCRIPTION
There was a wrapper `<div class="mdc-form-field">` remaining from MDC, which we forgot to remove in the last PR.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing features added.
- Refactor
  - Simplified the radio button component’s markup by removing an extra wrapper, with no changes to behavior.
- Style
  - Minor layout adjustment for radio buttons due to markup simplification; label and selection interactions remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
