### PR TITLE
chore(ai-avatar): add new custom CSS props for changing ring colors

### DIFF
--- a/src/components/ai-avatar/ai-avatar.scss
+++ b/src/components/ai-avatar/ai-avatar.scss
@@ -2,7 +2,12 @@
 * @prop --ai-avatar-animation-play-state: Set it to `running` to start the animation.
 * @prop --ai-avatar-core-blend-mode: Controls the blend mode for the core and orbitals. Defaults to `plus-lighter`.
 * @prop --ai-avatar-rings-blend-mode: Controls the blend mode for the SVG circles. Defaults to `screen`.
+* @prop --ai-avatar-color-one: Controls the color of the first ring. Defaults to `var(--color-red-default)`.
+* @prop --ai-avatar-color-two: Controls the color of the second ring. Defaults to `var(--color-green-default)`.
+* @prop --ai-avatar-color-three: Controls the color of the third ring. Defaults to `var(--color-blue-default)`.
+* @prop --ai-avatar-color-four: Controls the color of the fourth ring. Defaults to `var(--color-orange-default)`.
 */
+
 :host(limel-ai-avatar) {
     display: flex;
     justify-content: center;
@@ -134,28 +139,28 @@ svg {
 
 .red {
     rotate: 20deg;
-    color: rgb(var(--color-red-default));
+    color: var(--ai-avatar-color-one, rgb(var(--color-red-default)));
     animation-name: rotate, scale-circle-one;
     animation-duration: 5s;
 }
 
 .green {
     rotate: 36deg;
-    color: rgb(var(--color-green-default));
+    color: var(--ai-avatar-color-two, rgb(var(--color-green-default)));
     animation-name: rotate, scale-circle-two;
     animation-duration: 5.5s;
 }
 
 .blue {
     rotate: 100deg;
-    color: rgb(var(--color-blue-default));
+    color: var(--ai-avatar-color-three, rgb(var(--color-blue-default)));
     animation-name: rotate, scale-circle-three;
     animation-duration: 4.5s;
 }
 
 .orange {
     rotate: 165deg;
-    color: rgb(var(--color-orange-default));
+    color: var(--ai-avatar-color-four, rgb(var(--color-orange-default)));
     animation-name: rotate, scale-circle-four;
     animation-duration: 6.5s;
 }

--- a/src/components/ai-avatar/ai-avatar.tsx
+++ b/src/components/ai-avatar/ai-avatar.tsx
@@ -17,6 +17,7 @@ import translate from './../../global/translations';
  * @exampleComponent limel-example-ai-avatar-basic
  * @exampleComponent limel-example-ai-avatar-colors
  * @exampleComponent limel-example-ai-avatar-white-background
+ * @exampleComponent limel-example-ai-avatar-color-props
  */
 @Component({
     tag: 'limel-ai-avatar',

--- a/src/components/ai-avatar/examples/ai-avatar-color-props.scss
+++ b/src/components/ai-avatar/examples/ai-avatar-color-props.scss
@@ -1,0 +1,8 @@
+@forward './ai-avatar-basic.scss';
+
+limel-ai-avatar {
+    --ai-avatar-color-one: rgb(255, 105, 180); // hot pink
+    --ai-avatar-color-two: rgb(75, 0, 130); // indigo
+    --ai-avatar-color-three: rgb(0, 255, 255); // cyan
+    --ai-avatar-color-four: rgb(255, 140, 0); // dark orange
+}

--- a/src/components/ai-avatar/examples/ai-avatar-color-props.tsx
+++ b/src/components/ai-avatar/examples/ai-avatar-color-props.tsx
@@ -1,0 +1,40 @@
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Changing Colors
+ *
+ * Using the provided CSS Properties, you can customize the colors of the
+ * AI Avatar's rings to match your application's theme or personal preferences.
+ *
+ */
+@Component({
+    tag: 'limel-example-ai-avatar-color-props',
+    shadow: true,
+    styleUrl: 'ai-avatar-color-props.scss',
+})
+export class AiAvatarColorPropsExample {
+    @State()
+    private isThinking = false;
+
+    public render() {
+        return (
+            <Host>
+                <div class="avatar-container">
+                    <limel-ai-avatar isThinking={this.isThinking} />
+                </div>
+                <limel-example-controls>
+                    <limel-checkbox
+                        checked={this.isThinking}
+                        label="Is thinking"
+                        onChange={this.setIsThinking}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private readonly setIsThinking = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.isThinking = event.detail;
+    };
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Avatar ring colors can now be customized using CSS custom properties. The four new properties allow independent control of each ring color variant while maintaining full backward compatibility.

* **Documentation**
  * Added example demonstrating how to customize AI Avatar ring colors using the new CSS properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
