### PR TITLE
fix(form): handle deep-leaf changes inside array items correctly

### DIFF
--- a/src/components/form/fields/array-field.ts
+++ b/src/components/form/fields/array-field.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 import { getDefaultRegistry } from '@rjsf/core';
 import { FieldProps } from '@rjsf/utils';
-import { resetDependentFields } from './field-helpers';
+import { resetDependentFields, schemaAllowsNull } from './field-helpers';
 import { ARRAY_REORDER_EVENT } from '../templates/array-field';
+import { FormSchema } from '../form.types';
 
 const { fields: defaultFields } = getDefaultRegistry();
 const BaseArrayField = defaultFields.ArrayField;
@@ -87,8 +88,31 @@ export class ArrayField extends React.Component<FieldProps> {
     }
 
     private handleChange(newData, path) {
-        const { formData: oldData, schema } = this.props;
+        const { formData: oldData, schema, fieldPathId } = this.props;
         const { rootSchema } = this.props.registry;
+
+        // RJSF v6's built-in ArrayField shares one onChange handler across all
+        // descendants, so changes to leaves deep inside an array item bubble
+        // through here with the leaf value (not the full array) and a path
+        // that is deeper than this field's own path. In that case the
+        // array-shape logic below does not apply and would crash on scalar
+        // `newData`. The built-in handler also coerces `undefined` to `null`
+        // for every child change, which breaks field clearing for custom
+        // components; restore `undefined` when the leaf schema does not
+        // include `'null'`, mirroring the ingress conversion in `schema-field`.
+        if (fieldPathId && path.length > fieldPathId.path.length) {
+            const leafSchema = getSchemaAtPath(
+                schema as FormSchema,
+                path.slice(fieldPathId.path.length)
+            );
+            const value =
+                newData === null && !schemaAllowsNull(leafSchema)
+                    ? undefined
+                    : newData;
+            this.props.onChange(value, path);
+
+            return;
+        }
 
         // This case handles when the first list item is added. When there are no
         // items we get undefined instead of []
@@ -145,4 +169,33 @@ export class ArrayField extends React.Component<FieldProps> {
             React.createElement(BaseArrayField as any, arrayProps)
         );
     }
+}
+
+function getSchemaAtPath(
+    schema: FormSchema,
+    pathSegments: Array<string | number>
+): FormSchema | undefined {
+    let current: FormSchema | undefined = schema;
+    for (const segment of pathSegments) {
+        if (!current) {
+            return;
+        }
+
+        current = resolveSchemaSegment(current, segment);
+    }
+
+    return current;
+}
+
+function resolveSchemaSegment(
+    schema: FormSchema,
+    segment: string | number
+): FormSchema | undefined {
+    if (typeof segment === 'number') {
+        const items = schema.items;
+
+        return Array.isArray(items) ? items[segment] : items;
+    }
+
+    return schema.properties?.[segment];
 }

--- a/src/components/form/fields/array-field.ts
+++ b/src/components/form/fields/array-field.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getDefaultRegistry } from '@rjsf/core';
-import { FieldProps } from '@rjsf/utils';
+import { FieldProps, FieldPathList } from '@rjsf/utils';
+import { cloneDeep, isPlainObject, set } from 'lodash-es';
 import { resetDependentFields, schemaAllowsNull } from './field-helpers';
 import { ARRAY_REORDER_EVENT } from '../templates/array-field';
 import { FormSchema } from '../form.types';
