### PR TITLE
Add custom palettes and configurable columns to color picker 

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -324,6 +324,8 @@ export namespace Components {
     export interface LimelColorPicker {
         "helperText": string;
         "label": string;
+        "palette"?: Array<string | CustomColorSwatch>;
+        "paletteColumnCount"?: number;
         "readonly": boolean;
         "required": boolean;
         "tooltipLabel": string;
@@ -331,8 +333,10 @@ export namespace Components {
     }
     // (undocumented)
     export interface LimelColorPickerPalette {
+        "columnCount"?: number;
         "helperText": string;
         "label": string;
+        "palette"?: CustomPalette;
         "required": boolean;
         "value": string;
     }
@@ -823,6 +827,13 @@ export type Config = {
     featureSwitches?: Record<string, boolean>;
 };
 
+// @public
+export interface CustomColorSwatch {
+    disabled?: boolean;
+    name?: string;
+    value: string;
+}
+
 // @alpha
 export type CustomElement = Omit<CustomElementDefinition, 'attributes'> & {
     attributes: Record<string, any>;
@@ -835,6 +846,9 @@ export interface CustomElementDefinition {
     // (undocumented)
     tagName: string;
 }
+
+// @public
+export type CustomPalette = Array<string | CustomColorSwatch>;
 
 // @public (undocumented)
 export type DateType = 'datetime' | 'date' | 'time' | 'week' | 'month' | 'quarter' | 'year';
@@ -1460,6 +1474,8 @@ export namespace JSX {
         "helperText"?: string;
         "label"?: string;
         "onChange"?: (event: LimelColorPickerCustomEvent<string>) => void;
+        "palette"?: Array<string | CustomColorSwatch>;
+        "paletteColumnCount"?: number;
         "readonly"?: boolean;
         "required"?: boolean;
         "tooltipLabel"?: string;
@@ -1467,9 +1483,11 @@ export namespace JSX {
     }
     // (undocumented)
     export interface LimelColorPickerPalette {
+        "columnCount"?: number;
         "helperText"?: string;
         "label"?: string;
         "onChange"?: (event: LimelColorPickerPaletteCustomEvent<string>) => void;
+        "palette"?: CustomPalette;
         "required"?: boolean;
         "value"?: string;
     }

--- a/src/components/color-picker/color-picker-palette.scss
+++ b/src/components/color-picker/color-picker-palette.scss
@@ -1,68 +1,148 @@
-@use '../../design-guidelines/color-system/examples/extended-color-palette';
+@use '../../style/internal/shared_input-select-picker';
 @use '../../style/mixins';
-@import './color-picker';
+@import './partial-styles/lime-admin-hack';
 
-:host {
+:host(limel-color-picker-palette) {
+    --limel-color-palette-gap: 0.25rem;
+    --limel-color-palette-max-column-count: 25;
+    --limel-color-palette-min-width: 8rem;
+    box-sizing: border-box;
+
     border-radius: 0.75rem; // is like popover's default `--popover-border-radius`
-    background-color: rgb(var(--kompendium-contrast-300));
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0.75rem;
+}
+
+*,
+*:before,
+:after {
+    box-sizing: border-box;
 }
 
 .color-picker-palette {
     display: grid;
-    gap: 0.25rem;
-    grid-auto-flow: column;
-    grid-template-columns: repeat(20, 1fr);
-    grid-template-rows: repeat(4, 1fr) auto;
-    margin: 1rem;
+    gap: var(--limel-color-palette-gap);
+    grid-template-columns: repeat(
+        min(
+            var(--color-picker-column-count),
+            var(--limel-color-palette-max-column-count)
+        ),
+        1fr
+    );
+    width: 100%;
+    max-width: 58rem;
+    min-width: var(--limel-color-palette-min-width);
 }
 
 .chosen-color-name {
-    box-sizing: border-box;
-    padding: 1rem;
-    display: grid;
-    grid-template-columns: 1fr auto;
+    display: flex;
     gap: 0.5rem;
 }
 
-.chosen-color-preview {
-    border: 1px solid rgba(var(--contrast-700), 0.65); // color is the same as
-    // colors in shared_input-select-picker.scss
-    border-radius: 50%;
+limel-input-field {
+    flex-grow: 1;
+    width: min-content;
 }
 
-.swatch:not(.hue) {
-    border: none;
+.chosen-color-preview {
+    flex-shrink: 0;
+    isolation: isolate;
+
+    position: relative;
+    width: shared_input-select-picker.$height-of-mdc-text-field;
+    height: shared_input-select-picker.$height-of-mdc-text-field;
+
+    border: 1px solid rgba(var(--contrast-700), 0.65);
+    border-radius: 50%;
+
+    &:before,
+    &:after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+    }
+
+    &:before {
+        @include mixins.add-chessboard-background();
+        z-index: 0;
+    }
+
+    &:after {
+        background: var(--background);
+        z-index: 1;
+    }
+}
+
+button.swatch {
+    all: unset;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    max-width: 3rem;
+    min-width: max(
+        2rem,
+        100% /
+            min(
+                var(--color-picker-column-count),
+                var(--limel-color-palette-max-column-count)
+            ) -
+            (
+                min(
+                        var(--color-picker-column-count),
+                        var(--limel-color-palette-max-column-count)
+                    ) -
+                    1
+            ) *
+            var(--limel-color-palette-gap)
+    );
     aspect-ratio: 1;
+    border-radius: 0.1875rem;
 
     @include mixins.visualize-keyboard-focus();
 
-    // We could use the `@include mixins.is-flat-clickable();` mixin
-    // But its `background-color` arguments would interfere with the
-    // styles here. So we just copy/pasted the useful parts of the mixin here
-    transition:
-        color 0.2s ease,
-        background-color 0.2s ease,
-        box-shadow 0.2s ease,
-        transform 0.1s ease-out;
-
-    &:hover {
-        box-shadow: var(--button-shadow-hovered);
+    // Since the background color will be overwritten by the mixin,
+    // we need to set it explicitly here and repeated in the mixin.
+    background-color: var(--limel-color-picker-swatch-color);
+    &:not([disabled]) {
+        @include mixins.is-flat-clickable(
+            $background-color: var(--limel-color-picker-swatch-color),
+            $background-color--hovered: var(--limel-color-picker-swatch-color)
+        );
     }
-
-    &:active {
-        box-shadow: var(--button-shadow-pressed);
-
-        transform: translate3d(0, 0.08rem, 0);
-    }
-    cursor: pointer;
 
     &:focus-visible {
         box-shadow:
             var(--shadow-depth-8-focused),
-            0 0 0 0.25rem rgb(var(--contrast-100)) inset;
+            0 0 0 0.125rem rgb(var(--contrast-100)) inset;
+    }
+
+    &[disabled] {
+        cursor: not-allowed;
+        box-shadow: 0 0 0 0.125rem rgb(var(--contrast-100), 0.6) inset;
+
+        &:after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            margin: auto;
+            width: 0.125rem;
+            height: 100%;
+
+            opacity: 0.6;
+            rotate: 45deg;
+            border-radius: 1rem;
+            background-color: rgb(var(--contrast-100));
+        }
     }
 }
 
-.swatch--selected {
+button.swatch--selected {
+    box-shadow: var(--button-shadow-inset);
+
     border-radius: 50%;
 }

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -136,7 +136,8 @@ export class Palette implements FormComponent {
 
     private handleSwatchClick = (value: string) => (event: MouseEvent) => {
         event.stopPropagation();
-        this.change.emit(value);
+        const newValue = this.value === value ? '' : value;
+        this.change.emit(newValue);
     };
 
     private normalizeEntry(

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
 import { FormComponent } from '../form/form.types';
-import { brightnesses, colors, getColorName, getCssColor } from './swatches';
+import { brightnesses, colors, createSwatch, Swatch } from './swatches';
+import type { CustomPalette, CustomColorSwatch } from './color-picker.types';
 
 /**
  * @private
@@ -36,6 +37,19 @@ export class Palette implements FormComponent {
     public required: boolean;
 
     /**
+     * Defines the number of columns in the color swatch grid.
+     * If not provided, it will default to the number of colors in the palette.
+     */
+    @Prop({ reflect: true })
+    public columnCount?: number;
+
+    /**
+     * Custom color palette to use instead of Lime palette. Internal prop passed from parent.
+     */
+    @Prop()
+    public palette?: CustomPalette;
+
+    /**
      * Emits chosen value to the parent component
      */
     @Event()
@@ -45,7 +59,14 @@ export class Palette implements FormComponent {
         const background = this.value ? { '--background': this.value } : {};
 
         return [
-            <div class="color-picker-palette">{this.renderSwatches()}</div>,
+            <div
+                class="color-picker-palette"
+                style={{
+                    '--color-picker-column-count': `${this.getColumnCount()}`,
+                }}
+            >
+                {this.renderSwatches()}
+            </div>,
             <div class="chosen-color-name">
                 <limel-input-field
                     label={this.label}
@@ -60,23 +81,50 @@ export class Palette implements FormComponent {
     }
 
     private renderSwatches = () => {
-        return colors.map((color) => {
-            return brightnesses.map(this.renderSwatch(color));
-        });
+        return this.getPalette().map(this.renderSwatchButton);
     };
 
-    private renderSwatch = (color: string) => (brightness: string) => {
-        const colorName = getColorName(color, brightness);
+    private getPalette(): Swatch[] {
+        if (this.usesCustomPalette()) {
+            return (this.palette || []).map((entry) => {
+                const normalized = this.normalizeEntry(entry);
+                return {
+                    name: normalized.name || normalized.value,
+                    value: normalized.value,
+                    disabled: normalized.disabled,
+                };
+            });
+        }
+
+        // Order default swatches by brightness first, then by color.
+        // This gives a more intuitive CSS grid layout logic, and
+        // enables adding the `columnCount` prop.
+        const swatches: Swatch[] = [];
+        for (const b of brightnesses) {
+            for (const color of colors) {
+                swatches.push(createSwatch(color, b));
+            }
+        }
+        return swatches;
+    }
+
+    private renderSwatchButton = (swatch: Swatch, index: number) => {
+        const isSelected = this.value === swatch.value;
         const classList = {
             swatch: true,
-            [colorName]: true,
-            'swatch--selected': this.value === getCssColor(color, brightness),
+            'swatch--selected': isSelected,
+            'custom-swatch': this.usesCustomPalette(),
         };
 
         return (
             <button
                 class={classList}
-                onClick={this.handleClick(color, brightness)}
+                style={{ '--limel-color-picker-swatch-color': swatch.value }}
+                title={swatch.name}
+                disabled={swatch.disabled}
+                data-index={index}
+                key={index}
+                onClick={this.handleSwatchClick(swatch.value)}
             />
         );
     };
@@ -86,10 +134,36 @@ export class Palette implements FormComponent {
         this.change.emit(event.detail);
     };
 
-    private handleClick =
-        (color: string, brightness: string) => (event: MouseEvent) => {
-            const value = getCssColor(color, brightness);
-            event.stopPropagation();
-            this.change.emit(value);
-        };
+    private handleSwatchClick = (value: string) => (event: MouseEvent) => {
+        event.stopPropagation();
+        this.change.emit(value);
+    };
+
+    private normalizeEntry(
+        entry: string | CustomColorSwatch
+    ): CustomColorSwatch {
+        if (typeof entry === 'string') {
+            return { value: entry };
+        }
+        return entry;
+    }
+
+    private usesCustomPalette(): boolean {
+        return this.palette?.length > 0;
+    }
+
+    private getColumnCount(): number {
+        if (this.columnCount > 0) {
+            return this.columnCount;
+        }
+
+        // Default palette: fixed 20 columns (one per base color)
+        if (!this.usesCustomPalette()) {
+            return 20;
+        }
+
+        // Custom palette: span all provided swatches unless empty
+        const palette = this.getPalette();
+        return palette.length > 0 ? palette.length : 1;
+    }
 }

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -2,9 +2,8 @@
 @use '../../style/internal/shared_input-select-picker';
 @import './partial-styles/lime-admin-hack';
 
-:host {
-    position: relative;
-    --popover-surface-width: 50rem;
+:host(limel-color-picker) {
+    isolation: isolate;
 }
 
 .color-picker {
@@ -24,7 +23,6 @@
     }
 }
 
-.chosen-color-preview,
 .picker-trigger {
     box-sizing: border-box;
     position: relative;

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -3,32 +3,25 @@
 @import './partial-styles/lime-admin-hack';
 
 :host(limel-color-picker) {
-    isolation: isolate;
-}
-
-.color-picker {
     display: grid;
     gap: 0.25rem;
     grid-template-columns: auto 1fr;
 }
 
-.picker-trigger {
+button[slot='trigger'] {
     all: unset;
-    border-radius: 0.5rem;
-    @include mixins.is-elevated-clickable();
-    @include mixins.visualize-keyboard-focus();
-
-    &:after {
-        box-shadow: 0 0 0 0.25rem rgb(var(--contrast-100)) inset;
-    }
-}
-
-.picker-trigger {
     box-sizing: border-box;
     position: relative;
     isolation: isolate;
     width: shared_input-select-picker.$height-of-mdc-text-field;
     height: shared_input-select-picker.$height-of-mdc-text-field;
+
+    border-radius: 0.5rem;
+
+    &:not([disabled]):not([disabled='true']) {
+        @include mixins.is-elevated-clickable();
+        @include mixins.visualize-keyboard-focus();
+    }
 
     &:before,
     &:after {
@@ -44,29 +37,28 @@
     }
 
     &:after {
-        background: var(--background);
         z-index: 1;
+        box-shadow: 0 0 0 0.25rem rgb(var(--contrast-100)) inset;
+        background: var(--background);
     }
 }
 
-:host([readonly]) {
-    .picker-trigger {
-        &:hover,
-        &:active {
-            cursor: default;
-            box-shadow: var(--button-shadow-normal);
-            transform: none;
-        }
-    }
-}
-
-.chosen-color-input[readonly] {
-    transform: translateX(
-            calc(
-                #{shared_input-select-picker.$height-of-mdc-text-field} / 4 * -1
+:host([readonly]:not([readonly='false'])) {
+    limel-input-field {
+        transform: translateX(
+                calc(
+                    #{shared_input-select-picker.$height-of-mdc-text-field} /
+                        4 * -1
+                )
             )
-        )
-        translateY(
-            calc(#{shared_input-select-picker.$height-of-mdc-text-field} / 4)
-        );
+            translateY(
+                calc(
+                    #{shared_input-select-picker.$height-of-mdc-text-field} / 4
+                )
+            );
+    }
+
+    button[slot='trigger'] {
+        border: 1px solid rgba(var(--contrast-700), 0.65);
+    }
 }

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -26,15 +26,13 @@ test('the component renders', () => {
     expect(page.body).toEqualHtml(`
         <limel-color-picker label="Hair color">
             <mock:shadow-root>
-                    <div class="color-picker">
-                        <limel-popover opendirection="bottom-start">
-                            <button class="picker-trigger" id="tooltip-button" role="button" slot="trigger"></button>
-                            <limel-color-picker-palette label="Hair color">
-                                <mock:shadow-root></mock:shadow-root>
-                            </limel-color-picker-palette>
-                        </limel-popover>
-                        <limel-input-field class="chosen-color-input" label="Hair color"></limel-input-field>
-                    </div>
+                <limel-popover opendirection="bottom-start">
+                    <button id="tooltip-button" role="button" slot="trigger"></button>
+                    <limel-color-picker-palette label="Hair color">
+                        <mock:shadow-root></mock:shadow-root>
+                    </limel-color-picker-palette>
+                </limel-popover>
+                <limel-input-field label="Hair color"></limel-input-field>
             </mock:shadow-root>
         </limel-color-picker>`);
 });

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -43,9 +43,12 @@ test('the component renders all colors in the palette', () => {
     for (const color of colors) {
         for (const brightness of brightnesses) {
             const swatchElement = getSwatchElement(color, brightness);
-            expect(swatchElement).toEqualHtml(`
-                <button class="--color-${color}-${brightness} swatch"></button>
-            `);
+            expect(swatchElement).not.toBeNull();
+            expect(swatchElement).toHaveClass('swatch');
+            const expectedStyle = `--limel-color-picker-swatch-color: rgb(var(--color-${color}-${brightness}))`;
+            expect(swatchElement.getAttribute('style')).toContain(
+                expectedStyle
+            );
         }
     }
 });
@@ -77,6 +80,54 @@ test('swatch is set to selected when a value is set', async () => {
     expect(swatchElement).not.toHaveClass('swatch--selected');
 });
 
+describe('with a custom palette', () => {
+    let customPage: SpecPage;
+    let customHandleChange: jest.Mock;
+    const customPalette = [
+        { name: 'Primary', value: '#112233' },
+        '#abcdef',
+        { name: 'Disabled', value: 'rebeccapurple', disabled: true },
+    ];
+
+    beforeEach(async () => {
+        customHandleChange = jest.fn();
+        customPage = await newSpecPage({
+            components: [ColorPicker, Palette],
+            template: () => (
+                <limel-color-picker
+                    label="Custom"
+                    palette={customPalette}
+                    onChange={customHandleChange}
+                />
+            ),
+        });
+        await customPage.waitForChanges();
+    });
+
+    test('renders only the provided custom swatches', () => {
+        const palette = customPage.body
+            .querySelector('limel-color-picker')
+            .shadowRoot.querySelector('limel-color-picker-palette').shadowRoot;
+        const buttons = palette.querySelectorAll('button.custom-swatch');
+        expect(buttons.length).toBe(customPalette.length);
+    });
+
+    test('emits raw color value when a custom swatch is clicked', async () => {
+        const palette = customPage.body
+            .querySelector('limel-color-picker')
+            .shadowRoot.querySelector('limel-color-picker-palette').shadowRoot;
+        const secondButton = palette.querySelectorAll(
+            'button.custom-swatch'
+        )[1] as HTMLButtonElement;
+        secondButton.click();
+        await customPage.waitForChanges();
+        expect(customHandleChange).toHaveBeenCalledWith(
+            expect.objectContaining({ detail: '#abcdef' })
+        );
+    });
+});
+
+// Helpers
 function getPickerElement(): HTMLLimelColorPickerElement {
     return page.body.querySelector('limel-color-picker');
 }
@@ -87,8 +138,18 @@ function getPaletteElement(): HTMLLimelColorPickerPaletteElement {
     );
 }
 
-function getSwatchElement(color: string, brightness: string): HTMLDivElement {
-    return getPaletteElement().shadowRoot.querySelector(
-        `.--color-${color}-${brightness}`
+function getSwatchElement(
+    color: string,
+    brightness: string
+): HTMLButtonElement {
+    const expectedValue = `rgb(var(--color-${color}-${brightness}))`;
+    const buttons = [
+        ...getPaletteElement().shadowRoot.querySelectorAll('button.swatch'),
+    ] as HTMLButtonElement[];
+    return buttons.find(
+        (btn) =>
+            btn.style
+                .getPropertyValue('--limel-color-picker-swatch-color')
+                .trim() === expectedValue
     );
 }

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -1,4 +1,12 @@
-import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import {
+    Component,
+    h,
+    Prop,
+    State,
+    Event,
+    EventEmitter,
+    Host,
+} from '@stencil/core';
 import { FormComponent } from '../form/form.types';
 import type { CustomColorSwatch } from './color-picker.types';
 
@@ -96,11 +104,10 @@ export class ColorPicker implements FormComponent {
     private shouldFocus = false;
 
     public render() {
-        return [
-            this.renderTooltip(),
-            <div class="color-picker">
+        return (
+            <Host>
+                {this.renderTooltip()}
                 {this.renderPickerPalette()}
-
                 <limel-input-field
                     label={this.label}
                     helperText={this.helperText}
@@ -108,10 +115,9 @@ export class ColorPicker implements FormComponent {
                     onChange={this.handleChange}
                     required={this.required}
                     readonly={this.readonly}
-                    class="chosen-color-input"
                 />
-            </div>,
-        ];
+            </Host>
+        );
     }
     private renderTooltip = () => {
         if (!this.readonly && this.tooltipLabel) {
@@ -155,7 +161,6 @@ export class ColorPicker implements FormComponent {
 
         return (
             <button
-                class="picker-trigger"
                 slot="trigger"
                 style={background}
                 role="button"

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -161,6 +161,7 @@ export class ColorPicker implements FormComponent {
                 role="button"
                 onClick={this.openPopover}
                 id="tooltip-button"
+                disabled={this.readonly}
             />
         );
     };

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -1,5 +1,6 @@
 import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
 import { FormComponent } from '../form/form.types';
+import type { CustomColorSwatch } from './color-picker.types';
 
 /**
  * This component enables you to select a swatch from out color palette, simply
@@ -14,6 +15,7 @@ import { FormComponent } from '../form/form.types';
  *
  * @exampleComponent limel-example-color-picker
  * @exampleComponent limel-example-color-picker-readonly
+ * @exampleComponent limel-example-color-picker-custom-palette
  */
 @Component({
     tag: 'limel-color-picker',
@@ -56,6 +58,22 @@ export class ColorPicker implements FormComponent {
      */
     @Prop({ reflect: true })
     public readonly: boolean;
+
+    /**
+     * An array of either color value strings, or objects with a `name` and a `value`,
+     * which replaces the default palette. Any valid CSS color format is accepted as value
+     * (HEX, RGB/A, HSL, HWB, color-mix(), named colors, etc.).
+     */
+    @Prop()
+    public palette?: Array<string | CustomColorSwatch>;
+
+    /**
+     * Defines the number of columns in the color swatch grid.
+     * If not provided, it will default to the number of colors in the palette;
+     * but stops at a maximum of 25 columns.
+     */
+    @Prop({ reflect: true })
+    public paletteColumnCount?: number;
 
     /**
      * Emits chosen value to the parent component
@@ -125,6 +143,8 @@ export class ColorPicker implements FormComponent {
                     helperText={this.helperText}
                     onChange={this.handleChange}
                     required={this.required}
+                    palette={this.palette as any}
+                    columnCount={this.paletteColumnCount}
                 />
             </limel-popover>
         );

--- a/src/components/color-picker/color-picker.types.ts
+++ b/src/components/color-picker/color-picker.types.ts
@@ -1,0 +1,24 @@
+/**
+ * Represents a single custom color swatch that can be supplied to the color picker.
+ * @public
+ */
+export interface CustomColorSwatch {
+    /**
+     * Human readable name used for tooltip / accessibility. If omitted, `value` is shown.
+     */
+    name?: string;
+    /**
+     * Any valid CSS color (hex, rgb[a], hsl[a], lab, lch, color-mix(), named, etc.).
+     */
+    value: string;
+    /**
+     * Disables the swatch when true.
+     */
+    disabled?: boolean;
+}
+
+/**
+ * A custom palette: each entry is either a color string or a structured swatch object.
+ * @public
+ */
+export type CustomPalette = Array<string | CustomColorSwatch>;

--- a/src/components/color-picker/examples/color-picker-custom-palette.tsx
+++ b/src/components/color-picker/examples/color-picker-custom-palette.tsx
@@ -1,0 +1,76 @@
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Custom palette example
+ * You can easily provide your own array of colors, to be rendered
+ * as a palette of swatches. To improve accessibility, we recommend that you
+ * also provide a name for each color, which will be used as tooltip
+ * and screen reader text.
+ *
+ * :::note
+ * The number of provided colors will determine the number of columns
+ * in the palette.
+ *
+ * However, if the provided array includes many colors,
+ * the grid will render at the maximum only 25 columns to avoid
+ * unusable UI.
+ *
+ * If you want to control the number of columns, you can
+ * use the `paletteColumnCount` prop.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-color-picker-custom-palette',
+    shadow: true,
+})
+export class ColorPickerCustomPaletteExample {
+    @State()
+    private value: string;
+
+    @State()
+    private paletteColumnCount: number;
+
+    private customPalette = [
+        { name: 'Brand Primary', value: '#0055ff' },
+        { name: 'Brand Secondary', value: '#ff0099' },
+        '#ffbf00',
+        'rebeccapurple',
+        { name: 'Deprecated Green', value: 'hsl(150 60% 45%)', disabled: true },
+        { name: 'Soft Gray', value: 'rgb(120 130 140 / 60%)' },
+    ];
+
+    public render() {
+        return (
+            <Host>
+                <limel-color-picker
+                    value={this.value}
+                    palette={this.customPalette}
+                    tooltipLabel="Click to pick a custom palette color"
+                    label="Brand color"
+                    onChange={this.onChange}
+                    paletteColumnCount={this.paletteColumnCount}
+                />
+                <limel-example-controls
+                    style={{
+                        '--example-controls-column-layout': 'auto-fit',
+                    }}
+                >
+                    <limel-checkbox
+                        checked={this.paletteColumnCount === 3}
+                        label="Set `paletteColumnCount` to 3"
+                        onChange={this.setPaletteColumnCount}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private onChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+
+    private setPaletteColumnCount = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.paletteColumnCount = event.detail ? 3 : undefined;
+    };
+}

--- a/src/components/color-picker/swatches.ts
+++ b/src/components/color-picker/swatches.ts
@@ -23,20 +23,58 @@ export const colors = [
 
 export const brightnesses = ['lighter', 'light', 'default', 'dark', 'darker'];
 
+export interface Swatch {
+    name: string;
+    value: string;
+    disabled?: boolean;
+}
+
 /**
+ * Returns the CSS variable name holding the RGB triplet for the color & brightness.
  *
- * @param color
- * @param brightness
+ * @param color the base color identifier (e.g. "red", "blue")
+ * @param brightness the brightness variant (e.g. "light", "default")
+ * @returns CSS variable name in the form --color-{color}-{brightness}
  */
 export function getColorName(color: string, brightness: string): string {
     return `--color-${color}-${brightness}`;
 }
 
 /**
- *
+ * Swatch value: inline CSS color value in the required format: rgb(var(--color-*-*))
+ * @param color
+ * @param brightness
+ */
+export function getSwatchValue(color: string, brightness: string): string {
+    return `rgb(var(${getColorName(color, brightness)}))`;
+}
+
+/**
+ * Swatch name: human readable label like "red default"
+ * @param color
+ * @param brightness
+ */
+export function getSwatchName(color: string, brightness: string): string {
+    return `${color} ${brightness}`;
+}
+
+/**
+ * Convenience factory returning both name & value.
+ * @param color
+ * @param brightness
+ */
+export function createSwatch(color: string, brightness: string): Swatch {
+    return {
+        name: getSwatchName(color, brightness),
+        value: getSwatchValue(color, brightness),
+    };
+}
+
+/**
+ * Returns the CSS color value for the given color and brightness.
  * @param color
  * @param brightness
  */
 export function getCssColor(color: string, brightness: string): string {
-    return `rgb(var(${getColorName(color, brightness)}))`;
+    return getSwatchValue(color, brightness);
 }


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
required for https://github.com/Lundalogik/hack-tuesday/issues/430
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Color Picker now supports custom palettes (named and disabled swatches) and a configurable column count.
* Style
  * Responsive palette layout with flexible columns.
  * Refined swatch buttons with clearer selected, focus, hover, and disabled states.
  * Updated trigger styling with consistent border radius and improved keyboard focus visuals.
* Tests
  * Added tests validating custom palette rendering and interactions.
* Documentation
  * New example showcasing custom palettes and adjustable column count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
