### PR TITLE
fix(table): prevent local re-sort of server data in remote mode

### DIFF
--- a/src/components/table/table.e2e.tsx
+++ b/src/components/table/table.e2e.tsx
@@ -165,6 +165,64 @@ describe('limel-table', () => {
     });
 
     describe('remote sorting', () => {
+        it('displays data in the order returned by the server, without re-sorting locally', async () => {
+            // Initial data is in reverse numeric order (unsorted).
+            // After sorting, the server returns data in numeric ASC order.
+            // If Tabulator re-sorts locally as strings, it would produce
+            // "1","10","11","2","20" instead of 1, 2, 10, 11, 20.
+            const columns = [{ field: 'order', title: 'Order' }];
+            const initialData = [
+                { id: 5, order: 20 },
+                { id: 4, order: 11 },
+                { id: 3, order: 10 },
+                { id: 2, order: 2 },
+                { id: 1, order: 1 },
+            ];
+
+            const { root, waitForChanges, setProps } = await renderTable({
+                mode: 'remote',
+                data: initialData,
+                columns,
+                totalRows: 5,
+                pageSize: 5,
+            });
+
+            // Simulate server responding with numerically sorted data
+            const serverSortedData = [
+                { id: 1, order: 1 },
+                { id: 2, order: 2 },
+                { id: 3, order: 10 },
+                { id: 4, order: 11 },
+                { id: 5, order: 20 },
+            ];
+
+            root.addEventListener('load', (event: CustomEvent) => {
+                if (event.detail?.sorters?.length) {
+                    setProps({ data: serverSortedData });
+                }
+            });
+
+            const container = getContainer(root);
+            const headers = container.querySelectorAll('[role="columnheader"]');
+
+            (headers[0] as HTMLElement).click();
+            await waitForChanges();
+            await new Promise((resolve) => setTimeout(resolve, 300));
+            await waitForChanges();
+
+            const rows = container.querySelectorAll(
+                '.tabulator-table .tabulator-row'
+            );
+            const displayedValues = [...rows].map((row) => {
+                const cell = row.querySelector('[role="gridcell"]');
+
+                return Number(cell?.textContent);
+            });
+
+            // Must match server response — string sort would give [1, 10, 11, 2, 20]
+            expect(displayedValues).toEqual([1, 2, 10, 11, 20]);
+        });
+
         it('emits load event with sorters when clicking a column header', async () => {
             const columns = [
                 { field: 'colA', title: 'A' },

--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -138,3 +138,66 @@ describe('limel-table data updates', () => {
         expect(tabulator.updateOrAddData).toHaveBeenCalledWith(data);
     });
 });
+
+describe('limel-table aggregate updates', () => {
+    let component: Table;
+
+    beforeEach(() => {
+        component = new Table();
+        (component as any).columns = [
+            { field: 'name', title: 'Name' },
+            { field: 'amount', title: 'Amount' },
+        ];
+        (component as any).tabulator = {
+            setColumns: vi.fn(),
+            recalc: vi.fn(),
+            rowManager: { redraw: vi.fn() },
+            destroy: vi.fn(),
+        };
+        (component as any).pool = { releaseAll: vi.fn() };
+        (component as any).initialized = true;
+        (component as any).host = {
+            shadowRoot: {
+                querySelector: vi
+                    .fn()
+                    .mockReturnValue(document.createElement('div')),
+            },
+        };
+    });
+
+    it('does not destroy tabulator when aggregate fields change', () => {
+        const oldAggregates: any[] = [];
+        const newAggregates = [{ field: 'amount', value: 100 }];
+
+        (component as any).updateAggregates(newAggregates, oldAggregates);
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.destroy).not.toHaveBeenCalled();
+        expect(tabulator.setColumns).toHaveBeenCalled();
+        expect(tabulator.recalc).toHaveBeenCalled();
+        expect(tabulator.rowManager.redraw).toHaveBeenCalled();
+    });
+
+    it('recalculates without setColumns when aggregate values change but fields are the same', () => {
+        const oldAggregates = [{ field: 'amount', value: 100 }];
+        const newAggregates = [{ field: 'amount', value: 200 }];
+
+        (component as any).updateAggregates(newAggregates, oldAggregates);
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.destroy).not.toHaveBeenCalled();
+        expect(tabulator.setColumns).not.toHaveBeenCalled();
+        expect(tabulator.recalc).toHaveBeenCalled();
+        expect(tabulator.rowManager.redraw).toHaveBeenCalled();
+    });
+
+    it('does nothing when aggregates are equal', () => {
+        const aggregates = [{ field: 'amount', value: 100 }];
+
+        (component as any).updateAggregates(aggregates, aggregates);
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.setColumns).not.toHaveBeenCalled();
+        expect(tabulator.recalc).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -139,6 +139,26 @@ describe('limel-table data updates', () => {
     });
 });
 
+describe('limel-table remote mode options', () => {
+    let component: Table;
+
+    beforeEach(() => {
+        component = new Table();
+    });
+
+    it('sets sortMode to "remote" when mode is remote', () => {
+        (component as any).mode = 'remote';
+        const options = (component as any).getAjaxOptions();
+        expect(options.sortMode).toEqual('remote');
+    });
+
+    it('does not set sortMode when mode is not remote', () => {
+        (component as any).mode = 'local';
+        const options = (component as any).getAjaxOptions();
+        expect(options.sortMode).toBeUndefined();
+    });
+});
+
 describe('limel-table aggregate updates', () => {
     let component: Table;
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -399,9 +399,7 @@ export class Table {
         }
 
         if (!this.haveSameAggregateFields(newAggregates, oldAggregates)) {
-            this.init();
-
-            return;
+            this.tabulator.setColumns(this.getColumnDefinitions());
         }
 
         this.tabulator.recalc();

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -719,7 +719,7 @@ export class Table {
         const remoteUrl = 'https://localhost';
 
         return {
-            ajaxSorting: true,
+            sortMode: 'remote',
             ajaxURL: remoteUrl,
             ajaxRequestFunc: this.requestData,
             ajaxRequesting: this.handleAjaxRequesting,
@@ -766,10 +766,16 @@ export class Table {
         // we always return the existing data from this function, therefore
         // relying on the consumer component to handle the loading
         // state via the loading prop, if it actually decides to load new data.
-        const resolveExistingData = Promise.resolve({
-            last_page: this.calculatePageCount(),
-            data: this.data,
-        });
+        //
+        // When pagination is enabled, Tabulator's pagination module unwraps
+        // the `{last_page, data}` format. Without pagination, Tabulator
+        // expects a plain array directly.
+        const resolveExistingData = this.pageSize
+            ? Promise.resolve({
+                  last_page: this.calculatePageCount(),
+                  data: this.data,
+              })
+            : Promise.resolve(this.data);
 
         if (!isEqual(this.currentLoad, load)) {
             this.currentSorting = columnSorters;


### PR DESCRIPTION
## Summary

- Adds `sortMode: 'remote'` to Tabulator options when `mode="remote"`, which is the Tabulator 6 API for disabling client-side sorting — replacing the now-dead `ajaxSorting: true` (Tabulator 4/5 only)
- Fixes `requestData` to return a plain data array when pagination is not enabled, since `sortMode: 'remote'` causes Tabulator to call `requestData` on sort changes and the `{last_page, data}` wrapper requires the pagination module to unwrap it

## Test plan

- [ ] Unit test: `getAjaxOptions()` includes `sortMode: 'remote'` when mode is remote, absent otherwise (`table.spec.ts`)
- [ ] E2e test: table with integer data in reverse order — after sort click and server response with numerically sorted data, display matches server order and not string sort order (`table.e2e.tsx`)
- [ ] Existing remote sorting e2e test still passes

Closes #4008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end and unit tests covering remote sorting behavior and aggregate-field updates.

* **Bug Fixes**
  * Ensured remote sorting returns rows in the same order provided by the server.
  * Fixed aggregate-change handling to update table columns without full reinitialization.

* **Improvements**
  * Made data responses consistent for paginated vs non-paginated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->