### PR TITLE
chore(markdown): add a private helper class to reset hardcoded height on `img` tags

### DIFF
--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -33,3 +33,15 @@ hr {
 .MsoNormal {
     margin: 0;
 }
+
+:host(limel-markdown.reset-img-height) {
+    // This is not a publicly documented helper class, intended for CRM's internal use.
+    // Reset image height to auto to avoid issues with fixed heights in some markdown content
+    // e.g., content copied from MS Word or emails that are sent from a user that has
+    // added fixed heights to images that appear in the activity feed.
+    #markdown {
+        img {
+            height: auto;
+        }
+    }
+}


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-client/issues/409
fix https://github.com/Lundalogik/limepkg-email/issues/1745

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where images in markdown content retained fixed heights from source documents (such as Word documents or emails), preventing proper display scaling. Images now automatically adjust to appropriate heights based on the content width and layout requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
