### PR TITLE
ci(build-docs): correct condition for artifact upload steps

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -62,12 +62,12 @@ jobs:
           npm run docs:publish -- --v="$DOCS_VERSION"
         fi
     - name: Build docs for artifact
-      if: github.event_name == 'workflow_call' && inputs.buildOnly
+      if: inputs.buildOnly
       env:
         DOCS_VERSION: ${{ inputs.version }}
       run: npm run docs:publish -- --v="$DOCS_VERSION" --artifactMode
     - name: Write metadata
-      if: github.event_name == 'workflow_call' && inputs.buildOnly
+      if: inputs.buildOnly
       run: |
         if [ -z "${{ inputs.prNumber }}" ]; then
           echo "prNumber input is required when buildOnly=true" >&2
@@ -76,7 +76,7 @@ jobs:
         echo "${{ inputs.version }}" > pr-metadata.txt
         echo "${{ inputs.prNumber }}" >> pr-metadata.txt
     - name: Upload docs artifact
-      if: github.event_name == 'workflow_call' && inputs.buildOnly
+      if: inputs.buildOnly
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: pr-docs
@@ -87,7 +87,7 @@ jobs:
           docs-index.css
         retention-days: 1
     - name: Upload metadata artifact
-      if: github.event_name == 'workflow_call' && inputs.buildOnly
+      if: inputs.buildOnly
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: pr-docs-metadata


### PR DESCRIPTION
`github.event_name` in a reusable workflow reflects the caller's event (e.g., `pull_request`), not `workflow_call`. The condition was never true, so artifact upload steps never ran.

Changed from: `github.event_name == 'workflow_call' && inputs.buildOnly`
Changed to: `inputs.buildOnly`

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation build workflow conditions for improved reliability.

* **Bug Fixes**
  * Enhanced error detection in the build process with explicit failure handling when critical build parameters are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
