### PR TITLE
fix(chip-set): keep input visible when it contains text

### DIFF
--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -540,6 +540,13 @@ export class ChipSet {
             return this.isFull();
         }
 
+        // Keep the input visible while it holds uncommitted text, so typed
+        // content doesn't disappear when focus leaves (e.g. tabbing to a
+        // sibling action).
+        if (this.textValue) {
+            return false;
+        }
+
         // If there are chips in the picker, hide the input to avoid the input
         // being placed on a new line and adding ugly space beneath the chips.
         // If there are no chips, show the input, or the picker will look weird.


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the input field visibility in the chip selection component. The input field now correctly remains visible when there is uncommitted text, improving the editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Summary
- `inputHidden()` now returns `false` whenever `textValue` is non-empty, so typed-but-uncommitted text stays visible when focus leaves the input.
- Fixes #4037.

Surfaced while implementing [limepkg-email #1934](https://github.com/Lundalogik/limepkg-email/pull/1995) where users tab from the recipient input to a "Create new recipient" static action and lost visibility of the email they had typed.

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS