### PR TITLE
fix(card): skip image rendering when no src provided

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -130,7 +130,7 @@ export class Card {
     }
 
     private renderImage() {
-        if (!this.image) {
+        if (!this.image?.src) {
             return;
         }
 


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/crm-client/issues/249
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where cards could render a broken/empty image when the image source was missing or blank.
  * Cards now display an image only when a valid source is available, preventing broken image placeholders.
  * Improves visual consistency and reduces layout glitches by hiding the image area when no valid image is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
