### PR TITLE
fix(form): prevent duplication of sections after drag to reorder

### DIFF
--- a/src/components/form/templates/array-field.spec.ts
+++ b/src/components/form/templates/array-field.spec.ts
@@ -1,0 +1,46 @@
+import { ArrayFieldTemplate } from './array-field';
+
+function createTemplate() {
+    return new ArrayFieldTemplate({
+        items: [],
+        schema: { type: 'array', items: { type: 'string' } },
+        formData: [],
+        formContext: { schema: {} },
+        title: 'Test',
+        canAdd: false,
+        onAddClick: jest.fn(),
+        disabled: false,
+        readonly: false,
+    } as any);
+}
+
+describe('ArrayFieldTemplate', () => {
+    describe('readOrderFromDom()', () => {
+        it('ignores nested array items when reading order', () => {
+            const template = createTemplate();
+
+            const container = document.createElement('div');
+
+            const item0 = document.createElement('div');
+            item0.className = 'array-item';
+            item0.dataset.reorderId = '0';
+
+            // Simulate a nested array field rendering its own `.array-item`s
+            // inside a parent item (e.g. when a collapsible section is expanded).
+            const nested0 = document.createElement('div');
+            nested0.className = 'array-item';
+            nested0.dataset.reorderId = '0';
+            item0.append(nested0);
+
+            const item1 = document.createElement('div');
+            item1.className = 'array-item';
+            item1.dataset.reorderId = '1';
+
+            container.append(item0, item1);
+
+            (template as any).container = container;
+
+            expect((template as any).readOrderFromDom()).toEqual([0, 1]);
+        });
+    });
+});

--- a/src/components/form/templates/array-field.ts
+++ b/src/components/form/templates/array-field.ts
@@ -397,7 +397,12 @@ export class ArrayFieldTemplate extends React.Component<
             return [];
         }
 
-        const items = [...this.container.querySelectorAll('.array-item')];
+        // Only read the order of the direct children of this array field.
+        // Nested array fields may render `.array-item` elements inside items,
+        // and those must not affect the parent order.
+        const items = [...this.container.children].filter((element) => {
+            return Boolean(element?.classList?.contains?.('array-item'));
+        }) as HTMLElement[];
 
         const order: number[] = [];
 
@@ -411,16 +416,12 @@ export class ArrayFieldTemplate extends React.Component<
         return order;
     }
 
-    private getReorderId(element: Element | null): number | undefined {
+    private getReorderId(element: HTMLElement | null): number | undefined {
         if (!element) {
             return undefined;
         }
 
-        if (!(element instanceof HTMLElement)) {
-            return undefined;
-        }
-
-        const value = element.dataset.reorderId;
+        const value = element?.dataset?.reorderId;
         if (value === undefined) {
             return undefined;
         }


### PR DESCRIPTION
Fixes a bug where reordering a collapsible array item duplicated items when the section contained a nested reorderable list.

fix https://github.com/Lundalogik/crm-client/issues/623

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array field ordering to correctly ignore nested arrays when determining item order.

* **Tests**
  * Added unit test coverage for array field template ordering with nested items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
