### PR TITLE
fix(text-editor): preserve image height when parsing HTML

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/image/node.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/image/node.ts
@@ -170,6 +170,7 @@ function createImageNodeSpec(language: Languages): NodeSpec {
                         src: dom.getAttribute('src') || '',
                         alt: dom.getAttribute('alt') || 'file',
                         width: dom.style.width || '',
+                        height: dom.style.height || '',
                         maxWidth: '100%',
                         state: 'success',
                         fileInfoId: crypto.randomUUID(),

--- a/src/components/text-editor/prosemirror-adapter/plugins/image/view.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/image/view.ts
@@ -99,6 +99,7 @@ class ImageView implements NodeView {
 
         const startX = event.clientX;
         const startWidth = this.img.offsetWidth;
+        this.img.style.height = '';
 
         const onPointerMove = (e: PointerEvent) => {
             const delta = e.clientX - startX;


### PR DESCRIPTION
## Summary
- The text editor's image node `parseDOM` only extracted `width` from inline styles, ignoring `height`. This caused images with explicit CSS height (e.g. from imported emails) to lose their dimensions and render at natural size, blowing up the layout.
- Added `height` extraction in `parseDOM` so image dimensions are fully preserved.
- Clear explicit `height` when starting a resize drag so the browser auto-scales proportionally.

Closes Lundalogik/crm-client#788

## Test plan
- [ ] Import an email with images that have `height` in their inline style — verify height is preserved
- [ ] Resize an image in the text editor — verify it scales proportionally (not squished)
- [ ] Upload a new image in the editor — verify it renders and resizes correctly
- [ ] Open an existing saved email with images — verify no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Image height attributes are now correctly preserved when editing existing images in the text editor, ensuring height styling is maintained across parse and render operations
* Image resizing behavior has been improved: height styling is properly managed during drag operations for better control over width adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->