### PR TITLE
fix(collapsible-section): prevent nested sections to remain open after collapsing

### DIFF
--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -152,16 +152,26 @@ limel-icon {
 // from `0` to `auto`
 .body {
     transition: grid-template-rows
-        var(--limel-cs-grid-template-rows-transition-speed, 0.3s)
+        var(--limel-cs-grid-template-rows-transition-speed)
         cubic-bezier(1, 0.09, 0, 0.89);
     display: grid;
-    grid-template-rows: var(--limel-cs-grid-template-rows, 0fr);
+    grid-template-rows: var(--limel-cs-grid-template-rows);
 
     slot {
-        transition: opacity var(--limel-cs-opacity-transition-speed, 0.1s) ease
-            var(--limel-cs-opacity-transition-delay, 0s);
+        transition: opacity var(--limel-cs-opacity-transition-speed) ease
+            var(--limel-cs-opacity-transition-delay);
         display: block;
         overflow: hidden;
+    }
+}
+
+:host(limel-collapsible-section:not([is-open])) {
+    --limel-cs-opacity-transition-speed: 0.1s;
+    --limel-cs-opacity-transition-delay: 0s;
+    --limel-cs-grid-template-rows-transition-speed: 0.3s;
+    --limel-cs-grid-template-rows: 0fr;
+
+    slot {
         opacity: 0;
     }
 }


### PR DESCRIPTION
The bug was introduced here: https://github.com/Lundalogik/lime-elements/pull/3737

The refactored custom css props remained `undefined` when the section was collapsed. Therefore when the section was nested inside another section, it inherited its custom css props' values from the parent section which was open. 

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined collapsible section animations with more explicit transition controls, improving consistency for opacity and layout transitions when opening and closing sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
