### PR TITLE
Adjust markdown paragraph, heading code, and table styling

### DIFF
--- a/src/components/markdown/partial-styles/_body-text.scss
+++ b/src/components/markdown/partial-styles/_body-text.scss
@@ -22,7 +22,7 @@ p {
     margin-top: 0;
     margin-bottom: 0.5rem;
 
-    &:only-child {
+    &:last-child {
         margin-bottom: 0;
     }
 }

--- a/src/components/markdown/partial-styles/_headings.scss
+++ b/src/components/markdown/partial-styles/_headings.scss
@@ -54,6 +54,12 @@ h6 {
     hyphens: auto;
     -webkit-hyphens: auto;
 
+    // Inline `code` should scale with the heading size instead of
+    // collapsing to the standalone `code` font-size from `_pre-code.scss`.
+    code {
+        font-size: inherit;
+    }
+
     :not([contenteditable='true']) & {
         text-wrap: balance;
     }

--- a/src/components/markdown/partial-styles/_tables.scss
+++ b/src/components/markdown/partial-styles/_tables.scss
@@ -27,6 +27,17 @@
         vertical-align: top;
         transition: background-color 0.2s ease;
         font-size: var(--limel-theme-default-font-size); // 14px
+
+        // Tables scroll horizontally (see `overflow-x: auto` below), so
+        // cell content should not be broken mid-word. Override the
+        // aggressive `word-break` rules from `_body-text.scss` that
+        // would otherwise shatter emails and links character-by-character.
+        p,
+        li,
+        a {
+            word-break: normal;
+            overflow-wrap: normal;
+        }
     }
 
     td {


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix https://github.com/Lundalogik/lime-elements/issues/4045
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved paragraph spacing in markdown content
  * Enhanced code display within headings for better visual consistency
  * Refined table text wrapping to prevent awkward mid-word breaks in horizontally scrollable tables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
