### PR TITLE
refactor(scss): add explicit @use statements to partial files

### DIFF
--- a/src/components/chart/partial-styles/_layout-for-charts-with-x-y-axises.scss
+++ b/src/components/chart/partial-styles/_layout-for-charts-with-x-y-axises.scss
@@ -1,3 +1,5 @@
+@use '../../../style/mixins';
+
 :host(limel-chart[type='bar']),
 :host(limel-chart[type='dot']),
 :host(limel-chart[type='line']),

--- a/src/components/dock/partial-styles/shrink-expand-button.scss
+++ b/src/components/dock/partial-styles/shrink-expand-button.scss
@@ -1,3 +1,6 @@
+@use '../../../style/mixins';
+@use '../../../style/functions';
+
 .expand-shrink {
     all: unset;
     box-sizing: border-box;

--- a/src/components/file-viewer/partial-styles/ui-controls.scss
+++ b/src/components/file-viewer/partial-styles/ui-controls.scss
@@ -1,3 +1,6 @@
+@use '../../../style/functions';
+@use '../../../style/mixins';
+
 .buttons {
     position: absolute;
     z-index: 1;

--- a/src/components/input-field/partial-styles/_readonly.scss
+++ b/src/components/input-field/partial-styles/_readonly.scss
@@ -1,3 +1,7 @@
+@use '../../../style/internal/z-index';
+@use '../../../style/mixins';
+@use '../../../style/internal/shared_input-select-picker';
+
 :host([type='url']),
 :host([type='urlAsText']),
 :host([type='tel']) {

--- a/src/components/list/partial-styles/_has-grid-layout.scss
+++ b/src/components/list/partial-styles/_has-grid-layout.scss
@@ -1,3 +1,5 @@
+@use '../../../style/functions';
+
 :host(.has-grid-layout) {
     --gap: var(--list-grid-gap, 0.5rem);
     padding: var(--gap);

--- a/src/components/list/partial-styles/_static-actions.scss
+++ b/src/components/list/partial-styles/_static-actions.scss
@@ -1,3 +1,5 @@
+@use '../../../style/functions';
+
 // This is used in limel-picker only for now
 
 :host(.static-actions-list) {

--- a/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
+++ b/src/components/progress-flow/progress-flow-item/partial-styles/_selected-indicator.scss
@@ -1,3 +1,5 @@
+@use '../../../../style/functions';
+
 .step {
     // `before` is circle
 

--- a/src/components/select/partial-styles/_readonly.scss
+++ b/src/components/select/partial-styles/_readonly.scss
@@ -1,3 +1,5 @@
+@use '../../../style/internal/shared_input-select-picker';
+
 .limel-select.mdc-select {
     &.limel-select--readonly {
         .limel-select-trigger {

--- a/src/components/slider/partial-styles/_thumb.scss
+++ b/src/components/slider/partial-styles/_thumb.scss
@@ -1,3 +1,5 @@
+@use '../../../style/functions';
+
 .mdc-slider__thumb-knob {
     .mdc-slider:not(.mdc-slider--disabled) & {
         &:before,


### PR DESCRIPTION
Add `@use` declarations for mixins, functions, and internal modules, to resolve deprecation warnings. These warnings will start breaking the build when Stencil and Sass is updated.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated select component readonly styling with improved visual consistency and disabled interaction states.

* **Refactor**
  * Reorganized internal style dependencies across multiple components for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
