### PR TITLE
feat(menu): use primaryComponent from the limel-list

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -645,6 +645,7 @@ export namespace Components {
         "commandText"?: string;
         "disabled": boolean;
         "hotkey"?: string;
+        "primaryComponent"?: ListComponent;
         "showChevron": boolean;
     }
     // @internal (undocumented)
@@ -2854,6 +2855,7 @@ export namespace JSX {
         "commandText"?: string;
         "disabled"?: boolean;
         "hotkey"?: string;
+        "primaryComponent"?: ListComponent;
         "showChevron"?: boolean;
     }
 
@@ -4191,6 +4193,7 @@ interface MenuItem<T = any> {
     items?: Array<MenuItem<T> | ListSeparator> | MenuLoader;
     // @internal
     parentItem?: MenuItem;
+    primaryComponent?: ListComponent;
     secondaryText?: string;
     selected?: boolean;
     text: string;

--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -67,7 +67,8 @@ limel-list-item[disabled]:not([disabled='false']) {
     .text,
     limel-icon,
     img,
-    .boolean-input {
+    .boolean-input,
+    limel-menu-item-meta {
         opacity: 0.4;
     }
 }

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -252,7 +252,7 @@ export class ListItemComponent implements ListItem {
         const PrimaryComponent: any = primary.name;
         const props = primary.props || {};
 
-        return <PrimaryComponent {...props} />;
+        return <PrimaryComponent {...props} disabled={this.disabled} />;
     };
 
     private renderImage = () => {

--- a/src/components/list-item/menu-item-meta/menu-item-meta.tsx
+++ b/src/components/list-item/menu-item-meta/menu-item-meta.tsx
@@ -1,5 +1,6 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 import { normalizeHotkeyString } from '../../../util/hotkeys';
+import { ListComponent } from '../list-item.types';
 
 /**
  * Meta content for menu list items
@@ -47,9 +48,16 @@ export class MenuItemMeta {
     @Prop()
     public showChevron = false;
 
+    /**
+     * Optional primary component to render before other meta content
+     */
+    @Prop()
+    public primaryComponent?: ListComponent;
+
     public render() {
         return (
             <Host>
+                {this.renderPrimaryComponent()}
                 {this.renderCommandText()}
                 {this.renderBadge()}
                 {this.renderChevron()}
@@ -78,6 +86,18 @@ export class MenuItemMeta {
         }
 
         return <limel-badge label={String(this.badge)} />;
+    }
+
+    private renderPrimaryComponent() {
+        const primary = this.primaryComponent;
+        if (!primary?.name) {
+            return;
+        }
+
+        const PrimaryComponent: any = primary.name;
+        const props = primary.props || {};
+
+        return <PrimaryComponent {...props} disabled={this.disabled} />;
     }
 
     private renderChevron() {

--- a/src/components/menu-list/menu-list-renderer.tsx
+++ b/src/components/menu-list/menu-list-renderer.tsx
@@ -111,18 +111,20 @@ export class MenuListRenderer {
             !!item.hotkey ||
             !!item.commandText;
 
-        const primaryComponent = hasMeta
-            ? {
-                  name: 'limel-menu-item-meta',
-                  props: {
-                      commandText: item.commandText,
-                      hotkey: item.hotkey,
-                      disabled: !!item.disabled,
-                      badge: item.badge,
-                      showChevron: hasSubMenu,
-                  },
-              }
-            : undefined;
+        const primaryComponent =
+            hasMeta || item.primaryComponent
+                ? {
+                      name: 'limel-menu-item-meta',
+                      props: {
+                          commandText: item.commandText,
+                          hotkey: item.hotkey,
+                          disabled: !!item.disabled,
+                          badge: item.badge,
+                          showChevron: hasSubMenu,
+                          primaryComponent: item.primaryComponent,
+                      },
+                  }
+                : undefined;
 
         const key = (item as any).id ?? `item-${index}`;
         const classNames = {

--- a/src/components/menu/examples/menu-primary-component.tsx
+++ b/src/components/menu/examples/menu-primary-component.tsx
@@ -1,0 +1,77 @@
+import { LimelMenuCustomEvent, MenuItem } from '@limetech/lime-elements';
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * With a primary component
+ *
+ * Menu items can render a custom primary component using the
+ * `primaryComponent` prop, just like list items.
+ *
+ * The component is rendered before the item's text.
+ */
+@Component({
+    tag: 'limel-example-menu-primary-component',
+    shadow: true,
+})
+export class MenuPrimaryComponentExample {
+    @State()
+    private lastSelectedItem: string;
+
+    private items: MenuItem[] = [
+        {
+            text: 'Upload file',
+            secondaryText: 'Completed',
+            primaryComponent: {
+                name: 'limel-circular-progress',
+                props: {
+                    value: 10,
+                    maxValue: 10,
+                    suffix: '%',
+                    displayPercentageColors: true,
+                    size: 'small',
+                },
+            },
+        },
+        {
+            text: 'Sync contacts',
+            secondaryText: 'In progress…',
+            primaryComponent: {
+                name: 'limel-circular-progress',
+                props: {
+                    value: 4,
+                    maxValue: 10,
+                    suffix: '%',
+                    displayPercentageColors: true,
+                    size: 'small',
+                },
+            },
+        },
+        {
+            text: 'Generate report',
+            secondaryText: 'Just started',
+            primaryComponent: {
+                name: 'limel-circular-progress',
+                props: {
+                    value: 1,
+                    maxValue: 10,
+                    suffix: '%',
+                    displayPercentageColors: true,
+                    size: 'small',
+                },
+            },
+        },
+    ];
+
+    public render() {
+        return [
+            <limel-menu items={this.items} onSelect={this.handleSelect}>
+                <limel-button label="Tasks" slot="trigger" />
+            </limel-menu>,
+            <limel-example-value value={this.lastSelectedItem} />,
+        ];
+    }
+
+    private handleSelect = (event: LimelMenuCustomEvent<MenuItem>) => {
+        this.lastSelectedItem = event.detail.text;
+    };
+}

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -60,6 +60,7 @@ const DEFAULT_ROOT_BREADCRUMBS_ITEM: BreadcrumbsItem = {
  * @exampleComponent limel-example-menu-surface-width
  * @exampleComponent limel-example-menu-separators
  * @exampleComponent limel-example-menu-icons
+ * @exampleComponent limel-example-menu-primary-component
  * @exampleComponent limel-example-menu-badge-icons
  * @exampleComponent limel-example-menu-grid
  * @exampleComponent limel-example-menu-secondary-text

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -1,6 +1,7 @@
 import { ListSeparator } from '../../global/shared-types/separator.types';
 import { Icon } from '../../global/shared-types/icon.types';
 import { Color } from '../../global/shared-types/color.types';
+import { ListComponent } from '../list-item/list-item.types';
 
 /**
  * The direction in which the menu should open.
@@ -120,6 +121,16 @@ export interface MenuItem<T = any> {
      * If specified, will display a notification badge on the buttons in the dock.
      */
     badge?: number | string;
+
+    /**
+     * Component used to render additional content in the menu item.
+     *
+     * When the menu item is disabled, the `disabled` prop is automatically
+     * propagated to the primary component.
+     *
+     * See `limel-example-menu-primary-component` for usage.
+     */
+    primaryComponent?: ListComponent;
 
     /**
      * Value of the menu item.


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/lime-crm-components/pull/4166

<img width="299" height="424" alt="Screenshot 2026-04-01 at 15 55 02" src="https://github.com/user-attachments/assets/f232fbbd-e17b-42e0-b7e5-67b49bf61382" />


<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu items can include a custom primary component rendered before text, badge, and chevron for richer item visuals.
* **Bug Fixes**
  * The menu item's disabled state now correctly propagates to primary components and their visual opacity reflects disabled styling.
* **Documentation**
  * Added an example demonstrating menu items with a primary component and selection display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
