### PR TITLE
feat(input-field): enable focus delegation for programmatic focus

### DIFF
--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -55,7 +55,7 @@ const RESIZE_HANDLER_DEBOUNCE_TIMEOUT = 100;
  */
 @Component({
     tag: 'limel-input-field',
-    shadow: true,
+    shadow: { delegatesFocus: true },
     styleUrl: 'input-field.scss',
 })
 export class InputField {


### PR DESCRIPTION
We want to be able to focus the input field in our editor merge tags dialog in lime-marketing:
<img width="1017" height="219" alt="Skärmavbild 2026-01-28 kl  11 52 11" src="https://github.com/user-attachments/assets/5af3bf5c-3fbe-4135-aa90-d35c563e4f8a" />

fix Lundalogik/lime-marketing#130

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling in the input field component by enabling proper focus delegation. This enhances keyboard navigation and accessibility when interacting with input fields containing nested content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
