### PR TITLE
chore: remove entirely unused private type `TextEditorPlugin`

### DIFF
--- a/src/components/text-editor/types.ts
+++ b/src/components/text-editor/types.ts
@@ -1,13 +1,3 @@
-import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
-
-/**
- * set to private to avoid usage while under development
- * @private
- */
-export type TextEditorPlugin = {
-    node: CustomElementDefinition[];
-};
-
 /**
  * @beta
  */


### PR DESCRIPTION
`TextEditorPlugin` is literally only found here when searching the whole of our GitHub org:
https://github.com/search?q=org%3ALundalogik%20TextEditorPlugin&type=code

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal type definitions in the text editor module by removing unused type exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
