### PR TITLE
Markdown: enable removing or keeping empty paragraphs of an HTML `value`

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -574,6 +574,7 @@ export namespace Components {
     }
     export interface LimelMarkdown {
         "lazyLoadImages": boolean;
+        "removeEmptyParagraphs": boolean;
         "value": string;
         // @alpha
         "whitelist"?: CustomElementDefinition[];
@@ -1782,6 +1783,7 @@ export namespace JSX {
     }
     export interface LimelMarkdown {
         "lazyLoadImages"?: boolean;
+        "removeEmptyParagraphs"?: boolean;
         "value"?: string;
         // @alpha
         "whitelist"?: CustomElementDefinition[];

--- a/src/components/markdown/examples/markdown-remove-empty-paragraphs.scss
+++ b/src/components/markdown/examples/markdown-remove-empty-paragraphs.scss
@@ -1,0 +1,10 @@
+:host(limel-example-markdown-remove-empty-paragraphs) {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+}
+
+limel-markdown {
+    display: block;
+    padding: 0.5rem 1rem;
+}

--- a/src/components/markdown/examples/markdown-remove-empty-paragraphs.tsx
+++ b/src/components/markdown/examples/markdown-remove-empty-paragraphs.tsx
@@ -1,0 +1,81 @@
+import { Component, h, Host } from '@stencil/core';
+
+const zeroWidthHexCodes = ['200B', '200C', '200D', 'FEFF'];
+const zeroWidthSequence = zeroWidthHexCodes
+    .map((hexCode) => String.fromCodePoint(Number.parseInt(hexCode, 16)))
+    .join('');
+const zeroWidthCharacter = zeroWidthSequence.charAt(0);
+
+const markdownWithEmptyParagraphs = `
+<p>In some use cases, empty paragraphs may be desired to keep certain spacing
+in the content, while in other cases they may be unwanted and just add
+unnecessary vertical space.</p>
+<p></p>
+<p><p></p></p>
+<p>Having an empty paragraph like the above, or like the one below this paragraph</p>
+<p>&nbsp;</p>
+<p>can easily happen when the <code>value</code> is simply some HTML output
+that comes for instance from an email.</p>
+<p class="something"><br></p>
+<p>Many email editors do not have standard typographic margins between paragraphs,
+which force users to manually add empty spaces between their lines,
+by pressing the <kbd>Enter</kbd> key multiple times, while typing an email.</p>
+<p><span style="font-size:10.5pt; color:#333333">&nbsp;</span></p>
+<p><span></span></p>
+<p> </p>
+<p>${zeroWidthSequence}</p>
+<p><span>${zeroWidthCharacter}</span></p>
+<p>Rendering all the empty paragraphs that you see in this example would just add lots
+of vertical scrolling to large content.</p>
+`;
+
+/**
+ * Removing empty paragraphs
+ *
+ * Sometimes, when a `value` in HTML format is imported from an external source, it
+ * may contain undesired data. This could be for instance malicious scripts,
+ * or styles that may be used to visually hide unwanted content from the reader.
+ *
+ * This component does its best to sanitize the input HTML, and clean it up
+ * before rendering the content.
+ *
+ * However, one of the things that the component cannot fully decide by its own is
+ * rendering empty paragraphs. Empty paragraphs are paragraphs that do not contain
+ * any meaningful content (text, images, etc.), or only contain whitespace
+ * (`<br />` or `&nbsp;`).
+ *
+ * By setting the `removeEmptyParagraphs` property to `false`, all empty paragraphs
+ * will be preserved before rendering the content.
+ */
+@Component({
+    tag: 'limel-example-markdown-remove-empty-paragraphs',
+    shadow: true,
+    styleUrl: 'markdown-remove-empty-paragraphs.scss',
+})
+export class MarkdownRemoveEmptyParagraphsExample {
+    public render() {
+        return (
+            <Host>
+                <section>
+                    <limel-header
+                        icon="multiline_text"
+                        heading="Default rendering"
+                        subheading="Empty paragraphs removed"
+                    />
+                    <limel-markdown value={markdownWithEmptyParagraphs} />
+                </section>
+                <section>
+                    <limel-header
+                        icon="space_after_paragraph"
+                        heading="Empty paragraphs preserved"
+                        subheading="`removeEmptyParagraphs={false}`"
+                    />
+                    <limel-markdown
+                        value={markdownWithEmptyParagraphs}
+                        removeEmptyParagraphs={false}
+                    />
+                </section>
+            </Host>
+        );
+    }
+}

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -13,6 +13,7 @@ import { Schema } from 'rehype-sanitize/lib';
 import { createLazyLoadImagesPlugin } from './image-markdown-plugin';
 import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 import { createLinksPlugin } from './link-markdown-plugin';
+import { createRemoveEmptyParagraphsPlugin } from './remove-empty-paragraphs-plugin';
 
 /**
  * Takes a string as input and returns a new string
@@ -52,6 +53,7 @@ export async function markdownToHTML(
                 visit(tree, 'element', sanitizeStyle);
             };
         })
+        .use(createRemoveEmptyParagraphsPlugin(options?.removeEmptyParagraphs))
         .use(createLazyLoadImagesPlugin(options?.lazyLoadImages))
         .use(rehypeStringify)
         .process(text);
@@ -129,4 +131,5 @@ export interface MarkdownToHTMLOptions {
     forceHardLineBreaks?: boolean;
     whitelist?: CustomElementDefinition[];
     lazyLoadImages?: boolean;
+    removeEmptyParagraphs?: boolean;
 }

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -20,8 +20,9 @@ import { ImageIntersectionObserver } from './image-intersection-observer';
  * @exampleComponent limel-example-markdown-keys
  * @exampleComponent limel-example-markdown-blockquotes
  * @exampleComponent limel-example-markdown-horizontal-rule
- * @exampleComponent limel-example-markdown-composite
  * @exampleComponent limel-example-markdown-custom-component
+ * @exampleComponent limel-example-markdown-remove-empty-paragraphs
+ * @exampleComponent limel-example-markdown-composite
  */
 @Component({
     tag: 'limel-markdown',
@@ -55,6 +56,15 @@ export class Markdown {
     @Prop({ reflect: true })
     public lazyLoadImages = false;
 
+    /**
+     * Set to `false` to preserve empty paragraphs before rendering.
+     * Empty paragraphs are paragraphs that do not contain
+     * any meaningful content (text, images, etc.), or only contain
+     * whitespace (`<br />` or `&nbsp;`).
+     */
+    @Prop({ reflect: true })
+    public removeEmptyParagraphs = true;
+
     @Watch('value')
     public async textChanged() {
         try {
@@ -64,6 +74,7 @@ export class Markdown {
                 forceHardLineBreaks: true,
                 whitelist: this.whitelist ?? [],
                 lazyLoadImages: this.lazyLoadImages,
+                removeEmptyParagraphs: this.removeEmptyParagraphs,
             });
 
             this.rootElement.innerHTML = html;
@@ -72,6 +83,11 @@ export class Markdown {
         } catch (error) {
             console.error(error);
         }
+    }
+
+    @Watch('removeEmptyParagraphs')
+    public handleRemoveEmptyParagraphsChange() {
+        return this.textChanged();
     }
 
     private rootElement: HTMLDivElement;

--- a/src/components/markdown/remove-empty-paragraphs-plugin.spec.ts
+++ b/src/components/markdown/remove-empty-paragraphs-plugin.spec.ts
@@ -1,0 +1,115 @@
+import { createRemoveEmptyParagraphsPlugin } from './remove-empty-paragraphs-plugin';
+
+describe('remove empty paragraphs plugin', () => {
+    it('keeps empty paragraphs when disabled', () => {
+        const tree = createRoot([createParagraph()]);
+
+        runPlugin(tree, false);
+
+        expect(tree.children).toHaveLength(1);
+    });
+
+    it('removes empty paragraphs with only whitespace content', () => {
+        const tree = createRoot([
+            createParagraph(),
+            createParagraph([createText('   ')]),
+            createParagraph([createText('\n')]),
+            createParagraph([createText('\u00A0')]),
+            createParagraph([createElement('span')]),
+            createParagraph([createElement('span', [createText('\u00A0')])]),
+        ]);
+
+        runPlugin(tree, true);
+
+        expect(tree.children).toHaveLength(0);
+    });
+
+    it('keeps paragraphs with meaningful content', () => {
+        const paragraph = createParagraph([
+            createElement('img', undefined, { src: 'test.jpg' }),
+        ]);
+        const tree = createRoot([paragraph]);
+
+        runPlugin(tree, true);
+
+        expect(tree.children).toHaveLength(1);
+        expect(tree.children[0]).toBe(paragraph);
+    });
+
+    it('removes paragraphs containing only line breaks', () => {
+        const tree = createRoot([
+            createParagraph([createElement('br')]),
+            createParagraph([createElement('span', [createElement('br')])]),
+        ]);
+
+        runPlugin(tree, true);
+
+        expect(tree.children).toHaveLength(0);
+    });
+
+    it('removes paragraphs containing only zero-width whitespace characters', () => {
+        const zeroWidthText = '\u200B\u200C\u200D\uFEFF';
+        const tree = createRoot([
+            createParagraph([createText(zeroWidthText)]),
+            createParagraph([
+                createElement('span', [createText(zeroWidthText)]),
+            ]),
+        ]);
+
+        runPlugin(tree, true);
+
+        expect(tree.children).toHaveLength(0);
+    });
+
+    it('keeps text content inside paragraphs', () => {
+        const paragraph = createParagraph([
+            createElement('span', [createText('Meaningful text')]),
+        ]);
+        const tree = createRoot([paragraph]);
+
+        runPlugin(tree, true);
+
+        expect(tree.children).toHaveLength(1);
+        expect(tree.children[0]).toBe(paragraph);
+    });
+});
+
+const runPlugin = (tree: any, enabled: boolean) => {
+    const plugin = createRemoveEmptyParagraphsPlugin(enabled);
+    const transformer = plugin.call(mockProcessor);
+
+    if (typeof transformer === 'function') {
+        transformer(tree);
+    }
+};
+
+const mockProcessor: any = {};
+mockProcessor.data = () => mockProcessor;
+
+const createRoot = (children: any[] = []) => ({
+    type: 'root',
+    children,
+});
+
+const createParagraph = (children: any[] = []) => ({
+    type: 'element',
+    tagName: 'p',
+    properties: {},
+    children,
+});
+
+const createElement = (
+    tagName: string,
+    children: any[] = [],
+    properties: Record<string, any> = {}
+) => ({
+    type: 'element',
+    tagName,
+    properties,
+    children,
+});
+
+const createText = (value: string) => ({
+    type: 'text',
+    value,
+});

--- a/src/components/markdown/remove-empty-paragraphs-plugin.ts
+++ b/src/components/markdown/remove-empty-paragraphs-plugin.ts
@@ -1,0 +1,135 @@
+import { Plugin, Transformer } from 'unified';
+import { Node } from 'unist';
+
+export const createRemoveEmptyParagraphsPlugin = (enabled = false): Plugin => {
+    return (): Transformer => {
+        if (!enabled) {
+            return (tree: Node) => tree;
+        }
+
+        return (tree: Node) => {
+            pruneEmptyParagraphs(tree, null);
+
+            return tree;
+        };
+    };
+};
+
+const NBSP_REGEX = /\u00A0/g;
+const ZERO_WIDTH_HEX_CODES = ['200B', '200C', '200D', 'FEFF'];
+const MEANINGFUL_VOID_ELEMENTS = new Set([
+    'audio',
+    'canvas',
+    'embed',
+    'iframe',
+    'img',
+    'input',
+    'object',
+    'svg',
+    'video',
+]);
+
+const TREAT_AS_EMPTY_ELEMENTS = new Set(['br']);
+
+const stripZeroWidthCharacters = (text: string): string => {
+    let cleaned = text;
+
+    for (const hexCode of ZERO_WIDTH_HEX_CODES) {
+        const character = String.fromCodePoint(Number.parseInt(hexCode, 16));
+        cleaned = cleaned.split(character).join('');
+    }
+
+    return cleaned;
+};
+
+const pruneEmptyParagraphs = (node: any, parent: any) => {
+    if (!node || typeof node !== 'object') {
+        return;
+    }
+
+    if (
+        node.type === 'element' &&
+        node.tagName === 'p' &&
+        parent &&
+        isParagraphEffectivelyEmpty(node) &&
+        Array.isArray(parent.children)
+    ) {
+        const index = parent.children.indexOf(node);
+
+        if (index !== -1) {
+            parent.children.splice(index, 1);
+            return;
+        }
+    }
+
+    if (!Array.isArray(node.children) || node.children.length === 0) {
+        return;
+    }
+
+    for (let i = node.children.length - 1; i >= 0; i--) {
+        pruneEmptyParagraphs(node.children[i], node);
+    }
+};
+
+const isParagraphEffectivelyEmpty = (element: any): boolean => {
+    if (!Array.isArray(element.children) || element.children.length === 0) {
+        return true;
+    }
+
+    return element.children.every((child: any) =>
+        isNodeEffectivelyEmpty(child)
+    );
+};
+
+const isNodeEffectivelyEmpty = (node: any): boolean => {
+    if (!node) {
+        return true;
+    }
+
+    if (node.type === 'text') {
+        return isWhitespace(typeof node.value === 'string' ? node.value : '');
+    }
+
+    if (node.type === 'comment') {
+        return true;
+    }
+
+    if (node.type === 'element') {
+        const element = node;
+        const tagName = element.tagName;
+
+        if (typeof tagName !== 'string') {
+            return true;
+        }
+
+        if (MEANINGFUL_VOID_ELEMENTS.has(tagName)) {
+            return false;
+        }
+
+        if (TREAT_AS_EMPTY_ELEMENTS.has(tagName)) {
+            return true;
+        }
+
+        if (!Array.isArray(element.children) || element.children.length === 0) {
+            return true;
+        }
+
+        return element.children.every((child: any) =>
+            isNodeEffectivelyEmpty(child)
+        );
+    }
+
+    return true;
+};
+
+const isWhitespace = (value: string): boolean => {
+    if (!value) {
+        return true;
+    }
+
+    const normalized = stripZeroWidthCharacters(
+        value.replaceAll(NBSP_REGEX, ' ')
+    );
+
+    return normalized.trim() === '';
+};


### PR DESCRIPTION
When an email is imported into the CRM, the spacing between paragraphs in the CRM appears to be much larger than the spacing between paragraphs in emails, created in Outlook. This is visible in the Activity Feed, and creates a lot of additional vertical scrolling for users.

This issue stems from how email clients like Outlook handle paragraphs. Unlike standard text editing programs like Word, Outlook (or Gmail) doesn’t follow the standard typographic rules. In Word, there’s usually a greater space between paragraphs than between lines. However, users often hit the Enter key twice to create a gap between lines in while they are typing their emails.

When these emails are imported into the CRM, our standard paragraph styling adds even more space, creating the appearance of double line spacing because there are extra empty paragraphs in the actual imported email.

We don’t want to have a non-standard typographic style in CRM. So we can't simply remove our default styling for margins between paragraphs. 

So we need to remove the empty paragraphs from the input `value` that has `HTML` format. The issue is that the depending on the email client which is used, the empty paragraphs would be different. They could be anything like:
```html
<p></p>
<p><p></p></p>
<p>&nbsp;</p>
<p class="something"><br></p>
<p><span style="font-size:10.5pt; color:#333333">&nbsp;</span></p>
<p><span></span></p>
<p> </p>
```

Therefore, we can’t do this purely with CSS in a fully reliable way, since CSS selectors can’t inspect text content. So something like:
```scss
p:empty {
  display: none;
}
// or
p:has(:only-child:empty),
p:has(br:only-child),
p:has(:not(:empty)) {
  display: none;
}
```
… still won’t detect invisible text like `&nbsp;` or empty nested paragraphs inside each other. 

Additionally, this feel like something that should be controlled via a `prop` by the consumer. Because sometimes, they my really need the empty paragraphs for some legit reason.

So we need JS to handle this, as done in this PR.


<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/limepkg-email/issues/1744

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public option to preserve or remove empty paragraphs in rendered Markdown, with preservation enabled by default; examples demonstrate both behaviors.
* **Chores**
  * Improved component attribute reflection for image lazy-loading.
* **Style**
  * Added styling for the new Markdown example layout.
* **Tests**
  * Added unit tests covering empty-paragraph preservation and removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
