### PR TITLE
feat(code-editor): make rendering the copy button a property

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -319,6 +319,7 @@ export namespace Components {
         "lint": boolean;
         "readonly": boolean;
         "required": boolean;
+        "showCopyButton": boolean;
         "translationLanguage": Languages;
         "value": string;
     }
@@ -1534,6 +1535,7 @@ export namespace JSX {
         "onChange"?: (event: LimelCodeEditorCustomEvent<string>) => void;
         "readonly"?: boolean;
         "required"?: boolean;
+        "showCopyButton"?: boolean;
         "translationLanguage"?: Languages;
         "value"?: string;
     }

--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -34,6 +34,7 @@ type CopyState = 'idle' | 'success' | 'failed';
  * @exampleComponent limel-example-code-editor
  * @exampleComponent limel-example-code-editor-readonly-with-line-numbers
  * @exampleComponent limel-example-code-editor-fold-lint-wrap
+ * @exampleComponent limel-example-code-editor-copy
  * @exampleComponent limel-example-code-editor-composite
  */
 @Component({
@@ -132,6 +133,12 @@ export class CodeEditor {
      */
     @Prop({ reflect: true })
     public translationLanguage: Languages = 'en';
+
+    /**
+     * Set to false to hide the copy button
+     */
+    @Prop({ reflect: true })
+    public showCopyButton = true;
 
     /**
      * Emitted when the code has changed. Will only be emitted when the code
@@ -389,7 +396,7 @@ export class CodeEditor {
     private renderCopyButton() {
         const hasContent = !!(this.editor?.getValue() || this.value);
 
-        if (!hasContent || this.disabled) {
+        if (!hasContent || this.disabled || !this.showCopyButton) {
             return;
         }
 

--- a/src/components/code-editor/examples/code-editor-copy.tsx
+++ b/src/components/code-editor/examples/code-editor-copy.tsx
@@ -1,0 +1,52 @@
+import { Component, h, State, Host } from '@stencil/core';
+import { data } from '../../table/examples/birds';
+
+/**
+ * Copy Button
+ * The copy button of the code editor appears on hover and focus, when the editor contains content and is
+ * in any state other than disabled. The appearance of the button can be configured via the `copyButton` property.
+ */
+
+@Component({
+    tag: 'limel-example-code-editor-copy',
+    shadow: true,
+    styleUrl: 'code-editor.scss',
+})
+export class CodeExampleCopy {
+    @State()
+    private json: string = JSON.stringify(data, null, '    ');
+
+    @State()
+    private showCopyButton = true;
+
+    public render() {
+        return (
+            <Host>
+                <limel-code-editor
+                    value={this.json}
+                    language="json"
+                    showCopyButton={this.showCopyButton}
+                    onChange={this.handleChange}
+                />
+
+                <limel-example-controls
+                    style={{ '--example-controls-column-layout': 'auto-fit' }}
+                >
+                    <limel-switch
+                        value={this.showCopyButton}
+                        label="showCopyButton"
+                        onChange={this.toggleCopyButton}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.json = event.detail;
+    };
+
+    private toggleCopyButton = (event: CustomEvent<boolean>) => {
+        this.showCopyButton = event.detail;
+    };
+}


### PR DESCRIPTION
fix: https://github.com/Lundalogik/lime-elements/issues/3797

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CodeEditor now includes a new setting to control the visibility of the copy-to-clipboard button. The button is enabled by default, but you can disable it when needed. This provides greater flexibility for customizing the editor interface while maintaining full backward compatibility with existing implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
