### PR TITLE
fix(info-tile): improve ux when size is extra small

### DIFF
--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -155,6 +155,7 @@ slot[name='primary'] {
 .label {
     z-index: 1;
     color: var(--info-tile-text-color, rgb(var(--contrast-1100)));
+    opacity: 0.8;
 
     line-height: 1.2;
     font-size: clamp(


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/crm-feature/issues/4689

reported bug: https://product.lime-crm.com/client/object/bug/10090/

Before the fix:


https://github.com/user-attachments/assets/db789f88-03d6-486f-8635-17d10782e195

<img width="567" height="429" alt="Screenshot 2025-12-09 at 11 05 57" src="https://github.com/user-attachments/assets/7cdd086b-7c30-48fa-ae43-225bd263afb1" />
<img width="445" height="205" alt="Screenshot 2025-12-09 at 11 06 33" src="https://github.com/user-attachments/assets/5b9a5c52-fbc6-4cae-b35c-501985ca8cb0" />



After the fix:


https://github.com/user-attachments/assets/5f06ce3f-9fea-4c24-9da4-aa0bf65e959e




<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
