### PR TITLE
fix(list): prevent double `interact` event emits, when an item is clicked

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1733,10 +1733,6 @@ export namespace JSX {
         "iconSize"?: IconSize;
         "image"?: ListItem['image'];
         "language"?: Languages;
-        "onInteract"?: (event: LimelListItemCustomEvent<{
-            selected: boolean;
-            item: ListItem;
-        }>) => void;
         "primaryComponent"?: ListItem['primaryComponent'];
         "secondaryText"?: string;
         "selected"?: boolean;
@@ -2343,16 +2339,6 @@ export interface LimelListCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     // (undocumented)
     target: HTMLLimelListElement;
-}
-
-// Warning: (ae-missing-release-tag) "LimelListItemCustomEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface LimelListItemCustomEvent<T> extends CustomEvent<T> {
-    // (undocumented)
-    detail: T;
-    // (undocumented)
-    target: HTMLLimelListItemElement;
 }
 
 // Warning: (ae-missing-release-tag) "LimelMenuCustomEvent" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/src/components/list-item/examples/list-item-interactive.tsx
+++ b/src/components/list-item/examples/list-item-interactive.tsx
@@ -4,13 +4,23 @@ import { Component, h, Host, State } from '@stencil/core';
  * Interactive list item example
  *
  * A list item with the default type (`type="listitem"`) shows a simpler
- * visual feedback when hovered. Once it is clicked, it emits an event
- * with details about the item.
+ * visual feedback when hovered.
  *
- * However, certain item `type`s are "selectable";
- * for instance `option`, `radio` and `checkbox`.
+ * However, certain item `type`s are "selectable"; for instance `option`, `radio` and `checkbox`.
  * When users click them (or focus and press <kbd>Enter</kbd> or <kbd>Space</kbd>)
- * these items toggle their selection.
+ * these items must toggle their selection.
+ *
+ * This example demonstrates manual selection handling. Note that
+ * `limel-list-item` does not emit its own `interact` event. The consumer
+ * should listen for native `click` events and handle keyboard events.
+ *
+ * The component is purely presentational; selection state is passed in
+ * via the `selected` prop and updated by the parent example using
+ * native `click` and keyboard events.
+ *
+ * Item `type`s that are "selectable" (`option`, `radio`, `checkbox`)
+ * are expected to be managed by a container component like `limel-list`.
+ * For standalone demo purposes we toggle `selected` ourselves.
  *
  * A `selected` item will both visually indicate that it is selected
  * and also informs assistive technology about its state, using proper ARIA attributes.