@@ -88,28 +89,11 @@ export class ArrayField extends React.Component<FieldProps> {
     }
 
     private handleChange(newData, path) {
-        const { formData: oldData, schema, fieldPathId } = this.props;
+        const { formData: oldData, schema } = this.props;
         const { rootSchema } = this.props.registry;
 
-        // RJSF v6's built-in ArrayField shares one onChange handler across all
-        // descendants, so changes to leaves deep inside an array item bubble
-        // through here with the leaf value (not the full array) and a path
-        // that is deeper than this field's own path. In that case the
-        // array-shape logic below does not apply and would crash on scalar
-        // `newData`. The built-in handler also coerces `undefined` to `null`
-        // for every child change, which breaks field clearing for custom
-        // components; restore `undefined` when the leaf schema does not
-        // include `'null'`, mirroring the ingress conversion in `schema-field`.
-        if (fieldPathId && path.length > fieldPathId.path.length) {
-            const leafSchema = getSchemaAtPath(
-                schema as FormSchema,
-                path.slice(fieldPathId.path.length)
-            );
-            const value =
-                newData === null && !schemaAllowsNull(leafSchema)
-                    ? undefined
-                    : newData;
-            this.props.onChange(value, path);
+        if (this.isDeepLeafChange(path)) {
+            this.handleDeepLeafChange(newData, path);
 
             return;
         }
@@ -157,6 +141,69 @@ export class ArrayField extends React.Component<FieldProps> {
         this.props.onChange(newData, path);
     }
 
+    /**
+     * RJSF v6's built-in ArrayField shares one onChange handler across all
+     * descendants, so changes to leaves deep inside an array item bubble
+     * through here with the leaf value (not the full array) and a path that
+     * is deeper than this field's own path.
+     * @param path
+     */
+    private isDeepLeafChange(path: FieldPathList): boolean {
+        const { formData, fieldPathId } = this.props;
+
+        return (
+            Array.isArray(formData) &&
+            !!fieldPathId &&
+            path.length > fieldPathId.path.length
+        );
+    }
+
+    /**
+     * Rebuild the affected item locally so we can (a) restore `undefined`
+     * when the leaf schema does not allow `null` — the built-in handler
+     * coerces `undefined` to `null`, which breaks field clearing for custom
+     * components — and (b) still run `resetDependentFields` at the item
+     * level so sibling fields that became obsolete for the new data are
+     * cleared.
+     * @param newData
+     * @param path
+     */
+    private handleDeepLeafChange(newData: unknown, path: FieldPathList): void {
+        const { formData: oldData, fieldPathId } = this.props;
+
+        const [indexSegment, ...pathInItem] = path.slice(
+            fieldPathId.path.length
+        );
+        const index = Number(indexSegment);
+
+        const newArray = [...oldData];
+        newArray[index] = this.buildResetItem(newData, index, pathInItem);
+        this.props.onChange(newArray, fieldPathId.path);
+    }
+
+    private buildResetItem(
+        newData: unknown,
+        index: number,
+        pathInItem: Array<string | number>
+    ): unknown {
+        const { formData: oldData, schema } = this.props;
+        const { rootSchema } = this.props.registry;
+
+        const itemSchema = (
+            Array.isArray(schema.items) ? schema.items[index] : schema.items
+        ) as FormSchema;
+        const leafSchema = getSchemaAtPath(itemSchema, pathInItem);
+        const value =
+            newData === null && !schemaAllowsNull(leafSchema)
+                ? undefined
+                : newData;
+
+        const oldItem = oldData[index];
+        const newItem = setValueAtPath(oldItem, pathInItem, value);
+
+        return resetDependentFields(oldItem, newItem, itemSchema, rootSchema);
+    }
+
     render() {
         const arrayProps = {
             ...this.props,
@@ -198,4 +245,47 @@ function resolveSchemaSegment(
     }
 
     return schema.properties?.[segment];
+}
+
+/**
+ * Return a copy of `target` with `value` written at the location described
+ * by `pathSegments`, creating intermediate containers as needed. Numeric
+ * segments address arrays; string segments address object keys. `target`
+ * is not mutated.
+ *
+ * @param target
+ * @param pathSegments
+ * @param value
+ * @example
+ * setValueAtPath({ a: { b: 1 } }, ['a', 'b'], 2); // → { a: { b: 2 } }
+ * setValueAtPath([{ x: 1 }], [0, 'x'], 9);        // → [{ x: 9 }]
+ */
+function setValueAtPath(
+    target: unknown,
+    pathSegments: Array<string | number>,
+    value: unknown
+): unknown {
+    if (pathSegments.length === 0) {
+        return value;
+    }
+
+    const clone = cloneContainer(target, pathSegments[0]);
+    set(clone, pathSegments, value);
+
+    return clone;
+}
+
+function cloneContainer(
+    target: unknown,
+    firstSegment: string | number
+): object {
+    if (Array.isArray(target) || isPlainObject(target)) {
+        return cloneDeep(target) as object;
+    }
+
+    if (typeof firstSegment === 'number') {
+        return [];
+    }
+
+    return {};
 }

--- a/src/components/form/fields/field-helpers.ts
+++ b/src/components/form/fields/field-helpers.ts
@@ -1,5 +1,6 @@
 import { union, isEqual, isPlainObject, negate } from 'lodash-es';
 import { retrieveSchema, ADDITIONAL_PROPERTY_FLAG } from '@rjsf/utils';
+import { JSONSchema7 } from 'json-schema';
 import { FormSchema } from '../form.types';
 import { rjsfValidator } from '../validator';
 
@@ -97,3 +98,20 @@ export function isCustomObjectSchema(schema: FormSchema) {
 function isAdditionalProperty(schema: FormSchema): boolean {
     return schema[ADDITIONAL_PROPERTY_FLAG] === true;
 }
+
+/**
+ * Check whether a schema permits `null` as a valid value. Used to decide
+ * whether a cleared field value should be preserved as `null` or converted
+ * to `undefined` so the property can be removed from the form data.
+ *
+ * @param schema - the schema to check
+ * @returns true if the schema's type is `'null'` or includes `'null'`
+ */
+export const schemaAllowsNull = (schema: JSONSchema7 | undefined): boolean => {
+    const type = schema?.type;
+    if (!type) {
+        return false;
+    }
+
+    return Array.isArray(type) ? type.includes('null') : type === 'null';
+};

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -161,6 +161,12 @@ export class SchemaField extends React.Component<FieldProps> {
 
         this.setState({ modified: true });
 
+        if (this.isDeepLeafChange(path)) {
+            this.props.onChange(data, path);
+
+            return;
+        }
+
         const newData = resetDependentFields(
             formData,
             data,
@@ -169,6 +175,21 @@ export class SchemaField extends React.Component<FieldProps> {
         );
 
         this.props.onChange(newData, path);
+    }
+
+    /**
+     * RJSF v6's built-in ArrayField shares one onChange handler across all
+     * descendants, so changes to leaves deep inside an array item bubble
+     * through this SchemaField with a path that is deeper than its own.
+     * The enclosing ArrayField rebuilds the affected item and runs
+     * `resetDependentFields` at the item level (see array-field.ts), so we
+     * must pass the partial leaf data through untouched here.
+     * @param path
+     */
+    private isDeepLeafChange(path: FieldPathList): boolean {
+        const { fieldPathId } = this.props;
+
+        return !!fieldPathId && path.length > fieldPathId.path.length;
     }
 
     private buildCustomComponentProps() {

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -8,7 +8,7 @@ import {
     isFieldRequired,
     getErrorText,
 } from '../validation-display';
-import { resetDependentFields } from './field-helpers';
+import { resetDependentFields, schemaAllowsNull } from './field-helpers';
 import { FieldTemplate } from '../templates';
 import { getHelpComponent } from '../help';
 import { FormComponent, FormSchema } from '../form.types';
@@ -43,7 +43,7 @@ const BaseSchemaField = defaultFields.SchemaField;
  * @returns whether or not null should be changed to undefined
  */
 const shouldChangeToUndefined = (value, schema): boolean => {
-    return value === null && !schema.type.includes('null');
+    return value === null && !schemaAllowsNull(schema);
 };
 
 const hasCustomComponent = (schema): boolean => {

--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -29,6 +29,8 @@ import {
     rowLayoutSchema,
     rowLayoutWithCustomComponentSchema,
     nestedArrayObjectSchema,
+    topLevelStringCustomComponentSchema,
+    nestedStringCustomComponentSchema,
 } from './form.test-schemas';
 
 const fieldTypeTests = [
@@ -498,6 +500,36 @@ test('renders nested objects inside array items without inheriting array context
         'limel-collapsible-section limel-collapsible-section'
     );
     expect(nestedCollapsibles.length).toBe(0);
+});
+
+test('converts null to undefined via schema-field when top-level custom component clears', async () => {
+    const onChange = vi.fn();
+    const { change } = await renderForm({
+        schema: topLevelStringCustomComponentSchema,
+        value: { icon: 'star' },
+        onChange,
+    });
+
+    await change('Icon', undefined);
+
+    expect(onChange).toHaveBeenCalled();
+    const latest = onChange.mock.lastCall[0].detail;
+    expect(latest.icon).toBeUndefined();
+});
+
+test('converts null to undefined via array-field when nested custom component clears', async () => {
+    const onChange = vi.fn();
+    const { change } = await renderForm({
+        schema: nestedStringCustomComponentSchema,
+        value: { views: [{}] },
+        onChange,
+    });
+
+    await change('Icon', 'star');
+    await change('Icon', undefined);
+
+    const latest = onChange.mock.lastCall[0].detail;
+    expect(latest.views[0].icon).toBeUndefined();
 });
 
 async function renderForm(props: Record<string, any> = {}) {

--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -31,6 +31,7 @@ import {
     nestedArrayObjectSchema,
     topLevelStringCustomComponentSchema,
     nestedStringCustomComponentSchema,
+    arrayItemWithDependenciesSchema,
 } from './form.test-schemas';
 
 const fieldTypeTests = [
@@ -515,6 +516,22 @@ test('converts null to undefined via schema-field when top-level custom componen
     expect(onChange).toHaveBeenCalled();
     const latest = onChange.mock.lastCall[0].detail;
     expect(latest.icon).toBeUndefined();
+});
+
+test('resets dependent sibling in array item when trigger field changes', async () => {
+    const onChange = vi.fn();
+    const { change } = await renderForm({
+        schema: arrayItemWithDependenciesSchema,
+        value: { entries: [{}] },
+        onChange,
+    });
+
+    await change('Use A', true);
+    await change('Value A', 'hello');
+    await change('Use A', false);
+
+    const latest = onChange.mock.lastCall[0].detail;
+    expect(latest.entries[0].valueA).toBeUndefined();
 });
 
 test('converts null to undefined via array-field when nested custom component clears', async () => {

--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -32,6 +32,7 @@ import {
     topLevelStringCustomComponentSchema,
     nestedStringCustomComponentSchema,
     arrayItemWithDependenciesSchema,
+    arrayItemWithDependenciesAndCustomConfigSchema,
 } from './form.test-schemas';
 
 const fieldTypeTests = [
@@ -532,6 +533,22 @@ test('resets dependent sibling in array item when trigger field changes', async 
 
     const latest = onChange.mock.lastCall[0].detail;
     expect(latest.entries[0].valueA).toBeUndefined();
+});
+
+test('preserves nested-object leaf change inside array item with additionalProperties:true and dependencies', async () => {
+    const onChange = vi.fn();
+    const { change } = await renderForm({
+        schema: arrayItemWithDependenciesAndCustomConfigSchema,
+        value: { entries: [{}] },
+        onChange,
+    });
+
+    await change('Use A', true);
+    await change('Config', { color: 'red' });
+
+    const latest = onChange.mock.lastCall[0].detail;
+    expect(latest.entries[0].config).toEqual({ color: 'red' });
+    expect(latest.entries[0].useA).toBe(true);
 });
 
 test('converts null to undefined via array-field when nested custom component clears', async () => {

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -347,6 +347,50 @@ export const topLevelStringCustomComponentSchema: FormSchema = {
     },
 };
 
+export const arrayItemWithDependenciesSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        entries: {
+            type: 'array',
+            title: 'Entries',
+            items: {
+                type: 'object',
+                properties: {
+                    useA: {
+                        type: 'boolean',
+                        title: 'Use A',
+                    },
+                },
+                required: ['useA'],
+                dependencies: {
+                    useA: {
+                        oneOf: [
+                            {
+                                properties: {
+                                    useA: { const: true },
+                                    valueA: {
+                                        type: 'string',
+                                        title: 'Value A',
+                                    },
+                                },
+                            },
+                            {
+                                properties: {
+                                    useA: { const: false },
+                                    valueB: {
+                                        type: 'string',
+                                        title: 'Value B',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+};
+
 export const nestedStringCustomComponentSchema: FormSchema = {
     type: 'object',
     properties: {

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -335,3 +335,34 @@ export const nestedArrayObjectSchema: FormSchema = {
         },
     },
 };
+
+export const topLevelStringCustomComponentSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        icon: {
+            type: 'string',
+            title: 'Icon',
+            lime: { component: { name: 'limel-input-field' } },
+        },
+    },
+};
+
+export const nestedStringCustomComponentSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        views: {
+            type: 'array',
+            title: 'Views',
+            items: {
+                type: 'object',
+                properties: {
+                    icon: {
+                        type: 'string',
+                        title: 'Icon',
+                        lime: { component: { name: 'limel-input-field' } },
+                    },
+                },
+            },
+        },
+    },
+};

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -391,6 +391,53 @@ export const arrayItemWithDependenciesSchema: FormSchema = {
     },
 };
 
+export const arrayItemWithDependenciesAndCustomConfigSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        entries: {
+            type: 'array',
+            title: 'Entries',
+            items: {
+                type: 'object',
+                properties: {
+                    useA: {
+                        type: 'boolean',
+                        title: 'Use A',
+                    },
+                    config: {
+                        type: 'object',
+                        title: 'Config',
+                        additionalProperties: { type: 'string' },
+                        lime: {
+                            component: { name: 'limel-input-field' },
+                        },
+                    },
+                },
+                required: ['useA'],
+                dependencies: {
+                    useA: {
+                        oneOf: [
+                            {
+                                properties: {
+                                    useA: { const: true },
+                                    valueA: {
+                                        type: 'string',
+                                        title: 'Value A',
+                                    },
+                                },
+                            },
+                            {
+                                properties: { useA: { const: false } },
+                            },
+                        ],
+                    },
+                },
+                additionalProperties: true,
+            },
+        },
+    },
+};
+
 export const nestedStringCustomComponentSchema: FormSchema = {
     type: 'object',
     properties: {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent clearing: cleared fields (including nested array/object items and custom-rendered fields) now emit undefined.
  * Improved deep-update handling: deep changes inside arrays and nested fields rebuild and emit the correct updated value while preserving dependent sibling state.
  * Null handling: conversion from null→undefined now follows schema nullability rules.

* **Tests**
  * Added end-to-end and schema tests covering clearing, deep array updates, dependency propagation, and custom-rendered fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fix 1: custom string components (e.g. `limel-input-field`) inside array items could not
  be cleared — emitting `undefined` left the field stuck at its previous value.
- Fix 2: when a trigger field inside an array item changed branch (e.g. a
  `dependencies`/`oneOf` schema), siblings that became invalid under the new branch kept
  their stale values.
- Fix 3: nested-object leaf data inside an array item (e.g. a `config` object with
  `additionalProperties` rendered by a custom component) was lost when the enclosing item
  also had `dependencies` — the deep-leaf change bubbled through the ancestor
  `SchemaField` for the array, which ran `resetDependentFields` with the leaf value
  against the array schema, corrupting `formData` before `ArrayField` could rebuild the
  item.
- Shared root cause: RJSF v6's `ArrayField` funnels every descendant change through one
  shared `onChange` that coerces `undefined` to `null` and bypasses our item-level
  `resetDependentFields` pass.
- In `ArrayField.handleChange`, intercept deep-path changes before the array-shape logic:
  rebuild the affected item locally with `undefined` restored where the leaf schema does
  not permit `null`, run `resetDependentFields` on it, then propagate the new array up.
- In `SchemaField.handleChange`, mirror the same `isDeepLeafChange` guard so deep-leaf
  bubbles pass through untouched — `resetDependentFields` should only run at the level
  where schema and data shapes line up.
- Adds e2e coverage for clearing top-level and array-nested string custom components, for
  resetting obsolete dependent siblings on a trigger change, and for preserving
  nested-object leaf data inside array items with dependencies.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
