### PR TITLE
fix(file-viewer): defer blob URL revocation to survive portal DOM moves

### DIFF
--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -157,13 +157,28 @@ export class FileViewer {
     private email?: Email;
 
     private pdfBlobUrl?: string;
+    private revokeAnimationFrame?: number;
 
     constructor() {
         this.fullscreen = new Fullscreen(this.HostElement);
     }
 
     public disconnectedCallback() {
-        this.revokePdfBlobUrl();
+        if (this.revokeAnimationFrame !== undefined) {
+            cancelAnimationFrame(this.revokeAnimationFrame);
+        }
+
+        this.revokeAnimationFrame = requestAnimationFrame(() => {
+            this.revokePdfBlobUrl();
+            this.revokeAnimationFrame = undefined;
+        });
+    }
+
+    public connectedCallback() {
+        if (this.revokeAnimationFrame !== undefined) {
+            cancelAnimationFrame(this.revokeAnimationFrame);
+            this.revokeAnimationFrame = undefined;
+        }
     }
 
     public async componentWillLoad() {


### PR DESCRIPTION
## Summary
- When `limel-file-viewer` renders a PDF inside a `limel-popover`, the portal moves the DOM element via `append()`, triggering `disconnectedCallback`
- The previous implementation immediately revoked the PDF blob URL in `disconnectedCallback`, breaking the iframe
- This PR defers revocation using `requestAnimationFrame`: portal DOM moves trigger `connectedCallback` synchronously in the same frame, which cancels the pending revocation. Real removals proceed on the next animation frame.

## Problem
Portal-based components (`limel-popover`, `limel-portal`) physically move DOM elements to `document.body`. This triggers `disconnectedCallback` → `connectedCallback` in quick succession. The file-viewer was revoking its internal PDF blob URL on disconnect, leaving the iframe pointing at a dead URL.

## Solution
```typescript
public disconnectedCallback() {
    this.revokeAnimationFrame = requestAnimationFrame(() => {
        this.revokePdfBlobUrl();
    });
}

public connectedCallback() {
    if (this.revokeAnimationFrame) {
        cancelAnimationFrame(this.revokeAnimationFrame);
        this.revokeAnimationFrame = undefined;
    }
}
```

- **Portal move** (sync disconnect → reconnect): revocation cancelled → blob URL survives
- **Real removal** (no reconnect): revocation executes next frame → blob URL cleaned up
- No memory leak: `createURL()` also revokes the previous blob URL before creating a new one

## Test plan
- [ ] Render a PDF inside a `limel-popover` — verify it displays correctly
- [ ] Close the popover / remove the file-viewer — verify blob URL is revoked (no memory leak)
- [ ] Render a PDF outside a popover (normal usage) — verify no regression
- [ ] Open/close popover multiple times — verify no accumulation of blob URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File viewer: improved handling of PDF URLs during quick detach/reattach — URL revocation is now deferred and cancellable, and reconnection cancels pending revocation to prevent premature removal, reduce memory issues, and avoid errors during lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->