### PR TITLE
fix(card): ensure small images won't create huge cards

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -55,12 +55,12 @@ section {
     gap: 0.5rem;
 }
 
-img {
-    transition: filter 0.6s ease;
-    object-fit: cover;
-    border-radius: calc(
-        var(--card-border-radius, $default-border-radius) / 1.4
-    );
+.image-wrapper {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     :host(limel-card[orientation='portrait']) & {
         width: 100%;
     }
@@ -70,7 +70,23 @@ img {
 
         max-width: 40%;
         height: 100%;
+
+        img {
+            height: 100%;
+        }
     }
+}
+
+img {
+    transition: filter 0.6s ease;
+    object-fit: cover;
+    border-radius: calc(
+        var(--card-border-radius, $default-border-radius) / 1.4
+    );
+    min-width: 0.5rem;
+    min-height: 0.5rem;
+    max-width: 100%;
+    max-height: 100%;
 
     section:hover &,
     section:focus-visible & {

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -214,7 +214,11 @@ export class Card {
             return;
         }
 
-        return <img src={this.image.src} alt={this.image.alt} loading="lazy" />;
+        return (
+            <div class="image-wrapper">
+                <img src={this.image.src} alt={this.image.alt} loading="lazy" />
+            </div>
+        );
     }
 
     private renderHeader() {


### PR DESCRIPTION
How would a small image get rendered in the card:

**Before:**
<img width="320" height="438" alt="image" src="https://github.com/user-attachments/assets/72fda8f5-850c-4732-9c2d-638d78dd2879" />

**After:**
<img width="353" height="261" alt="image" src="https://github.com/user-attachments/assets/d1e42c42-2669-438c-871a-1b3d7d952613" />

link to this linkedIn logo for testing: 
```
https://external-content.duckduckgo.com/ip3/www.linkedin.com.ico
```

⚠️ Note. This is for now only working on `orientation="portrait"` (the default orientation). For `orientation="landscape"` fixing it will be hard. So it's not traetd in this PR. 

fix https://github.com/Lundalogik/crm-client/issues/668

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->


<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved card image layout with centered content and a dedicated wrapper for consistent alignment.
  * Enhanced responsive sizing to maintain proportions in portrait and landscape orientations.
  * Preserved hover/focus effects while adjusting scope to match the new structure.
  * Refined image scaling and sizing constraints for more consistent visuals across viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
