### PR TITLE
ci(testing): add verbose output when GitHub Actions debug logging is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --max-warnings=0 && prettier -c --ignore-path .gitignore **/*.scss",
     "lint:fix": "eslint --max-warnings=0 --fix && prettier --write --ignore-path .gitignore **/*.scss",
     "start": "npm run watch",
-    "test": "cross-env-shell SASS_PATH=node_modules \"stencil test --spec --e2e\"",
+    "test": "node scripts/run-tests.cjs",
     "test:watch": "cross-env-shell SASS_PATH=node_modules \"stencil test --spec --e2e --watch\"",
     "test:e2e": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e\"",
     "test:e2e:watch": "cross-env-shell SASS_PATH=node_modules \"stencil test --e2e --watch\"",


### PR DESCRIPTION
Adds a test runner wrapper script that automatically enables verbose output when debug logging is enabled.

The wrapper detects ACTIONS_STEP_DEBUG, RUNNER_DEBUG, or DEBUG env vars and adds the --verbose flag to the stencil test command.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test execution now uses a new Node-based test runner (replacing the prior invocation).
  * Debugging support improved: enabling debug environment variables increases verbosity.
  * Runner logs the invoked command and better propagates process exit codes and termination signals for clearer CI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
