### PR TITLE
feat(card): show selected state when an article is selected

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -222,6 +222,7 @@ export namespace Components {
         "icon"?: string | Icon;
         "image"?: Image_2;
         "orientation": 'landscape' | 'portrait';
+        "selected": boolean;
         "subheading"?: string;
         "value"?: string;
     }
@@ -1655,6 +1656,7 @@ export namespace JSX {
         "image"?: Image_2;
         "onActionSelected"?: (event: LimelCardCustomEvent<ActionBarItem>) => void;
         "orientation"?: 'landscape' | 'portrait';
+        "selected"?: boolean;
         "subheading"?: string;
         "value"?: string;
     }
@@ -1669,6 +1671,8 @@ export namespace JSX {
         "icon": string | Icon;
         // (undocumented)
         "orientation": 'landscape' | 'portrait';
+        // (undocumented)
+        "selected": boolean;
         // (undocumented)
         "subheading": string;
         // (undocumented)

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -224,3 +224,12 @@ section {
         @include mixins.the-3d-element--clickable;
     }
 }
+
+:host(limel-card[selected]) section {
+    &,
+    &:hover,
+    &:focus-visible,
+    &:active {
+        box-shadow: var(--shadow-focused-state);
+    }
+}

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -25,6 +25,7 @@ import { getMouseEventHandlers } from '../../util/3d-tilt-hover-effect';
  * @exampleComponent limel-example-card-image
  * @exampleComponent limel-example-card-actions
  * @exampleComponent limel-example-card-clickable
+ * @exampleComponent limel-example-card-selected
  * @exampleComponent limel-example-card-orientation
  * @exampleComponent limel-example-card-slot
  * @exampleComponent limel-example-card-styling
@@ -90,6 +91,13 @@ export class Card {
      */
     @Prop({ reflect: true })
     public orientation: 'landscape' | 'portrait' = 'portrait';
+
+    /**
+     * When `true`, the card displays a visual selected state (highlighted border shadow).
+     * Should be used together with `clickable` to let users toggle selection.
+     */
+    @Prop({ reflect: true })
+    public selected: boolean = false;
 
     /**
      * Fired when a action bar item has been clicked.
@@ -195,7 +203,14 @@ export class Card {
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
             >
-                <section tabindex={this.clickable ? 0 : ''}>
+                <section
+                    tabindex={this.clickable ? 0 : undefined}
+                    role={this.clickable ? 'button' : undefined}
+                    aria-pressed={
+                        this.clickable ? String(this.selected) : undefined
+                    }
+                    onKeyDown={this.clickable ? this.handleKeyDown : undefined}
+                >
                     {this.renderImage()}
                     <div class="body">
                         {this.renderHeader()}
@@ -305,6 +320,17 @@ export class Card {
         event.stopPropagation();
         if (isItem(event.detail)) {
             this.actionSelected.emit(event.detail);
+        }
+    };
+
+    private handleKeyDown = (event: KeyboardEvent) => {
+        if (event.target !== event.currentTarget) {
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.host.click();
         }
     };
 

--- a/src/components/card/examples/card-selected.scss
+++ b/src/components/card/examples/card-selected.scss
@@ -1,0 +1,5 @@
+@forward './card-resizable-container';
+
+limel-switch {
+    padding-top: 1rem;
+}

--- a/src/components/card/examples/limel-example-card-selected.tsx
+++ b/src/components/card/examples/limel-example-card-selected.tsx
@@ -1,0 +1,47 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Example: Card with selectable state
+ */
+@Component({
+    tag: 'limel-example-card-selected',
+    shadow: true,
+    styleUrl: 'card-selected.scss',
+})
+export class LimelExampleCardSelected {
+    @State()
+    private selected = false;
+
+    private toggleSelected = () => {
+        this.selected = !this.selected;
+    };
+
+    private handleSwitchChange = (event: CustomEvent<boolean>) => {
+        this.selected = event.detail;
+    };
+
+    public render() {
+        const icon = {
+            name: 'ok',
+            color: 'rgb(var(--color-green-default))',
+            title: 'Selectable Card',
+        };
+        return (
+            <div>
+                <limel-card
+                    icon={icon}
+                    heading="Selectable Card"
+                    value="Click the card or toggle the switch to select/deselect it."
+                    selected={this.selected}
+                    clickable={true}
+                    onClick={this.toggleSelected}
+                />
+                <limel-switch
+                    label="Selected"
+                    value={this.selected}
+                    onChange={this.handleSwitchChange}
+                />
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/limepkg-knowledge-base/issues/29


https://github.com/user-attachments/assets/33017aad-421d-44fb-a9c9-e8aaf157110c



<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cards now support a selectable state with keyboard accessibility (toggle via Enter/Space).

* **Style**
  * Selected cards receive a focused visual treatment (enhanced box-shadow across interaction states).

* **Examples**
  * Added an interactive example demonstrating synchronized card selection with a control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
