### PR TITLE
feat(icons): allow 3rd party packages to provide icon names for auto completion

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -24,7 +24,7 @@ export type ActionBarItem<T = any> = ActionBarItemOnlyIcon<T> | ActionBarItemWit
 // @public
 export interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
     // (undocumented)
-    icon: string | Icon;
+    icon: IconName | Icon;
     // (undocumented)
     iconOnly: true;
 }
@@ -74,7 +74,7 @@ export interface ChartItem<T extends number | [number, number] = number | [numbe
 export interface Chip<T = any> {
     badge?: number;
     href?: string;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // @deprecated
     iconBackgroundColor?: Color;
     // @deprecated
@@ -187,7 +187,7 @@ export namespace Components {
     // (undocumented)
     export interface LimelBanner {
         "close": () => Promise<void>;
-        "icon": string;
+        "icon": IconName;
         "message": string;
         "open": () => Promise<void>;
     }
@@ -197,7 +197,7 @@ export namespace Components {
     }
     export interface LimelButton {
         "disabled": boolean;
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         "label": string;
         "loading": boolean;
         "loadingFailed": boolean;
@@ -218,7 +218,7 @@ export namespace Components {
         "actions"?: Array<ActionBarItem | ListSeparator>;
         "clickable": boolean;
         "heading"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "image"?: Image_2;
         "orientation": 'landscape' | 'portrait';
         "selected": boolean;
@@ -264,7 +264,7 @@ export namespace Components {
     export interface LimelChip {
         "badge"?: string | number;
         "disabled": boolean;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "identifier"?: number | string;
         "image"?: Image_2;
         "invalid": boolean;
@@ -293,7 +293,7 @@ export namespace Components {
         "invalid": boolean;
         "label": string;
         "language": Languages;
-        "leadingIcon": string;
+        "leadingIcon": IconName;
         "maxItems": number;
         "readonly": boolean;
         "required": boolean;
@@ -344,7 +344,7 @@ export namespace Components {
     export interface LimelCollapsibleSection {
         "actions": Action[];
         "header": string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "invalid": boolean;
         "isOpen": boolean;
         "language": Languages;
@@ -500,7 +500,7 @@ export namespace Components {
     }
     export interface LimelHeader {
         "heading"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "subheading"?: string;
         "subheadingDivider"?: string;
         "supportingText"?: string;
@@ -541,7 +541,7 @@ export namespace Components {
         "disabled": boolean;
         "elevated": boolean;
         "helperLabel"?: string;
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         "label": string;
     }
     export interface LimelInfoTile {
@@ -567,7 +567,7 @@ export namespace Components {
         "helperText": string;
         "invalid": boolean;
         "label": string;
-        "leadingIcon": string;
+        "leadingIcon": IconName;
         "locale": string;
         "max": number;
         "maxlength": number;
@@ -581,7 +581,7 @@ export namespace Components {
         "showLink": boolean;
         "step": number | 'any';
         "suffix": string;
-        "trailingIcon": string;
+        "trailingIcon": IconName;
         "type": InputType;
         "value": string;
     }
@@ -687,7 +687,7 @@ export namespace Components {
         "helperText": string;
         "invalid": boolean;
         "label": string;
-        "leadingIcon": string;
+        "leadingIcon": IconName;
         "multiple": boolean;
         "readonly": boolean;
         "required": boolean;
@@ -718,7 +718,7 @@ export namespace Components {
         "accept": string;
         "disabled": boolean;
         "helperText"?: string;
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         "imageFit": 'cover' | 'contain';
         "invalid": boolean;
         "label": string;
@@ -791,7 +791,7 @@ export namespace Components {
     export interface LimelShortcut {
         "badge"?: number | string;
         "disabled"?: boolean;
-        "icon": string;
+        "icon": IconName;
         "label"?: string;
         "link"?: Link;
     }
@@ -830,7 +830,7 @@ export namespace Components {
     }
     export interface LimelSplitButton {
         "disabled": boolean;
-        "icon": string;
+        "icon": IconName;
         "items": Array<MenuItem | ListSeparator>;
         "label": string;
         "loading": boolean;
@@ -958,7 +958,7 @@ export type DateType = 'datetime' | 'date' | 'time' | 'week' | 'month' | 'quarte
 // @public (undocumented)
 export interface DialogHeading {
     // (undocumented)
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // (undocumented)
     subtitle?: string;
     // (undocumented)
@@ -972,7 +972,7 @@ export interface DockItem {
     badge?: number | string;
     dockMenu?: DockMenu;
     helperLabel?: string;
-    icon: string;
+    icon: IconName;
     id: string;
     label: string;
     selected?: boolean;
@@ -1082,7 +1082,7 @@ export interface FileInfo {
     fileContent?: File;
     filename: string;
     href?: string;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // @deprecated
     iconBackgroundColor?: Color;
     // @deprecated
@@ -1218,8 +1218,15 @@ export interface Help {
 export interface Icon {
     backgroundColor?: Color;
     color?: Color;
-    name: string;
+    name: IconName;
     title?: string;
+}
+
+// @public
+export type IconName = keyof IconNameRegistry extends never ? string : keyof IconNameRegistry | (string & {});
+
+// @public
+export interface IconNameRegistry {
 }
 
 // @public (undocumented)
@@ -1604,14 +1611,14 @@ export namespace JSX {
 
     // (undocumented)
     export interface LimelBanner {
-        "icon"?: string;
+        "icon"?: IconName;
         "message"?: string;
     }
 
     // (undocumented)
     export interface LimelBannerAttributes {
         // (undocumented)
-        "icon": string;
+        "icon": IconName;
         // (undocumented)
         "message": string;
     }
@@ -1630,7 +1637,7 @@ export namespace JSX {
 
     export interface LimelButton {
         "disabled"?: boolean;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "label"?: string;
         "loading"?: boolean;
         "loadingFailed"?: boolean;
@@ -1643,7 +1650,7 @@ export namespace JSX {
         // (undocumented)
         "disabled": boolean;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "label": string;
         // (undocumented)
@@ -1691,7 +1698,7 @@ export namespace JSX {
         "actions"?: Array<ActionBarItem | ListSeparator>;
         "clickable"?: boolean;
         "heading"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "image"?: Image_2;
         "onActionSelected"?: (event: LimelCardCustomEvent<ActionBarItem>) => void;
         "orientation"?: 'landscape' | 'portrait';
@@ -1708,7 +1715,7 @@ export namespace JSX {
         // (undocumented)
         "heading": string;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "orientation": 'landscape' | 'portrait';
         // (undocumented)
@@ -1819,7 +1826,7 @@ export namespace JSX {
     export interface LimelChip {
         "badge"?: string | number;
         "disabled"?: boolean;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "identifier"?: number | string;
         "image"?: Image_2;
         "invalid"?: boolean;
@@ -1845,7 +1852,7 @@ export namespace JSX {
         // (undocumented)
         "disabled": boolean;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "identifier": string;
         // (undocumented)
@@ -1881,7 +1888,7 @@ export namespace JSX {
         "invalid"?: boolean;
         "label"?: string;
         "language"?: Languages;
-        "leadingIcon"?: string;
+        "leadingIcon"?: IconName;
         "maxItems"?: number;
         "onChange"?: (event: LimelChipSetCustomEvent<Chip | Chip[]>) => void;
         "onInput"?: (event: LimelChipSetCustomEvent<string>) => void;
@@ -1918,7 +1925,7 @@ export namespace JSX {
         // (undocumented)
         "language": Languages;
         // (undocumented)
-        "leadingIcon": string;
+        "leadingIcon": IconName;
         // (undocumented)
         "maxItems": number;
         // (undocumented)
@@ -2051,7 +2058,7 @@ export namespace JSX {
     export interface LimelCollapsibleSection {
         "actions"?: Action[];
         "header"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "invalid"?: boolean;
         "isOpen"?: boolean;
         "language"?: Languages;
@@ -2065,7 +2072,7 @@ export namespace JSX {
         // (undocumented)
         "header": string;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "invalid": boolean;
         // (undocumented)
@@ -2480,7 +2487,7 @@ export namespace JSX {
 
     export interface LimelHeader {
         "heading"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "subheading"?: string;
         "subheadingDivider"?: string;
         "supportingText"?: string;
@@ -2491,7 +2498,7 @@ export namespace JSX {
         // (undocumented)
         "heading": string;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "subheading": string;
         // (undocumented)
@@ -2589,7 +2596,7 @@ export namespace JSX {
         "disabled"?: boolean;
         "elevated"?: boolean;
         "helperLabel"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "label"?: string;
     }
 
@@ -2602,7 +2609,7 @@ export namespace JSX {
         // (undocumented)
         "helperLabel": string;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "label": string;
     }
@@ -2648,7 +2655,7 @@ export namespace JSX {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
-        "leadingIcon"?: string;
+        "leadingIcon"?: IconName;
         "locale"?: string;
         "max"?: number;
         "maxlength"?: number;
@@ -2664,7 +2671,7 @@ export namespace JSX {
         "showLink"?: boolean;
         "step"?: number | 'any';
         "suffix"?: string;
-        "trailingIcon"?: string;
+        "trailingIcon"?: IconName;
         "type"?: InputType;
         "value"?: string;
     }
@@ -2682,7 +2689,7 @@ export namespace JSX {
         // (undocumented)
         "label": string;
         // (undocumented)
-        "leadingIcon": string;
+        "leadingIcon": IconName;
         // (undocumented)
         "locale": string;
         // (undocumented)
@@ -2710,7 +2717,7 @@ export namespace JSX {
         // (undocumented)
         "suffix": string;
         // (undocumented)
-        "trailingIcon": string;
+        "trailingIcon": IconName;
         // (undocumented)
         "type": InputType;
         // (undocumented)
@@ -2972,7 +2979,7 @@ export namespace JSX {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
-        "leadingIcon"?: string;
+        "leadingIcon"?: IconName;
         "multiple"?: boolean;
         "onAction"?: (event: LimelPickerCustomEvent<Action>) => void;
         "onChange"?: (event: LimelPickerCustomEvent<ListItem<PickerValue> | Array<ListItem<PickerValue>>>) => void;
@@ -3005,7 +3012,7 @@ export namespace JSX {
         // (undocumented)
         "label": string;
         // (undocumented)
-        "leadingIcon": string;
+        "leadingIcon": IconName;
         // (undocumented)
         "multiple": boolean;
         // (undocumented)
@@ -3065,7 +3072,7 @@ export namespace JSX {
         "accept"?: string;
         "disabled"?: boolean;
         "helperText"?: string;
-        "icon"?: string | Icon;
+        "icon"?: IconName | Icon;
         "imageFit"?: 'cover' | 'contain';
         "invalid"?: boolean;
         "label"?: string;
@@ -3088,7 +3095,7 @@ export namespace JSX {
         // (undocumented)
         "helperText": string;
         // (undocumented)
-        "icon": string | Icon;
+        "icon": IconName | Icon;
         // (undocumented)
         "imageFit": 'cover' | 'contain';
         // (undocumented)
@@ -3266,7 +3273,7 @@ export namespace JSX {
     export interface LimelShortcut {
         "badge"?: number | string;
         "disabled"?: boolean;
-        "icon"?: string;
+        "icon"?: IconName;
         "label"?: string;
         "link"?: Link;
     }
@@ -3278,7 +3285,7 @@ export namespace JSX {
         // (undocumented)
         "disabled": boolean;
         // (undocumented)
-        "icon": string;
+        "icon": IconName;
         // (undocumented)
         "label": string;
     }
@@ -3378,7 +3385,7 @@ export namespace JSX {
 
     export interface LimelSplitButton {
         "disabled"?: boolean;
-        "icon"?: string;
+        "icon"?: IconName;
         "items"?: Array<MenuItem | ListSeparator>;
         "label"?: string;
         "loading"?: boolean;
@@ -3392,7 +3399,7 @@ export namespace JSX {
         // (undocumented)
         "disabled": boolean;
         // (undocumented)
-        "icon": string;
+        "icon": IconName;
         // (undocumented)
         "label": string;
         // (undocumented)
@@ -3647,7 +3654,7 @@ export namespace JSX {
 
 // @public
 export interface Label<T = LabelValue> {
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     text?: string;
     value: T;
 }
@@ -4183,7 +4190,7 @@ export interface ListComponent {
 export interface ListItem<T = any> {
     actions?: Array<MenuItem | ListSeparator>;
     disabled?: boolean;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // @deprecated
     iconColor?: Color;
     image?: Image_2;
@@ -4214,7 +4221,7 @@ interface MenuItem<T = any> {
     commandText?: string;
     disabled?: boolean;
     hotkey?: string;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // @deprecated
     iconColor?: Color;
     items?: Array<MenuItem<T> | ListSeparator> | MenuLoader;
@@ -4253,7 +4260,7 @@ export type OpenDirection = 'left-start' | 'left' | 'left-end' | 'right-start' |
 // @public
 interface Option_2<T extends string = string> {
     disabled?: boolean;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // @deprecated
     iconColor?: Color;
     secondaryText?: string;
@@ -4317,7 +4324,7 @@ export type SurfaceWidth = 'inherit-from-items' | 'inherit-from-trigger' | 'inhe
 export interface Tab {
     active?: boolean;
     badge?: number | string;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
     // @deprecated
     iconColor?: Color;
     id: number | string;

--- a/src/components/action-bar/action-bar.types.ts
+++ b/src/components/action-bar/action-bar.types.ts
@@ -1,4 +1,4 @@
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { MenuItem } from '../menu/menu.types';
 
 /**
@@ -16,7 +16,7 @@ export type ActionBarItem<T = any> =
  */
 export interface ActionBarItemOnlyIcon<T> extends MenuItem<T> {
     iconOnly: true;
-    icon: string | Icon;
+    icon: IconName | Icon;
 }
 
 /**

--- a/src/components/banner/banner.tsx
+++ b/src/components/banner/banner.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Method, Prop, State } from '@stencil/core';
+import { IconName } from '../../global/shared-types/icon.types';
 
 /**
  * @exampleComponent limel-example-banner-basic
@@ -20,7 +21,7 @@ export class Banner {
      * Set icon for the banner
      */
     @Prop({ reflect: true })
-    public icon: string;
+    public icon: IconName;
 
     @State()
     private isOpen = false;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -3,7 +3,7 @@ import {
     makeEnterClickable,
     removeEnterClickable,
 } from '../../util/make-enter-clickable';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { getIconName, getIconTitle } from '../icon/get-icon-props';
 
 /**
@@ -61,7 +61,7 @@ export class Button {
      * Set icon for the button
      */
     @Prop({ reflect: true })
-    public icon: string | Icon;
+    public icon: IconName | Icon;
 
     /**
      * Set to `true` to disable the button.
@@ -163,7 +163,7 @@ export class Button {
         ];
     }
 
-    private renderIcon(icon?: string | Icon) {
+    private renderIcon(icon?: IconName | Icon) {
         const iconName = getIconName(icon);
         if (!iconName) {
             return;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -9,7 +9,7 @@ import {
     State,
 } from '@stencil/core';
 import { Image } from '../../global/shared-types/image.types';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { isItem } from '../action-bar/is-item';
 import { getIconName } from '../icon/get-icon-props';
 import { ListSeparator } from '../../global/shared-types/separator.types';
@@ -63,7 +63,7 @@ export class Card {
      * An icon, to display along with the heading and subheading.
      */
     @Prop({ reflect: true })
-    public icon?: string | Icon;
+    public icon?: IconName | Icon;
 
     /**
      * The content of the card.

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -19,6 +19,7 @@ import { getHref, getTarget } from '../../util/link-helper';
 import { isEqual } from 'lodash-es';
 import { LimelChipCustomEvent } from '../../components';
 import { createRandomString } from '../../util/random-string';
+import { IconName } from '../../global/shared-types/icon.types';
 
 /**
  * :::note
@@ -169,7 +170,7 @@ export class ChipSet {
      * Leading icon to show to the far left in the text field
      */
     @Prop({ reflect: true })
-    public leadingIcon: string = null;
+    public leadingIcon: IconName = null;
 
     /**
      * For chip-set of type `input`. Sets delimiters between chips.

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -1,5 +1,5 @@
 import { Image } from '../../global/shared-types/image.types';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { MenuItem } from '../menu/menu.types';
 import { ListSeparator } from '../list-item/list-item.types';
 import { Color } from '../../global/shared-types/color.types';
@@ -21,7 +21,7 @@ export interface Chip<T = any> {
     /**
      * Name of the icon to use. Not valid for `filter`.
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 
     /**
      * A picture to be displayed instead of the icon on the chip.

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -7,7 +7,7 @@ import {
     Host,
     Prop,
 } from '@stencil/core';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { Languages } from '../date-picker/date.types';
 import { Link } from '../../global/shared-types/link.types';
 import { getRel } from '../../util/link-helper';
@@ -106,7 +106,7 @@ export class Chip implements ChipInterface {
      * Icon of the chip.
      */
     @Prop()
-    public icon?: string | Icon;
+    public icon?: IconName | Icon;
 
     /**
      * A picture to be displayed instead of the icon on the chip.

--- a/src/components/collapsible-section/collapsible-section.tsx
+++ b/src/components/collapsible-section/collapsible-section.tsx
@@ -13,7 +13,7 @@ import {
     removeEnterClickable,
 } from '../../util/make-enter-clickable';
 import { createRandomString } from '../../util/random-string';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import {
     getIconColor,
     getIconName,
@@ -65,7 +65,7 @@ export class CollapsibleSection {
      * Icon to display in the header of the section
      */
     @Prop()
-    public icon?: string | Icon;
+    public icon?: IconName | Icon;
 
     /**
      * `true` if the section is invalid, `false` if valid.

--- a/src/components/dialog/dialog.types.ts
+++ b/src/components/dialog/dialog.types.ts
@@ -1,4 +1,4 @@
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 
 /**
  * @public
@@ -7,7 +7,7 @@ export interface DialogHeading {
     title: string;
     subtitle?: string;
     supportingText?: string;
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 }
 
 /**

--- a/src/components/dock/dock.types.ts
+++ b/src/components/dock/dock.types.ts
@@ -1,3 +1,5 @@
+import { IconName } from '../../global/shared-types/icon.types';
+
 /**
  * @public
  */
@@ -15,7 +17,7 @@ export interface DockItem {
     /**
      * Name of the icon to use.
      */
-    icon: string;
+    icon: IconName;
 
     /**
      * Additional helper text for the dock item.

--- a/src/components/dynamic-label/dynamic-label.tsx
+++ b/src/components/dynamic-label/dynamic-label.tsx
@@ -1,7 +1,7 @@
 import { getIconName } from '../icon/get-icon-props';
 import { Component, Prop, h } from '@stencil/core';
 import { Label, LabelValue } from './label.types';
-import { Icon } from '../../interface';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 
 /**
  * This components displays a different label depending on the current given
@@ -59,7 +59,7 @@ export class DynamicLabel {
         ];
     }
 
-    private renderIcon(icon?: string | Icon) {
+    private renderIcon(icon?: IconName | Icon) {
         const iconName = getIconName(icon);
         if (!iconName) {
             return;

--- a/src/components/dynamic-label/label.types.ts
+++ b/src/components/dynamic-label/label.types.ts
@@ -1,4 +1,4 @@
-import { Icon } from '../../interface';
+import { IconName, Icon } from '../../interface';
 
 export type LabelValue = string | number | boolean | null | undefined;
 
@@ -22,5 +22,5 @@ export interface Label<T = LabelValue> {
     /**
      * Icon to display when the label is active
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, Host } from '@stencil/core';
-import { Icon } from '../../global/shared-types/icon.types';
+import { IconName, Icon } from '../../global/shared-types/icon.types';
 import { getIconName } from '../icon/get-icon-props';
 
 /**
@@ -64,7 +64,7 @@ export class Header {
      * Icon to display
      */
     @Prop()
-    public icon?: string | Icon;
+    public icon?: IconName | Icon;
 
     /**
      * Title to display

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -4,7 +4,7 @@ import {
     removeEnterClickable,
 } from '../../util/make-enter-clickable';
 import { createRandomString } from '../../util/random-string';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { getIconName, getIconTitle } from '../icon/get-icon-props';
 
 /**
@@ -26,7 +26,7 @@ export class IconButton {
      * The icon to display.
      */
     @Prop()
-    public icon: string | Icon;
+    public icon: IconName | Icon;
 
     /**
      * Set to `true` to give the button our standard "elevated" look, lifting

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -27,6 +27,7 @@ import { JSXBase } from '@stencil/core/internal';
 import { createRandomString } from '../../util/random-string';
 import { LimelListCustomEvent } from '../../components';
 import { globalConfig } from '../../global/config';
+import { IconName } from '../../global/shared-types/icon.types';
 
 interface LinkProperties {
     href: string;
@@ -134,13 +135,13 @@ export class InputField {
      * Trailing icon to show to the far right in the field.
      */
     @Prop({ reflect: true })
-    public trailingIcon: string;
+    public trailingIcon: IconName;
 
     /**
      * Leading icon to show to the far left in the field.
      */
     @Prop({ reflect: true })
-    public leadingIcon: string;
+    public leadingIcon: IconName;
 
     /**
      * Regular expression that the current value of the input field must match.
@@ -757,7 +758,7 @@ export class InputField {
         return props;
     };
 
-    private renderLinkIcon = (linkProps: LinkProperties, icon: string) => {
+    private renderLinkIcon = (linkProps: LinkProperties, icon: IconName) => {
         // If the trailing icon uses the class `mdc-text-field__icon--trailing`,
         // MDC attaches a click handler to it, which apparently runs
         // `preventDefault()` on the event. For links, we don't want that,
@@ -775,7 +776,7 @@ export class InputField {
         );
     };
 
-    private renderTrailingIcon = (icon: string) => {
+    private renderTrailingIcon = (icon: IconName) => {
         if (this.isInvalid()) {
             return (
                 <i

--- a/src/components/list-item/list-item.types.ts
+++ b/src/components/list-item/list-item.types.ts
@@ -1,5 +1,5 @@
 import { ListSeparator } from '../../global/shared-types/separator.types';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { MenuItem } from '../menu/menu.types';
 import { Image } from '../../global/shared-types/image.types';
 import { Color } from '../../global/shared-types/color.types';
@@ -27,7 +27,7 @@ export interface ListItem<T = any> {
     /**
      * Icon of the list item.
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,5 +1,5 @@
 import { ListSeparator } from '../../global/shared-types/separator.types';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { Color } from '../../global/shared-types/color.types';
 
 /**
@@ -94,7 +94,7 @@ export interface MenuItem<T = any> {
     /**
      * Name of the icon to use.
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 
     /**
      * Background color of the icon. Overrides `--icon-background-color`.

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -23,6 +23,7 @@ import {
 import { getIconFillColor, getIconName } from '../icon/get-icon-props';
 import { PickerValue } from './value.types';
 import { DebouncedFunc, debounce } from 'lodash-es';
+import { IconName } from '../../global/shared-types/icon.types';
 
 const SEARCH_DEBOUNCE = 300;
 const CHIP_SET_TAG_NAME = 'limel-chip-set';
@@ -82,7 +83,7 @@ export class Picker {
      * Leading icon to show to the far left in the text field
      */
     @Prop()
-    public leadingIcon: string;
+    public leadingIcon: IconName;
 
     /**
      * A message to display when the search returned an empty result

--- a/src/components/profile-picture/profile-picture.tsx
+++ b/src/components/profile-picture/profile-picture.tsx
@@ -10,7 +10,7 @@ import {
 } from '@stencil/core';
 import { FileInfo } from '../../global/shared-types/file.types';
 import { isTypeAccepted } from '../../util/files';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { getIconName } from '../icon/get-icon-props';
 import translate from '../../global/translations';
 import { Languages } from '../date-picker/date.types';
@@ -60,7 +60,7 @@ export class ProfilePicture {
      * Placeholder icon of the component, displayed when no image is present.
      */
     @Prop()
-    public icon: string | Icon = 'user';
+    public icon: IconName | Icon = 'user';
 
     /**
      * Helper text shown as a tooltip on hover or focus.

--- a/src/components/select/option.types.ts
+++ b/src/components/select/option.types.ts
@@ -1,5 +1,5 @@
 import { Color } from '../../global/shared-types/color.types';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 /**
  * Describes an option for limel-select.
  * @public
@@ -37,7 +37,7 @@ export interface Option<T extends string = string> {
     /**
      * Displays an icon beside the name of the option.
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 
     /**
      * Adds a color to the icon.

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -2,6 +2,7 @@ import { Component, Prop, h, Element, Host } from '@stencil/core';
 import { Link } from '../../global/shared-types/link.types';
 import { getRel } from '../../util/link-helper';
 import { getMouseEventHandlers } from '../../util/3d-tilt-hover-effect';
+import { IconName } from '../../global/shared-types/icon.types';
 
 /**
  * This component can be used on places such as a start page or a dashboard.
@@ -28,7 +29,7 @@ export class Shortcut {
      * Name of icon for the shortcut.
      */
     @Prop({ reflect: true })
-    public icon: string;
+    public icon: IconName;
 
     /**
      * The text to show below the shortcut. Long label will be truncated.

--- a/src/components/split-button/split-button.tsx
+++ b/src/components/split-button/split-button.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
 import { ListSeparator } from '../list-item/list-item.types';
 import { MenuItem } from '../menu/menu.types';
+import { IconName } from '../../global/shared-types/icon.types';
 
 /**
  * A split button is a button with two components:
@@ -41,7 +42,7 @@ export class SplitButton {
      * Set icon for the button
      */
     @Prop({ reflect: true })
-    public icon: string;
+    public icon: IconName;
 
     /**
      * Set to `true` to disable the button.

--- a/src/components/tab-bar/tab.types.ts
+++ b/src/components/tab-bar/tab.types.ts
@@ -1,5 +1,5 @@
 import { Color } from '../../global/shared-types/color.types';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from '../../global/shared-types/icon.types';
 
 /**
  * Tab interface.
@@ -19,7 +19,7 @@ export interface Tab {
     /**
      * Name of the icon to use.
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 
     /**
      * True if the tab should be selected.

--- a/src/global/shared-types/file.types.ts
+++ b/src/global/shared-types/file.types.ts
@@ -1,5 +1,5 @@
 import { MenuItem } from '../../components';
-import { Icon } from '../../global/shared-types/icon.types';
+import { Icon, IconName } from './icon.types';
 import { Color } from './color.types';
 import { ListSeparator } from './separator.types';
 
@@ -45,7 +45,7 @@ export interface FileInfo {
     /**
      * Name of the icon to use.
      */
-    icon?: string | Icon;
+    icon?: IconName | Icon;
 
     /**
      * Icon color. Overrides `--icon-color`.

--- a/src/global/shared-types/icon.types.ts
+++ b/src/global/shared-types/icon.types.ts
@@ -1,6 +1,38 @@
 import { Color } from './color.types';
 
 /**
+ * An empty interface intended for module augmentation by consuming packages.
+ *
+ * Packages can extend this interface to register their own icon names,
+ * enabling type-safe autocompletion for custom icon sets.
+ *
+ * @example
+ * ```ts
+ * declare module '@limetech/lime-elements' {
+ *     interface IconNameRegistry {
+ *         'my-custom-icon': string;
+ *         'another-icon': string;
+ *     }
+ * }
+ * ```
+ *
+ * @public
+ */
+export interface IconNameRegistry {}
+
+/**
+ * Represents a valid icon name.
+ *
+ * When `IconNameRegistry` is augmented, this type provides autocompletion
+ * for registered icon names while still accepting any string value.
+ *
+ * @public
+ */
+export type IconName = keyof IconNameRegistry extends never
+    ? string
+    : keyof IconNameRegistry | (string & {});
+
+/**
  * This interface is used to specify which icon to use in many components,
  * along with related properties, like color.
  * @public
@@ -9,7 +41,7 @@ export interface Icon {
     /**
      * Name of the icon, refers to the icon's filename in lime-icons8 repository.
      */
-    name: string;
+    name: IconName;
 
     /**
      * Color of the icon.


### PR DESCRIPTION
fix Lundalogik/crm-client#622

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified icon typing across components for consistent icon selection.
  * Standardized icon props to accept named icon identifiers or icon objects, improving IDE autocompletion.
  * No runtime or visual changes — type-level updates that make configuring icons more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## How to test
- Build `@limetech/lime-elements`
- Link `@limetech/lime-elements` inside `@lundalogik/lime-icons8`
- Build `@lundalogik/lime-icons8`
- Link `@limetech/lime-elements` and `@lundalogik/lime-icons8` inside any package (or test in https://github.com/Lundalogik/lime-crm-building-blocks/pull/1264 or https://github.com/Lundalogik/lime-crm-components/pull/3994)
- Ensure the icon types are imported, e.g. by adding `import '@lundalogik/lime-icons8';` somewhere
- Test the auto completion on any component using an icon
 
<img width="875" height="386" alt="image" src="https://github.com/user-attachments/assets/bb01b5d4-786a-4d12-86d2-f59fc03742a2" />


## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
