### PR TITLE
feat(list): add `--list-item-image-border-radius` custom CSS prop

### DIFF
--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -2,6 +2,7 @@
  * @prop --notification-badge-text-color: (Publicly documented in `limel-menu` too) Defines the text color of notification badges. Defaults to `--color-white`.
  * @prop --notification-badge-background-color: (Publicly documented in `limel-menu` too) Defines the background color of notification badges. Defaults to `--color-red-default`.
  * @prop --limel-list-item-menu-order: Defines the order of the menu, within the list item's flexbox. Defaults to `3`.
+ * @prop --list-item-image-border-radius: Defines the border radius of the list item image. Defaults to `50%`.
  */
 
 @use '../../style/mixins';
@@ -141,7 +142,7 @@ limel-list-item {
     img {
         flex-shrink: 0;
         object-fit: cover;
-        border-radius: 50%;
+        border-radius: var(--list-item-image-border-radius, 50%);
         width: 2rem;
         height: 2rem;
         box-shadow: 0 0 0 1px rgb(var(--contrast-800), 0.5);

--- a/src/components/list/examples/list-pictures.tsx
+++ b/src/components/list/examples/list-pictures.tsx
@@ -3,6 +3,9 @@ import { Component, h, Host, State } from '@stencil/core';
 
 /**
  * List with Pictures and Icons
+ * A list item can display a picture, an icon, or both simultaneously.
+ * By default, the picture has a rounded shape, but you can customize it
+ * using the `--list-item-image-border-radius` CSS custom property.
  *
  * :::note
  * While it's technically possible to display both images and icons simultaneously

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -12,7 +12,8 @@
 * @prop --list-grid-gap: Distance between items in a list that has `has-grid-layout` class. Defaults to `0.75rem`.
 * @prop --list-background-color-of-odd-interactive-items: Background color of odd list items, when `has-striped-rows` class is applied to the component. Defaults to `--contrast-200`.
 * @prop --list-background-color-of-even-interactive-items:  Background color of even list items, when `has-striped-rows` class is applied to the component. Defaults to `transparent`.
-* @prop --list-margin: Space around the list. Defaults to `0.25rem`, which visualizes keyboard-focused items in a better way, as it adds some space for the outline effect;
+* @prop --list-margin: Space around the list. Defaults to `0.25rem`, which visualizes keyboard-focused items in a better way, as it adds some space for the outline effect.
+* @prop --list-item-image-border-radius: Defines the border radius of the list item image. Defaults to `50%`.
 */
 
 :host(limel-list) {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
related to https://github.com/Lundalogik/hack-tuesday/issues/195
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * List item image border-radius is now customizable via CSS variable while maintaining the default circular appearance.

* **Documentation**
  * Updated component documentation to clarify that list items can display pictures, icons, or both.
  * Documented new CSS variable for customizing list item image border styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
