### PR TITLE
Add reset-button-user-agent-styles mixin and apply to buttons

### DIFF
--- a/src/components/action-bar/action-bar-item/action-bar-item.scss
+++ b/src/components/action-bar/action-bar-item/action-bar-item.scss
@@ -14,7 +14,7 @@ limel-action-bar-item {
 }
 
 button {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
 
     &:not([disabled]) {
         @include mixins.is-flat-inset-clickable(

--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -97,8 +97,8 @@
     }
 }
 
-.expand-shrink {
-    all: unset;
+button.expand-shrink {
+    @include mixins.reset-button-user-agent-styles;
     box-sizing: border-box;
     border-radius: 50%;
 

--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -209,8 +209,8 @@ limel-badge {
     font-size: var(--limel-theme-default-font-size);
 }
 
-.trailing-button {
-    all: unset;
+button.trailing-button {
+    @include mixins.reset-button-user-agent-styles;
     @include mixins.is-flat-clickable();
 
     z-index: 1;

--- a/src/components/code-diff/code-diff.scss
+++ b/src/components/code-diff/code-diff.scss
@@ -365,8 +365,8 @@ mark {
 }
 
 // ─── Expand button ───────────────────────────────────────────────────
-.expand-button {
-    all: unset;
+button.expand-button {
+    @include mixins.reset-button-user-agent-styles;
     @include mixins.is-flat-clickable();
     @include mixins.visualize-keyboard-focus();
     padding: 0 0.75rem;

--- a/src/components/code-editor/code-editor.scss
+++ b/src/components/code-editor/code-editor.scss
@@ -274,8 +274,8 @@ limel-notched-outline {
     flex-grow: 1;
 }
 
-.copy-button {
-    all: unset;
+button.copy-button {
+    @include mixins.reset-button-user-agent-styles;
     @include mixins.is-elevated-clickable();
     @include mixins.visualize-keyboard-focus();
     position: absolute;

--- a/src/components/collapsible-section/collapsible-section.scss
+++ b/src/components/collapsible-section/collapsible-section.scss
@@ -19,8 +19,8 @@
     display: none;
 }
 
-.open-close-toggle {
-    all: unset;
+button.open-close-toggle {
+    @include mixins.reset-button-user-agent-styles;
     position: absolute;
     inset: 0;
     width: 100%; // for Firefox

--- a/src/components/color-picker/color-picker-palette.scss
+++ b/src/components/color-picker/color-picker-palette.scss
@@ -77,7 +77,7 @@ limel-input-field {
 }
 
 button.swatch {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
     position: relative;
     display: flex;
     justify-content: center;

--- a/src/components/color-picker/color-picker.scss
+++ b/src/components/color-picker/color-picker.scss
@@ -9,7 +9,7 @@
 }
 
 button[slot='trigger'] {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
     box-sizing: border-box;
     position: relative;
     isolation: isolate;

--- a/src/components/dock/dock-button/dock-button.scss
+++ b/src/components/dock/dock-button/dock-button.scss
@@ -1,8 +1,8 @@
 @use '../../../style/mixins';
 @use '../../../style/functions';
 
-.button {
-    all: unset;
+button.button {
+    @include mixins.reset-button-user-agent-styles;
     isolation: isolate;
     position: relative;
 

--- a/src/components/dock/partial-styles/shrink-expand-button.scss
+++ b/src/components/dock/partial-styles/shrink-expand-button.scss
@@ -1,8 +1,8 @@
 @use '../../../style/mixins';
 @use '../../../style/functions';
 
-.expand-shrink {
-    all: unset;
+button.expand-shrink {
+    @include mixins.reset-button-user-agent-styles;
     box-sizing: border-box;
 
     @include mixins.is-flat-clickable();

--- a/src/components/drag-handle/drag-handle.scss
+++ b/src/components/drag-handle/drag-handle.scss
@@ -7,7 +7,7 @@ limel-drag-handle {
 }
 
 button.limel-drag-handle {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
     @include mixins.visualize-keyboard-focus();
     @include mixins.is-flat-clickable(
         $color--hovered: var(--mdc-theme-primary),

--- a/src/components/email-viewer/email-viewer.scss
+++ b/src/components/email-viewer/email-viewer.scss
@@ -172,7 +172,7 @@ limel-collapsible-section {
     box-shadow: var(--shadow-depth-8);
 
     button {
-        all: unset;
+        @include mixins.reset-button-user-agent-styles;
         flex-shrink: 0;
         border-radius: 0.375rem;
         padding: 0.25rem 0.5rem;

--- a/src/components/help/help.scss
+++ b/src/components/help/help.scss
@@ -6,7 +6,7 @@ limel-popover {
 }
 
 button[slot='trigger'] {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
 
     @include mixins.is-flat-clickable(
         $color--hovered: rgb(var(--color-sky-dark)),

--- a/src/components/icon-button/icon-button.scss
+++ b/src/components/icon-button/icon-button.scss
@@ -7,7 +7,7 @@
 @include mixins.visualize-aria-expanded('button');
 
 button {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
     &:not(:disabled) {
         @include mixins.is-flat-clickable(
             $background-color: var(--icon-background-color, transparent)

--- a/src/components/profile-picture/profile-picture.scss
+++ b/src/components/profile-picture/profile-picture.scss
@@ -31,7 +31,7 @@ button.avatar {
 }
 
 button {
-    all: unset;
+    @include mixins.reset-button-user-agent-styles;
     display: block;
     @include mixins.visualize-keyboard-focus();
 

--- a/src/components/split-button/split-button.scss
+++ b/src/components/split-button/split-button.scss
@@ -66,8 +66,8 @@ limel-menu {
     }
 }
 
-.menu-trigger {
-    all: unset;
+button.menu-trigger {
+    @include mixins.reset-button-user-agent-styles;
 
     text-align: center;
     font-weight: bold;

--- a/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
+++ b/src/components/tab-bar/partial-styles/tab-bar-scroller.scss
@@ -63,7 +63,7 @@ $space-around-buttons: 0.25rem;
     }
 
     button {
-        all: unset;
+        @include mixins.reset-button-user-agent-styles;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -21,6 +21,26 @@
 }
 
 /**
+* Neutralizes the user-agent styles that browsers apply to `<button>` elements
+* (their default background, border, padding, font, etc.), without stripping
+* the useful defaults that `all: unset;` would also remove
+* (such as `display`, `cursor`, and focus behavior).
+*
+* Prefer this mixin over `all: unset;` on `<button>` elements, then layer
+* the styling you want on top — often one of the `is-*-clickable` mixins.
+*/
+@mixin reset-button-user-agent-styles {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    text-align: inherit;
+}
+
+/**
 * This can be used on a trigger element that opens a dropdown menu or a popover.
 */
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-client/issues/923
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated button styling reset logic across components using a shared standardized approach, improving consistency and maintainability of button styling throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
