### PR TITLE
chore: remove entirely unused private type `TextEditorPlugin`

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -2850,13 +2850,6 @@ export type TextEditorNode = {
     children?: Array<TextEditorNode | string>;
 };
 
-// Warning: (ae-missing-release-tag) "TextEditorPlugin" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
-export type TextEditorPlugin = {
-    node: CustomElementDefinition[];
-};
-
 // @alpha
 export type Trigger = {
     character: TriggerCharacter;
@@ -2883,10 +2876,6 @@ export interface ValidationStatus {
     errors?: FormError[];
     valid: boolean;
 }
-
-// Warnings were encountered during analysis:
-//
-// dist/types/components/text-editor/types.d.ts:7:3 - (ae-incompatible-release-tags) The symbol "node" is marked as @public, but its signature references "CustomElementDefinition" which is marked as @alpha
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/components/text-editor/types.ts
+++ b/src/components/text-editor/types.ts
@@ -1,13 +1,3 @@
-import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
-
-/**
- * set to private to avoid usage while under development
- * @private
- */
-export type TextEditorPlugin = {
-    node: CustomElementDefinition[];
-};
-
 /**
  * @beta
  */


### PR DESCRIPTION
`TextEditorPlugin` is literally only found here when searching the whole of our GitHub org:
https://github.com/search?q=org%3ALundalogik%20TextEditorPlugin&type=code

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * A public type definition previously exported from the text editor component has been removed. Applications that were importing or utilizing this type will need to be updated accordingly, either by implementing alternative approaches to achieve the same functionality or by refactoring code sections that relied on this specific type export.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
