### PR TITLE
Add Icon interface support to limel-icon-button; update styles and example

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -477,7 +477,7 @@ export namespace Components {
     export interface LimelIconButton {
         "disabled": boolean;
         "elevated": boolean;
-        "icon": string;
+        "icon": string | Icon;
         "label": string;
     }
     export interface LimelInfoTile {
@@ -1590,7 +1590,7 @@ export namespace JSX {
     export interface LimelIconButton {
         "disabled"?: boolean;
         "elevated"?: boolean;
-        "icon"?: string;
+        "icon"?: string | Icon;
         "label"?: string;
     }
     export interface LimelInfoTile {

--- a/src/components/icon-button/examples/icon-button-icon.tsx
+++ b/src/components/icon-button/examples/icon-button-icon.tsx
@@ -1,0 +1,44 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Styling
+ * Using the `Icon` interface, you can easily customize the
+ * appearance of icons within the button, tweaking its `color`,
+ * `backgroundColor`, or adding an accessible `title` to it.
+ */
+@Component({
+    tag: 'limel-example-icon-button-icon',
+    shadow: true,
+})
+export class IconButtonIconExample {
+    @State()
+    private isFavorite = false;
+
+    public render() {
+        return (
+            <limel-icon-button
+                elevated={true}
+                label={this.getLabel()}
+                icon={this.getIcon()}
+                onClick={this.toggleFavorite}
+            />
+        );
+    }
+
+    private getLabel() {
+        return this.isFavorite ? 'Remove Favorite' : 'Add Favorite';
+    }
+
+    private getIcon() {
+        const defaultIcon = 'heart_outlined';
+        const toggledIcon = {
+            name: 'heart_filled',
+            color: 'rgb(var(--color-red-default))',
+        };
+        return this.isFavorite ? toggledIcon : defaultIcon;
+    }
+
+    private toggleFavorite = () => {
+        this.isFavorite = !this.isFavorite;
+    };
+}

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -1,9 +1,5 @@
 @use '../../style/mixins';
 
-/**
- * @prop --icon-background-color: Background color of the button.
- */
-
 :host([hidden]) {
     display: none;
 }

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -44,5 +44,6 @@ button {
 }
 
 limel-icon {
-    width: 1.25rem;
+    padding: 0.25rem;
+    width: 1.75rem;
 }

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -4,12 +4,15 @@ import {
     removeEnterClickable,
 } from '../../util/make-enter-clickable';
 import { createRandomString } from '../../util/random-string';
+import { Icon } from '../../global/shared-types/icon.types';
+import { getIconName, getIconTitle } from '../icon/get-icon-props';
 
 /**
  * @exampleComponent limel-example-icon-button-basic
  * @exampleComponent limel-example-icon-button-disabled
  * @exampleComponent limel-example-icon-button-elevated
  * @exampleComponent limel-example-icon-button-toggle-state
+ * @exampleComponent limel-example-icon-button-icon
  * @exampleComponent limel-example-icon-button-composite
  */
 @Component({
@@ -21,8 +24,8 @@ export class IconButton {
     /**
      * The icon to display.
      */
-    @Prop({ reflect: true })
-    public icon: string;
+    @Prop()
+    public icon: string | Icon;
 
     /**
      * Set to `true` to give the button our standard "elevated" look, lifting
@@ -85,12 +88,32 @@ export class IconButton {
                     id={this.tooltipId}
                     {...buttonAttributes}
                 >
-                    <limel-icon name={this.icon} badge={true} />
+                    {this.renderIcon()}
                     {this.renderTooltip(this.tooltipId)}
                 </button>
             </Host>
         );
     }
+
+    private renderIcon() {
+        const icon = getIconName(this.icon);
+        const title = getIconTitle(this.icon);
+
+        return (
+            <limel-icon
+                name={icon}
+                aria-label={title}
+                aria-hidden={title ? null : 'true'}
+                style={{
+                    color: `${(this.icon as Icon)?.color}`,
+                    '--icon-background-color': `${
+                        (this.icon as Icon)?.backgroundColor
+                    }`,
+                }}
+            />
+        );
+    }
+
     private renderTooltip(tooltipId) {
         if (this.label) {
             return <limel-tooltip elementId={tooltipId} label={this.label} />;


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/lime-elements/issues/3666
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Icon Button now accepts rich icons with customizable color and background, improving flexibility and accessibility (dynamic labels and aria handling).
- Style
  - Increased icon size and added padding inside the button for clearer visuals and spacing.
- Documentation
  - Added an example demonstrating a toggleable “favorite” Icon Button, showcasing label/icon changes and styling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
