### PR TITLE
fix(picker): reset search query when a value is selected or removed

### DIFF
--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -661,6 +661,7 @@ export class Picker {
 
     private handleChange(event: LimelChipSetCustomEvent<Chip | Chip[]>) {
         event.stopPropagation();
+        this.textValue = '';
 
         let newValue = null;
         if (this.multiple) {


### PR DESCRIPTION
## Summary
- Reset `textValue` to `''` in `handleChange` so the picker doesn't retain a stale search query after selecting or removing a value
- Fixes the bug where focusing an empty picker would still search using the previous query string

Closes #4031


https://github.com/user-attachments/assets/3ad19155-0b15-4232-b250-34c4f856eb49



## Test plan
- [ ] Open a picker, search for a value (e.g. "Ayla"), and select it
- [ ] Remove the selected chip so the field is empty
- [ ] Focus the picker again and verify the dropdown shows unfiltered results (not filtered by the old query)
- [ ] Verify the same works correctly for multi-select pickers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where search text in the picker wasn't clearing when chip selections changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->