### PR TITLE
feat(image): support referrerpolicy on rendered images

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1255,6 +1255,7 @@ export type IconSize = 'x-small' | 'small' | 'medium' | 'large';
 interface Image_2 {
     alt: string;
     loading?: 'lazy' | 'eager';
+    referrerpolicy?: ReferrerPolicy;
     src: string;
 }
 export { Image_2 as Image }

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -9,6 +9,7 @@ import {
     State,
 } from '@stencil/core';
 import { Image } from '../../global/shared-types/image.types';
+import { ImageTemplate } from '../../util/image.template';
 import { Icon, IconName } from '../../global/shared-types/icon.types';
 import { isItem } from '../action-bar/is-item';
 import { getIconName } from '../icon/get-icon-props';
@@ -243,7 +244,7 @@ export class Card {
 
         return (
             <div class="image-wrapper">
-                <img src={this.image.src} alt={this.image.alt} loading="lazy" />
+                <ImageTemplate image={this.image} />
             </div>
         );
     }

--- a/src/components/chip/chip.tsx
+++ b/src/components/chip/chip.tsx
@@ -8,6 +8,7 @@ import {
     Prop,
 } from '@stencil/core';
 import { Icon, IconName } from '../../global/shared-types/icon.types';
+import { ImageTemplate } from '../../util/image.template';
 import { Languages } from '../date-picker/date.types';
 import { Link } from '../../global/shared-types/link.types';
 import { getRel } from '../../util/link-helper';
