### PR TITLE
fix(date-picker): avoid console error on disconnect

### DIFF
--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -186,7 +186,7 @@ export class DatePicker {
     }
 
     public disconnectedCallback() {
-        this.hideCalendar();
+        this.removeDocumentListeners();
     }
 
     public render() {
@@ -322,16 +322,21 @@ export class DatePicker {
         setTimeout(() => {
             this.showPortal = false;
         });
+
+        this.removeDocumentListeners();
+
+        if (!this.pickerIsAutoClosing()) {
+            this.fixFlatpickrFocusBug();
+        }
+    }
+
+    private removeDocumentListeners() {
         document.removeEventListener('mousedown', this.documentClickListener);
         document.removeEventListener(
             'blur',
             this.preventBlurFromCalendarContainer,
             { capture: true }
         );
-
-        if (!this.pickerIsAutoClosing()) {
-            this.fixFlatpickrFocusBug();
-        }
     }
 
     private fixFlatpickrFocusBug() {

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -342,9 +342,12 @@ export class DatePicker {
     private fixFlatpickrFocusBug() {
         // Flatpickr removes the focus from the input field
         // but the 'visual focus' is still there
-        const mdcTextField = new MDCTextField(
-            this.textField.shadowRoot.querySelector('.mdc-text-field')
-        );
+        const root =
+            this.textField?.shadowRoot?.querySelector('.mdc-text-field');
+        if (!root) {
+            return;
+        }
+        const mdcTextField = new MDCTextField(root);
         mdcTextField.getDefaultFoundation().deactivateFocus();
         mdcTextField.valid = !this.invalid;
     }


### PR DESCRIPTION
Refs https://github.com/Lundalogik/crm-client/issues/972

## Summary
- `disconnectedCallback` was calling `hideCalendar()` (added in fb4b92b13 to fix a memory leak), which in turn ran `fixFlatpickrFocusBug()`. That function constructs `new MDCTextField(this.textField.shadowRoot.querySelector('.mdc-text-field'))`, but during teardown the inner `limel-input-field`'s shadow tree is gone, so the lookup returns `null` and MDC throws `Cannot read properties of null (reading 'querySelector')` from its own initializer. The error surfaced as a console error in our integration tests.
- First commit narrows the disconnect path: extract a `removeDocumentListeners()` helper and call only that from `disconnectedCallback`. The portal toggle and focus fix have no purpose on a torn-down component.
- Second commit adds a defensive null guard inside `fixFlatpickrFocusBug` so any other caller hitting a missing shadow tree returns cleanly instead of throwing.

## Test plan
- [ ] Open a date-picker, pick a date, close — no regression in focus visuals
- [ ] Navigate away from a page with an open date-picker calendar — no console error
- [ ] Re-run the consumer integration tests that originally caught this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DatePicker stability by ensuring proper cleanup of event listeners when the component disconnects and the calendar is hidden.
  * Enhanced focus handling robustness with better validation checks to prevent potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
