### PR TITLE
fix(markdown): strip style tags and their content

### DIFF
--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -99,6 +99,7 @@ function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
 
     const whitelist: Schema = {
         ...defaultSchema,
+        strip: [...(defaultSchema.strip ?? []), 'style'],
         tagNames: [
             ...(defaultSchema.tagNames || []),
             ...allowedComponents.map((component) => component.tagName),


### PR DESCRIPTION
## Summary

- `rehypeSanitize` unwraps disallowed tags by default — the tag is removed but its text content is preserved as a visible text node
- This caused CSS from `<style>` blocks (e.g. Outlook Web HTML emails) to appear as visible text when rendered by `limel-markdown`
- Fixed by extending `defaultSchema.strip` with `'style'` so that `<style>` elements are removed along with all their content
- `<script>` is already in `defaultSchema.strip`; this change adds only `'style'` and merges with the default rather than overriding it

## Test plan

- [ ] Send an HTML email from Outlook on the Web (OWA) that includes inline styles — verify no CSS text leaks into the rendered output
- [ ] Verify that regular HTML content (paragraphs, links, images) is still rendered correctly
- [ ] Verify that `<script>` content is still stripped (existing behaviour, not changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)