@@ -295,9 +296,7 @@ export class Chip implements ChipInterface {
         }
 
         if (!isEmpty(this.image)) {
-            return (
-                <img src={this.image.src} alt={this.image.alt} loading="lazy" />
-            );
+            return <ImageTemplate image={this.image} />;
         }
 
         return (

--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -245,6 +245,7 @@ export class FileViewer {
                     image={{
                         src: this.sanitizeUrl(this.fileUrl),
                         alt: this.alt ?? '',
+                        referrerpolicy: 'no-referrer',
                     }}
                 />
             </Fragment>

--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -1,6 +1,7 @@
 import {
     Component,
     Element,
+    Fragment,
     h,
     Prop,
     State,
@@ -17,6 +18,7 @@ import { FileType, OfficeViewer } from './file-viewer.types';
 import { LimelMenuCustomEvent } from '../../components';
 import { Email } from '../email-viewer/email-viewer.types';
 import { loadEmail } from '../email-viewer/email-loader';
+import { ImageTemplate } from '../../util/image.template';
 
 /**
  * This is a smart component that automatically detects
@@ -236,14 +238,17 @@ export class FileViewer {
     };
 
     private renderImage = () => {
-        return [
-            this.renderButtons(),
-            <img
-                src={this.sanitizeUrl(this.fileUrl)}
-                alt={this.alt}
-                loading="lazy"
-            />,
-        ];
+        return (
+            <Fragment>
+                {this.renderButtons()}
+                <ImageTemplate
+                    image={{
+                        src: this.sanitizeUrl(this.fileUrl),
+                        alt: this.alt ?? '',
+                    }}
+                />
+            </Fragment>
+        );
     };
 
     private renderVideo = () => {

--- a/src/components/list-item/list-item.e2e.tsx
+++ b/src/components/list-item/list-item.e2e.tsx
@@ -108,5 +108,41 @@ describe('limel-list-item', () => {
 
         const imgEl = root.querySelector('img');
         expect(imgEl).not.toBeNull();
+        expect(imgEl?.hasAttribute('referrerpolicy')).toBe(false);
+        expect(imgEl?.getAttribute('loading')).toEqual('lazy');
+    });
+
+    it('forwards referrerpolicy to the rendered image when set', async () => {
+        const imgSrc =
+            'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+        const { root, waitForChanges } = await render(
+            <limel-list-item
+                text="Pic"
+                image={{
+                    src: imgSrc,
+                    alt: 'a',
+                    referrerpolicy: 'no-referrer',
+                }}
+            ></limel-list-item>
+        );
+        await waitForChanges();
+
+        const imgEl = root.querySelector('img');
+        expect(imgEl?.getAttribute('referrerpolicy')).toEqual('no-referrer');
+    });
+
+    it('applies the image loading strategy when set', async () => {
+        const imgSrc =
+            'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+        const { root, waitForChanges } = await render(
+            <limel-list-item
+                text="Pic"
+                image={{ src: imgSrc, alt: 'a', loading: 'eager' }}
+            ></limel-list-item>
+        );
+        await waitForChanges();
+
+        const imgEl = root.querySelector('img');
+        expect(imgEl?.getAttribute('loading')).toEqual('eager');
     });
 });

--- a/src/components/list-item/list-item.tsx
+++ b/src/components/list-item/list-item.tsx
@@ -9,6 +9,7 @@ import { ListSeparator } from '../../global/shared-types/separator.types';
 import { CheckboxTemplate } from '../checkbox/checkbox.template';
 import translate from '../../global/translations';
 import { Languages } from '../date-picker/date.types';
+import { ImageTemplate } from '../../util/image.template';
 
 /**
  * This components displays the list item.
@@ -253,7 +254,7 @@ export class ListItemComponent implements ListItem {
             return;
         }
 
-        return <img src={this.image.src} alt={this.image.alt} loading="lazy" />;
+        return <ImageTemplate image={this.image} />;
     };
 
     private renderActionMenu = (actions: Array<MenuItem | ListSeparator>) => {

--- a/src/components/profile-picture/profile-picture.e2e.tsx
+++ b/src/components/profile-picture/profile-picture.e2e.tsx
@@ -1,0 +1,38 @@
+import { render, h } from '@stencil/vitest';
+
+describe('limel-profile-picture', () => {
+    const imgSrc =
+        'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+
+    it('renders the avatar with no-referrer, lazy loading and the object-fit style', async () => {
+        const { root, waitForChanges } = await render(
+            <limel-profile-picture
+                value={imgSrc}
+                imageFit="contain"
+            ></limel-profile-picture>
+        );
+        await waitForChanges();
+
+        const imgEl = root.shadowRoot.querySelector('img');
+        expect(imgEl).not.toBeNull();
+        expect(imgEl?.getAttribute('referrerpolicy')).toEqual('no-referrer');
+        expect(imgEl?.getAttribute('loading')).toEqual('lazy');
+        expect(
+            imgEl?.style.getPropertyValue('--limel-profile-picture-object-fit')
+        ).toEqual('contain');
+    });
+
+    it('flags the host with has-image-error when the image fails to load', async () => {
+        const { root, waitForChanges } = await render(
+            <limel-profile-picture value={imgSrc}></limel-profile-picture>
+        );
+        await waitForChanges();
+
+        expect(root.classList.contains('has-image-error')).toBe(false);
+
+        root.shadowRoot.querySelector('img')?.dispatchEvent(new Event('error'));
+        await waitForChanges();
+
+        expect(root.classList.contains('has-image-error')).toBe(true);
+    });
+});

--- a/src/components/profile-picture/profile-picture.tsx
+++ b/src/components/profile-picture/profile-picture.tsx
@@ -254,6 +254,7 @@ export class ProfilePicture {
                     }}
                     loading="lazy"
                     onError={this.onImageError}
+                    referrerPolicy="no-referrer"
                 />
             );
         }

--- a/src/components/profile-picture/profile-picture.tsx
+++ b/src/components/profile-picture/profile-picture.tsx
@@ -16,6 +16,7 @@ import translate from '../../global/translations';
 import { Languages } from '../date-picker/date.types';
 import { createRandomString } from '../../util/random-string';
 import { resizeImage, ResizeOptions } from '../../util/image-resize';
+import { ImageTemplate } from '../../util/image.template';
 
 /**
  * This component displays a profile picture, while allowing the user
@@ -246,15 +247,12 @@ export class ProfilePicture {
 
         if (src) {
             return (
-                <img
-                    src={src}
-                    alt=""
+                <ImageTemplate
+                    image={{ src, alt: '', referrerpolicy: 'no-referrer' }}
                     style={{
                         '--limel-profile-picture-object-fit': this.imageFit,
                     }}
-                    loading="lazy"
                     onError={this.onImageError}
-                    referrerPolicy="no-referrer"
                 />
             );
         }

--- a/src/global/shared-types/image.types.ts
+++ b/src/global/shared-types/image.types.ts
@@ -20,4 +20,13 @@ export interface Image {
      * - `eager` means that the image will be loaded as soon as possible.
      */
     loading?: 'lazy' | 'eager';
+
+    /**
+     * The `referrerpolicy` attribute of the image. Set to `'no-referrer'`
+     * when `src` points to a third-party service that should not receive
+     * the originating page URL in the `Referer` header (e.g. external
+     * favicon or avatar services). When omitted, the attribute is not
+     * emitted and the browser's default referrer policy applies.
+     */
+    referrerpolicy?: ReferrerPolicy;
 }

--- a/src/util/image.template.tsx
+++ b/src/util/image.template.tsx
@@ -1,0 +1,29 @@
+import { FunctionalComponent, h } from '@stencil/core';
+import { Image } from '../global/shared-types/image.types';
+
+interface ImageTemplateProps {
+    image: Image;
+}
+
+/**
+ * Renders an `Image` as a plain `<img>` element. Centralises the
+ * attribute forwarding so consumer components do not have to
+ * reimplement it. Intended for internal use by lime-elements
+ * components that accept an `Image`-shaped prop.
+ *
+ * @param props
+ * @param props.image - the image to render
+ * @internal
+ */
+export const ImageTemplate: FunctionalComponent<ImageTemplateProps> = ({
+    image,
+}) => {
+    return (
+        <img
+            src={image.src}
+            alt={image.alt}
+            loading={image.loading ?? 'lazy'}
+            referrerPolicy={image.referrerpolicy}
+        />
+    );
+};

--- a/src/util/image.template.tsx
+++ b/src/util/image.template.tsx
@@ -3,20 +3,39 @@ import { Image } from '../global/shared-types/image.types';
 
 interface ImageTemplateProps {
     image: Image;
+
+    /**
+     * Inline styles to set on the rendered `<img>`, e.g. to drive
+     * `object-fit` through a custom property.
+     */
+    style?: { [key: string]: string | undefined };
+
+    /**
+     * Handler invoked when the image fails to load (the `<img>`
+     * `error` event), letting the host react to a broken or blocked
+     * source.
+     */
+    onError?: (event: Event) => void;
 }
 
 /**
  * Renders an `Image` as a plain `<img>` element. Centralises the
  * attribute forwarding so consumer components do not have to
- * reimplement it. Intended for internal use by lime-elements
- * components that accept an `Image`-shaped prop.
+ * reimplement it. Optional `style` and `onError` are
+ * forwarded to the element for consumers that also need to control
+ * its presentation or react to load failures. Intended for internal
+ * use by lime-elements components that accept an `Image`-shaped prop.
  *
  * @param props
  * @param props.image - the image to render
+ * @param props.style - inline styles for the `<img>`
+ * @param props.onError - handler for the `<img>` `error` event
  * @internal
  */
 export const ImageTemplate: FunctionalComponent<ImageTemplateProps> = ({
     image,
+    style,
+    onError,
 }) => {
     return (
         <img
@@ -24,6 +43,8 @@ export const ImageTemplate: FunctionalComponent<ImageTemplateProps> = ({
             alt={image.alt}
             loading={image.loading ?? 'lazy'}
             referrerPolicy={image.referrerpolicy}
+            style={style}
+            onError={onError}
         />
     );
 };


### PR DESCRIPTION
## Summary

- Adds an optional `referrerpolicy?: ReferrerPolicy` field to the shared `Image` interface (`src/global/shared-types/image.types.ts`) + the api report.
- Adds an internal `ImageTemplate` functional component (`src/util/image.template.tsx`, `@internal`, not exported) that renders an `<img>` from an `Image` — forwarding `src`, `alt`, `loading` (`image.loading ?? 'lazy'`), and `referrerPolicy` via the **typed** Stencil prop (no cast/workaround). It also forwards optional `style` and `onError` for consumers that need to control presentation or react to a load failure.
- Routes `limel-card`, `limel-chip`, `limel-list-item`, `limel-file-viewer`, and `limel-profile-picture` through `ImageTemplate`, removing each component's hand-rolled `<img>`.
- `limel-profile-picture` and `limel-file-viewer` set `referrerpolicy="no-referrer"` (their images point at third-party avatar / file hosts).
- Adds e2e coverage on `limel-list-item` (referrerpolicy set/absent, loading default/eager) and `limel-profile-picture` (no-referrer + object-fit style + image-error state).

When `referrerpolicy` is omitted, the attribute is not emitted — existing consumers are unaffected.

## Why

When an image `src` points at a third-party service, the browser otherwise sends the originating CRM page URL in the `Referer` request header — leaking customer-relationship metadata (which tenant viewed which record while researching which company) to whoever runs that service. `referrerpolicy="no-referrer"` removes the leak at no functional cost: the image still loads, the third party still receives the request, but no originating-page URL is attached. This PR gives `Image`-shaped props a first-class way to opt into that, and makes the affected components honor it.

## Context (downstream consumers)

Upstream prerequisite for [`lime-crm-components` PR #4122](https://github.com/Lundalogik/lime-crm-components/pull/4122) ("Company favicons"), which loads favicons from Google's S2 favicon service (a third party) and sets `referrerpolicy` via the `Image` objects it passes into `limel-list-item` / `limel-chip` / `limel-card`. Originating request: [`hack-tuesday` #195](https://github.com/Lundalogik/hack-tuesday/issues/195).

## Implementation notes

- **Helper naming.** `ImageTemplate` (a `FunctionalComponent`) is named distinctly from the existing private `renderImage` methods on individual components, so the shared, stateless render path is unambiguous. It is `@internal` and not exported from the public API.
- **No typing workaround.** `referrerPolicy` is the typed Stencil JSX prop, used directly with no cast — the installed `@stencil/core` (4.43.5) declares `referrerPolicy` on `ImgHTMLAttributes` (the fix for stenciljs/core#6692).
- **`limel-profile-picture`** renders through `ImageTemplate`; the helper forwards its `style` binding (the `--limel-profile-picture-object-fit` custom property) and its `onError` handler, so behavior is unchanged.
- **`limel-file-viewer`** switched its image branch to `ImageTemplate` (wrapped in a `<Fragment>`; passes `alt: this.alt ?? ''` since the component's `alt` is optional but `Image.alt` is required).

### A note on `limel-file-viewer` and `referrerpolicy`

`limel-file-viewer` now renders images with `referrerpolicy="no-referrer"` unconditionally. We considered exposing a `referrerPolicy` prop as an escape hatch but **skipped it for now**: the main consumer (Lime CRM) does not render SharePoint/third-party images through file-viewer's `<img>` path — SharePoint Live Docs previews use an `<iframe>`, thumbnails render via building-blocks' own `<img>`, and the file URLs file-viewer *does* render are same-origin CRM links, where `no-referrer` is a harmless no-op. We can add a `referrerPolicy` prop later if a consumer ever needs to override it.

### Out of scope / follow-up

`limel-card` / `limel-chip` / `limel-list-item` render `image.src` without URL sanitization (pre-existing; not a script-execution vector for `<img>`, but inconsistent with `limel-file-viewer`). Tracked for a separate PR in #4143.

## Commit structure

Eight commits:

1. `feat(image): add referrerpolicy to the Image interface` — type + api report.
2. `chore(image): add ImageTemplate helper for shared image rendering` — internal helper.
3. `refactor(card,chip,list-item): render Image via ImageTemplate helper` — wires three components + e2e.
4. `refactor(file-viewer): render image via ImageTemplate helper`.
5. `fix(profile-picture): suppress referrer on rendered <img>`.
6. `refactor(image): forward style and onError through ImageTemplate` — widens the helper.
7. `refactor(profile-picture): render avatar via ImageTemplate helper` — migrates onto the widened helper + e2e.
8. `fix(file-viewer): suppress referrer on rendered <img>`.

## Test plan

- e2e on `limel-list-item`: `referrerpolicy` present when set / absent when unset; `loading` defaults to `lazy` and honors an explicit `eager`.
- e2e on `limel-profile-picture`: the avatar renders with `no-referrer`, lazy loading, and the object-fit style var; an image `error` flips the `has-image-error` host state.
- `npm run build` passes; `npm run api:update` produces no diff beyond the documented `referrerpolicy` addition.
- `limel-card` / `limel-chip` / `limel-file-viewer` are exercised through the same shared `ImageTemplate` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for referrer policy configuration on images to enhance privacy.
  * Enabled customizable image loading behavior (lazy vs. eager).

* **Refactor**
  * Consolidated image rendering logic across components for improved consistency.

* **Tests**
  * Added comprehensive tests to verify image attribute handling and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->