### PR TITLE
fix(chip): make font size smaller when `size="small"`

### DIFF
--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -36,6 +36,10 @@
 :host(limel-chip[size='small']) {
     --limel-chip-height: 1.5rem;
     --limel-chip-gap: 0.25rem;
+
+    .text {
+        font-size: var(--limel-theme-default-small-font-size);
+    }
 }
 
 * {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/lime-elements/issues/4024
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted text sizing for small-sized chips to use a reduced font size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
