### PR TITLE
fix(markdown): avoid unnecessary destruction and recreation of custom elements when value is updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "lodash-es": "^4.17.23",
         "material-components-web": "^13.0.0",
         "moment": "^2.30.1",
+        "morphdom": "^2.7.8",
         "number-abbreviate": "^2.0.0",
         "parse-css-color": "^0.2.1",
         "postal-mime": "^2.7.3",
@@ -12483,6 +12484,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/morphdom": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
+      "integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -26331,6 +26339,12 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true
+    },
+    "morphdom": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
+      "integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
       "dev": true
     },
     "mrmime": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lodash-es": "^4.17.23",
     "material-components-web": "^13.0.0",
     "moment": "^2.30.1",
+    "morphdom": "^2.7.8",
     "number-abbreviate": "^2.0.0",
     "parse-css-color": "^0.2.1",
     "postal-mime": "^2.7.3",

--- a/src/components/markdown/markdown.e2e.tsx
+++ b/src/components/markdown/markdown.e2e.tsx
@@ -1,0 +1,75 @@
+import { render, h } from '@stencil/vitest';
+
+describe('limel-markdown', () => {
+    describe('DOM morphing', () => {
+        it('renders markdown content', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-markdown value="**Hello** world"></limel-markdown>
+            );
+            await waitForChanges();
+
+            const container = root.shadowRoot.querySelector('#markdown');
+            expect(container.querySelector('strong').textContent).toBe('Hello');
+        });
+
+        it('updates content without destroying preserved elements', async () => {
+            const { root, waitForChanges, setProps } = await render(
+                <limel-markdown value="First paragraph"></limel-markdown>
+            );
+            await waitForChanges();
+
+            const container = root.shadowRoot.querySelector('#markdown');
+            const firstP = container.querySelector('p');
+
+            await setProps({ value: 'First paragraph\n\nSecond paragraph' });
+            await waitForChanges();
+
+            // The first paragraph should be the same DOM node
+            expect(container.querySelector('p')).toBe(firstP);
+            expect(container.querySelectorAll('p').length).toBe(2);
+        });
+
+        it('preserves a whitelisted custom element across value updates', async () => {
+            const chipHtml = '<limel-chip text="Test"></limel-chip>';
+            const { root, waitForChanges, setProps } = await render(
+                <limel-markdown
+                    value={`Before\n\n${chipHtml}`}
+                ></limel-markdown>
+            );
+            await waitForChanges();
+
+            const container = root.shadowRoot.querySelector('#markdown');
+            const chip = container.querySelector('limel-chip');
+            expect(chip).not.toBeNull();
+
+            // Update surrounding text, keep the chip
+            await setProps({
+                value: `Updated before\n\n${chipHtml}\n\nAfter`,
+            });
+            await waitForChanges();
+
+            const updatedChip = container.querySelector('limel-chip');
+            expect(updatedChip).toBe(chip);
+        });
+
+        it('renders content after clearing and setting new value', async () => {
+            const { root, waitForChanges, setProps } = await render(
+                <limel-markdown value="Initial content"></limel-markdown>
+            );
+            await waitForChanges();
+
+            await setProps({ value: '' });
+            await waitForChanges();
+
+            const container = root.shadowRoot.querySelector('#markdown');
+            expect(container.innerHTML).toBe('');
+
+            await setProps({ value: 'New content' });
+            await waitForChanges();
+
+            expect(container.querySelector('p').textContent).toBe(
+                'New content'
+            );
+        });
+    });
+});

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -4,6 +4,7 @@ import { globalConfig } from '../../global/config';
 import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 import { ImageIntersectionObserver } from './image-intersection-observer';
 import { hydrateCustomElements } from './hydrate-custom-elements';
