### PR TITLE
build(style): include mixins.scss in dist output

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -19,7 +19,10 @@ export const config: Config = {
     outputTargets: [
         {
             type: 'dist',
-            copy: [{ src: 'style/' }],
+            copy: [
+                { src: 'style/' },
+                { src: 'style/mixins.scss', dest: '../scss/mixins.scss' },
+            ],
         },
         {
             type: 'docs-custom',


### PR DESCRIPTION
Copy the SCSS mixins file to the dist `scss/` directory so that consuming apps can import shared mixins directly from the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Distribution packaging updated to include SCSS mixins in the published build, making styling tokens and mixins available to downstream projects for easier theming and customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->