### PR TITLE
Form: Add hidden schema option and early null return in SchemaField

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -2559,6 +2559,7 @@ export interface LimeSchemaOptions {
     disabled?: boolean;
     // (undocumented)
     help?: string | Partial<Help>;
+    hidden?: boolean;
     layout?: LimeLayoutOptions;
 }
 

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -270,6 +270,10 @@ export class SchemaField extends React.Component<FieldProps> {
     }
 
     render() {
+        if (this.props.schema.lime?.hidden) {
+            return null;
+        }
+
         if (hasCustomComponent(this.props.schema)) {
             return this.renderCustomComponent(this.props);
         }

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -209,6 +209,11 @@ export interface LimeSchemaOptions {
      */
     disabled?: boolean;
 
+    /**
+     * Hide the field from the UI while preserving its value in the form data.
+     */
+    hidden?: boolean;
+
     help?: string | Partial<Help>;
 }
 


### PR DESCRIPTION
## What?
Add support for `lime.hidden` property in form schemas to hide fields from the UI while preserving their values in form data.

Changes:
- Add `hidden?: boolean` to LimeSchemaOptions interface
- Values are still  preserved in form state for all types (objects, arrays, primitives)
- Hidden fields don't participate in CSS grid layout

Usage:
```python
field = fields.Str(
  metadata={
    "lime": {
      "hidden": True
    }
  }
)
```

Fixes: https://github.com/Lundalogik/crm-insights-and-intelligence/issues/95

## Why?
There was no straightforward way to hide form fields generated from schemas simply by adding a property to the schema. I need it so I added it. It think it can be useful for other people too.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now hide form fields from the UI while preserving their values in the form data via a new schema option.
  * Hidden fields are fully excluded from rendering, including any custom rendering paths, enabling cleaner conditional or advanced workflows.
  * Backwards compatible: existing forms behave unchanged unless the new hidden flag is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
