### PR TITLE
fix(card): don't show hover effects when card is neither clickable no…

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -39,12 +39,23 @@ section {
     padding: 0.25rem;
     background-color: var(--card-background-color, rgb(var(--contrast-300)));
 
+    :host(limel-card[clickable]) &,
+    :host(limel-card[show-3d-effect]) & {
+        @include mixins.the-3d-element;
+    }
+
+    :host(limel-card[clickable]) & {
+        @include mixins.the-3d-element--clickable;
+    }
+
     &:hover {
-        border-color: transparent;
-        background-color: var(
-            --card-background-color--hovered,
-            var(--card-background-color, rgb(var(--contrast-200)))
-        );
+        :host(limel-card[clickable]) & {
+            border-color: transparent;
+            background-color: var(
+                --card-background-color--hovered,
+                var(--card-background-color, rgb(var(--contrast-200)))
+            );
+        }
     }
 }
 
@@ -88,8 +99,8 @@ img {
     max-width: 100%;
     max-height: 100%;
 
-    section:hover &,
-    section:focus-visible & {
+    :host(limel-card[show-3d-effect]) section:hover &,
+    :host(limel-card[show-3d-effect]) section:focus-visible & {
         transition-duration: 0.2s;
         filter: saturate(1.3);
     }
@@ -215,14 +226,6 @@ limel-3d-hover-effect-glow {
 
 :host(limel-card[show-3d-effect]) {
     @include mixins.parent-of-the-3d-element;
-}
-
-section {
-    @include mixins.the-3d-element;
-
-    :host(limel-card[clickable]) & {
-        @include mixins.the-3d-element--clickable;
-    }
 }
 
 :host(limel-card[selected]) section {


### PR DESCRIPTION
…r has 3D effect
fix: https://github.com/Lundalogik/lime-elements/issues/4052


https://github.com/user-attachments/assets/4e4ee17e-7fe3-49e5-a134-3fcea51b97e4



<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined 3D and hover visuals so effects only apply to cards explicitly marked interactive, preventing unintended styling on non-interactive cards.
  * Restricted image saturation and transition triggers to cards with the interactive/3D setting, improving visual clarity and reducing accidental hover effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
