### PR TITLE
feat(select): add `hotkey` prop for items & improve keyboard navigation

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -4224,6 +4224,7 @@ export type OpenDirection = 'left-start' | 'left' | 'left-end' | 'right-start' |
 // @public
 interface Option_2<T extends string = string> {
     disabled?: boolean;
+    hotkey?: string;
     icon?: string | Icon;
     // @deprecated
     iconColor?: Color;

--- a/src/components/select/examples/select-hotkeys.tsx
+++ b/src/components/select/examples/select-hotkeys.tsx
@@ -1,0 +1,89 @@
+import {
+    LimelSelectCustomEvent,
+    Option,
+    ListSeparator,
+} from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Select with option hotkeys.
+ *
+ * Use `hotkey` on options to bind keyboard interaction while the select
+ * dropdown is open.
+ *
+ * :::note
+ * 1. Hotkeys work only while the custom dropdown is open.
+ * 2. On mobile/iOS, `limel-select` uses a native `<select>`, so option
+ * hotkeys are not active.
+ * 3. Some keys are reserved for dropdown navigation and are ignored as
+ * option hotkeys: `tab` and arrow keys are always reserved; `enter`, `escape`,
+ * and `space` are reserved unless used with a modifier (for example
+ * `alt+enter`).
+ * :::
+ *
+ * :::important
+ * `meta` means the Meta key.
+ * It is rendered as <kbd>⌘</kbd> on Apple devices and <kbd>⊞ Win</kbd> on
+ * Windows/Linux. (`cmd`, `command`, `win`, `windows` are aliases for `meta`.)
+ *
+ * `ctrl` means the Control key on all platforms.
+ *
+ * Choose hotkeys that do not conflict with common browser shortcuts.
+ * :::
+ */
+@Component({
+    shadow: true,
+    tag: 'limel-example-select-hotkeys',
+})
+export class SelectHotkeysExample {
+    @State()
+    private value: Option;
+
+    private readonly options: (Option | ListSeparator)[] = [
+        {
+            text: 'Started',
+            value: 'started',
+            hotkey: 's',
+        },
+        {
+            text: 'In progress',
+            value: 'in-progress',
+            hotkey: 'p',
+        },
+        {
+            text: 'Blocked',
+            value: 'blocked',
+            hotkey: 'b',
+        },
+        {
+            text: 'Done',
+            value: 'done',
+            hotkey: 'd',
+        },
+        { separator: true },
+        {
+            text: 'Closed',
+            secondaryText: 'as not planned',
+            value: 'closed',
+            hotkey: 'cmd+d',
+        },
+    ];
+
+    public render() {
+        return (
+            <Host>
+                <limel-select
+                    label="Task status"
+                    value={this.value}
+                    options={this.options}
+                    onChange={this.handleChange}
+                />
+                <limel-example-value value={this.value} />
+            </Host>
+        );
+    }
+
+    private readonly handleChange = (event: LimelSelectCustomEvent<Option>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/select/option.types.ts
+++ b/src/components/select/option.types.ts
@@ -30,6 +30,12 @@ export interface Option<T extends string = string> {
     value: T;
 
     /**
+     * Optional keyboard shortcut for selecting this option when the custom
+     * dropdown is open.
+     */
+    hotkey?: string;
+
+    /**
      * Set to `true` to make this option disabled and not possible to select.
      */
     disabled?: boolean;

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -189,7 +189,12 @@ const SelectDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
 };
 
 const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
-    const items = createMenuItems(props.options, props.value, props.required);
+    const items = createMenuItems(
+        props.options,
+        props.value,
+        props.required,
+        props.isOpen
+    );
 
     return (
         <limel-portal
@@ -274,7 +279,8 @@ function isSelected(option: Option, value: Option | Option[]): boolean {
 function createMenuItems(
     options: Array<Option | ListSeparator>,
     value: Option | Option[],
-    selectIsRequired = false
+    selectIsRequired = false,
+    isOpen = false
 ): Array<ListItem<Option> | ListSeparator> {
     const menuOptionFilter = getMenuOptionFilter(selectIsRequired);
 
@@ -287,10 +293,23 @@ function createMenuItems(
         }
 
         const selected = isSelected(option, value);
-        const { text, secondaryText, disabled } = option;
+        const { text, secondaryText, disabled, hotkey } = option;
         const name = getIconName(option.icon);
 
         const color = getIconColor(option.icon, option.iconColor);
+
+        const primaryComponent = hotkey
+            ? {
+                  name: 'limel-hotkey',
+                  props: {
+                      value: hotkey,
+                      disabled: !isOpen || disabled,
+                      style: {
+                          order: '2',
+                      },
+                  },
+              }
+            : undefined;
 
         if (!name) {
             return {
@@ -298,6 +317,7 @@ function createMenuItems(
                 secondaryText: secondaryText,
                 selected: selected,
                 disabled: disabled,
+                primaryComponent,
                 value: option,
             };
         }
@@ -307,6 +327,7 @@ function createMenuItems(
             secondaryText: secondaryText,
             selected: selected,
             disabled: disabled,
+            primaryComponent,
             value: option,
             icon: {
                 name: name,

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -14,6 +14,11 @@ import {
 } from '@stencil/core';
 import { isMobileDevice } from '../../util/device';
 import { ENTER, SPACE } from '../../util/keycodes';
+import {
+    hotkeyFromKeyboardEvent,
+    normalizeHotkeyString,
+    tokenizeHotkeyString,
+} from '../../util/hotkeys';
 import { isMultiple } from '../../util/multiple';
 import { createRandomString } from '../../util/random-string';
 import { SelectTemplate, triggerIconColorWarning } from './select.template';
@@ -28,6 +33,7 @@ import { SelectTemplate, triggerIconColorWarning } from './select.template';
  * @exampleComponent limel-example-select-with-empty-option
  * @exampleComponent limel-example-select-preselected
  * @exampleComponent limel-example-select-change-options
+ * @exampleComponent limel-example-select-hotkeys
  * @exampleComponent limel-example-select-dialog
  */
 @Component({
@@ -126,6 +132,7 @@ export class Select {
     private portalId: string;
     private focusObserver: IntersectionObserver;
     private focusTimeoutId: ReturnType<typeof setTimeout>;
+    private readonly normalizedHotkeyCache = new Map<string, string | null>();
 
     constructor() {
         this.handleMenuChange = this.handleMenuChange.bind(this);
@@ -174,6 +181,11 @@ export class Select {
     }
 
     public disconnectedCallback() {
+        document.removeEventListener(
+            'keydown',
+            this.handleDocumentKeyDown,
+            true
+        );
         this.cancelPendingFocus();
 
         if (this.mdcFloatingLabel) {
@@ -224,6 +236,20 @@ export class Select {
 
     @Watch('menuOpen')
     protected watchOpen(newValue: boolean, oldValue: boolean) {
+        if (newValue) {
+            document.addEventListener(
+                'keydown',
+                this.handleDocumentKeyDown,
+                true
+            );
+        } else {
+            document.removeEventListener(
+                'keydown',
+                this.handleDocumentKeyDown,
+                true
+            );
+        }
+
         if (this.checkValid) {
             return;
         }
@@ -232,6 +258,11 @@ export class Select {
         if (!newValue && oldValue) {
             this.checkValid = true;
         }
+    }
+
+    @Watch('options')
+    protected watchOptions() {
+        this.normalizedHotkeyCache.clear();
     }
 
     private setMenuFocus() {
@@ -365,6 +396,105 @@ export class Select {
         this.menuOpen = false;
         this.cancelPendingFocus();
         this.setTriggerFocus();
+    }
+
+    private readonly handleDocumentKeyDown = (event: KeyboardEvent) => {
+        if (
+            this.isMobileDevice ||
+            !this.menuOpen ||
+            event.defaultPrevented ||
+            event.repeat
+        ) {
+            return;
+        }
+
+        const pressedHotkey = hotkeyFromKeyboardEvent(event);
+        if (!pressedHotkey || this.isReservedSelectHotkey(pressedHotkey)) {
+            return;
+        }
+
+        const matchedOption = this.findOptionByHotkey(pressedHotkey);
+        if (!matchedOption || matchedOption.disabled) {
+            return;
+        }
+
+        event.stopPropagation();
+        event.preventDefault();
+
+        if (this.multiple) {
+            const currentValue = isMultiple(this.value) ? this.value : [];
+            const hasSelectedOption = currentValue.some(
+                (option) => option.value === matchedOption.value
+            );
+
+            const nextValue = hasSelectedOption
+                ? currentValue.filter(
+                      (option) => option.value !== matchedOption.value
+                  )
+                : [...currentValue, matchedOption];
+
+            this.change.emit(nextValue);
+
+            return;
+        }
+
+        this.change.emit(matchedOption);
+        this.menuOpen = false;
+        this.setTriggerFocus();
+    };
+
+    private isReservedSelectHotkey(hotkey: string): boolean {
+        const tokens = tokenizeHotkeyString(hotkey);
+        const key = tokens.at(-1);
+        if (!key) {
+            return false;
+        }
+
+        if (
+            key === 'arrowup' ||
+            key === 'arrowdown' ||
+            key === 'arrowleft' ||
+            key === 'arrowright'
+        ) {
+            return true;
+        }
+
+        if (key === 'tab') {
+            return true;
+        }
+
+        const hasModifiers = tokens.length > 1;
+        return (
+            !hasModifiers &&
+            (key === 'enter' || key === 'space' || key === 'escape')
+        );
+    }
+
+    private findOptionByHotkey(pressedHotkey: string): Option | null {
+        for (const option of this.getOptionsExcludingSeparators()) {
+            if (option.disabled || !option.hotkey) {
+                continue;
+            }
+
+            const normalized = this.getNormalizedHotkey(option.hotkey);
+            if (normalized && normalized === pressedHotkey) {
+                return option;
+            }
+        }
+
+        return null;
+    }
+
+    private getNormalizedHotkey(raw: string): string | null {
+        const cacheKey = raw.trim();
+        if (this.normalizedHotkeyCache.has(cacheKey)) {
+            return this.normalizedHotkeyCache.get(cacheKey) ?? null;
+        }
+
+        const normalized = normalizeHotkeyString(cacheKey);
+        this.normalizedHotkeyCache.set(cacheKey, normalized);
+
+        return normalized;
     }
 
     private openMenu() {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/crm-client/issues/755

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added keyboard shortcut support for select options—users can now assign and use hotkeys to quickly select items when the dropdown is open
* Hotkeys are only active when the dropdown menu is open and only for enabled options
* Includes support for platform-specific modifier key behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
