### PR TITLE
ci(docs): ensure documentation version matches release version

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,6 +21,10 @@ on:
         required: false
         default: false
         type: boolean
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to checkout. If not specified, uses the default ref for the triggering event.'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -40,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: ${{ inputs.ref }}
     - uses: ./.github/actions/set-up-node
     - run: npm ci
     - run: git config --global user.email "93315277+lime-opensource@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
       last_release_git_tag: ${{ steps.semantic.outputs.last_release_git_tag }}
       last_release_version: ${{ steps.semantic.outputs.last_release_version }}
     steps:
@@ -65,5 +66,6 @@ jobs:
     uses: ./.github/workflows/publish-docs.yml
     with:
       version: "${{ needs.semantic-release.outputs.new_release_version }}"
+      ref: "${{ needs.semantic-release.outputs.new_release_git_tag }}"
       forcePush: true
     secrets: inherit


### PR DESCRIPTION
Documentation was being generated from the commit before semantic-release's version bump, opening the risk of potentialluy using the previous version number. Now checks out the release tag to ensure package.json has the correct version when building the documentation.

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation publishing workflow to support specifying git references during the publication process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
