### PR TITLE
feat(button): add distinct disabled styles for default, primary and o…

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -23,6 +23,11 @@ button.mdc-button {
 }
 
 button {
+    --_primary-color: var(
+        --lime-primary-color,
+        var(--limel-theme-primary-color)
+    );
+
     display: flex;
     align-items: center;
     justify-content: center;
@@ -40,42 +45,51 @@ button {
     min-height: 2.25rem;
     width: 100%;
 
-    &:disabled {
-        cursor: not-allowed;
-
-        &.outlined {
-            border-color: rgba(var(--contrast-1700), 0.2);
-        }
-    }
-
     &:not(:disabled) {
         @include mixins.is-elevated-clickable();
         @include mixins.visualize-keyboard-focus;
     }
 
+    &:disabled {
+        cursor: not-allowed;
+    }
+
+    // Primary button
     :host(limel-button[primary]) & {
         &:not(:disabled) {
             color: var(
                 --lime-on-primary-color,
                 var(--limel-theme-on-primary-color)
             );
-            background-color: var(
-                --lime-primary-color,
-                var(--limel-theme-primary-color)
-            );
+            background-color: var(--_primary-color);
         }
         &:disabled {
-            background-color: rgba(var(--contrast-1700), 0.15);
+            background-color: color-mix(
+                in srgb,
+                var(--_primary-color),
+                transparent 80%
+            );
         }
     }
 
+    // Outlined button
     :host(limel-button:not([primary])) & {
         &:not(:disabled) {
-            color: var(--lime-primary-color, var(--limel-theme-primary-color));
+            color: var(--_primary-color);
         }
-        &:disabled {
-            color: rgba(var(--contrast-1600), 0.37);
-            background-color: rgba(var(--contrast-1600), 0.1);
+        &:disabled.outlined {
+            color: color-mix(in srgb, var(--_primary-color), transparent 60%);
+            border-color: color-mix(
+                in srgb,
+                var(--_primary-color),
+                transparent 70%
+            );
+        }
+
+        // Default button
+        &:disabled:not(.outlined) {
+            color: rgba(var(--contrast-1100), 0.37);
+            background-color: rgba(var(--contrast-900), 0.1);
         }
     }
 }
@@ -145,7 +159,7 @@ svg {
 
 .outlined {
     border: 1px solid;
-    border-color: var(--lime-primary-color, var(--limel-theme-primary-color));
+    border-color: var(--_primary-color);
 }
 
 @keyframes shake {

--- a/src/components/button/examples/button-disabled.scss
+++ b/src/components/button/examples/button-disabled.scss
@@ -1,0 +1,6 @@
+.disabled-buttons {
+    display: flex;
+    gap: 1rem;
+    margin: 0 auto;
+    align-items: center;
+}

--- a/src/components/button/examples/button-disabled.tsx
+++ b/src/components/button/examples/button-disabled.tsx
@@ -9,19 +9,20 @@ import { Component, h } from '@stencil/core';
 @Component({
     tag: 'limel-example-button-disabled',
     shadow: true,
+    styleUrl: 'button-disabled.scss',
 })
 export class ButtonDisabledExample {
     public render() {
         return (
-            <limel-button
-                label="My Button"
-                disabled={true}
-                onClick={this.onClick}
-            />
+            <div class="disabled-buttons">
+                <limel-button label="Default" disabled={true} />
+                <limel-button label="Primary" primary={true} disabled={true} />
+                <limel-button
+                    label="Outlined"
+                    outlined={true}
+                    disabled={true}
+                />
+            </div>
         );
-    }
-
-    private onClick() {
-        console.log('This should never happen, since the button is disabled.');
     }
 }


### PR DESCRIPTION
…utlined variants

fix: https://github.com/Lundalogik/lime-elements/issues/4018

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button visuals for consistent primary/outlined colors using a local fallback CSS variable and blended disabled colors
  * Simplified disabled-state handling to ensure uniform cursor and border behavior

* **Documentation**
  * Improved disabled-button example to display three centered variants (default, primary, outlined) with layout spacing and no click interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
