### PR TITLE
Prevent serialize from treating custom elements as empty content

### DIFF
--- a/src/components/text-editor/utils/has-custom-element-node.ts
+++ b/src/components/text-editor/utils/has-custom-element-node.ts
@@ -1,0 +1,31 @@
+import { Node } from 'prosemirror-model';
+import { CustomElementDefinition } from '../../../interface';
+
+/**
+ * Recursively checks if a ProseMirror node or
+ * any of its child nodes is a registered custom element node.
+ * @param node - the ProseMirror node to check
+ * @param customElements - the registered custom element definitions
+ */
+export function hasCustomElementNode(
+    node: Node,
+    customElements: CustomElementDefinition[]
+): boolean {
+    const tagNames = new Set(customElements.map((ce) => ce.tagName));
+
+    return hasNodeWithType(node, tagNames);
+}
+
+function hasNodeWithType(node: Node, tagNames: Set<string>): boolean {
+    if (tagNames.has(node.type.name)) {
+        return true;
+    }
+
+    for (let i = 0; i < node.childCount; i++) {
+        if (hasNodeWithType(node.child(i), tagNames)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/components/text-editor/utils/html-converter.spec.ts
+++ b/src/components/text-editor/utils/html-converter.spec.ts
@@ -1,0 +1,192 @@
+import { Schema } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
+import { HTMLConverter } from './html-converter';
+
+function createSchema() {
+    return new Schema({
+        nodes: {
+            doc: { content: 'block+' },
+            paragraph: {
+                group: 'block',
+                content: 'inline*',
+                toDOM: () => ['p', 0] as const,
+            },
+            text: { group: 'inline' },
+            image: {
+                group: 'inline',
+                inline: true,
+                attrs: {
+                    src: { default: '' },
+                    alt: { default: '' },
+                    fileInfoId: { default: '' },
+                    state: { default: 'success' },
+                },
+                toDOM: (node) => [
+                    'img',
+                    { src: node.attrs.src, alt: node.attrs.alt },
+                ],
+            },
+            'custom-mention': {
+                group: 'inline',
+                content: 'text*',
+                inline: true,
+                atom: true,
+                selectable: true,
+                attrs: {
+                    limetype: {},
+                    objectid: {},
+                },
+                toDOM: (node) => ['custom-mention', node.attrs, 0],
+            },
+        },
+    });
+}
+
+function createMockView(schema: Schema, docJson: any): EditorView {
+    const doc = schema.nodeFromJSON(docJson);
+
+    return {
+        state: {
+            doc: doc,
+            schema: schema,
+        },
+        dom: {
+            textContent: doc.textContent,
+        },
+    } as unknown as EditorView;
+}
+
+describe('HTMLConverter', () => {
+    let converter: HTMLConverter;
+    let schema: Schema;
+
+    beforeEach(() => {
+        converter = new HTMLConverter([
+            {
+                tagName: 'custom-mention',
+                attributes: ['limetype', 'objectid'],
+            },
+        ]);
+        schema = createSchema();
+    });
+
+    describe('serialize', () => {
+        it('returns empty string for an empty document', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [{ type: 'paragraph' }],
+            });
+
+            expect(converter.serialize(view)).toBe('');
+        });
+
+        it('returns html for a document with text', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [{ type: 'text', text: 'hello' }],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).toContain('hello');
+        });
+
+        it('does not return empty string for a document with only an image', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'image',
+                                attrs: {
+                                    src: 'img.jpg',
+                                    alt: 'test',
+                                    fileInfoId: 'id1',
+                                    state: 'success',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).not.toBe('');
+        });
+
+        it('does not return empty string for a document with only a custom element', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'custom-mention',
+                                attrs: {
+                                    limetype: 'user',
+                                    objectid: '1',
+                                },
+                                content: [{ type: 'text', text: 'Admin' }],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).not.toBe('');
+        });
+
+        it('does not return empty string for a document with only an attribute-only custom element', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'custom-mention',
+                                attrs: {
+                                    limetype: 'user',
+                                    objectid: '1',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).not.toBe('');
+        });
+
+        it('returns html containing the custom element for a document with text and a custom element', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            { type: 'text', text: 'hello ' },
+                            {
+                                type: 'custom-mention',
+                                attrs: {
+                                    limetype: 'user',
+                                    objectid: '1',
+                                },
+                                content: [{ type: 'text', text: 'Admin' }],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const result = converter.serialize(view);
+            expect(result).toContain('hello');
+            expect(result).toContain('custom-mention');
+        });
+    });
+});

--- a/src/components/text-editor/utils/html-converter.ts
+++ b/src/components/text-editor/utils/html-converter.ts
@@ -4,6 +4,7 @@ import { sanitizeHTML } from '../../markdown/markdown-parser';
 import { CustomElementDefinition } from '../../../interface';
 import { DOMSerializer } from 'prosemirror-model';
 import { hasImageNode } from '../prosemirror-adapter/plugins/image/node';
