### PR TITLE
fix(chart): proper render the last item

### DIFF
--- a/src/components/chart/partial-styles/_area_line.scss
+++ b/src/components/chart/partial-styles/_area_line.scss
@@ -52,6 +52,12 @@
                     1%
             );
         }
+
+        &:last-of-type {
+            &:before {
+                display: none;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/lime-elements/issues/3343

**before**
<img width="1464" height="523" alt="image" src="https://github.com/user-attachments/assets/f9836097-8954-4498-ae8b-f093ec79d112" />


**after**
<img width="1126" height="470" alt="Screenshot 2025-12-09 at 15 46 24" src="https://github.com/user-attachments/assets/3d95f1d1-2125-4bd3-9447-369703981c8f" />


<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chart rendering for line and area chart types to properly handle the last data item, ensuring consistent styling is applied throughout the entire chart.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
