### PR TITLE
feat(card): handle shadow effect for long item content

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -79,9 +79,57 @@ img {
     }
 }
 
-limel-markdown {
-    overflow-y: auto;
-    padding: 0.5rem 0.75rem;
+.markdown-wrapper {
+    position: relative;
+
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+
+    limel-markdown {
+        overflow-y: auto;
+        flex-grow: 1;
+        padding: 0.5rem 0.75rem;
+    }
+
+    &::before {
+        top: 0;
+
+        background: radial-gradient(
+            farthest-side at 50% 0%,
+            rgb(0 0 0 / 16%),
+            rgb(0 0 0 / 0%)
+        );
+    }
+
+    &::after {
+        bottom: 0;
+
+        background: radial-gradient(
+            farthest-side at 50% 100%,
+            rgb(0 0 0 / 16%),
+            rgb(0 0 0 / 0%)
+        );
+    }
+
+    &::before,
+    &::after {
+        content: '';
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        left: 0;
+        height: 0.75rem;
+
+        opacity: 0;
+        transition: opacity 0.6s ease;
+        background-repeat: no-repeat;
+    }
+
+    &.can-scroll-up::before,
+    &.can-scroll-down::after {
+        opacity: 1;
+    }
 }
 
 header {

--- a/src/components/card/examples/card-scrollable-shadow.scss
+++ b/src/components/card/examples/card-scrollable-shadow.scss
@@ -1,0 +1,5 @@
+@import './card-resizable-container';
+
+limel-card {
+    max-height: 20rem;
+}

--- a/src/components/card/examples/card-scrollable-shadow.tsx
+++ b/src/components/card/examples/card-scrollable-shadow.tsx
@@ -1,0 +1,92 @@
+import { Component, h, State } from '@stencil/core';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
+
+/**
+ * Scrollable content with shadow indicators
+ * When a card contains long content that exceeds the container height,
+ * shadow fade effects automatically appear to indicate scrollable areas.
+ *
+ * The shadows dynamically show/hide based on scroll position:
+ * - **Top shadow** appears when you can scroll up
+ * - **Bottom shadow** appears when you can scroll down
+ *
+ * This provides a visual cue to users that there is more content available,
+ * improving the overall user experience and discoverability of information.
+ *
+ * :::tip
+ * Try scrolling the content to see how the shadows adapt to your scroll position!
+ * :::
+ */
+@Component({
+    shadow: true,
+    tag: 'limel-example-card-scrollable-shadow',
+    styleUrl: 'card-scrollable-shadow.scss',
+})
+export class CardScrollableShadowExample {
+    @State()
+    private actions: Array<ActionBarItem | ListSeparator> = [
+        {
+            text: 'Read more',
+        },
+        {
+            text: 'Copy',
+            icon: {
+                name: 'copy',
+                color: 'rgb(var(--color-blue-default))',
+            },
+        },
+    ];
+    public render() {
+        const icon = {
+            name: 'scroll',
+            title: 'Scroll indicator',
+        };
+
+        const longMarkdownContent = `
+## Interactive Scroll Shadows
+
+This card demonstrates **automatic scroll shadow indicators** that help users understand when content extends beyond the visible area.
+
+### How it works
+
+The shadows appear dynamically based on your scroll position:
+
+1. **Bottom Shadow**: Visible when there's content below
+2. **Top Shadow**: Appears when you scroll down and can scroll back up
+3. **No Shadow**: When you've reached the end in either direction
+
+### Benefits
+
+- ✨ Provides visual feedback about scrollable content
+- 🎯 Improves content discoverability
+- 🚀 Enhances user experience with subtle cues
+- ♿ Better accessibility through clear affordances
+
+### Technical Details
+
+The implementation uses:
+- \`scrollHeight\` vs \`clientHeight\` detection
+- Dynamic CSS classes based on scroll position
+- ResizeObserver for responsive updates
+- Smooth opacity transitions
+
+### Try it yourself
+
+Scroll up and down to see the shadows appear and disappear at the top and bottom edges of the content area.
+
+---
+
+*This is the end of the content. Notice how the bottom shadow disappears!*
+`;
+
+        return (
+            <limel-card
+                icon={icon}
+                heading="Scrollable Content"
+                subheading="With dynamic shadow indicators"
+                value={longMarkdownContent}
+                actions={this.actions}
+            />
+        );
+    }
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/limepkg-knowledge-base/issues/19


https://github.com/user-attachments/assets/59ea80e7-a5f7-439f-b6a0-6c6e45b711fe


<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cards with long content now show top and bottom scroll-shadow indicators that reveal additional content and indicate scroll position.

* **Style**
  * Subtle, animated fade effects added to card edges that appear/disappear as you scroll; preserves existing spacing and confines scrolling to the card content.

* **Examples**
  * Added an example demonstrating the scroll-shadow behavior and card-contained scrolling with long Markdown content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
