### PR TITLE
feat(table): drag and drop for table rows

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -3460,7 +3460,7 @@ export namespace JSX {
         "onChangeColumns"?: (event: LimelTableCustomEvent<Column[]>) => void;
         "onChangePage"?: (event: LimelTableCustomEvent<number>) => void;
         "onLoad"?: (event: LimelTableCustomEvent<TableParams>) => void;
-        "onReorder"?: (event: LimelTableCustomEvent<RowReorderEvent<any>>) => void;
+        "onReorder"?: (event: LimelTableCustomEvent<RowReorderEvent<unknown>>) => void;
         "onSelect"?: (event: LimelTableCustomEvent<object[]>) => void;
         "onSelectAll"?: (event: LimelTableCustomEvent<boolean>) => void;
         "onSort"?: (event: LimelTableCustomEvent<ColumnSorter[]>) => void;

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -861,6 +861,7 @@ export namespace Components {
         "loading": boolean;
         "mode": 'local' | 'remote';
         "movableColumns": boolean;
+        "movableRows": boolean;
         "page": number;
         "pageSize": number;
         "paginationLocation": 'top' | 'bottom';
@@ -3454,10 +3455,12 @@ export namespace JSX {
         "loading"?: boolean;
         "mode"?: 'local' | 'remote';
         "movableColumns"?: boolean;
+        "movableRows"?: boolean;
         "onActivate"?: (event: LimelTableCustomEvent<object>) => void;
         "onChangeColumns"?: (event: LimelTableCustomEvent<Column[]>) => void;
         "onChangePage"?: (event: LimelTableCustomEvent<number>) => void;
         "onLoad"?: (event: LimelTableCustomEvent<TableParams>) => void;
+        "onReorder"?: (event: LimelTableCustomEvent<RowReorderEvent<any>>) => void;
         "onSelect"?: (event: LimelTableCustomEvent<object[]>) => void;
         "onSelectAll"?: (event: LimelTableCustomEvent<boolean>) => void;
         "onSort"?: (event: LimelTableCustomEvent<ColumnSorter[]>) => void;
@@ -3485,6 +3488,8 @@ export namespace JSX {
         "mode": 'local' | 'remote';
         // (undocumented)
         "movableColumns": boolean;
+        // (undocumented)
+        "movableRows": boolean;
         // (undocumented)
         "page": number;
         // (undocumented)
@@ -4309,6 +4314,13 @@ export type RowData = {
 // @public
 export interface RowLayoutOptions extends FormLayoutOptions<FormLayoutType | `${FormLayoutType}`> {
     icon?: string;
+}
+
+// @public
+export interface RowReorderEvent<T> {
+    above: boolean;
+    fromRow: T;
+    toRow: T;
 }
 
 // @public

--- a/package-lock.json
+++ b/package-lock.json
@@ -9156,6 +9156,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"

--- a/src/components/table/examples/table-basic.scss
+++ b/src/components/table/examples/table-basic.scss
@@ -5,3 +5,7 @@
 limel-table {
     height: 300px;
 }
+
+limel-example-controls {
+    --example-controls-column-layout: auto-fit;
+}

--- a/src/components/table/examples/table-movable-rows.tsx
+++ b/src/components/table/examples/table-movable-rows.tsx
@@ -1,5 +1,9 @@
 import { Component, h, Host, State } from '@stencil/core';
-import { Column, RowReorderEvent } from '@limetech/lime-elements';
+import {
+    Column,
+    LimelTableCustomEvent,
+    RowReorderEvent,
+} from '@limetech/lime-elements';
 import { data, Bird } from './birds';
 import { capitalize } from 'lodash-es';
 
@@ -42,7 +46,7 @@ export class TableExampleMovableRows {
     ];
 
     private readonly handleReorder = (
-        event: CustomEvent<RowReorderEvent<Bird>>
+        event: LimelTableCustomEvent<RowReorderEvent<Bird>>
     ) => {
         const { fromRow, toRow, above } = event.detail;
         const items = [...this.tableData];

--- a/src/components/table/examples/table-movable-rows.tsx
+++ b/src/components/table/examples/table-movable-rows.tsx
@@ -1,0 +1,122 @@
+import { Component, h, Host, State } from '@stencil/core';
+import { Column, RowReorderEvent } from '@limetech/lime-elements';
+import { data, Bird } from './birds';
+import { capitalize } from 'lodash-es';
+
+/**
+ * Movable rows
+ *
+ * This option is aimed more for managing data, rather than just viewing it.
+ * Hence, it is not suitable combining with attributes that affect sorting.
+ *
+ *  With `mode="remote"` sorting is provided by remote data source, so any user provided sorting is ignored
+ *  on data updates.
+ *
+ *  Combining with `sortableColumns` makes the data look different from what it is.
+ *  It is recommended to set `sortableColumns` to `false` when using movable rows.
+ *  Try to reorder the data in this example after sorting by any column, and then
+ *  see how the reorder behaves.
+ *
+ * @sourceFile birds.ts
+ */
+@Component({
+    tag: 'limel-example-table-movable-rows',
+    styleUrl: 'table-basic.scss',
+    shadow: true,
+})
+export class TableExampleMovableRows {
+    @State()
+    private movableRows = true;
+
+    @State()
+    private selectable = false;
+
+    @State()
+    private tableData: Bird[] = [...data];
+
+    private readonly columns: Array<Column<Bird>> = [
+        { title: 'Name', field: 'name' },
+        { title: 'Binominal name', field: 'binominalName' },
+        { title: 'Nest type', field: 'nest', formatter: capitalize },
+        { title: 'Eggs per clutch', field: 'eggs', horizontalAlign: 'right' },
+    ];
+
+    private readonly handleReorder = (
+        event: CustomEvent<RowReorderEvent<Bird>>
+    ) => {
+        const { fromRow, toRow, above } = event.detail;
+        const items = [...this.tableData];
+
+        const fromIndex = items.findIndex((bird) => bird.name === fromRow.name);
+        if (fromIndex === -1) {
+            return;
+        }
+        items.splice(fromIndex, 1);
+
+        let toIndex = items.findIndex((bird) => bird.name === toRow.name);
+        if (toIndex === -1) {
+            return;
+        }
+        if (!above) {
+            toIndex += 1;
+        }
+
+        items.splice(toIndex, 0, fromRow);
+        this.tableData = items;
+    };
+
+    public render() {
+        const rowOrder = this.tableData.map((bird) => bird.name);
+
+        return (
+            <Host>
+                <limel-table
+                    data={this.tableData}
+                    columns={this.columns}
+                    movableRows={this.movableRows}
+                    selectable={this.selectable}
+                    sortableColumns={false}
+                    onReorder={this.handleReorder}
+                />
+                <limel-example-controls>
+                    <limel-switch
+                        label="movableRows"
+                        onChange={this.toggleMovableRows}
+                        value={this.movableRows}
+                    />
+                    <limel-switch
+                        label="selectable"
+                        onChange={this.toggleSelectable}
+                        value={this.selectable}
+                    />
+                    <limel-switch
+                        label="sortableColumns"
+                        value={false}
+                        disabled={true}
+                        id="sortableColumns"
+                    />
+                    <limel-tooltip
+                        label="You cannot use `sortableColumns` and `movableRows` together"
+                        helperLabel="Combining `movableRows` with `sortableColumns` is not recommended. Sorting reorders the rows visually, so dragging a row to a new position will not match the underlying data order."
+                        elementId="sortableColumns"
+                        max-length="100ch"
+                    />
+                </limel-example-controls>
+                <limel-example-value
+                    label="Current row order is"
+                    value={rowOrder}
+                />
+            </Host>
+        );
+    }
+
+    private toggleMovableRows = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.movableRows = event.detail;
+    };
+
+    private toggleSelectable = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.selectable = event.detail;
+    };
+}

--- a/src/components/table/partial-styles/_row-drag-handle.scss
+++ b/src/components/table/partial-styles/_row-drag-handle.scss
@@ -9,6 +9,7 @@
     // Stack above the row-selector so pointer events reach the drag handle
     // even when `selectable` is enabled and the selector cell visually overlaps.
     z-index: calc(var(--limel-table-row-selector-z-index) + 1) !important;
+    background-color: transparent !important;
 
     .has-rowselector & {
         background-image: none !important;

--- a/src/components/table/partial-styles/_row-drag-handle.scss
+++ b/src/components/table/partial-styles/_row-drag-handle.scss
@@ -6,6 +6,10 @@
     height: 2rem !important;
     user-select: none;
 
+    // Stack above the row-selector so pointer events reach the drag handle
+    // even when `selectable` is enabled and the selector cell visually overlaps.
+    z-index: calc(var(--limel-table-row-selector-z-index) + 1) !important;
+
     .has-rowselector & {
         background-image: none !important;
         background-color: rgb(

--- a/src/components/table/partial-styles/_row-drag-handle.scss
+++ b/src/components/table/partial-styles/_row-drag-handle.scss
@@ -1,27 +1,12 @@
-.select-all,
-.limel-table--row-selector {
-    --limel-checkbox-min-height: 1.25rem; // as big as the box itself
+.limel-table-drag-handle {
     display: inline-flex !important;
     align-items: center;
     justify-content: center;
 
-    text-overflow: unset !important; // Otherwise a `…` will be rendered besides the checkbox, since we truncate all cells
+    text-overflow: unset !important;
     padding: 0 !important;
-}
 
-.select-all {
-    position: absolute;
-    z-index: var(--limel-table-row-selector-z-index);
-    left: 0.375rem;
-    top: 0.1875rem;
-
-    .has-movable-rows & {
-        left: calc(var(--limel-table-drag-handle-width) + 0.375rem);
-    }
-}
-
-.limel-table--row-selector {
-    position: sticky !important; // otherwise will be overwritten from `.tabulator-row .tabulator-cell`
+    position: sticky !important;
     left: 0;
     border-width: 0;
     z-index: var(--limel-table-row-selector-z-index);
@@ -37,7 +22,7 @@
         );
     }
 
-    limel-checkbox {
+    limel-drag-handle {
         transition: opacity 0.2s ease;
         opacity: 0.3;
 
@@ -45,14 +30,13 @@
             opacity: 1;
         }
 
-        .has-selection & {
-            opacity: 1;
+        .tabulator-block-select .tabulator-row & {
+            opacity: 0.3;
+            transition: none;
+            pointer-events: none;
         }
     }
 
-    // make the row selector column non-resizable by hiding
-    // the resize handles between the frozen column and the
-    // column next to it
     .tabulator-col-resize-handle {
         display: none;
     }
@@ -62,14 +46,22 @@
             display: none;
         }
     }
+
+    &.tabulator-cell {
+        border-bottom: transparent !important;
+        border-right: inherit !important;
+    }
+    &.tabulator-col {
+        border-right: inherit !important;
+    }
 }
 
-.has-movable-columns
-    .tabulator-header
-    .tabulator-col.limel-table--row-selector {
+.has-movable-columns .tabulator-header .tabulator-col.limel-table-drag-handle {
     border: none;
     cursor: default !important;
     pointer-events: none;
+    border-right: inherit;
+    border-bottom: inherit;
     background-color: transparent;
     background-image: linear-gradient(
         to right,
@@ -79,12 +71,9 @@
     left: 0;
 }
 
-.tabulator-calcs {
-    .tabulator-cell {
-        .has-selection & {
-            color: var(
-                --table-arrow-color--active
-            ); // to indicate that aggregated numbers are coming from the selcted rows not all rows
-        }
-    }
+.tabulator-row.tabulator-moving
+    .limel-table-drag-handle
+    limel-drag-handle
+    button:last-of-type {
+    display: none; /** tabulator will make a copy of limel-drag-handle on move. So hide the 2nd child */
 }

--- a/src/components/table/partial-styles/_row-drag-handle.scss
+++ b/src/components/table/partial-styles/_row-drag-handle.scss
@@ -1,74 +1,22 @@
+// common styles are written in `_row-selection.scss` and imported in `table.scss`
 .limel-table-drag-handle {
-    display: inline-flex !important;
-    align-items: center;
-    justify-content: center;
-
-    text-overflow: unset !important;
-    padding: 0 !important;
-
-    position: sticky !important;
+    transition: opacity 0.3s ease;
     left: 0;
-    border-width: 0;
-    z-index: var(--limel-table-row-selector-z-index);
+    width: var(--limel-table-drag-handle-width) !important;
+    height: 2rem !important;
+    user-select: none;
 
-    &:before {
-        content: '';
-        inset: 0.25rem 0;
-        position: absolute;
-        background-image: linear-gradient(
-            to right,
-            rgb(var(--limel-table-row-background-color)) 70%,
-            rgb(var(--limel-table-row-background-color), 0)
-        );
+    .has-rowselector & {
+        background-image: none !important;
+        background-color: rgb(
+            var(--limel-table-row-background-color)
+        ) !important;
     }
 
-    limel-drag-handle {
-        transition: opacity 0.2s ease;
+    .tabulator-block-select & {
+        pointer-events: none;
         opacity: 0.3;
-
-        .tabulator-row:hover & {
-            opacity: 1;
-        }
-
-        .tabulator-block-select .tabulator-row & {
-            opacity: 0.3;
-            transition: none;
-            pointer-events: none;
-        }
     }
-
-    .tabulator-col-resize-handle {
-        display: none;
-    }
-    & + .tabulator-col,
-    & + .tabulator-cell {
-        .tabulator-col-resize-handle.prev {
-            display: none;
-        }
-    }
-
-    &.tabulator-cell {
-        border-bottom: transparent !important;
-        border-right: inherit !important;
-    }
-    &.tabulator-col {
-        border-right: inherit !important;
-    }
-}
-
-.has-movable-columns .tabulator-header .tabulator-col.limel-table-drag-handle {
-    border: none;
-    cursor: default !important;
-    pointer-events: none;
-    border-right: inherit;
-    border-bottom: inherit;
-    background-color: transparent;
-    background-image: linear-gradient(
-        to right,
-        rgb(var(--table-header-background-color--hover)) 70%,
-        rgb(var(--table-header-background-color--hover), 0)
-    );
-    left: 0;
 }
 
 .tabulator-row.tabulator-moving

--- a/src/components/table/partial-styles/_row-drag-handle.scss
+++ b/src/components/table/partial-styles/_row-drag-handle.scss
@@ -14,14 +14,18 @@
     }
 
     .tabulator-block-select & {
-        pointer-events: none;
         opacity: 0.3;
+        cursor: grabbing;
+
+        limel-drag-handle,
+        limel-drag-handle * {
+            pointer-events: none !important;
+        }
     }
 }
 
-.tabulator-row.tabulator-moving
-    .limel-table-drag-handle
-    limel-drag-handle
-    button:last-of-type {
-    display: none; /** tabulator will make a copy of limel-drag-handle on move. So hide the 2nd child */
+.tabulator-row.tabulator-moving {
+    .limel-table-drag-handle limel-drag-handle button:last-of-type {
+        display: none; /** tabulator will make a copy of limel-drag-handle on move. So hide the 2nd child */
+    }
 }

--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -1,5 +1,6 @@
 .select-all,
-.limel-table--row-selector {
+.limel-table--row-selector,
+.limel-table-drag-handle {
     --limel-checkbox-min-height: 1.25rem; // as big as the box itself
     display: inline-flex !important;
     align-items: center;
@@ -21,10 +22,18 @@
 }
 
 .limel-table--row-selector {
-    position: sticky !important; // otherwise will be overwritten from `.tabulator-row .tabulator-cell`
     left: 0;
-    border-width: 0;
-    z-index: var(--limel-table-row-selector-z-index);
+
+    .has-movable-rows & {
+        left: var(--limel-table-drag-handle-width);
+    }
+}
+
+.limel-table--row-selector,
+.limel-table-drag-handle {
+    position: sticky !important; // otherwise will be overwritten from `.tabulator-row .tabulator-cell`
+    border: none !important;
+    z-index: var(--limel-table-row-selector-z-index) !important;
 
     &:before {
         content: '';
@@ -64,19 +73,20 @@
     }
 }
 
-.has-movable-columns
-    .tabulator-header
-    .tabulator-col.limel-table--row-selector {
-    border: none;
-    cursor: default !important;
-    pointer-events: none;
-    background-color: transparent;
-    background-image: linear-gradient(
-        to right,
-        rgb(var(--table-header-background-color--hover)) 70%,
-        rgb(var(--table-header-background-color--hover), 0)
-    );
-    left: 0;
+.has-movable-columns .tabulator-header {
+    .tabulator-col.limel-table--row-selector,
+    .tabulator-col.limel-table-drag-handle {
+        border: none;
+        cursor: default !important;
+        pointer-events: none;
+        background-color: transparent;
+        background-image: linear-gradient(
+            to right,
+            rgb(var(--table-header-background-color--hover)) 70%,
+            rgb(var(--table-header-background-color--hover), 0)
+        );
+        left: 0;
+    }
 }
 
 .tabulator-calcs {

--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -27,6 +27,16 @@
     .has-movable-rows & {
         left: var(--limel-table-drag-handle-width);
     }
+
+    // During a row-drag, let mousemove reach the row element so Tabulator
+    // can track the drop target — otherwise the checkbox child captures
+    // events and the row never registers the hover.
+    .tabulator-block-select & {
+        &,
+        * {
+            pointer-events: none !important;
+        }
+    }
 }
 
 .limel-table--row-selector,
@@ -86,6 +96,12 @@
             rgb(var(--table-header-background-color--hover), 0)
         );
         left: 0;
+    }
+}
+
+.has-movable-columns.has-movable-rows .tabulator-header {
+    .tabulator-col.limel-table--row-selector {
+        left: var(--limel-table-drag-handle-width);
     }
 }
 

--- a/src/components/table/row-drag-manager.spec.ts
+++ b/src/components/table/row-drag-manager.spec.ts
@@ -274,4 +274,29 @@ describe('RowDragManager', () => {
             expect(() => manager.destroy()).not.toThrow();
         });
     });
+
+    describe('post-drop click gate', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('is false before any drag has ended', () => {
+            expect(manager.wasDragJustEnded()).toBe(false);
+        });
+
+        it('is true immediately after markDragEnd', () => {
+            manager.markDragEnd();
+            expect(manager.wasDragJustEnded()).toBe(true);
+        });
+
+        it('returns to false after the suppression window elapses', () => {
+            manager.markDragEnd();
+            vi.advanceTimersByTime(500);
+            expect(manager.wasDragJustEnded()).toBe(false);
+        });
+    });
 });

--- a/src/components/table/row-drag-manager.spec.ts
+++ b/src/components/table/row-drag-manager.spec.ts
@@ -33,13 +33,19 @@ describe('RowDragManager', () => {
     let manager: RowDragManager;
     let mockPool: ReturnType<typeof createMockPool>;
     let mockEmitter: ReturnType<typeof createMockEventEmitter>;
+    let language: 'en' | 'sv';
 
     beforeEach(() => {
         vi.clearAllMocks();
         mockPool = createMockPool();
         mockEmitter = createMockEventEmitter();
+        language = 'en';
 
-        manager = new RowDragManager(mockPool as any, mockEmitter as any, 'en');
+        manager = new RowDragManager(
+            mockPool as any,
+            mockEmitter as any,
+            () => language
+        );
     });
 
     describe('getRowHeaderDefinition', () => {
@@ -70,6 +76,19 @@ describe('RowDragManager', () => {
             expect(setElementProperties).toHaveBeenCalledWith(
                 expect.any(HTMLElement),
                 { dragDirection: 'vertical', language: 'en' }
+            );
+        });
+
+        it('reads language lazily so host prop changes propagate', () => {
+            const definition = manager.getRowHeaderDefinition() as any;
+            const formatter = definition.formatter as () => HTMLElement;
+
+            language = 'sv';
+            formatter();
+
+            expect(setElementProperties).toHaveBeenLastCalledWith(
+                expect.any(HTMLElement),
+                { dragDirection: 'vertical', language: 'sv' }
             );
         });
 

--- a/src/components/table/row-drag-manager.spec.ts
+++ b/src/components/table/row-drag-manager.spec.ts
@@ -1,0 +1,277 @@
+import { vi } from 'vitest';
+
+vi.mock('./columns', () => ({
+    setElementProperties: vi.fn(),
+}));
+
+import { RowDragManager } from './row-drag-manager';
+import { setElementProperties } from './columns';
+
+function createMockRow(data: any, prevRow: any = false, nextRow: any = false) {
+    return {
+        getData: vi.fn(() => data),
+        getPrevRow: vi.fn(() => prevRow),
+        getNextRow: vi.fn(() => nextRow),
+    };
+}
+
+function createMockPool() {
+    return {
+        get: vi.fn(() => document.createElement('div')),
+        release: vi.fn(),
+        releaseAll: vi.fn(),
+    };
+}
+
+function createMockEventEmitter() {
+    return {
+        emit: vi.fn(),
+    };
+}
+
+describe('RowDragManager', () => {
+    let manager: RowDragManager;
+    let mockPool: ReturnType<typeof createMockPool>;
+    let mockEmitter: ReturnType<typeof createMockEventEmitter>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockPool = createMockPool();
+        mockEmitter = createMockEventEmitter();
+
+        manager = new RowDragManager(mockPool as any, mockEmitter as any, 'en');
+    });
+
+    describe('getRowHeaderDefinition', () => {
+        it('returns a column definition with correct properties', () => {
+            const definition = manager.getRowHeaderDefinition() as any;
+
+            expect(definition.headerSort).toBe(false);
+            expect(definition.resizable).toBe(false);
+            expect(definition.frozen).toBe(true);
+            expect(definition.rowHandle).toBe(true);
+            expect(definition.cssClass).toEqual('limel-table-drag-handle');
+        });
+
+        it('provides a formatter that uses the element pool', () => {
+            const definition = manager.getRowHeaderDefinition() as any;
+            const formatter = definition.formatter as () => HTMLElement;
+
+            const element = formatter();
+            expect(mockPool.get).toHaveBeenCalledWith('limel-drag-handle');
+            expect(element).toBeTruthy();
+        });
+
+        it('sets drag handle properties via setElementProperties', () => {
+            const definition = manager.getRowHeaderDefinition() as any;
+            const formatter = definition.formatter as () => HTMLElement;
+
+            formatter();
+            expect(setElementProperties).toHaveBeenCalledWith(
+                expect.any(HTMLElement),
+                { dragDirection: 'vertical', language: 'en' }
+            );
+        });
+
+        it('provides a cellClick handler that stops propagation', () => {
+            const definition = manager.getRowHeaderDefinition() as any;
+            const event = {
+                stopPropagation: vi.fn(),
+                preventDefault: vi.fn(),
+            };
+
+            definition.cellClick(event);
+
+            expect(event.stopPropagation).toHaveBeenCalled();
+            expect(event.preventDefault).toHaveBeenCalled();
+        });
+    });
+
+    describe('handleRowMoved', () => {
+        it('emits reorder event with above=false when row has a previous row', () => {
+            const prevRow = createMockRow({ id: 1, name: 'Alice' });
+            const movedRow = createMockRow(
+                { id: 2, name: 'Bob' },
+                prevRow,
+                false
+            );
+
+            manager.handleRowMoved(movedRow as any);
+
+            expect(mockEmitter.emit).toHaveBeenCalledWith({
+                fromRow: { id: 2, name: 'Bob' },
+                toRow: { id: 1, name: 'Alice' },
+                above: false,
+            });
+        });
+
+        it('emits reorder event with above=true when row is first (no previous row)', () => {
+            const nextRow = createMockRow({ id: 2, name: 'Bob' });
+            const movedRow = createMockRow(
+                { id: 1, name: 'Alice' },
+                false,
+                nextRow
+            );
+
+            manager.handleRowMoved(movedRow as any);
+
+            expect(mockEmitter.emit).toHaveBeenCalledWith({
+                fromRow: { id: 1, name: 'Alice' },
+                toRow: { id: 2, name: 'Bob' },
+                above: true,
+            });
+        });
+
+        it('does not emit when row has no neighbors', () => {
+            const movedRow = createMockRow(
+                { id: 1, name: 'Alice' },
+                false,
+                false
+            );
+
+            manager.handleRowMoved(movedRow as any);
+
+            expect(mockEmitter.emit).not.toHaveBeenCalled();
+        });
+
+        it('prefers previous row over next row for positioning', () => {
+            const prevRow = createMockRow({ id: 1, name: 'Alice' });
+            const nextRow = createMockRow({ id: 3, name: 'Charlie' });
+            const movedRow = createMockRow(
+                { id: 2, name: 'Bob' },
+                prevRow,
+                nextRow
+            );
+
+            manager.handleRowMoved(movedRow as any);
+
+            expect(mockEmitter.emit).toHaveBeenCalledWith({
+                fromRow: { id: 2, name: 'Bob' },
+                toRow: { id: 1, name: 'Alice' },
+                above: false,
+            });
+        });
+    });
+
+    describe('observe', () => {
+        let observerCallback: MutationCallback | null;
+        let observerInstance: { observe: any; disconnect: any } | null;
+        let originalMutationObserver: typeof MutationObserver | undefined;
+
+        beforeEach(() => {
+            observerCallback = null;
+            observerInstance = null;
+            originalMutationObserver = (globalThis as any).MutationObserver;
+            (globalThis as any).MutationObserver = function (
+                cb: MutationCallback
+            ) {
+                observerCallback = cb;
+                observerInstance = {
+                    observe: vi.fn(),
+                    disconnect: vi.fn(),
+                    takeRecords: vi.fn(),
+                };
+
+                return observerInstance;
+            };
+        });
+
+        afterEach(() => {
+            (globalThis as any).MutationObserver = originalMutationObserver;
+        });
+
+        function fireRemoval(...nodes: Node[]) {
+            const record = {
+                removedNodes: nodes as any,
+            } as MutationRecord;
+            observerCallback!([record], observerInstance as any);
+        }
+
+        it('releases drag-handle elements detached from the observed container', () => {
+            const container = document.createElement('div');
+            const row = document.createElement('div');
+            const handle = document.createElement('limel-drag-handle');
+            row.append(handle);
+            // row is never re-attached, so handle.isConnected is false
+
+            manager.observe(container);
+            expect(observerInstance!.observe).toHaveBeenCalledTimes(1);
+            expect(observerInstance!.observe.mock.calls[0][0]).toBe(container);
+            expect(observerInstance!.observe.mock.calls[0][1]).toEqual({
+                childList: true,
+                subtree: true,
+            });
+
+            fireRemoval(row);
+
+            expect(mockPool.release).toHaveBeenCalledTimes(1);
+            expect(mockPool.release.mock.calls[0][0]).toBe(handle);
+        });
+
+        it('releases a drag-handle that is itself the removed node', () => {
+            const handle = document.createElement('limel-drag-handle');
+
+            manager.observe(document.createElement('div'));
+            fireRemoval(handle);
+
+            expect(mockPool.release).toHaveBeenCalledTimes(1);
+            expect(mockPool.release.mock.calls[0][0]).toBe(handle);
+        });
+
+        it('skips handles still connected to the DOM (re-attached)', () => {
+            const container = document.createElement('div');
+            document.body.append(container);
+            const handle = document.createElement('limel-drag-handle');
+            container.append(handle);
+
+            manager.observe(container);
+            fireRemoval(handle);
+
+            expect(mockPool.release).not.toHaveBeenCalled();
+            container.remove();
+        });
+
+        it('ignores non-element removed nodes', () => {
+            const text = document.createTextNode('hello');
+
+            manager.observe(document.createElement('div'));
+            fireRemoval(text);
+
+            expect(mockPool.release).not.toHaveBeenCalled();
+        });
+
+        it('disconnects a previous observer before attaching a new one', () => {
+            const first = document.createElement('div');
+            const second = document.createElement('div');
+
+            manager.observe(first);
+            const firstObserver = observerInstance!;
+            manager.observe(second);
+
+            expect(firstObserver.disconnect).toHaveBeenCalled();
+        });
+    });
+
+    describe('destroy', () => {
+        it('disconnects the observer', () => {
+            const disconnect = vi.fn();
+            const originalMutationObserver = (globalThis as any)
+                .MutationObserver;
+            (globalThis as any).MutationObserver = class {
+                public observe = vi.fn();
+                public disconnect = disconnect;
+                public takeRecords = vi.fn();
+            };
+
+            manager.observe(document.createElement('div'));
+            manager.destroy();
+
+            expect(disconnect).toHaveBeenCalled();
+            (globalThis as any).MutationObserver = originalMutationObserver;
+        });
+
+        it('is a no-op when no observer is attached', () => {
+            expect(() => manager.destroy()).not.toThrow();
+        });
+    });
+});

--- a/src/components/table/row-drag-manager.spec.ts
+++ b/src/components/table/row-drag-manager.spec.ts
@@ -294,28 +294,63 @@ describe('RowDragManager', () => {
         });
     });
 
-    describe('post-drop click gate', () => {
+    describe('armPostDropClickGuard', () => {
+        let target: {
+            addEventListener: ReturnType<typeof vi.fn>;
+            removeEventListener: ReturnType<typeof vi.fn>;
+        };
+
         beforeEach(() => {
             vi.useFakeTimers();
+            target = {
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            };
         });
 
         afterEach(() => {
             vi.useRealTimers();
         });
 
-        it('is false before any drag has ended', () => {
-            expect(manager.wasDragJustEnded()).toBe(false);
+        function getInstalledListener(): (event: Event) => void {
+            return target.addEventListener.mock.calls[0][1];
+        }
+
+        it('registers a one-shot capture-phase click listener', () => {
+            manager.armPostDropClickGuard(target as unknown as EventTarget);
+
+            expect(target.addEventListener).toHaveBeenCalledWith(
+                'click',
+                expect.any(Function),
+                { once: true, capture: true }
+            );
         });
 
-        it('is true immediately after markDragEnd', () => {
-            manager.markDragEnd();
-            expect(manager.wasDragJustEnded()).toBe(true);
+        it('swallows the click via stopImmediatePropagation + preventDefault', () => {
+            manager.armPostDropClickGuard(target as unknown as EventTarget);
+            const listener = getInstalledListener();
+            const event = {
+                stopImmediatePropagation: vi.fn(),
+                preventDefault: vi.fn(),
+            };
+
+            listener(event as unknown as Event);
+
+            expect(event.stopImmediatePropagation).toHaveBeenCalled();
+            expect(event.preventDefault).toHaveBeenCalled();
         });
 
-        it('returns to false after the suppression window elapses', () => {
-            manager.markDragEnd();
-            vi.advanceTimersByTime(500);
-            expect(manager.wasDragJustEnded()).toBe(false);
+        it('removes the listener on the next macrotask if no click fires', () => {
+            manager.armPostDropClickGuard(target as unknown as EventTarget);
+            const listener = getInstalledListener();
+
+            vi.advanceTimersByTime(0);
+
+            expect(target.removeEventListener).toHaveBeenCalledWith(
+                'click',
+                listener,
+                true
+            );
         });
     });
 });

--- a/src/components/table/row-drag-manager.ts
+++ b/src/components/table/row-drag-manager.ts
@@ -6,6 +6,7 @@ import { RowReorderEvent } from './table.types';
 import { Languages } from '../date-picker/date.types';
 
 const LIMEL_DRAG_HANDLE = 'limel-drag-handle';
+const POST_DROP_CLICK_WINDOW_MS = 250;
 
 /**
  * Provides row drag-and-drop reordering configuration for Tabulator
@@ -13,6 +14,7 @@ const LIMEL_DRAG_HANDLE = 'limel-drag-handle';
  */
 export class RowDragManager {
     private mutationObserver: MutationObserver | null = null;
+    private dragEndTimestamp = 0;
 
     constructor(
         private readonly pool: ElementPool,
@@ -91,6 +93,25 @@ export class RowDragManager {
                 above: true,
             });
         }
+    }
+
+    /**
+     * Tabulator fires `rowMoved` (and `rowMoveCancelled`) from its `mouseup`
+     * handler. The browser may then dispatch a `click` on the drop target,
+     * which would bubble to Tabulator's own click handling and trigger a
+     * spurious row activation. Call this from both events so
+     * {@link wasDragJustEnded} can gate the click.
+     */
+    public readonly markDragEnd = (): void => {
+        this.dragEndTimestamp = Date.now();
+    };
+
+    /**
+     * True if a drag just finished within the post-drop window. Used by the
+     * host to ignore the click that the browser fires after `mouseup`.
+     */
+    public wasDragJustEnded(): boolean {
+        return Date.now() - this.dragEndTimestamp < POST_DROP_CLICK_WINDOW_MS;
     }
 
     private readonly handleCellClick = (ev: Event): void => {

--- a/src/components/table/row-drag-manager.ts
+++ b/src/components/table/row-drag-manager.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from '@stencil/core';
-import { RowComponent as TabulatorRowComponent } from 'tabulator-tables';
+import {
+    ColumnDefinition as TabulatorColumnDefinition,
+    RowComponent as TabulatorRowComponent,
+} from 'tabulator-tables';
 import { setElementProperties } from './columns';
 import { ElementPool } from './element-pool';
 import { RowReorderEvent } from './table.types';
@@ -16,7 +19,7 @@ export class RowDragManager {
 
     constructor(
         private readonly pool: ElementPool,
-        private readonly reorderEvent: EventEmitter<RowReorderEvent<any>>,
+        private readonly reorderEvent: EventEmitter<RowReorderEvent<unknown>>,
         private readonly getLanguage: () => Languages
     ) {
         this.handleRowMoved = this.handleRowMoved.bind(this);
@@ -57,7 +60,7 @@ export class RowDragManager {
      * Returns the Tabulator rowHeader config that renders
      * a limel-drag-handle and restricts dragging to that cell
      */
-    public getRowHeaderDefinition(): object {
+    public getRowHeaderDefinition(): Partial<TabulatorColumnDefinition> {
         return {
             headerSort: false,
             resizable: false,

--- a/src/components/table/row-drag-manager.ts
+++ b/src/components/table/row-drag-manager.ts
@@ -19,7 +19,7 @@ export class RowDragManager {
     constructor(
         private readonly pool: ElementPool,
         private readonly reorderEvent: EventEmitter<RowReorderEvent<any>>,
-        private readonly language: Languages
+        private readonly getLanguage: () => Languages
     ) {
         this.handleRowMoved = this.handleRowMoved.bind(this);
     }
@@ -140,7 +140,7 @@ export class RowDragManager {
             const element = this.pool.get(LIMEL_DRAG_HANDLE);
             setElementProperties(element, {
                 dragDirection: 'vertical',
-                language: this.language,
+                language: this.getLanguage(),
             });
 
             return element;

--- a/src/components/table/row-drag-manager.ts
+++ b/src/components/table/row-drag-manager.ts
@@ -1,0 +1,128 @@
+import { EventEmitter } from '@stencil/core';
+import { RowComponent as TabulatorRowComponent } from 'tabulator-tables';
+import { setElementProperties } from './columns';
+import { ElementPool } from './element-pool';
+import { RowReorderEvent } from './table.types';
+import { Languages } from '../date-picker/date.types';
+
+const LIMEL_DRAG_HANDLE = 'limel-drag-handle';
+
+/**
+ * Provides row drag-and-drop reordering configuration for Tabulator
+ * using native movableRows with a custom drag handle
+ */
+export class RowDragManager {
+    private mutationObserver: MutationObserver | null = null;
+
+    constructor(
+        private readonly pool: ElementPool,
+        private readonly reorderEvent: EventEmitter<RowReorderEvent<any>>,
+        private readonly language: Languages
+    ) {
+        this.handleRowMoved = this.handleRowMoved.bind(this);
+    }
+
+    /**
+     * Start releasing drag-handle elements back to the pool when Tabulator
+     * virtualizes rows out of view. Safe to call multiple times — a previous
+     * observer is disconnected first.
+     *
+     * @param container - The element that hosts the Tabulator table.
+     */
+    public observe(container: HTMLElement): void {
+        this.destroy();
+        this.mutationObserver = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                for (const node of mutation.removedNodes) {
+                    this.releaseDetachedHandles(node);
+                }
+            }
+        });
+        this.mutationObserver.observe(container, {
+            childList: true,
+            subtree: true,
+        });
+    }
+
+    /**
+     * Disconnects the mutation observer. Call when the manager is no longer
+     * needed (e.g. on `disconnectedCallback` or when `movableRows` is toggled).
+     */
+    public destroy(): void {
+        this.mutationObserver?.disconnect();
+        this.mutationObserver = null;
+    }
+
+    /**
+     * Returns the Tabulator rowHeader config that renders
+     * a limel-drag-handle and restricts dragging to that cell
+     */
+    public getRowHeaderDefinition(): object {
+        return {
+            headerSort: false,
+            resizable: false,
+            frozen: true,
+            rowHandle: true,
+            formatter: this.getDragHandleFormatter(),
+            cssClass: 'limel-table-drag-handle',
+            cellClick: this.handleCellClick,
+        };
+    }
+
+    /**
+     * Tabulator rowMoved event handler.
+     * Attach this to the tabulator instance via `tabulator.on('rowMoved', ...)`
+     * @param row
+     */
+    public handleRowMoved(row: TabulatorRowComponent): void {
+        const prevRow = row.getPrevRow();
+        const nextRow = row.getNextRow();
+
+        if (prevRow) {
+            this.reorderEvent.emit({
+                fromRow: row.getData(),
+                toRow: prevRow.getData(),
+                above: false,
+            });
+        } else if (nextRow) {
+            this.reorderEvent.emit({
+                fromRow: row.getData(),
+                toRow: nextRow.getData(),
+                above: true,
+            });
+        }
+    }
+
+    private readonly handleCellClick = (ev: Event): void => {
+        ev.stopPropagation();
+        ev.preventDefault();
+    };
+
+    private readonly releaseDetachedHandles = (node: Node): void => {
+        if (!(node instanceof HTMLElement)) {
+            return;
+        }
+
+        const handles = node.matches(LIMEL_DRAG_HANDLE)
+            ? [node]
+            : [...node.querySelectorAll<HTMLElement>(LIMEL_DRAG_HANDLE)];
+
+        for (const handle of handles) {
+            if (!handle.isConnected) {
+                this.pool.release(handle);
+            }
+        }
+    };
+
+    private getDragHandleFormatter() {
+        return () => {
+            const element = this.pool.get(LIMEL_DRAG_HANDLE);
+            setElementProperties(element, {
+                dragDirection: 'vertical',
+                language: this.language,
+            });
+
+            return element;
+        };
+    }
+}

--- a/src/components/table/row-drag-manager.ts
+++ b/src/components/table/row-drag-manager.ts
@@ -6,7 +6,6 @@ import { RowReorderEvent } from './table.types';
 import { Languages } from '../date-picker/date.types';
 
 const LIMEL_DRAG_HANDLE = 'limel-drag-handle';
-const POST_DROP_CLICK_WINDOW_MS = 250;
 
 /**
  * Provides row drag-and-drop reordering configuration for Tabulator
@@ -14,7 +13,6 @@ const POST_DROP_CLICK_WINDOW_MS = 250;
  */
 export class RowDragManager {
     private mutationObserver: MutationObserver | null = null;
-    private dragEndTimestamp = 0;
 
     constructor(
         private readonly pool: ElementPool,
@@ -96,23 +94,31 @@ export class RowDragManager {
     }
 
     /**
-     * Tabulator fires `rowMoved` (and `rowMoveCancelled`) from its `mouseup`
-     * handler. The browser may then dispatch a `click` on the drop target,
-     * which would bubble to Tabulator's own click handling and trigger a
-     * spurious row activation. Call this from both events so
-     * {@link wasDragJustEnded} can gate the click.
+     * Tabulator fires `rowMoved` / `rowMoveCancelled` from its `mouseup`
+     * handler. The browser may then dispatch a synthetic `click` on the drop
+     * target which would bubble to Tabulator's row-click handling and trigger
+     * a spurious row activation. Call this from both events: it installs a
+     * one-shot capture-phase click listener that swallows that single click
+     * before Tabulator can see it. If no click arrives (rare, but possible),
+     * the listener is removed on the next macrotask so it can never swallow a
+     * later, intentional click.
+     *
+     * @param target - Element that should swallow the post-drop click
+     * (typically the table host).
      */
-    public readonly markDragEnd = (): void => {
-        this.dragEndTimestamp = Date.now();
+    public readonly armPostDropClickGuard = (target: EventTarget): void => {
+        const swallow = (event: Event): void => {
+            event.stopImmediatePropagation();
+            event.preventDefault();
+        };
+        target.addEventListener('click', swallow, {
+            once: true,
+            capture: true,
+        });
+        setTimeout(() => {
+            target.removeEventListener('click', swallow, true);
+        }, 0);
     };
-
-    /**
-     * True if a drag just finished within the post-drop window. Used by the
-     * host to ignore the click that the browser fires after `mouseup`.
-     */
-    public wasDragJustEnded(): boolean {
-        return Date.now() - this.dragEndTimestamp < POST_DROP_CLICK_WINDOW_MS;
-    }
 
     private readonly handleCellClick = (ev: Event): void => {
         ev.stopPropagation();

--- a/src/components/table/table-selection.spec.ts
+++ b/src/components/table/table-selection.spec.ts
@@ -42,12 +42,10 @@ describe('table selection', () => {
         ...rowData: any[]
     ) => Map<any, { checked: boolean }> = (...rowData: any[]) => {
         const rowCheckboxMap = new Map<any, { checked: boolean }>();
-        const makeCell: (row: any, data: any) => CellComponent = (
+        const makeCell: (
             row: any,
-            data: any
-        ) => {
-            const checkbox = { checked: false };
-            rowCheckboxMap.set(data, checkbox);
+            checkbox: { checked: boolean }
+        ) => CellComponent = (row, checkbox) => {
             const cell: any = {
                 getElement: () => ({
                     querySelector: () => checkbox,
@@ -62,11 +60,17 @@ describe('table selection', () => {
             data,
             position
         ) => {
+            const checkbox = { checked: false };
+            rowCheckboxMap.set(data, checkbox);
             const row: Partial<RowComponent> = {
                 getData: () => data,
                 getPosition: () => position,
+                getElement: () =>
+                    ({
+                        querySelector: () => checkbox,
+                    }) as any,
             };
-            row.getCells = () => [makeCell(row, data)];
+            row.getCells = () => [makeCell(row, checkbox)];
 
             return row as any;
         };

--- a/src/components/table/table-selection.ts
+++ b/src/components/table/table-selection.ts
@@ -174,9 +174,16 @@ export class TableSelection {
         row: TabulatorRowComponent,
         checked: boolean
     ): void => {
-        const cell = row.getCells()[0];
-        if (cell) {
-            const checkBox = cell.getElement().querySelector(LIMEL_CHECKBOX);
+        // Look up by class instead of cell index: when `movableRows` is
+        // enabled, the drag-handle column occupies index 0 and the
+        // row-selector shifts to index 1. Keep the `.limel-table--row-selector`
+        // class in sync with `getRowSelectorColumnDefinition` if renamed.
+        const checkBox = row
+            .getElement()
+            .querySelector<HTMLLimelCheckboxElement>(
+                `.limel-table--row-selector ${LIMEL_CHECKBOX}`
+            );
+        if (checkBox) {
             checkBox.checked = checked;
         }
     };

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -21,6 +21,7 @@
     --limel-table-sorter-arrow-width: 0.5rem;
     --limel-table-table-cell-padding: 0.5rem;
     --limel-table-row-selector-z-index: 1;
+    --limel-table-drag-handle-width: 2rem;
     --limel-table-height-of-aggregations-row: 1.5rem;
     isolation: isolate;
     display: block;

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -10,6 +10,7 @@
 @forward './partial-styles/movable-columns';
 @forward './partial-styles/tabulator-footer';
 @forward './partial-styles/row-selection';
+@forward './partial-styles/row-drag-handle';
 
 /*
 * @prop --table-max-column-width: defines a maximum width for columns using standard size units, to prevent the table from growing too wide. Set to `auto` if you do not need this limitation. Defaults to `40rem`.

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -235,7 +235,7 @@ export class Table {
      * position.
      */
     @Event()
-    public reorder: EventEmitter<RowReorderEvent<any>>;
+    public reorder: EventEmitter<RowReorderEvent<unknown>>;
 
     /**
      * Emitted when the row selection has been changed
@@ -1014,14 +1014,18 @@ export class Table {
         };
     };
 
-    private readonly getRowDragOptions = (): object => {
+    private readonly getRowDragOptions = (): Partial<TabulatorOptions> => {
         if (!this.rowDragManager) {
             return {};
         }
 
         return {
             movableRows: true,
-            rowHeader: this.rowDragManager.getRowHeaderDefinition(),
+            // Tabulator's `rowHeader` inline type narrows `formatter` to a
+            // string, but the runtime accepts a function (as `ColumnDefinition`
+            // does). Cast bridges the incomplete upstream type.
+            rowHeader:
+                this.rowDragManager.getRowHeaderDefinition() as TabulatorOptions['rowHeader'],
         };
     };
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -641,9 +641,11 @@ export class Table {
         tabulator.on('renderComplete', this.handleRenderComplete);
 
         if (this.rowDragManager) {
+            const armClickGuard = () =>
+                this.rowDragManager.armPostDropClickGuard(table);
             tabulator.on('rowMoved', this.rowDragManager.handleRowMoved);
-            tabulator.on('rowMoved', this.rowDragManager.markDragEnd);
-            tabulator.on('rowMoveCancelled', this.rowDragManager.markDragEnd);
+            tabulator.on('rowMoved', armClickGuard);
+            tabulator.on('rowMoveCancelled', armClickGuard);
         }
 
         tabulator.on('tableBuilt', () => {
@@ -914,10 +916,6 @@ export class Table {
         }
 
         if (event.defaultPrevented) {
-            return;
-        }
-
-        if (this.rowDragManager?.wasDragJustEnded()) {
             return;
         }
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -28,10 +28,12 @@ import {
     ColumnSorter,
     ColumnAggregate,
     RowData,
+    RowReorderEvent,
 } from './table.types';
 import { ColumnDefinitionFactory, createColumnSorter } from './columns';
 import { isEqual, has } from 'lodash-es';
 import { ElementPool } from './element-pool';
+import { RowDragManager } from './row-drag-manager';
 import { TableSelection } from './table-selection';
 import { _mapLayout, Layout } from './layout';
 import { areRowsEqual } from './utils';
@@ -45,6 +47,7 @@ const FIRST_PAGE = 1;
  * @exampleComponent limel-example-table-custom-components
  * @exampleComponent limel-example-table-header-menu
  * @exampleComponent limel-example-table-movable-columns
+ * @exampleComponent limel-example-table-movable-rows
  * @exampleComponent limel-example-table-sorting-disabled
  * @exampleComponent limel-example-table-pagination
  * @exampleComponent limel-example-table-local
@@ -126,6 +129,14 @@ export class Table {
      */
     @Prop({ reflect: true })
     public movableColumns: boolean;
+
+    /**
+     * Set to `true` to enable reordering of the rows by dragging them.
+     * A drag handle will be rendered at the start of each row.
+     * Only available in `local` mode without pagination.
+     */
+    @Prop({ reflect: true })
+    public movableRows: boolean;
 
     /**
      * Set to `false` to disable column sorting through header interactions.
@@ -216,6 +227,13 @@ export class Table {
     public changeColumns: EventEmitter<Column[]>;
 
     /**
+     * Emitted when a row has been reordered via drag-and-drop.
+     * The event detail describes which row was moved and where it was placed.
+     */
+    @Event()
+    public reorder: EventEmitter<RowReorderEvent<any>>;
+
+    /**
      * Emitted when the row selection has been changed
      */
     @Event()
@@ -240,8 +258,10 @@ export class Table {
     private destroyed = false;
     private resizeObserver: ResizeObserver;
     private currentSorting: ColumnSorter[];
+    private rowDragManager: RowDragManager;
     private tableSelection: TableSelection;
     private shouldSort = false;
+    private hasWarnedOnConflictingMovableAndSortable = false;
 
     constructor() {
         this.handleDataSorting = this.handleDataSorting.bind(this);
@@ -261,6 +281,8 @@ export class Table {
     }
 
     public componentWillLoad() {
+        this.warnOnConflictingMovableAndSortable();
+        this.initRowDragManager();
         this.initTableSelection();
     }
 
@@ -272,6 +294,9 @@ export class Table {
     public disconnectedCallback() {
         this.destroyed = true;
         this.initialized = false;
+
+        this.rowDragManager?.destroy();
+        this.rowDragManager = null;
 
         if (this.resizeObserver) {
             this.resizeObserver.disconnect();
@@ -425,14 +450,38 @@ export class Table {
         this.init();
     }
 
+    @Watch('movableRows')
+    protected updateMovableRows() {
+        this.warnOnConflictingMovableAndSortable();
+        this.pool.releaseAll();
+        this.rowDragManager?.destroy();
+        this.rowDragManager = null;
+        this.initRowDragManager();
+        this.init();
+    }
+
     @Watch('sortableColumns')
     protected updateSortableColumns() {
+        this.warnOnConflictingMovableAndSortable();
         if (!this.tabulator) {
             return;
         }
 
         this.tabulator.setColumns(this.getColumnDefinitions());
         this.shouldSort = true;
+    }
+
+    private warnOnConflictingMovableAndSortable() {
+        if (this.hasWarnedOnConflictingMovableAndSortable) {
+            return;
+        }
+
+        if (this.movableRows && this.sortableColumns) {
+            console.warn(
+                'limel-table: combining `movableRows` with `sortableColumns` is not recommended. Sorting reorders the rows visually, so dragging a row to a new position will not match the underlying data order. Set `sortableColumns` to `false` when using `movableRows`.'
+            );
+            this.hasWarnedOnConflictingMovableAndSortable = true;
+        }
     }
 
     @Watch('sorting')
@@ -557,6 +606,7 @@ export class Table {
         // matter if its rendered or not.
         if (!('ResizeObserver' in window)) {
             this.tabulator = this.createTabulator(table);
+            this.rowDragManager?.observe(table);
             this.setSelection();
 
             return;
@@ -569,6 +619,7 @@ export class Table {
                 }
 
                 this.tabulator = this.createTabulator(table);
+                this.rowDragManager?.observe(table);
                 this.setSelection();
                 this.resizeObserver?.unobserve(table);
                 this.resizeObserver?.disconnect();
@@ -584,6 +635,11 @@ export class Table {
         tabulator.on('pageLoaded', this.handlePageLoaded);
         tabulator.on('columnMoved', this.handleMoveColumn);
         tabulator.on('renderComplete', this.handleRenderComplete);
+
+        if (this.rowDragManager) {
+            tabulator.on('rowMoved', this.rowDragManager.handleRowMoved);
+        }
+
         tabulator.on('tableBuilt', () => {
             if (this.destroyed) {
                 tabulator.destroy();
@@ -603,6 +659,16 @@ export class Table {
         });
 
         return tabulator;
+    }
+
+    private initRowDragManager() {
+        if (this.movableRows) {
+            this.rowDragManager = new RowDragManager(
+                this.pool,
+                this.reorder,
+                this.language
+            );
+        }
     }
 
     private initTableSelection() {
@@ -633,6 +699,7 @@ export class Table {
         const ajaxOptions = this.getAjaxOptions();
         const paginationOptions = this.getPaginationOptions();
         const columnOptions = this.getColumnOptions();
+        const rowDragOptions = this.getRowDragOptions();
 
         return {
             data: this.data,
@@ -644,6 +711,7 @@ export class Table {
             initialSort: this.getInitialSorting(),
             nestedFieldSeparator: false,
             ...columnOptions,
+            ...rowDragOptions,
         };
     }
 
@@ -938,6 +1006,17 @@ export class Table {
         };
     };
 
+    private readonly getRowDragOptions = (): object => {
+        if (!this.rowDragManager) {
+            return {};
+        }
+
+        return {
+            movableRows: true,
+            rowHeader: this.rowDragManager.getRowHeaderDefinition(),
+        };
+    };
+
     private readonly handleMoveColumn = (
         _,
         components: TabulatorColumnComponent[]
@@ -977,6 +1056,7 @@ export class Table {
                         'has-pagination': totalRows > this.pageSize,
                         'has-aggregation': this.hasAggregation(this.columns),
                         'has-movable-columns': this.movableColumns,
+                        'has-movable-rows': !!this.rowDragManager,
                         'has-rowselector': this.selectable,
                         'has-selection': this.tableSelection?.hasSelection,
                     }}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -133,7 +133,8 @@ export class Table {
     /**
      * Set to `true` to enable reordering of the rows by dragging them.
      * A drag handle will be rendered at the start of each row.
-     * Only available in `local` mode without pagination.
+     * Listen for the `reorder` event and update the `data` prop accordingly —
+     * the table will not persist the new order on its own.
      */
     @Prop({ reflect: true })
     public movableRows: boolean;
@@ -229,6 +230,9 @@ export class Table {
     /**
      * Emitted when a row has been reordered via drag-and-drop.
      * The event detail describes which row was moved and where it was placed.
+     * The consumer is responsible for updating the `data` prop to reflect the
+     * new order; otherwise the next render will revert the row to its original
+     * position.
      */
     @Event()
     public reorder: EventEmitter<RowReorderEvent<any>>;
@@ -638,6 +642,8 @@ export class Table {
 
         if (this.rowDragManager) {
             tabulator.on('rowMoved', this.rowDragManager.handleRowMoved);
+            tabulator.on('rowMoved', this.rowDragManager.markDragEnd);
+            tabulator.on('rowMoveCancelled', this.rowDragManager.markDragEnd);
         }
 
         tabulator.on('tableBuilt', () => {
@@ -908,6 +914,10 @@ export class Table {
         }
 
         if (event.defaultPrevented) {
+            return;
+        }
+
+        if (this.rowDragManager?.wasDragJustEnded()) {
             return;
         }
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -672,7 +672,7 @@ export class Table {
             this.rowDragManager = new RowDragManager(
                 this.pool,
                 this.reorder,
-                this.language
+                () => this.language
             );
         }
     }

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -217,3 +217,26 @@ export interface ColumnAggregate {
 export type RowData = {
     id?: string | number;
 };
+
+/**
+ * Describes a row reorder operation.
+ * Emitted when a row is moved via drag-and-drop.
+ * @public
+ */
+export interface RowReorderEvent<T> {
+    /**
+     * The data of the row that was moved
+     */
+    fromRow: T;
+
+    /**
+     * The data of the row that was used as the drop target
+     */
+    toRow: T;
+
+    /**
+     * If `true`, the row was placed above the target row.
+     * If `false`, it was placed below.
+     */
+    above: boolean;
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Row drag-and-drop reordering with a public prop and a reorder event (fromRow, toRow, above).

* **Examples**
  * New interactive example demonstrating movable rows, toggles for movable/selectable, and a live "Current row order" display.

* **Style**
  * Drag-handle and row-selector styles updated for spacing, stacking, sticky positioning, drag-state behavior, and a new drag-handle width variable.

* **Tests**
  * Added comprehensive tests for drag behavior, mutation observation, reorder logic, and click-suppression timing.

* **Bug Fixes**
  * More robust lookup for row selector checkbox updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
