### PR TITLE
ci(publish-docs): exclude pre-release versions from `latest` symlink

### DIFF
--- a/publish-docs.cjs
+++ b/publish-docs.cjs
@@ -311,10 +311,10 @@ function updateVersionList() {
 
     shell.cd('..');
 
-    // Keep only versions that begin with a digit. Any versions beginning with
-    // a letter are pull requests, pre-releases, or other special cases, not
-    // eligible as "Latest".
-    const fullVersions = files.filter((file) => file.match(/^\d.*/));
+    // Keep only full release versions (X.Y.Z format). Any versions with
+    // pre-release suffixes (like -dev, -alpha, -rc) or other non-standard
+    // formats are not eligible as "Latest".
+    const fullVersions = files.filter((file) => file.match(/^\d+\.\d+\.\d+$/));
     createSymlinkForRelease(fullVersions, 'latest');
 }
 


### PR DESCRIPTION
The regex `/^\d.*/` matched any version starting with a digit, including pre-release versions like `38.38.1-dev.2`. This caused the `latest` symlink to incorrectly point to pre-release versions.

Changed to `/^\d+\.\d+\.\d+$/` to match only strict semver format.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version filtering to strictly enforce semantic versioning format (X.Y.Z) for documentation releases. This ensures only properly formatted release versions are considered when assigning the 'latest' documentation alias, preventing potential issues with improperly formatted version strings being incorrectly included in the latest release documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