+import { morphChildren } from './morph-dom';
 import { DEFAULT_MARKDOWN_WHITELIST } from './default-whitelist';
 
 /**
@@ -118,7 +119,7 @@ export class Markdown {
                 removeEmptyParagraphs: this.removeEmptyParagraphs,
             });
 
-            this.rootElement.innerHTML = html;
+            morphChildren(this.rootElement, html);
 
             // Hydration parses JSON attribute values (e.g. link='{"href":"..."}')
             // into JS properties. URL sanitization happens here because

--- a/src/components/markdown/morph-dom.e2e.ts
+++ b/src/components/markdown/morph-dom.e2e.ts
@@ -1,0 +1,157 @@
+import { morphChildren } from './morph-dom';
+
+describe('morphChildren', () => {
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.append(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('sets initial content on an empty container', () => {
+        morphChildren(container, '<p>Hello</p>');
+        expect(container.innerHTML).toBe('<p>Hello</p>');
+    });
+
+    it('updates changed text content', () => {
+        container.innerHTML = '<p>Hello</p>';
+        morphChildren(container, '<p>Hello World</p>');
+        expect(container.innerHTML).toBe('<p>Hello World</p>');
+    });
+
+    it('preserves an unchanged DOM node instance', () => {
+        container.innerHTML = '<p>First</p><p>Second</p>';
+        const secondP = container.querySelectorAll('p')[1];
+
+        morphChildren(container, '<p>First</p><p>Second</p><p>Third</p>');
+
+        expect(container.querySelectorAll('p')[1]).toBe(secondP);
+    });
+
+    it('preserves a custom element when surrounding text changes', () => {
+        container.innerHTML =
+            '<p>Before</p><my-widget data-x="1"></my-widget><p>After</p>';
+        const widget = container.querySelector('my-widget');
+
+        morphChildren(
+            container,
+            '<p>Updated</p><my-widget data-x="1"></my-widget><p>After</p><p>New</p>'
+        );
+
+        expect(container.querySelector('my-widget')).toBe(widget);
+    });
+
+    it('preserves a custom element when its attributes change', () => {
+        container.innerHTML =
+            '<p>Hello</p><my-chip link=\'{"href":"old"}\' text="A"></my-chip>';
+        const chip = container.querySelector('my-chip');
+
+        morphChildren(
+            container,
+            '<p>Hello</p><my-chip link=\'{"href":"new","target":"_blank"}\' text="A"></my-chip>'
+        );
+
+        const updatedChip = container.querySelector('my-chip');
+        expect(updatedChip).toBe(chip);
+        expect(updatedChip.getAttribute('link')).toBe(
+            '{"href":"new","target":"_blank"}'
+        );
+    });
+
+    it('preserves custom elements with complex JSON attributes', () => {
+        const json = '{"href":"https://example.com","text":"Example"}';
+        container.innerHTML = `<p>Text</p><my-chip link='${json}'></my-chip>`;
+        const chip = container.querySelector('my-chip');
+
+        morphChildren(
+            container,
+            `<p>Updated text</p><my-chip link='${json}'></my-chip>`
+        );
+
+        expect(container.querySelector('my-chip')).toBe(chip);
+        expect(container.querySelector('my-chip').getAttribute('link')).toBe(
+            json
+        );
+    });
+
+    it('handles node removal', () => {
+        container.innerHTML = '<p>One</p><p>Two</p><p>Three</p>';
+        morphChildren(container, '<p>One</p><p>Three</p>');
+        expect(container.children.length).toBe(2);
+        expect(container.innerHTML).toBe('<p>One</p><p>Three</p>');
+    });
+
+    it('distinguishes multiple same-tag custom elements by attributes', () => {
+        container.innerHTML =
+            '<my-chip text="A"></my-chip><my-chip text="B"></my-chip>';
+        const chipB = container.querySelectorAll('my-chip')[1];
+
+        morphChildren(
+            container,
+            '<my-chip text="A"></my-chip><my-chip text="B"></my-chip><my-chip text="C"></my-chip>'
+        );
+
+        expect(container.querySelectorAll('my-chip')[1]).toBe(chipB);
+        expect(
+            container.querySelectorAll('my-chip')[1].getAttribute('text')
+        ).toBe('B');
+    });
+
+    it('recreates custom element when new content is inserted before it', () => {
+        // morphdom matches nodes positionally, so inserting a new sibling
+        // before a custom element causes it to be recreated. This is a
+        // known limitation — the element is still rendered correctly, but
+        // it loses its DOM identity (and thus any internal state).
+        container.innerHTML = '<p>Intro</p><my-chip text="Keep"></my-chip>';
+        const chip = container.querySelector('my-chip');
+
+        morphChildren(
+            container,
+            '<p>Intro</p><p>New paragraph</p><my-chip text="Keep"></my-chip>'
+        );
+
+        const updatedChip = container.querySelector('my-chip');
+        expect(updatedChip).not.toBe(chip);
+        expect(updatedChip.getAttribute('text')).toBe('Keep');
+    });
+
+    it('handles empty new HTML', () => {
+        container.innerHTML = '<p>Content</p>';
+        morphChildren(container, '');
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('does not replace the container element itself', () => {
+        const parent = container.parentNode;
+        const originalContainer = container;
+        container.innerHTML = '<p>Old</p>';
+        morphChildren(container, '<p>New</p>');
+        expect(container).toBe(originalContainer);
+        expect(container.parentNode).toBe(parent);
+    });
+
+    it('handles rapid successive updates preserving custom element identity', () => {
+        // Simulates the streaming scenario where value changes every ~50ms.
+        // The custom element must be preserved (same DOM node) across all
+        // updates — recreating it would cause lifecycle churn and flickering.
+        morphChildren(
+            container,
+            '<p>Initial</p><my-chip text="Persistent"></my-chip>'
+        );
+        const originalChip = container.querySelector('my-chip');
+
+        for (let i = 0; i < 20; i++) {
+            morphChildren(
+                container,
+                `<p>Update ${i}</p><my-chip text="Persistent"></my-chip>`
+            );
+        }
+
+        expect(container.querySelector('p').textContent).toBe('Update 19');
+        expect(container.querySelector('my-chip')).toBe(originalChip);
+    });
+});

--- a/src/components/markdown/morph-dom.ts
+++ b/src/components/markdown/morph-dom.ts
@@ -1,0 +1,29 @@
+import morphdom from 'morphdom';
+
+/**
+ * Morph the children of `container` to match the given HTML string.
+ *
+ * Uses morphdom to diff the existing DOM against the new HTML and apply
+ * only the minimum changes. This preserves existing DOM nodes (including
+ * custom elements with internal state) that haven't changed.
+ *
+ * @param container - The parent element whose children should be morphed.
+ * @param html - The new HTML content for the container's children.
+ */
+export function morphChildren(container: HTMLElement, html: string = ''): void {
+    // morphdom's second argument must be a single root element. We wrap
+    // the new HTML in a <div> purely to satisfy that requirement — the
+    // tag name doesn't matter because childrenOnly makes morphdom skip
+    // the root and only diff the children. The container element itself
+    // is never compared or replaced, so it can be any element type.
+    try {
+        morphdom(container, `<div>${html}</div>`, {
+            childrenOnly: true,
+        });
+    } catch (error) {
+        // Fall back to innerHTML so that content is at least visible,
+        // even though custom elements will be destroyed and recreated.
+        console.warn('morphdom failed, falling back to innerHTML:', error);
+        container.innerHTML = html;
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces `innerHTML` with [morphdom](https://github.com/patrick-steele-idem/morphdom) in `limel-markdown` to diff the DOM instead of destroying and recreating it on every value update
- Existing custom elements (e.g. `limebb-object-chip`) are preserved in the DOM across updates, preventing lifecycle churn and visual flickering
- Particularly impactful during streaming updates (AI chat), where the value changes every ~50ms

## Background
When `limel-markdown` is used in the AI chat to render streaming responses, every value update destroyed and recreated the entire DOM tree. Custom elements like `limebb-object-chip` would have their `disconnectedCallback` and `connectedCallback` fired on every update, triggering data refetching and causing severe flickering.

fix: Lundalogik/crm-insights-and-intelligence#237

## Test plan
- [ ] Verify all markdown component examples render correctly in the docs site
- [ ] Verify custom component examples (`limel-example-markdown-custom-component`, `limel-example-markdown-custom-component-with-json-props`) still hydrate properly
- [ ] Verify AI chat streaming with `limebb-object-chip` no longer flickers
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown rendering now uses intelligent DOM updates that preserve existing custom elements and node references during content changes, improving stability for dynamic markdown content.

* **Tests**
  * Added end-to-end test coverage for markdown component updates and DOM morphing behavior, including scenarios with custom elements and attribute changes.

* **Chores**
  * Added morphdom package to development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->