### PR TITLE
fix(action-bar): prevent shrink/expand button from stretching to full…

### DIFF
--- a/src/components/action-bar/action-bar.scss
+++ b/src/components/action-bar/action-bar.scss
@@ -99,6 +99,7 @@
 
 button.expand-shrink {
     @include mixins.reset-button-user-agent-styles;
+    width: auto; // override full-width from action-bar layout
     box-sizing: border-box;
     border-radius: 50%;
 


### PR DESCRIPTION
… width

before:
<img width="523" height="103" alt="Screenshot 2026-04-22 at 15 18 12" src="https://github.com/user-attachments/assets/ffced3e0-809f-45a5-8f2a-18f86baafb87" />

after:
<img width="464" height="126" alt="Screenshot 2026-04-22 at 15 17 01" src="https://github.com/user-attachments/assets/9679a82c-4210-4f9f-ab54-7716bfe0fee1" />


<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected button width behavior in the action bar to prevent unwanted full-width expansion and maintain proper layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
