### PR TITLE
fix(action-bar): do not render expand/shrink button for few icon-only…

### DIFF
--- a/src/components/action-bar/action-bar.tsx
+++ b/src/components/action-bar/action-bar.tsx
@@ -40,6 +40,7 @@ import { Icon } from '../../global/shared-types/icon.types';
  * @exampleComponent limel-example-action-bar-colors
  * @exampleComponent limel-example-action-bar-floating
  * @exampleComponent limel-example-action-bar-floating-expand
+ * @exampleComponent limel-example-action-bar-floating-few-icon-only
  * @exampleComponent limel-example-action-bar-styling
  * @exampleComponent limel-example-action-bar-as-primary-component
  * @exampleComponent limel-example-action-bar-icon-title
@@ -210,6 +211,12 @@ export class ActionBar {
 
     private renderCollapseExpandButton() {
         if (!this.collapsible || this.actions.length <= 1) {
+            return;
+        }
+
+        const items = this.actions.filter(isItem);
+        const allIconOnly = items.every((item) => item.iconOnly);
+        if (items.length < 4 && allIconOnly) {
             return;
         }
 

--- a/src/components/action-bar/examples/action-bar-floating-few-icon-only.tsx
+++ b/src/components/action-bar/examples/action-bar-floating-few-icon-only.tsx
@@ -1,0 +1,80 @@
+import { Component, h, State } from '@stencil/core';
+import { ActionBarItem, ListSeparator } from '@limetech/lime-elements';
+
+/**
+ * Floating action bar with only a few icon-only actions
+ *
+ * When a `collapsible` action bar contains fewer than 4 icon-only actions,
+ * the expand/shrink button is omitted. Icon-only actions already take minimal
+ * space, so collapsing them has no visual benefit and the toggle would just
+ * add noise.
+ *
+ * Toggle the switch below to add a 4th icon-only action and watch the
+ * expand/shrink button appear.
+ *
+ */
+@Component({
+    tag: 'limel-example-action-bar-floating-few-icon-only',
+    shadow: true,
+    styleUrl: 'action-bar-floating.scss',
+})
+export class ActionBarFloatingFewIconOnlyExample {
+    @State()
+    private showFourthAction = false;
+
+    private readonly baseItems: Array<ActionBarItem | ListSeparator> = [
+        {
+            text: 'Add',
+            icon: 'plus_math',
+            iconOnly: true,
+        },
+        {
+            text: 'Refresh',
+            icon: 'refresh',
+            iconOnly: true,
+        },
+        { separator: true },
+        {
+            text: 'Assign me',
+            commandText: 'Cmd + H',
+            icon: 'whole_hand_right',
+            iconOnly: true,
+        },
+    ];
+
+    private readonly fourthAction: ActionBarItem = {
+        text: 'Archive',
+        icon: 'archive',
+        iconOnly: true,
+    };
+
+    public render() {
+        const actions = this.showFourthAction
+            ? [...this.baseItems, this.fourthAction]
+            : this.baseItems;
+
+        return [
+            <div class="application has-floating-action-bar is-resizable">
+                <limel-action-bar
+                    accessibleLabel="Contextual Action Bar"
+                    actions={actions}
+                    openDirection="top"
+                    layout="floating"
+                    collapsible={true}
+                />
+            </div>,
+            <limel-example-controls>
+                <limel-checkbox
+                    checked={this.showFourthAction}
+                    label="Add a 4th action"
+                    onChange={this.setShowFourthAction}
+                />
+            </limel-example-controls>,
+        ];
+    }
+
+    private setShowFourthAction = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.showFourthAction = event.detail;
+    };
+}


### PR DESCRIPTION
… actions

https://github.com/user-attachments/assets/0a66e358-812d-4094-b6c9-837309827677



<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action bar collapse/expand button visibility: the button is now suppressed when displaying fewer than 4 items that are all icon-only.

* **Documentation**
  * Added a new example demonstrating a floating action bar with icon-only actions and dynamic action toggling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
