### PR TITLE
feat(chip-set): expose per-chip invalid state

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -83,6 +83,7 @@ export interface Chip<T = any> {
     iconTitle?: string;
     id: number | string;
     image?: Image_2;
+    invalid?: boolean;
     loading?: boolean;
     menuItems?: Array<MenuItem | ListSeparator>;
     removable?: boolean;

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -626,6 +626,7 @@ export class ChipSet {
             selected: chip.selected,
             disabled: this.disabled,
             loading: chip.loading,
+            invalid: chip.invalid,
             readonly: readonly,
             type: chipType,
             removable: removable,

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -57,6 +57,7 @@ import { IconName } from '../../global/shared-types/icon.types';
  * @exampleComponent limel-example-chip-set-filter
  * @exampleComponent limel-example-chip-set-filter-badge
  * @exampleComponent limel-example-chip-set-input
+ * @exampleComponent limel-example-chip-set-invalid-chips
  * @exampleComponent limel-example-chip-set-input-type-with-menu-items
  * @exampleComponent limel-example-chip-set-input-type-text
  * @exampleComponent limel-example-chip-set-input-type-search

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -108,6 +108,11 @@ export interface Chip<T = any> {
      * indeterminate progress indicator inside the chip.
      */
     loading?: boolean;
+
+    /**
+     * Set to `true` to visualize the chip in an "invalid" or "error" state.
+     */
+    invalid?: boolean;
 }
 
 /**

--- a/src/components/chip-set/examples/chip-set-invalid-chips.tsx
+++ b/src/components/chip-set/examples/chip-set-invalid-chips.tsx
@@ -1,0 +1,173 @@
+import {
+    Chip,
+    LimelChipSetCustomEvent,
+    Option,
+    JSX,
+    LimelSelectCustomEvent,
+} from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+import { ENTER } from '../../../util/keycodes';
+
+type ChipSetType = Exclude<JSX.LimelChipSet['type'], undefined>;
+
+/**
+ * Per-chip invalid state
+ *
+ * Set `invalid: true` on any chip in the `value` array to mark that
+ * specific chip as invalid. This is independent of the chip-set-level
+ * `invalid` prop, which is intended for signalling that the whole field
+ * is invalid. Per-chip `invalid` lets the consumer flag individual
+ * entries, for example an address that fails validation in a list of
+ * recipients.
+ *
+ * In this example, each entry is checked with a simple email regex when
+ * added. Invalid entries are rendered with `invalid: true` and an error
+ * icon.
+ *
+ * :::note
+ * Marking individual chips as `invalid` does **not** automatically set
+ * the invalid state of the chip-set as a whole. The consumer is
+ * responsible for deciding whether the field itself should be
+ * considered invalid, and for setting the chip-set-level `invalid` prop
+ * accordingly. This gives the consumer full control over the
+ * validity of the field.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-set-invalid-chips',
+    shadow: true,
+})
+export class ChipSetInvalidChipsExample {
+    @State()
+    private value: Chip[];
+
+    @State()
+    private textValue = '';
+
+    @State()
+    private selectedInputType?: Option<ChipSetType>;
+
+    private inputTypeOptions?: Array<Option<ChipSetType>>;
+
+    constructor() {
+        this.value = [
+            this.createChip('alice@example.com'),
+            this.createChip('invalid-email@address'),
+            this.createChip('bob@example.com'),
+        ];
+    }
+
+    public componentWillLoad() {
+        this.inputTypeOptions = [
+            { text: 'Input', value: 'input' },
+            { text: 'Choice', value: 'choice' },
+            { text: 'Filter', value: 'filter' },
+        ];
+        this.selectedInputType = this.inputTypeOptions[0];
+    }
+
+    public render() {
+        return (
+            <Host>
+                <limel-chip-set
+                    type={this.selectedInputType?.value}
+                    label="Recipients"
+                    helperText="Type an email address and press Enter. Invalid entries are flagged on the chip."
+                    searchLabel="Type an email address"
+                    value={this.value}
+                    onChange={this.handleChange}
+                    onInput={this.handleInput}
+                    onKeyUp={this.onKeyUp}
+                />
+                <limel-example-controls
+                    style={{ '--example-controls-max-columns-width': '9rem' }}
+                >
+                    <limel-select
+                        label="Chip set type"
+                        value={this.selectedInputType}
+                        options={this.inputTypeOptions}
+                        onChange={this.handleInputTypeChange}
+                    />
+                </limel-example-controls>
+                <limel-example-value value={this.value} />
+            </Host>
+        );
+    }
+
+    private handleInputTypeChange = (
+        event: LimelSelectCustomEvent<Option<ChipSetType>>
+    ) => {
+        this.selectedInputType = event.detail;
+        this.value = this.value.map((chip) => {
+            chip.selected = false;
+            return chip;
+        });
+    };
+
+    private handleInput = (
+        event: LimelChipSetCustomEvent<string> | InputEvent
+    ) => {
+        if (event instanceof CustomEvent) {
+            this.textValue = event.detail;
+        }
+    };
+
+    private onKeyUp = (event: KeyboardEvent) => {
+        if (event.key === ENTER && this.textValue.trim()) {
+            this.value = [
+                ...this.value,
+                this.createChip(this.textValue.trim()),
+            ];
+            this.textValue = '';
+        }
+    };
+
+    private handleChange = (event: LimelChipSetCustomEvent<Chip | Chip[]>) => {
+        if (Array.isArray(event.detail)) {
+            this.value = event.detail;
+        } else {
+            const interactedChip = event.detail as Chip;
+
+            if (this.selectedInputType?.value === 'filter') {
+                this.value = this.value.map((chip) => {
+                    if (chip.id === interactedChip.id) {
+                        return interactedChip;
+                    }
+
+                    return chip;
+                });
+            } else if (this.selectedInputType?.value === 'choice') {
+                this.value = this.value.map((chip) => {
+                    if (chip.id === interactedChip.id) {
+                        return interactedChip;
+                    }
+
+                    return { ...chip, selected: false };
+                });
+            }
+        }
+    };
+
+    private createChip = (text: string): Chip => {
+        const isValid = this.looksLikeEmail(text);
+
+        return {
+            id: text,
+            text: text,
+            removable: true,
+            invalid: !isValid,
+            ...(!isValid && { icon: 'error' }),
+        };
+    };
+
+    private looksLikeEmail = (text: string): boolean => {
+        const atIndex = text.indexOf('@');
+        if (atIndex <= 0 || atIndex === text.length - 1) {
+            return false;
+        }
+
+        const domain = text.slice(atIndex + 1);
+
+        return domain.includes('.') && !/\s/.test(text);
+    };
+}


### PR DESCRIPTION
Closes #4026

## Summary

- Add an optional `invalid` field to the `Chip` interface
- Forward `chip.invalid` through `limel-chip-set`'s `getChipProps` to the rendered `limel-chip`, which already supports the `invalid` prop
- Add a `limel-example-chip-set-invalid-chips` example demonstrating the feature with an email recipients input

Consumers can now flag individual chips as invalid via the `value` array:

```ts
value = [
  { id: 1, text: 'alice@example.com' },
  { id: 2, text: 'invalid-email@address', invalid: true, icon: 'error' },
  { id: 3, text: 'bob@example.com' },
];
```

This is independent of the chip-set-level `invalid` prop, which continues to mark the whole field as invalid.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test` — all 1119 tests pass
- [ ] Manual: open the new `limel-example-chip-set-invalid-chips` example and confirm `invalid-email@address` renders with the invalid styling and error icon while the two email entries render normally
- [ ] Manual: type a new invalid entry (e.g. `foo`) and a valid entry (e.g. `carol@example.com`) and confirm each is flagged correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chips can now be marked invalid individually so single chips show an error/validation appearance.
  * Chip objects accept an optional invalid flag to control per-chip error state.

* **Documentation**
  * Added an example demonstrating per‑chip invalid state, input handling, and dynamic chip updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->