### PR TITLE
fix(chip): expose correct CSS baseline for inline text alignment

### DIFF
--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -16,6 +16,21 @@
     align-items: center;
     min-width: 0;
     max-width: min(var(--chip-max-width, 100%), 25rem);
+
+    // Invisible baseline anchor.
+    // An inline-flex container with `align-items: center` synthesizes its
+    // CSS baseline at the bottom edge, which makes `vertical-align: baseline`
+    // useless for consumers embedding a chip in running text. This pseudo
+    // participates in baseline alignment, so the host's CSS baseline becomes
+    // the pseudo's text baseline. With `line-height` equal to the chip height
+    // and the same font-size as `.text`, that baseline sits at exactly the
+    // same vertical position as the centered `.text` element's baseline.
+    &::before {
+        content: '\200b'; // zero-width space
+        align-self: baseline;
+        line-height: var(--limel-chip-height);
+        font-size: var(--limel-theme-default-font-size, 0.875rem);
+    }
 }
 
 :host(limel-chip[size='small']) {


### PR DESCRIPTION
An inline-flex container with `align-items: center` synthesizes its CSS baseline at the bottom edge, making `vertical-align: baseline` useless for consumers embedding a chip in running text. Add an invisible zero-width pseudo-element that participates in baseline alignment, so the chip's CSS baseline matches its internal text baseline.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed baseline alignment of chip components in layouts with baseline-based vertical alignment, improving visual consistency and positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
