### PR TITLE
fix(readonly): make readonly state readable on mobile devices

### DIFF
--- a/src/components/input-field/partial-styles/_readonly.scss
+++ b/src/components/input-field/partial-styles/_readonly.scss
@@ -39,3 +39,14 @@
         }
     }
 }
+
+:host([readonly]) {
+    .mdc-text-field__input {
+        // Override browser default styling for readonly inputs to ensure proper visibility
+        // - opacity: 1 prevents browsers from making readonly text appear faded/dimmed
+        // - -webkit-text-fill-color ensures consistent text color across WebKit browsers
+        //   (overrides browser autofill colors and disabled state styling)
+        opacity: 1;
+        -webkit-text-fill-color: shared_input-select-picker.$input-text-color;
+    }
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

fix: https://github.com/Lundalogik/lime-elements/issues/3718

<img width="1189" height="748" alt="Screenshot 2025-10-31 at 14 41 22" src="https://github.com/user-attachments/assets/c9d76dc0-c195-4cb4-8542-5e555bb8d934" />

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced styling for readonly input fields to ensure proper text display and consistent visibility. Readonly form inputs now render with explicit color treatment and full opacity for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