+import { hasCustomElementNode } from './has-custom-element-node';
 
 /**
  * @private
@@ -21,8 +22,9 @@ export class HTMLConverter implements ContentTypeConverter {
 
     public serialize = (view: EditorView): string => {
         if (
-            view.dom.textContent.trim() === '' &&
-            !hasImageNode(view.state.doc)
+            view.state.doc.textContent.trim() === '' &&
+            !hasImageNode(view.state.doc) &&
+            !hasCustomElementNode(view.state.doc, this.customNodes)
         ) {
             return '';
         }

--- a/src/components/text-editor/utils/markdown-converter.spec.ts
+++ b/src/components/text-editor/utils/markdown-converter.spec.ts
@@ -1,0 +1,183 @@
+import { Schema } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
+import { MarkdownConverter } from './markdown-converter';
+
+function createSchema() {
+    return new Schema({
+        nodes: {
+            doc: { content: 'block+' },
+            paragraph: {
+                group: 'block',
+                content: 'inline*',
+            },
+            text: { group: 'inline' },
+            image: {
+                group: 'inline',
+                inline: true,
+                attrs: {
+                    src: { default: '' },
+                    alt: { default: '' },
+                    fileInfoId: { default: '' },
+                    state: { default: 'success' },
+                },
+            },
+            'custom-mention': {
+                group: 'inline',
+                content: 'text*',
+                inline: true,
+                atom: true,
+                selectable: true,
+                attrs: {
+                    limetype: {},
+                    objectid: {},
+                },
+            },
+        },
+    });
+}
+
+function createMockView(schema: Schema, docJson: any): EditorView {
+    const doc = schema.nodeFromJSON(docJson);
+
+    return {
+        state: { doc: doc },
+    } as unknown as EditorView;
+}
+
+describe('MarkdownConverter', () => {
+    let converter: MarkdownConverter;
+    let schema: Schema;
+
+    beforeEach(() => {
+        converter = new MarkdownConverter(
+            [
+                {
+                    tagName: 'custom-mention',
+                    attributes: ['limetype', 'objectid'],
+                },
+            ],
+            'en'
+        );
+        schema = createSchema();
+    });
+
+    describe('serialize', () => {
+        it('returns empty string for an empty document', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [{ type: 'paragraph' }],
+            });
+
+            expect(converter.serialize(view)).toBe('');
+        });
+
+        it('returns markdown for a document with text', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [{ type: 'text', text: 'hello' }],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).toContain('hello');
+        });
+
+        it('does not return empty string for a document with only an image', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'image',
+                                attrs: {
+                                    src: 'img.jpg',
+                                    alt: 'test',
+                                    fileInfoId: 'id1',
+                                    state: 'success',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).not.toBe('');
+        });
+
+        it('does not return empty string for a document with only a custom element', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'custom-mention',
+                                attrs: {
+                                    limetype: 'user',
+                                    objectid: '1',
+                                },
+                                content: [{ type: 'text', text: 'Admin' }],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).not.toBe('');
+        });
+
+        it('does not return empty string for a document with only an attribute-only custom element', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'custom-mention',
+                                attrs: {
+                                    limetype: 'user',
+                                    objectid: '1',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            expect(converter.serialize(view)).not.toBe('');
+        });
+
+        it('returns markdown containing the custom element for a document with text and a custom element', () => {
+            const view = createMockView(schema, {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            { type: 'text', text: 'hello ' },
+                            {
+                                type: 'custom-mention',
+                                attrs: {
+                                    limetype: 'user',
+                                    objectid: '1',
+                                },
+                                content: [{ type: 'text', text: 'Admin' }],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const result = converter.serialize(view);
+            expect(result).toContain('hello');
+            expect(result).toContain('custom-mention');
+        });
+    });
+});

--- a/src/components/text-editor/utils/markdown-converter.ts
+++ b/src/components/text-editor/utils/markdown-converter.ts
@@ -12,6 +12,7 @@ import {
     getImageNodeMarkdownSerializer,
     hasImageNode,
 } from '../prosemirror-adapter/plugins/image/node';
+import { hasCustomElementNode } from './has-custom-element-node';
 import { Languages } from '../../date-picker/date.types';
 
 type MarkdownSerializerFunction = (
@@ -83,8 +84,9 @@ export class MarkdownConverter implements ContentTypeConverter {
 
     public serialize = (view: EditorView): string => {
         if (
-            view.dom.textContent.trim() === '' &&
-            !hasImageNode(view.state.doc)
+            view.state.doc.textContent.trim() === '' &&
+            !hasImageNode(view.state.doc) &&
+            !hasCustomElementNode(view.state.doc, this.customNodes)
         ) {
             return '';
         }


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-document detection in the text and markdown exporters so media and custom inline elements no longer get omitted during serialization.

* **Tests**
  * Added thorough tests covering empty, text-only, media-only, custom-mention-only, and mixed-content documents to ensure consistent serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
