### PR TITLE
docs(snackbar): fix stray backslash in markdown example

### DIFF
--- a/src/components/snackbar/examples/snackbar-with-markdown.tsx
+++ b/src/components/snackbar/examples/snackbar-with-markdown.tsx
@@ -39,6 +39,8 @@ export class SnackbarWithMarkdownExample {
     @State()
     private isOpen: boolean = false;
 
+    private readonly message = String.raw`\#1374 — **"Westeros Ltd."** was saved successfully.`;
+
     public render() {
         return [
             <limel-button
@@ -49,7 +51,7 @@ export class SnackbarWithMarkdownExample {
             <limel-snackbar
                 key="snackbar"
                 open={this.isOpen}
-                message='\\#1374 — **"Westeros Ltd."** was saved successfully.'
+                message={this.message}
                 onHide={this.handleHideSnackbar}
             />,
         ];


### PR DESCRIPTION
## Summary
- The `snackbar-with-markdown` example rendered a visible `\` in front of `#1374` because the message was passed as a JSX string attribute, where backslashes are literal. Switched to a JSX expression so `\\` collapses to a single backslash and the markdown escape works as intended.

## Test plan
- [ ] Open the Snackbar docs, trigger the "Markdown formatting" example, and confirm the message reads `#1374 — "Westeros Ltd." was saved successfully.` with no leading `\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the snackbar example code to improve formatting and clarity.
  * Example now demonstrates message extraction into a single declared value rather than an inline string, making the sample easier to read and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->