### PR TITLE
feat(color-picker): allow disabling manual input by users

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -326,6 +326,7 @@ export namespace Components {
         "helperText": string;
         "invalid": boolean;
         "label": string;
+        "manualInput": boolean;
         "palette"?: Array<string | CustomColorSwatch>;
         "paletteColumnCount"?: number;
         "placeholder": string;
@@ -340,6 +341,7 @@ export namespace Components {
         "helperText": string;
         "invalid": boolean;
         "label": string;
+        "manualInput": boolean;
         "palette"?: CustomPalette;
         "placeholder": string;
         "required": boolean;
@@ -1480,6 +1482,7 @@ export namespace JSX {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
+        "manualInput"?: boolean;
         "onChange"?: (event: LimelColorPickerCustomEvent<string>) => void;
         "palette"?: Array<string | CustomColorSwatch>;
         "paletteColumnCount"?: number;
@@ -1495,6 +1498,7 @@ export namespace JSX {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
+        "manualInput"?: boolean;
         "onChange"?: (event: LimelColorPickerPaletteCustomEvent<string>) => void;
         "palette"?: CustomPalette;
         "placeholder"?: string;

--- a/src/components/color-picker/color-picker-palette.tsx
+++ b/src/components/color-picker/color-picker-palette.tsx
@@ -51,6 +51,12 @@ export class Palette implements FormComponent {
     public invalid = false;
 
     /**
+     * Set to `false` to disallow custom color values to be typed into the input field.
+     */
+    @Prop({ reflect: true })
+    public manualInput = true;
+
+    /**
      * Defines the number of columns in the color swatch grid.
      * If not provided, it will default to the number of colors in the palette.
      */
@@ -90,6 +96,7 @@ export class Palette implements FormComponent {
                     required={this.required}
                     invalid={this.invalid}
                     placeholder={this.placeholder}
+                    disabled={!this.manualInput}
                 />
                 <div class="chosen-color-preview" style={background} />
             </div>,

--- a/src/components/color-picker/color-picker.spec.tsx
+++ b/src/components/color-picker/color-picker.spec.tsx
@@ -24,11 +24,11 @@ test('the component renders', () => {
     palette.shadowRoot.innerHTML = '';
 
     expect(page.body).toEqualHtml(`
-        <limel-color-picker label="Hair color">
+        <limel-color-picker label="Hair color" manual-input="">
             <mock:shadow-root>
                 <limel-popover opendirection="bottom-start">
                     <button id="tooltip-button" role="button" slot="trigger"></button>
-                    <limel-color-picker-palette label="Hair color">
+                    <limel-color-picker-palette label="Hair color" manual-input="">
                         <mock:shadow-root></mock:shadow-root>
                     </limel-color-picker-palette>
                 </limel-popover>

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -21,7 +21,7 @@ import type { CustomColorSwatch } from './color-picker.types';
  * Make sure to read our [guidelines about usage of colors](/#/DesignGuidelines/color-system.md/) from our palette.
  * :::
  *
- * @exampleComponent limel-example-color-picker
+ * @exampleComponent limel-example-color-picker-basic
  * @exampleComponent limel-example-color-picker-readonly
  * @exampleComponent limel-example-color-picker-custom-palette
  * @exampleComponent limel-example-color-picker-manual-input

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -24,6 +24,7 @@ import type { CustomColorSwatch } from './color-picker.types';
  * @exampleComponent limel-example-color-picker
  * @exampleComponent limel-example-color-picker-readonly
  * @exampleComponent limel-example-color-picker-custom-palette
+ * @exampleComponent limel-example-color-picker-manual-input
  */
 @Component({
     tag: 'limel-color-picker',
@@ -93,6 +94,14 @@ export class ColorPicker implements FormComponent {
     public placeholder: string;
 
     /**
+     * Set to `false` to disallow custom color values to be typed into the input field.
+     * Setting this to `false` does not completely disable the color picker.
+     * It will only allow users to pick from the provided color palette.
+     */
+    @Prop({ reflect: true })
+    public manualInput = true;
+
+    /**
      * An array of either color value strings, or objects with a `name` and a `value`,
      * which replaces the default palette. Any valid CSS color format is accepted as value
      * (HEX, RGB/A, HSL, HWB, color-mix(), named colors, etc.).
@@ -140,7 +149,7 @@ export class ColorPicker implements FormComponent {
                     onChange={this.handleChange}
                     required={this.required}
                     readonly={this.readonly}
-                    disabled={this.disabled}
+                    disabled={this.disabled || !this.manualInput}
                     invalid={this.invalid}
                     placeholder={this.placeholder}
                 />
@@ -181,6 +190,7 @@ export class ColorPicker implements FormComponent {
                     required={this.required}
                     palette={this.palette as any}
                     columnCount={this.paletteColumnCount}
+                    manualInput={this.manualInput}
                 />
             </limel-popover>
         );

--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -22,9 +22,9 @@ import type { CustomColorSwatch } from './color-picker.types';
  * :::
  *
  * @exampleComponent limel-example-color-picker-basic
- * @exampleComponent limel-example-color-picker-readonly
  * @exampleComponent limel-example-color-picker-custom-palette
  * @exampleComponent limel-example-color-picker-manual-input
+ * @exampleComponent limel-example-color-picker-composite
  */
 @Component({
     tag: 'limel-color-picker',

--- a/src/components/color-picker/examples/color-picker-basic.tsx
+++ b/src/components/color-picker/examples/color-picker-basic.tsx
@@ -1,6 +1,6 @@
 import { Component, h, State } from '@stencil/core';
 @Component({
-    tag: 'limel-example-color-picker',
+    tag: 'limel-example-color-picker-basic',
     shadow: true,
 })
 export class ColorPickerExample {

--- a/src/components/color-picker/examples/color-picker-composite.tsx
+++ b/src/components/color-picker/examples/color-picker-composite.tsx
@@ -4,10 +4,10 @@ import { Component, h, Host, State } from '@stencil/core';
  */
 
 @Component({
-    tag: 'limel-example-color-picker-readonly',
+    tag: 'limel-example-color-picker-composite',
     shadow: true,
 })
-export class ColorPickerReadonlyExample {
+export class ColorPickerCompositeExample {
     @State()
     private value = 'rgba(var(--color-red-default), 0.4)';
 

--- a/src/components/color-picker/examples/color-picker-manual-input.tsx
+++ b/src/components/color-picker/examples/color-picker-manual-input.tsx
@@ -1,0 +1,77 @@
+import { Component, h, Host, State } from '@stencil/core';
+/**
+ * Disallowing manual input
+ * By default, users can not only pick a color from the palette,
+ * but also type in any valid color name or color value.
+ *
+ * By setting the `manualInput` to `false` you can easily prevent users from
+ * typing a custom color value into the input field.
+ *
+ * Naturally, setting this prop to `false` does not completely disable the color picker.
+ * It will only allow users to pick from the provided color palette.
+ */
+
+@Component({
+    tag: 'limel-example-color-picker-manual-input',
+    shadow: true,
+})
+export class ColorPickerManualInputExample {
+    @State()
+    private value = 'rgb(var(--color-cyan-default))';
+
+    @State()
+    private manualInput = false;
+
+    private customPalette = [
+        { name: 'red', value: 'rgb(var(--color-red-default))' },
+        { name: 'pink', value: 'rgb(var(--color-pink-default))' },
+        { name: 'magenta', value: 'rgb(var(--color-magenta-default))' },
+        { name: 'purple', value: 'rgb(var(--color-purple-default))' },
+        { name: 'violet', value: 'rgb(var(--color-violet-default))' },
+        { name: 'indigo', value: 'rgb(var(--color-indigo-default))' },
+        { name: 'blue', value: 'rgb(var(--color-blue-default))' },
+        { name: 'sky', value: 'rgb(var(--color-sky-default))' },
+        { name: 'cyan', value: 'rgb(var(--color-cyan-default))' },
+        { name: 'teal', value: 'rgb(var(--color-teal-default))' },
+        { name: 'green', value: 'rgb(var(--color-green-default))' },
+        { name: 'lime', value: 'rgb(var(--color-lime-default))' },
+        { name: 'grass', value: 'rgb(var(--color-grass-default))' },
+        { name: 'yellow', value: 'rgb(var(--color-yellow-default))' },
+        { name: 'amber', value: 'rgb(var(--color-amber-default))' },
+        { name: 'orange', value: 'rgb(var(--color-orange-default))' },
+        { name: 'coral', value: 'rgb(var(--color-coral-default))' },
+        { name: 'brown', value: 'rgb(var(--color-brown-default))' },
+        { name: 'gray', value: 'rgb(var(--color-gray-default))' },
+        { name: 'glaucous', value: 'rgb(var(--color-glaucous-default))' },
+    ];
+
+    public render() {
+        return (
+            <Host>
+                <limel-color-picker
+                    value={this.value}
+                    palette={this.customPalette}
+                    placeholder="Typing custom colors is not allowed"
+                    manualInput={this.manualInput}
+                    onChange={this.onChange}
+                />
+                <limel-example-controls>
+                    <limel-checkbox
+                        checked={this.manualInput}
+                        label="manualInput"
+                        onChange={this.setManualInput}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private onChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+
+    private setManualInput = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.manualInput = event.detail;
+    };
+}

--- a/src/components/color-picker/examples/color-picker-readonly.tsx
+++ b/src/components/color-picker/examples/color-picker-readonly.tsx
@@ -24,6 +24,9 @@ export class ColorPickerReadonlyExample {
     private readonly = false;
 
     @State()
+    private manualInput = true;
+
+    @State()
     private placeholder = 'Any valid CSS color format is accepted';
 
     public render() {
@@ -37,6 +40,7 @@ export class ColorPickerReadonlyExample {
                     required={this.required}
                     disabled={this.disabled}
                     invalid={this.invalid}
+                    manualInput={this.manualInput}
                     onChange={this.onChange}
                 />
                 <limel-example-controls>
@@ -59,6 +63,11 @@ export class ColorPickerReadonlyExample {
                         checked={this.readonly}
                         label="Readonly"
                         onChange={this.setReadonly}
+                    />
+                    <limel-checkbox
+                        checked={this.manualInput}
+                        label="manualInput"
+                        onChange={this.setManualInput}
                     />
                     <limel-input-field
                         label="Placeholder"
@@ -96,6 +105,11 @@ export class ColorPickerReadonlyExample {
     private setReadonly = (event: CustomEvent<boolean>) => {
         event.stopPropagation();
         this.readonly = event.detail;
+    };
+
+    private setManualInput = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.manualInput = event.detail;
     };
 
     private setPlaceholder = (event: CustomEvent<string>) => {


### PR DESCRIPTION
This provides a way to limit users to select colors from
the provided color palette only.

required for https://github.com/Lundalogik/hack-tuesday/issues/430

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual input toggle to the Color Picker and Palette. When disabled, users can only pick from the palette; text input is prevented and respects the component’s disabled state.

* **Documentation**
  * Added a new example demonstrating the manual input toggle.
  * Renamed example components and tags for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
