### PR TITLE
fix(radio-button-group): use internal import path for types

### DIFF
--- a/src/components/radio-button-group/radio-button-group.tsx
+++ b/src/components/radio-button-group/radio-button-group.tsx
@@ -1,6 +1,6 @@
 import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
 import { ListItem, ListSeparator } from '../list-item/list-item.types';
-import { LimelListCustomEvent } from '@limetech/lime-elements';
+import { LimelListCustomEvent } from '../../components';
 
 /**
  * The Radio Button component provides a convenient way to create a group of radio buttons


### PR DESCRIPTION
Update import path from '@limetech/lime-elements' to '../../components'.

This change is necessary because lime-elements cannot import from itself. Using the package name '@limetech/lime-elements' in imports within the src/ directory would create circular dependencies and cause issues with the components.d.ts file generation.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
