### PR TITLE
test(split-button): refactor some test cases to be more robust against jest implementation changes

### DIFF
--- a/src/components/split-button/split-button.spec.tsx
+++ b/src/components/split-button/split-button.spec.tsx
@@ -7,13 +7,13 @@ let page: SpecPage;
 test('the component renders without menu items', async () => {
     const splitButton = await createComponent([]);
 
-    expect(splitButton).toEqualHtml(`
-            <limel-split-button>
-                <mock:shadow-root>
-                    <limel-button></limel-button>
-                </mock:shadow-root>
-            </limel-split-button>
-        `);
+    expect(splitButton.tagName.toLowerCase()).toBe('limel-split-button');
+    expect(splitButton.classList.contains('has-menu')).toBe(false);
+
+    const shadowRoot = splitButton.shadowRoot;
+    expect(shadowRoot).toBeTruthy();
+    expect(shadowRoot.querySelector('limel-button')).toBeTruthy();
+    expect(shadowRoot.querySelector('limel-menu')).toBeFalsy(); // No menu when no items
 });
 
 test('the component renders with menu items', async () => {
@@ -24,18 +24,20 @@ test('the component renders with menu items', async () => {
 
     const splitButton = await createComponent(items);
 
-    expect(splitButton).toEqualHtml(`
-            <limel-split-button class="has-menu">
-                <mock:shadow-root>
-                    <limel-button></limel-button>
-                    <limel-menu opendirection="bottom">
-                        <button class="menu-trigger" slot="trigger">
-                            ⋮
-                        </button>
-                    </limel-menu>
-                </mock:shadow-root>
-            </limel-split-button>
-        `);
+    expect(splitButton.tagName.toLowerCase()).toBe('limel-split-button');
+    expect(splitButton.classList.contains('has-menu')).toBe(true);
+
+    const shadowRoot = splitButton.shadowRoot;
+    expect(shadowRoot).toBeTruthy();
+    expect(shadowRoot.querySelector('limel-button')).toBeTruthy();
+
+    const menu = shadowRoot.querySelector('limel-menu');
+    expect(menu).toBeTruthy();
+    expect(menu.getAttribute('opendirection')).toBe('bottom');
+
+    const menuTrigger = shadowRoot.querySelector('button.menu-trigger');
+    expect(menuTrigger).toBeTruthy();
+    expect(menuTrigger.getAttribute('slot')).toBe('trigger');
 });
 
 async function createComponent(items: any) {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for the split-button component by refactoring assertions to directly verify DOM structure and attributes, ensuring more robust validation of component behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
