### PR TITLE
Revert "refactor(collapsible-section): use more custom css props to c…

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -151,29 +151,35 @@ limel-icon {
 // This animates height of the body,
 // from `0` to `auto`
 .body {
+    // All below vars are for internal use only!
+    --limel-cs-opacity-transition-speed: 0.1s;
+    --limel-cs-opacity-transition-delay: 0s;
+    --limel-cs-grid-template-rows-transition-speed: 0.3s;
     transition: grid-template-rows
-        var(--limel-cs-grid-template-rows-transition-speed, 0.3s)
+        var(--limel-cs-grid-template-rows-transition-speed)
         cubic-bezier(1, 0.09, 0, 0.89);
     display: grid;
-    grid-template-rows: var(--limel-cs-grid-template-rows, 0fr);
+    grid-template-rows: 0fr;
 
     slot {
-        transition: opacity var(--limel-cs-opacity-transition-speed, 0.1s) ease
-            var(--limel-cs-opacity-transition-delay, 0s);
+        transition: opacity var(--limel-cs-opacity-transition-speed) ease
+            var(--limel-cs-opacity-transition-delay);
         display: block;
         overflow: hidden;
         opacity: 0;
     }
 }
 
-:host(limel-collapsible-section[is-open]) {
-    --limel-cs-opacity-transition-speed: 0.4s;
-    --limel-cs-opacity-transition-delay: 0.3s;
-    --limel-cs-grid-template-rows-transition-speed: 0.46s;
-    --limel-cs-grid-template-rows: 1fr;
+section.open {
+    .body {
+        --limel-cs-opacity-transition-speed: 0.4s;
+        --limel-cs-opacity-transition-delay: 0.3s;
+        --limel-cs-grid-template-rows-transition-speed: 0.46s;
+        grid-template-rows: 1fr;
 
-    slot {
-        opacity: 1;
+        slot {
+            opacity: 1;
+        }
     }
 }
 


### PR DESCRIPTION
…ontrol animations"

This reverts commit 6c5cfdd40bb4344ed309b6539492db9f812134d1.

This messed up nested collapsible sections. They remained opened, even after closing.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal styling organization of the collapsible section component for improved animation consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
