### PR TITLE
fix(callout): prevent slotted content from overflowing container

### DIFF
--- a/src/components/callout/callout.scss
+++ b/src/components/callout/callout.scss
@@ -4,7 +4,16 @@
  * @prop --callout-color: Color used in the UI to add more contextual meaning about the type of the information. This color is different based on the chosen `type`, but you can override it using this prop.
 */
 
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    min-height: 0;
+    min-width: 0;
+}
+
 :host(limel-callout) {
+    box-sizing: border-box;
     display: flex;
     border-radius: 0.5rem;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- Apply `box-sizing: border-box` and `min-width: 0` / `min-height: 0` reset to all elements inside the callout component
- This prevents flex children from overflowing their parent — without it, flex items default to their content's intrinsic size and `border-box` ensures padding/borders are included in the element's total size
- Fixes an issue where wide slotted content (e.g. a code editor) would push the callout beyond its parent's width

## Test plan
- [ ] Place a `limel-code-editor` or other wide content inside a `limel-callout`
- [ ] Put the callout in a narrow container (e.g. a side panel)
- [ ] Verify the callout stays within its parent's bounds and content wraps/clips correctly

Fix https://github.com/Lundalogik/crm-client/issues/764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved callout component styling with refined box model handling for better layout consistency and more predictable spacing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->