### PR TITLE
feat(snackbar): add support for Markdown format in `message` prop

### DIFF
--- a/src/components/snackbar/examples/snackbar-with-markdown.tsx
+++ b/src/components/snackbar/examples/snackbar-with-markdown.tsx
@@ -1,0 +1,65 @@
+import { Component, h, State } from '@stencil/core';
+
+/**
+ * Markdown formatting
+ *
+ * The `message` property supports [Markdown](#/component/limel-markdown/)
+ * syntax. This lets you lightly emphasize a single word with `**bold**`
+ * or `*italic*` so the reader can scan the feedback more quickly.
+ *
+ * In this example, the entity name *"Westeros Ltd."* is rendered in bold,
+ * and the ticket reference `#1374` is escaped with a leading backslash
+ * (`\#1374`) to prevent it from being interpreted as a Markdown heading.
+ *
+ * :::important
+ * Keep the feedback short and brief. A snackbar is a quick, ignorable
+ * nudge — not a place for rich content. Avoid complex Markdown such as
+ * headings, lists, tables, images, blockquotes, or long links. These
+ * push content off screen, add visual noise, and undermine the
+ * snackbar's purpose.
+ *
+ * If you need more than a single sentence, or the information is
+ * important enough to require the user's attention, reach for a
+ * [Banner](#/component/limel-banner/) or
+ * [Dialog](#/component/limel-dialog/) instead.
+ * :::
+ *
+ * :::important
+ * When the message is composed from dynamic content such as user
+ * input or translated strings, escape Markdown-sensitive characters
+ * (`*`, `_`, backtick, `#`, `[`, `]`) with a leading backslash to
+ * prevent unintended formatting.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-snackbar-with-markdown',
+    shadow: true,
+})
+export class SnackbarWithMarkdownExample {
+    @State()
+    private isOpen: boolean = false;
+
+    public render() {
+        return [
+            <limel-button
+                key="button"
+                label="Save company"
+                onClick={this.handleShowSnackbar}
+            />,
+            <limel-snackbar
+                key="snackbar"
+                open={this.isOpen}
+                message='\\#1374 — **"Westeros Ltd."** was saved successfully.'
+                onHide={this.handleHideSnackbar}
+            />,
+        ];
+    }
+
+    private readonly handleShowSnackbar = () => {
+        this.isOpen = true;
+    };
+
+    private readonly handleHideSnackbar = () => {
+        this.isOpen = false;
+    };
+}

--- a/src/components/snackbar/snackbar.e2e.tsx
+++ b/src/components/snackbar/snackbar.e2e.tsx
@@ -14,8 +14,11 @@ describe('limel-snackbar', () => {
             const popover = root.shadowRoot!.querySelector('[popover]');
             expect(popover.classList.contains('open')).toBe(true);
 
-            const label = popover.querySelector('.label');
-            expect(label.textContent).toEqual('This is a message');
+            const label = popover.querySelector(
+                'limel-markdown.label'
+            ) as HTMLLimelMarkdownElement;
+            const rendered = label.shadowRoot!.querySelector('#markdown');
+            expect(rendered!.textContent!.trim()).toEqual('This is a message');
         });
     });
 
@@ -34,8 +37,11 @@ describe('limel-snackbar', () => {
 
             const popover = root.shadowRoot!.querySelector('[popover]');
 
-            const label = popover.querySelector('.label');
-            expect(label.textContent).toEqual('This is a message');
+            const label = popover.querySelector(
+                'limel-markdown.label'
+            ) as HTMLLimelMarkdownElement;
+            const rendered = label.shadowRoot!.querySelector('#markdown');
+            expect(rendered!.textContent!.trim()).toEqual('This is a message');
 
             const button = root.shadowRoot!.querySelector('limel-button');
             expect(button.getAttribute('label')).toEqual('Press me!');

--- a/src/components/snackbar/snackbar.scss
+++ b/src/components/snackbar/snackbar.scss
@@ -49,14 +49,11 @@ aside {
     box-shadow: var(--shadow-depth-8), var(--shadow-depth-16);
 }
 
-.label {
+limel-markdown.label {
     color: rgb(var(--contrast-100));
+    --limel-theme-default-font-size: var(--limel-theme-default-small-font-size);
 
-    -webkit-font-smoothing: antialiased;
-    font-size: var(--limel-theme-default-small-font-size);
-    font-weight: 400;
     padding: 0 0.25rem;
-
     width: 100%;
     flex-grow: 1;
 }

--- a/src/components/snackbar/snackbar.tsx
+++ b/src/components/snackbar/snackbar.tsx
@@ -46,6 +46,7 @@ const hideAnimationDuration = 300;
  * @exampleComponent limel-example-snackbar-dismissible
  * @exampleComponent limel-example-snackbar-persistent
  * @exampleComponent limel-example-snackbar-persistent-non-dismissible
+ * @exampleComponent limel-example-snackbar-with-markdown
  */
 @Component({
     tag: 'limel-snackbar',
@@ -60,7 +61,18 @@ export class Snackbar {
     public open: boolean = false;
 
     /**
-     * The text message to display.
+     * The message to display.
+     *
+     * Supports [Markdown](#/component/limel-markdown/) for light inline
+     * emphasis such as `**bold**` or `*italic*`. See the Markdown example
+     * below for UX guidance.
+     *
+     * :::important
+     * When the message is composed from dynamic content such as user
+     * input or translated strings, escape Markdown-sensitive characters
+     * (`*`, `_`, backtick, `#`, `[`, `]`) with a leading backslash to
+     * prevent unintended formatting.
+     * :::
      */
     @Prop()
     public message: string;
@@ -229,7 +241,7 @@ export class Snackbar {
                 aria-relevant={this.open ? 'additions' : undefined}
             >
                 <div class="surface">
-                    <div class="label">{this.message}</div>
+                    <limel-markdown class="label" value={this.message} />
                     {this.renderActions(this.actionText)}
                     {this.renderDismissButton(this.dismissible)}
                 </div>


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<img width="357" height="103" alt="image" src="https://github.com/user-attachments/assets/ce3a68b5-44f1-48f6-9814-1d184067ba8e" />

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snackbar messages now render Markdown, enabling rich text (e.g., bold) in notifications; escape Markdown-sensitive characters for dynamic content.

* **Documentation**
  * Added an example demonstrating how to use Markdown in the snackbar.

* **Style**
  * Scoped label styling to markdown-rendered content and adjusted font sizing for snackbar text.

* **Tests**
  * Updated end-to-end assertions to verify rendered Markdown output in the snackbar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
