### PR TITLE
feat(table): allow disabling column sorting through header interactions

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -788,6 +788,7 @@ export namespace Components {
         "pageSize": number;
         "selectable": boolean;
         "selection": object[];
+        "sortableColumns": boolean;
         "sorting": ColumnSorter[];
         "totalRows": number;
     }
@@ -2011,6 +2012,7 @@ export namespace JSX {
         "pageSize"?: number;
         "selectable"?: boolean;
         "selection"?: object[];
+        "sortableColumns"?: boolean;
         "sorting"?: ColumnSorter[];
         "totalRows"?: number;
     }

--- a/src/components/table/examples/table-sorting-disabled.tsx
+++ b/src/components/table/examples/table-sorting-disabled.tsx
@@ -1,4 +1,4 @@
-import { Component, h, State } from '@stencil/core';
+import { Component, h, Host, State } from '@stencil/core';
 import { Column } from '@limetech/lime-elements';
 import { invoices, Invoice } from './invoices';
 
@@ -9,8 +9,13 @@ import { invoices, Invoice } from './invoices';
  * a column header. An arrow icon on the header visualizes the
  * direction of sorting, when a column is sorted.
  *
- * However, you can disable the sorting possibility in individual columns,
- * by setting the `headerSort` to `false`.
+ * To prevent sorting altogether, set the `sortableColumns` property on
+ * `limel-table` to `false`. If you only want to disable sorting for a
+ * specific column, set the column's `headerSort` property to `false`.
+ *
+ * The "Reference Person" column below has sorting disabled on the
+ * column definition, while the control lets you disable sorting for
+ * the whole table.
  *
  * @sourceFile invoices.ts
  */
@@ -24,11 +29,14 @@ export class TableExampleSortingDisabled {
     private tableData: Invoice[] = invoices;
 
     @State()
-    public columns: Column[] = [
+    private disableAllSorting: boolean = false;
+
+    @State()
+    private columns: Column[] = [
         { title: 'Invoice no.', field: 'invoiceNumber' },
         { title: 'Invoice Date', field: 'invoiceDate' },
         {
-            title: 'Reference Person',
+            title: 'Reference Person (no sorting)',
             field: 'referencePerson',
             headerSort: false,
         },
@@ -36,6 +44,28 @@ export class TableExampleSortingDisabled {
     ];
 
     render() {
-        return <limel-table data={this.tableData} columns={this.columns} />;
+        return (
+            <Host>
+                <limel-table
+                    data={this.tableData}
+                    columns={this.columns}
+                    sortableColumns={!this.disableAllSorting}
+                />
+                <limel-example-controls
+                    style={{ '--example-controls-column-layout': 'auto-fit' }}
+                >
+                    <limel-checkbox
+                        checked={this.disableAllSorting}
+                        label="Disable sorting on all columns"
+                        onChange={this.setDisableAllSorting}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
     }
+
+    private setDisableAllSorting = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.disableAllSorting = event.detail;
+    };
 }


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/lime-elements/issues/3715
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new sorting control for tables: tables can now enable or disable sorting functionality across all columns globally.
  * Introduced an interactive example demonstrating the sorting toggle feature with a checkbox control for users to enable/disable column sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