@@ -50,7 +60,7 @@ export class ListItemInteractiveExample {
 
     public render() {
         return (
-            <Host>
+            <Host onKeyDown={this.onHostKeyDown}>
                 <limel-list-item
                     tabindex={0}
                     text="Interactive List Item, with `type='option'`"
@@ -59,7 +69,7 @@ export class ListItemInteractiveExample {
                     disabled={this.disabled}
                     selected={this.selected}
                     type="option"
-                    onInteract={this.onInteract}
+                    onClick={this.onItemClick}
                 />
                 <limel-example-controls>
                     <limel-switch
@@ -81,10 +91,49 @@ export class ListItemInteractiveExample {
         );
     }
 
-    private onInteract = (event: CustomEvent) => {
-        this.lastEvent = `Item clicked - Selected: ${event.detail.selected}`;
-        this.selected = event.detail.selected;
-        console.log('List item interacted:', event.detail);
+    private toggleSelection = () => {
+        if (this.disabled) {
+            return;
+        }
+        this.selected = !this.selected;
+        this.lastEvent = `Item ${this.selected ? 'selected' : 'deselected'}`;
+    };
+
+    private onItemClick = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+        if (
+            target.closest('.action-menu-trigger') ||
+            target.closest('limel-menu')
+        ) {
+            return; // ignore action menu clicks
+        }
+        this.toggleSelection();
+    };
+
+    private onHostKeyDown = (event: KeyboardEvent) => {
+        if (this.disabled) {
+            return;
+        }
+        const isEnter = event.key === 'Enter';
+        const isSpace =
+            event.key === ' ' ||
+            event.key === 'Space' ||
+            event.key === 'Spacebar' ||
+            event.code === 'Space';
+        if (!isEnter && !isSpace) {
+            return;
+        }
+        if (event.repeat) {
+            return;
+        }
+        if (isSpace) {
+            event.preventDefault();
+        }
+        // Ensure the focused element is our list item before toggling
+        const active = document.activeElement as HTMLElement | null;
+        if (active && active.tagName.toLowerCase() === 'limel-list-item') {
+            this.toggleSelection();
+        }
     };
 
     private setDisabled = (event: CustomEvent<boolean>) => {

--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -45,55 +45,30 @@ describe('limel-list-item', () => {
         expect(checkbox).not.toBeNull();
     });
 
-    it('emits interact on click for selectable types', async () => {
+    it('renders action menu trigger without producing interact event', async () => {
         const page = await newE2EPage({
-            html: '<limel-list-item type="option" text="Sel"></limel-list-item>',
+            html: '<limel-list-item type="option" text="Actions"></limel-list-item>',
         });
         const host = await page.find('limel-list-item');
-        const spy = await page.spyOnEvent('interact');
-        await host.click();
-        await page.waitForChanges();
-        expect(spy).toHaveReceivedEventTimes(1);
-    });
-
-    it('does not emit interact when disabled', async () => {
-        const page = await newE2EPage({
-            html: '<limel-list-item type="option" disabled text="Disabled"></limel-list-item>',
-        });
-        const host = await page.find('limel-list-item');
-        const spy = await page.spyOnEvent('interact');
-        await host.click();
-        await page.waitForChanges();
-        expect(spy).not.toHaveReceivedEvent();
-    });
-
-    it('emits interact on Enter/Space when focused (keyboard activation)', async () => {
-        const page = await newE2EPage({
-            html: '<limel-list-item type="option" tabindex="0" text="KB"></limel-list-item>',
-        });
-        const host = await page.find('limel-list-item');
-        const spy = await page.spyOnEvent('interact');
-        await host.focus();
-        await page.keyboard.press('Enter');
-        await page.waitForChanges();
-        await page.keyboard.press('Space');
-        await page.waitForChanges();
-        expect(spy).toHaveReceivedEventTimes(2);
-    });
-
-    it('does not emit interact when activating the action menu trigger', async () => {
-        const page = await newE2EPage({
-            html: `<limel-list-item type="option" text="With actions"></limel-list-item>`,
-        });
-        const host = await page.find('limel-list-item');
-        const spy = await page.spyOnEvent('interact');
         await host.setProperty('actions', [{ text: 'Action', value: 'a' }]);
         await page.waitForChanges();
         const trigger = await host.find('.action-menu-trigger');
         expect(trigger).not.toBeNull();
+        const interactSpy = await page.spyOnEvent('interact');
         await trigger.click();
         await page.waitForChanges();
-        expect(spy).not.toHaveReceivedEvent();
+        expect(interactSpy).not.toHaveReceivedEvent();
+    });
+
+    it('reflects aria-selected when type=option and selected prop changes', async () => {
+        const page = await newE2EPage({
+            html: '<limel-list-item type="option" text="SelState"></limel-list-item>',
+        });
+        const host = await page.find('limel-list-item');
+        expect(host).toEqualAttribute('aria-selected', 'false');
+        await host.setProperty('selected', true);
+        await page.waitForChanges();
+        expect(host).toEqualAttribute('aria-selected', 'true');
     });
 
     it('renders icon and image when provided (presence checks)', async () => {


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-client/issues/367
fix https://github.com/Lundalogik/crm-client/issues/364

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyboard support: Enter/Space now toggle selection on focused list items.
  * Centralized interaction handling for more consistent selection across list variants.

* **Bug Fixes**
  * Clicking action menus no longer toggles items.
  * Disabled and aria-disabled items correctly ignore clicks and key presses.
  * More accurate selection state and feedback messages (Selected/Deselected).

* **Refactor**
  * Moved interaction handling from individual items to the list container for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
