### PR TITLE
feat(markdown): adapt low-contrast inline colors to surface

### DIFF
--- a/src/components/markdown/adapt-color-contrast.e2e.ts
+++ b/src/components/markdown/adapt-color-contrast.e2e.ts
@@ -1,0 +1,139 @@
+import { adaptColorContrast } from './adapt-color-contrast';
+
+function makeP(
+    host: HTMLElement,
+    attrs: { style?: string } = {},
+    text = 'x'
+): HTMLParagraphElement {
+    const p = document.createElement('p');
+    if (attrs.style) {
+        p.setAttribute('style', attrs.style);
+    }
+    p.textContent = text;
+    host.append(p);
+
+    return p;
+}
+
+describe('adaptColorContrast', () => {
+    let host: HTMLDivElement;
+
+    beforeEach(() => {
+        host = document.createElement('div');
+        host.style.backgroundColor = 'rgb(255, 255, 255)';
+        document.body.append(host);
+    });
+
+    afterEach(() => {
+        host.remove();
+    });
+
+    it('does nothing when there are no inline color styles', () => {
+        const plain = makeP(host, {}, 'plain');
+        const bold = makeP(host, { style: 'font-weight: bold' }, 'bold');
+        const beforePlain = plain.outerHTML;
+        const beforeBold = bold.outerHTML;
+        adaptColorContrast(host);
+        expect(plain.outerHTML).toBe(beforePlain);
+        expect(bold.outerHTML).toBe(beforeBold);
+    });
+
+    it('leaves elements with `color: inherit` alone', () => {
+        const p = makeP(host, { style: 'color: inherit' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('inherit');
+    });
+
+    it('leaves elements with `color: transparent` alone', () => {
+        const p = makeP(host, { style: 'color: transparent' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('transparent');
+    });
+
+    it('strips low-contrast color from inline style', () => {
+        const p = makeP(host, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('');
+    });
+
+    it('removes the style attribute entirely when color was its only declaration', () => {
+        const p = makeP(host, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        expect(p.hasAttribute('style')).toBe(false);
+    });
+
+    it('preserves other inline declarations when stripping color', () => {
+        const p = makeP(host, {
+            style: 'color: rgb(250, 250, 250); font-weight: bold; padding: 4px',
+        });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('');
+        expect(p.style.fontWeight).toBe('bold');
+        expect(p.style.padding).toBe('4px');
+    });
+
+    it('leaves brand colors that pass the contrast threshold alone', () => {
+        const p = makeP(host, { style: 'color: rgb(31, 73, 125)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('rgb(31, 73, 125)');
+    });
+
+    it('preserves a saturated red against a dark surface', () => {
+        host.style.backgroundColor = 'rgb(20, 20, 20)';
+        const p = makeP(host, { style: 'color: rgb(200, 38, 19)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('rgb(200, 38, 19)');
+    });
+
+    it('stashes the original color so re-evaluation can restore it', () => {
+        const p = makeP(host, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        expect(p.dataset.limelStrippedColor).toBe('rgb(250, 250, 250)');
+    });
+
+    it('restores stripped colors when called again on a flipped surface', () => {
+        const p = makeP(host, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('');
+
+        host.style.backgroundColor = 'rgb(0, 0, 0)';
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('rgb(250, 250, 250)');
+        expect(Object.hasOwn(p.dataset, 'limelStrippedColor')).toBe(false);
+    });
+
+    it('stays stripped and re-stashed when re-evaluated on the same surface', () => {
+        const p = makeP(host, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('');
+        expect(p.dataset.limelStrippedColor).toBe('rgb(250, 250, 250)');
+    });
+
+    it('strips black text on a dark surface and not on a light one', () => {
+        const p = makeP(host, { style: 'color: rgb(0, 0, 0)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('rgb(0, 0, 0)');
+
+        host.style.backgroundColor = 'rgb(20, 20, 20)';
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('');
+    });
+
+    it('walks across an ancestor with no background to find the surface', () => {
+        const inner = document.createElement('div');
+        host.append(inner);
+        const p = makeP(inner, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('');
+    });
+
+    it('does not strip when an ancestor has a background-image', () => {
+        const inner = document.createElement('div');
+        inner.style.backgroundImage = 'linear-gradient(to right, red, blue)';
+        host.append(inner);
+        const p = makeP(inner, { style: 'color: rgb(250, 250, 250)' });
+        adaptColorContrast(host);
+        expect(p.style.color).toBe('rgb(250, 250, 250)');
+    });
+});

--- a/src/components/markdown/adapt-color-contrast.spec.ts
+++ b/src/components/markdown/adapt-color-contrast.spec.ts
@@ -1,0 +1,86 @@
+import {
+    compositeOver,
+    contrastRatio,
+    parseColor,
+    relativeLuminance,
+} from './adapt-color-contrast';
+
+describe('parseColor', () => {
+    it.each([
+        ['rgb(0, 0, 0)', { r: 0, g: 0, b: 0, a: 1 }],
+        ['rgb(255,255,255)', { r: 255, g: 255, b: 255, a: 1 }],
+        ['rgba(10, 20, 30, 0.5)', { r: 10, g: 20, b: 30, a: 0.5 }],
+        ['rgba(10, 20, 30, 1)', { r: 10, g: 20, b: 30, a: 1 }],
+    ])('parses "%s"', (input, expected) => {
+        expect(parseColor(input)).toEqual(expected);
+    });
+
+    it('treats "transparent" as fully transparent black', () => {
+        expect(parseColor('transparent')).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    });
+
+    it.each(['', 'red', '#fff', 'hsl(0, 0%, 0%)', 'currentColor', null as any])(
+        'returns null for unsupported input "%s"',
+        (input) => {
+            expect(parseColor(input)).toBeNull();
+        }
+    );
+});
+
+describe('relativeLuminance', () => {
+    it('returns 1 for pure white', () => {
+        expect(relativeLuminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(1, 5);
+    });
+
+    it('returns 0 for pure black', () => {
+        expect(relativeLuminance({ r: 0, g: 0, b: 0 })).toBeCloseTo(0, 5);
+    });
+
+    it('is monotonic across grayscale', () => {
+        const dark = relativeLuminance({ r: 50, g: 50, b: 50 });
+        const mid = relativeLuminance({ r: 128, g: 128, b: 128 });
+        const light = relativeLuminance({ r: 200, g: 200, b: 200 });
+        expect(dark).toBeLessThan(mid);
+        expect(mid).toBeLessThan(light);
+    });
+});
+
+describe('contrastRatio', () => {
+    it('returns 21 for black on white (and vice versa)', () => {
+        const black = relativeLuminance({ r: 0, g: 0, b: 0 });
+        const white = relativeLuminance({ r: 255, g: 255, b: 255 });
+        expect(contrastRatio(black, white)).toBeCloseTo(21, 1);
+        expect(contrastRatio(white, black)).toBeCloseTo(21, 1);
+    });
+
+    it('returns 1 for identical colors', () => {
+        const l = relativeLuminance({ r: 128, g: 128, b: 128 });
+        expect(contrastRatio(l, l)).toBe(1);
+    });
+
+    it('passes WCAG AA for a dark navy on white', () => {
+        const navy = relativeLuminance({ r: 0x1f, g: 0x49, b: 0x7d });
+        const white = relativeLuminance({ r: 255, g: 255, b: 255 });
+        expect(contrastRatio(navy, white)).toBeGreaterThan(4.5);
+    });
+});
+
+describe('compositeOver', () => {
+    it('returns the foreground when alpha is 1', () => {
+        const fg = { r: 100, g: 150, b: 200, a: 1 };
+        const bg = { r: 0, g: 0, b: 0 };
+        expect(compositeOver(fg, bg)).toEqual({ r: 100, g: 150, b: 200 });
+    });
+
+    it('returns the background when alpha is 0', () => {
+        const fg = { r: 100, g: 150, b: 200, a: 0 };
+        const bg = { r: 50, g: 60, b: 70 };
+        expect(compositeOver(fg, bg)).toEqual({ r: 50, g: 60, b: 70 });
+    });
+
+    it('blends 50/50 when alpha is 0.5', () => {
+        const fg = { r: 0, g: 0, b: 0, a: 0.5 };
+        const bg = { r: 255, g: 255, b: 255 };
+        expect(compositeOver(fg, bg)).toEqual({ r: 128, g: 128, b: 128 });
+    });
+});

--- a/src/components/markdown/adapt-color-contrast.ts
+++ b/src/components/markdown/adapt-color-contrast.ts
@@ -1,0 +1,227 @@
+const MIN_CONTRAST_RATIO = 3;
+const STRIPPED_COLOR_ATTR = 'data-limel-stripped-color';
+const RGBA_PATTERN =
+    /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)$/i;
+const FALLBACK_BACKGROUND: RGB = { r: 255, g: 255, b: 255 };
+
+interface RGB {
+    r: number;
+    g: number;
+    b: number;
+}
+
+interface RGBA extends RGB {
+    a: number;
+}
+
+/**
+ * Walk the rendered DOM under `root` and remove inline `color` declarations
+ * that don't meet a 3:1 contrast ratio against their resolved background.
+ * Stripped colors are stashed on a data attribute so the same call can be
+ * used to re-evaluate after a theme change without re-rendering.
+ * @param root - Element whose descendants should be evaluated.
+ */
+export function adaptColorContrast(root: Element): void {
+    if (!root) {
+        return;
+    }
+    restoreStrippedColors(root);
+    const elements = root.querySelectorAll<HTMLElement>('[style*="color"]');
+    for (const el of elements) {
+        evaluateAndMaybeStrip(el);
+    }
+}
+
+function restoreStrippedColors(root: Element): void {
+    const stashed = root.querySelectorAll<HTMLElement>(
+        `[${STRIPPED_COLOR_ATTR}]`
+    );
+    for (const el of stashed) {
+        const original = el.getAttribute(STRIPPED_COLOR_ATTR);
+        if (original) {
+            el.style.color = original;
+        }
+        el.removeAttribute(STRIPPED_COLOR_ATTR);
+    }
+}
+
+function evaluateAndMaybeStrip(el: HTMLElement): void {
+    const inlineColor = el.style.color;
+    if (!inlineColor || isInheritKeyword(inlineColor)) {
+        return;
+    }
+
+    const fg = parseColor(getComputedStyle(el).color);
+    if (!fg || fg.a === 0) {
+        return;
+    }
+
+    const bg = resolveBackground(el);
+    if (!bg) {
+        return;
+    }
+
+    const composed = compositeOver(fg, bg);
+    const ratio = contrastRatio(
+        relativeLuminance(composed),
+        relativeLuminance(bg)
+    );
+    if (ratio >= MIN_CONTRAST_RATIO) {
+        return;
+    }
+
+    el.setAttribute(STRIPPED_COLOR_ATTR, inlineColor);
+    el.style.removeProperty('color');
+    if (!el.style.cssText) {
+        el.removeAttribute('style');
+    }
+}
+
+function isInheritKeyword(value: string): boolean {
+    const v = value.trim().toLowerCase();
+
+    return v === 'inherit' || v === 'currentcolor' || v === 'unset';
+}
+
+type BackgroundReading = RGBA | 'image' | 'transparent';
+
+function resolveBackground(start: Element): RGB | null {
+    let current: Element | null = start;
+    while (current) {
+        const reading = readBackgroundAt(current);
+        if (reading === 'image') {
+            return null;
+        }
+        if (reading !== 'transparent') {
+            return finalizeBackground(reading, nextAncestor(current));
+        }
+        current = nextAncestor(current);
+    }
+
+    return defaultBodyBackground();
+}
+
+function readBackgroundAt(el: Element): BackgroundReading {
+    const cs = getComputedStyle(el);
+    if (cs.backgroundImage && cs.backgroundImage !== 'none') {
+        return 'image';
+    }
+    const parsed = parseColor(cs.backgroundColor);
+    if (!parsed || parsed.a === 0) {
+        return 'transparent';
+    }
+
+    return parsed;
+}
+
+function finalizeBackground(reading: RGBA, parent: Element | null): RGB {
+    if (reading.a < 1 && parent) {
+        const upper = resolveBackground(parent);
+        if (upper) {
+            return compositeOver(reading, upper);
+        }
+    }
+
+    return { r: reading.r, g: reading.g, b: reading.b };
+}
+
+function defaultBodyBackground(): RGB {
+    if (!document.body) {
+        return FALLBACK_BACKGROUND;
+    }
+    const parsed = parseColor(getComputedStyle(document.body).backgroundColor);
+    if (parsed && parsed.a > 0) {
+        return { r: parsed.r, g: parsed.g, b: parsed.b };
+    }
+
+    return FALLBACK_BACKGROUND;
+}
+
+function nextAncestor(node: Element | null): Element | null {
+    if (!node) {
+        return null;
+    }
+    if (node.parentElement) {
+        return node.parentElement;
+    }
+    const root = node.getRootNode();
+    if (root instanceof ShadowRoot) {
+        return root.host;
+    }
+
+    return null;
+}
+
+/**
+ * Parse a CSS color string (as returned by `getComputedStyle`) into RGBA.
+ * Supports `rgb(...)`, `rgba(...)`, and the keyword `transparent`. Returns
+ * `null` for any other format (named colors, hex, hsl, var(), etc).
+ * @param value - The color string to parse.
+ */
+export function parseColor(value: string): RGBA | null {
+    if (!value) {
+        return null;
+    }
+    if (value === 'transparent') {
+        return { r: 0, g: 0, b: 0, a: 0 };
+    }
+    const match = RGBA_PATTERN.exec(value);
+    if (!match) {
+        return null;
+    }
+    const a = match[4] === undefined ? 1 : Number.parseFloat(match[4]);
+
+    return {
+        r: Number.parseInt(match[1], 10),
+        g: Number.parseInt(match[2], 10),
+        b: Number.parseInt(match[3], 10),
+        a,
+    };
+}
+
+/**
+ * Composite a translucent foreground over an opaque background using the
+ * standard "source-over" alpha blend. Returns the resulting opaque color.
+ * @param fg - Foreground color with alpha in [0..1].
+ * @param bg - Opaque background color.
+ */
+export function compositeOver(fg: RGBA, bg: RGB): RGB {
+    const a = fg.a;
+
+    return {
+        r: Math.round(fg.r * a + bg.r * (1 - a)),
+        g: Math.round(fg.g * a + bg.g * (1 - a)),
+        b: Math.round(fg.b * a + bg.b * (1 - a)),
+    };
+}
+
+/**
+ * WCAG 2.x relative luminance for an sRGB color. Returns a value in [0..1].
+ * @param rgb - The color whose luminance to compute.
+ */
+export function relativeLuminance(rgb: RGB): number {
+    const channel = (c: number) => {
+        const s = c / 255;
+
+        return s <= 0.039_28 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+    };
+
+    return (
+        0.2126 * channel(rgb.r) +
+        0.7152 * channel(rgb.g) +
+        0.0722 * channel(rgb.b)
+    );
+}
+
+/**
+ * WCAG contrast ratio between two relative luminances. Returns a value in
+ * [1..21]. Inputs may be passed in either order.
+ * @param l1 - First luminance.
+ * @param l2 - Second luminance.
+ */
+export function contrastRatio(l1: number, l2: number): number {
+    const lighter = Math.max(l1, l2);
+    const darker = Math.min(l1, l2);
+
+    return (lighter + 0.05) / (darker + 0.05);
+}

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -6,6 +6,7 @@ import { ImageIntersectionObserver } from './image-intersection-observer';
 import { hydrateCustomElements } from './hydrate-custom-elements';
 import { morphChildren } from './morph-dom';
 import { DEFAULT_MARKDOWN_WHITELIST } from './default-whitelist';
+import { adaptColorContrast } from './adapt-color-contrast';
 
 /**
  * The Markdown component receives markdown syntax
@@ -126,6 +127,8 @@ export class Markdown {
             // rehype-sanitize can't inspect values inside JSON strings.
             hydrateCustomElements(this.rootElement, combinedWhitelist);
 
+            adaptColorContrast(this.rootElement);
+
             this.setupImageIntersectionObserver();
         } catch (error) {
             console.error(error);
@@ -146,13 +149,22 @@ export class Markdown {
     private imageIntersectionObserver: ImageIntersectionObserver | null = null;
     private cachedConsumerWhitelist?: CustomElementDefinition[];
     private cachedCombinedWhitelist?: CustomElementDefinition[];
+    private prefersDarkMediaQuery?: MediaQueryList;
+    private themeMutationObserver?: MutationObserver;
+    private readonly handleThemeChange = () => {
+        if (this.rootElement) {
+            adaptColorContrast(this.rootElement);
+        }
+    };
 
     public async componentDidLoad() {
         this.textChanged();
+        this.setupThemeChangeListeners();
     }
 
     public disconnectedCallback() {
         this.cleanupImageIntersectionObserver();
+        this.teardownThemeChangeListeners();
     }
 
     public render() {
@@ -179,6 +191,43 @@ export class Markdown {
             this.imageIntersectionObserver.disconnect();
             this.imageIntersectionObserver = null;
         }
+    }
+
+    private setupThemeChangeListeners() {
+        if (globalThis.window === undefined) {
+            return;
+        }
+        if (typeof globalThis.matchMedia === 'function') {
+            this.prefersDarkMediaQuery = globalThis.matchMedia(
+                '(prefers-color-scheme: dark)'
+            );
+            this.prefersDarkMediaQuery.addEventListener(
+                'change',
+                this.handleThemeChange
+            );
+        }
+        if (
+            typeof globalThis.MutationObserver === 'function' &&
+            document.documentElement
+        ) {
+            this.themeMutationObserver = new globalThis.MutationObserver(
+                this.handleThemeChange
+            );
+            this.themeMutationObserver.observe(document.documentElement, {
+                attributes: true,
+                attributeFilter: ['data-theme'],
+            });
+        }
+    }
+
+    private teardownThemeChangeListeners() {
+        this.prefersDarkMediaQuery?.removeEventListener(
+            'change',
+            this.handleThemeChange
+        );
+        this.prefersDarkMediaQuery = undefined;
+        this.themeMutationObserver?.disconnect();
+        this.themeMutationObserver = undefined;
     }
 }
 


### PR DESCRIPTION
@coderabbitai summary

Fixes Lundalogik/crm-client#621
Fixes Lundalogik/crm-client#966

When an HTML email is rendered through `<limel-markdown>` in Lime CRM, inline `color:` styles from the source override the feed's themed text color and produce unreadable text — black on dark in dark mode, or white on white when the sender designed for a dark backdrop.

This adds a small post-render pass to `<limel-markdown>` that walks the rendered DOM and removes inline `color:` declarations whose contrast against the resolved background falls below 3:1. Stripped colors are stashed on `data-limel-stripped-color`, so flipping the theme restores them and re-evaluates against the new surface — no re-render needed. The 3.0:1 threshold keeps reds, blues and greens intact while still cleaning up the broken cases.

The change is default-on for every consumer of `<limel-markdown>`. There's no public API change.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

## Test plan:
- [ ] Render an email containing red, green and blue text in CRM. Verify the colors render correctly in both light and dark mode.
- [ ] Render an email with explicit `color: white` text on a CRM surface in light mode. Verify the text falls back to a readable color rather than being invisible.
- [ ] Render an email body whose text has an inline `color: black` in CRM dark mode. Verify the text doesn't render as black-on-dark.
- [ ] Toggle CRM between light and dark mode while a feed is open. Verify previously-stripped colors come back when contrast against the new surface is fine.
- [ ] Spot-check a regular markdown surface (e.g. comments, descriptions) authored inside CRM to confirm nothing visually changes for content that already had proper contrast.

### Browsers tested:

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS


<img width="633" height="634" alt="Screenshot 2026-05-06 at 13 30 57" src="https://github.com/user-attachments/assets/d7b09475-1c3a-4e61-bb32-999192ae2ebd" />

<img width="627" height="624" alt="Screenshot 2026-05-06 at 13 31 32" src="https://github.com/user-attachments/assets/f95e02f3-e3c5-4ff7-8277-8f588603255f" />
