### PR TITLE
feat(list): add a custom CSS prop for controlling images' object fit

### DIFF
--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -3,6 +3,7 @@
  * @prop --notification-badge-background-color: (Publicly documented in `limel-menu` too) Defines the background color of notification badges. Defaults to `--color-red-default`.
  * @prop --limel-list-item-menu-order: Defines the order of the menu, within the list item's flexbox. Defaults to `3`.
  * @prop --list-item-image-border-radius: Defines the border radius of the list item image. Defaults to `50%`.
+ * @prop --list-item-image-object-fit: Defines the object-fit property of the list item image. Defaults to `cover`.
  */
 
 @use '../../style/mixins';
@@ -141,7 +142,7 @@ limel-list-item {
 
     img {
         flex-shrink: 0;
-        object-fit: cover;
+        object-fit: var(--list-item-image-object-fit, cover);
         border-radius: var(--list-item-image-border-radius, 50%);
         width: 2rem;
         height: 2rem;

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -14,6 +14,7 @@
 * @prop --list-background-color-of-even-interactive-items:  Background color of even list items, when `has-striped-rows` class is applied to the component. Defaults to `transparent`.
 * @prop --list-margin: Space around the list. Defaults to `0.25rem`, which visualizes keyboard-focused items in a better way, as it adds some space for the outline effect.
 * @prop --list-item-image-border-radius: Defines the border radius of the list item image. Defaults to `50%`.
+* @prop --list-item-image-object-fit: Defines the object-fit property of the list item image. Defaults to `cover`.
 */
 
 :host(limel-list) {


### PR DESCRIPTION
called `--list-item-image-object-fit`
related to https://github.com/Lundalogik/hack-tuesday/issues/195
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--list-item-image-object-fit` CSS custom property, enabling customization of how images are displayed in list items while maintaining the existing default behavior.

* **Documentation**
  * Documented the new CSS variable for component theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
