### PR TITLE
feat(icon-button): add `helperLabel` prop

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -536,6 +536,7 @@ export namespace Components {
     export interface LimelIconButton {
         "disabled": boolean;
         "elevated": boolean;
+        "helperLabel"?: string;
         "icon": string | Icon;
         "label": string;
     }
@@ -2553,6 +2554,7 @@ export namespace JSX {
     export interface LimelIconButton {
         "disabled"?: boolean;
         "elevated"?: boolean;
+        "helperLabel"?: string;
         "icon"?: string | Icon;
         "label"?: string;
     }
@@ -2563,6 +2565,8 @@ export namespace JSX {
         "disabled": boolean;
         // (undocumented)
         "elevated": boolean;
+        // (undocumented)
+        "helperLabel": string;
         // (undocumented)
         "icon": string | Icon;
         // (undocumented)

--- a/src/components/icon-button/examples/icon-button-helper-label.tsx
+++ b/src/components/icon-button/examples/icon-button-helper-label.tsx
@@ -1,0 +1,23 @@
+import { Component, h } from '@stencil/core';
+
+/**
+ * With `helperLabel`
+ *
+ * You can use the `helperLabel` prop to display additional
+ * helper text in the tooltip, for example a keyboard shortcut.
+ */
+@Component({
+    tag: 'limel-example-icon-button-helper-label',
+    shadow: true,
+})
+export class IconButtonHelperLabelExample {
+    public render() {
+        return (
+            <limel-icon-button
+                label="Add favourite"
+                helperLabel="alt + F"
+                icon="heart_outlined"
+            />
+        );
+    }
+}

--- a/src/components/icon-button/icon-button.tsx
+++ b/src/components/icon-button/icon-button.tsx
@@ -13,6 +13,7 @@ import { getIconName, getIconTitle } from '../icon/get-icon-props';
  * @exampleComponent limel-example-icon-button-elevated
  * @exampleComponent limel-example-icon-button-toggle-state
  * @exampleComponent limel-example-icon-button-icon
+ * @exampleComponent limel-example-icon-button-helper-label
  * @exampleComponent limel-example-icon-button-composite
  */
 @Component({
@@ -36,9 +37,19 @@ export class IconButton {
 
     /**
      * The text to show to screenreaders and other assistive tech.
+     * It is also displayed as a tooltip when the user hovers
+     * or focuses the button.
      */
     @Prop({ reflect: true })
     public label: string;
+
+    /**
+     * Additional helper text for the tooltip.
+     * Example usage can be a keyboard shortcut to activate
+     * the function of the button.
+     */
+    @Prop({ reflect: true })
+    public helperLabel?: string;
 
     /**
      * Set to `true` to disable the button.
@@ -116,7 +127,13 @@ export class IconButton {
 
     private renderTooltip(tooltipId) {
         if (this.label) {
-            return <limel-tooltip elementId={tooltipId} label={this.label} />;
+            return (
+                <limel-tooltip
+                    elementId={tooltipId}
+                    label={this.label}
+                    helperLabel={this.helperLabel}
+                />
+            );
         }
     }
 


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a `helperLabel` property to icon buttons, enabling you to display supplementary information such as keyboard shortcuts in the tooltip alongside the primary label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
