### PR TITLE
fix(picker): enter results list with Tab when it starts with a separator

### DIFF
--- a/src/components/picker/examples/picker-sections.tsx
+++ b/src/components/picker/examples/picker-sections.tsx
@@ -1,0 +1,86 @@
+import { ListItem, ListSeparator, PickerValue } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * With sectioned results
+ *
+ * A custom searcher can return a mix of `ListItem`s and `ListSeparator`s to
+ * group results into sections. Separators can appear anywhere in the list,
+ * including as the very first entry, and keyboard navigation (Tab into the
+ * results, arrow keys within) still focuses the first focusable list item.
+ */
+@Component({
+    tag: 'limel-example-picker-sections',
+    shadow: true,
+})
+export class PickerSectionsExample {
+    @State()
+    private selectedItem?: ListItem<PickerValue>;
+
+    private closeCombat: Array<ListItem<number>> = [
+        { text: 'Admiral Swiggins', value: 1 },
+        { text: 'Clunk', value: 3 },
+        { text: 'Derpl', value: 5 },
+        { text: 'Lonestar', value: 8 },
+        { text: 'Skølldir', value: 11 },
+    ];
+
+    private ranged: Array<ListItem<number>> = [
+        { text: 'Ayla', value: 2 },
+        { text: 'Coco', value: 4 },
+        { text: 'Froggy G', value: 6 },
+        { text: 'Gnaw', value: 7 },
+        { text: 'Leon', value: 9 },
+        { text: 'Raelynn', value: 10 },
+        { text: 'Voltar', value: 12 },
+        { text: 'Yuri', value: 13 },
+    ];
+
+    public render() {
+        return (
+            <Host>
+                <limel-picker
+                    label="Pick an awesomenaut"
+                    value={this.selectedItem}
+                    searcher={this.search}
+                    emptyResultMessage="No matching awesomenauts"
+                    onChange={this.onChange}
+                />
+                <limel-example-value value={this.selectedItem} />
+            </Host>
+        );
+    }
+
+    private search = async (
+        query: string
+    ): Promise<Array<ListItem<number> | ListSeparator>> => {
+        const matches = (item: ListItem<number>) =>
+            item.text.toLowerCase().includes(query.toLowerCase());
+        const matchedCloseCombat = this.closeCombat.filter(matches);
+        const matchedRanged = this.ranged.filter(matches);
+
+        const result: Array<ListItem<number> | ListSeparator> = [];
+        if (matchedCloseCombat.length > 0) {
+            result.push(
+                { separator: true, text: 'Close combat' },
+                ...matchedCloseCombat
+            );
+        }
+        if (matchedRanged.length > 0) {
+            result.push({ separator: true, text: 'Ranged' }, ...matchedRanged);
+        }
+
+        return result;
+    };
+
+    private onChange = (event: Event) => {
+        if (!(event instanceof CustomEvent)) {
+            return;
+        }
+        const detail: ListItem<PickerValue> | Array<ListItem<PickerValue>> =
+            event.detail;
+        if (!Array.isArray(detail)) {
+            this.selectedItem = detail;
+        }
+    };
+}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -707,12 +707,15 @@ export class Picker {
             return;
         }
 
-        event.preventDefault();
-
         if (isForwardTab || isDown) {
             const listElement: HTMLElement = list.shadowRoot.querySelector(
                 '.mdc-deprecated-list-item:first-child'
             );
+            if (!listElement) {
+                return;
+            }
+
+            event.preventDefault();
             listElement.focus();
 
             return;
@@ -722,6 +725,11 @@ export class Picker {
             const listElement: HTMLElement = list.shadowRoot.querySelector(
                 '.mdc-deprecated-list-item:last-child'
             );
+            if (!listElement) {
+                return;
+            }
+
+            event.preventDefault();
             listElement.focus();
         }
     }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -708,8 +708,10 @@ export class Picker {
         }
 
         if (isForwardTab || isDown) {
+            // Match by class only (not `:first-child`) so a leading
+            // `ListSeparator` doesn't shadow the first focusable item.
             const listElement: HTMLElement = list.shadowRoot.querySelector(
-                '.mdc-deprecated-list-item:first-child'
+                '.mdc-deprecated-list-item'
             );
             if (!listElement) {
                 return;
@@ -722,9 +724,10 @@ export class Picker {
         }
 
         if (isUp) {
-            const listElement: HTMLElement = list.shadowRoot.querySelector(
-                '.mdc-deprecated-list-item:last-child'
+            const listItems = list.shadowRoot.querySelectorAll<HTMLElement>(
+                '.mdc-deprecated-list-item'
             );
+            const listElement = [...listItems].at(-1);
             if (!listElement) {
                 return;
             }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -38,6 +38,7 @@ const DEFAULT_SEARCHER_MAX_RESULTS = 20;
  * @exampleComponent limel-example-picker-empty-suggestions
  * @exampleComponent limel-example-picker-leading-icon
  * @exampleComponent limel-example-picker-static-actions
+ * @exampleComponent limel-example-picker-sections
  * @exampleComponent limel-example-picker-composite
  */
 @Component({


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a picker example demonstrating sectioned results with separators, async searching, and live selection display.

* **Bug Fixes**
  * Improved picker keyboard navigation: forward-tab/down and up-arrow now correctly focus items, avoid forcing focus when none exist, and only prevent default behavior when a valid target is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Summary
- Match the first/last focusable result by class only (`.mdc-deprecated-list-item`) instead of by position (`:first-child` / `:last-child`), so a leading `ListSeparator` does not hide the first focusable item from the Tab-into-dropdown handler.
- Guard the focus call against a missing list item. If the selector returns nothing (e.g. a results list that contains only separators), the handler returns without calling `event.preventDefault()`, letting the browser do the default Tab action rather than crashing.

Fixes #4039.
Closes #4040.

## Background

`handleInputKeyDown` uses `querySelector('.mdc-deprecated-list-item:first-child' | ':last-child')` to find the first or last focusable list item in the dropdown. The `:first-child` / `:last-child` pseudo-classes are *positional* — they match only when the element is literally the first or last child of its parent. When the results list starts with a `ListSeparator` (rendered as `<li class="mdc-deprecated-list-divider">`), position 0 is the `<li>` separator, not a `<limel-list-item>`, so the selector returns `null` and the previous code threw on `.focus()`.

Switching to a class-only selector for "first" and `querySelectorAll(...)` + `.at(-1)` for "last" finds the first/last focusable item regardless of whether a separator precedes or follows it. The null guard protects the edge case where no focusable items exist at all (e.g. a list that contains only separators).

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS