### PR TITLE
ci(publish-docs.yml): add manual trigger to workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,6 +21,17 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The "name" of the version to be published. IMPORTANT: This only _names_ the published docs, it does not affect what is actually published. This workflow always builds and publishes the docs for whatever is the latest in the branch on which it is run.'
+        required: true
+        type: string
+      forcePush:
+        description: 'Pass `true` if git push should use `--force`.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
 
@@ -34,10 +45,10 @@ jobs:
     - run: git config --global user.email "93315277+lime-opensource@users.noreply.github.com"
     - run: git config --global user.name "Lime Technologies OSS"
     - name: Publish docs
-      if: inputs.buildOnly == false
+      if: github.event_name == 'workflow_dispatch' || inputs.buildOnly == false
       env:
-        DOCS_VERSION: ${{ inputs.version }}
-        FORCE_PUSH: ${{ inputs.forcePush }}
+        DOCS_VERSION: ${{ inputs.version || github.event.inputs.version }}
+        FORCE_PUSH: ${{ inputs.forcePush || github.event.inputs.forcePush || 'false' }}
         GH_TOKEN: ${{ secrets.PUBLISH_DOCS }}
       run: |
         if [ "$FORCE_PUSH" = "true" ]; then
@@ -46,11 +57,11 @@ jobs:
           npm run docs:publish -- --v="$DOCS_VERSION"
         fi
     - name: Build docs, but do not publish
-      if: inputs.buildOnly
+      if: github.event_name == 'workflow_call' && inputs.buildOnly
       run: npm run docs:build
 
   link-docs:
-    if: inputs.buildOnly == false && inputs.linkToPR == true
+    if: github.event_name == 'workflow_call' && inputs.buildOnly == false && inputs.linkToPR == true
     name: Post link to docs on PR
     needs: [publish-docs]
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual trigger for the docs publishing workflow with version and force-push options.
  * Improved workflow conditions so build-only and publish steps run correctly for both manual and workflow-call invocations.
  * Environment variables for docs version and force-push now accept inputs from manual invocation or workflow_call with sensible fallbacks.
  * Adjusted post-link and build-only checks to respect workflow-call contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
