### PR TITLE
fix(form): namespace schema $id by content to avoid stale validator

### DIFF
--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -181,6 +181,50 @@ test('validates against new schema after schema changes at runtime', async () =>
     expect(detail.errors[0].name).toBe('required');
 });
 
+test('validates against new content when schema changes but $id stays the same', async () => {
+    // Two schemas sharing an $id but differing in content must be treated
+    // as distinct by the validator — otherwise a cached validator from
+    // the first schema would reject the second schema's properties as
+    // additional.
+    const emptySchema = {
+        $id: 'shared-id',
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+    };
+    const schemaWithName = {
+        $id: 'shared-id',
+        type: 'object',
+        properties: { name: { type: 'string', title: 'Name' } },
+        required: ['name'],
+        additionalProperties: false,
+    };
+
+    const onValidate = vi.fn();
+    const { root, waitForChanges, setProps } = await renderForm({
+        schema: emptySchema,
+        value: {},
+        onValidate,
+    });
+
+    // Swap to a schema that requires a property the value doesn't yet have.
+    await setProps({ schema: schemaWithName, value: {} });
+    await waitForReactRender(root, waitForChanges);
+
+    const invalidDetail = onValidate.mock.lastCall[0].detail;
+    expect(invalidDetail.valid).toBe(false);
+    expect(invalidDetail.errors[0].name).toBe('required');
+
+    // Provide the required value — should now validate.
+    await setProps({ schema: schemaWithName, value: { name: 'hello' } });
+    await waitForReactRender(root, waitForChanges);
+
+    const validDetail = onValidate.mock.lastCall[0].detail;
+    expect(validDetail.valid).toBe(true);
+    expect(validDetail.errors).toEqual([]);
+});
+
 test('renders disabled fields when disabled prop is set', async () => {
     const { formContent } = await renderForm({
         schema: stringSchema,

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -170,7 +170,7 @@ export class Form {
             React.createElement(
                 JSONSchemaForm,
                 {
-                    schema: this.schema,
+                    schema: this.prepareSchema(this.schema),
                     formData: this.value,
                     onChange: this.handleChange,
                     widgets: widgets,
@@ -209,9 +209,40 @@ export class Form {
     private validateFormData() {
         const { errors } = rjsfValidator.validateFormData(
             this.value ?? {},
-            this.schema
+            this.prepareSchema(this.schema)
         );
         this.emitValidationStatus(errors);
+    }
+
+    /**
+     * Returns a copy of the schema with `$id` replaced by a content-based
+     * value, so the validator never confuses two schemas that share the
+     * same `$id` but differ in content — e.g. a server schema reused with
+     * a different subset of properties at runtime.
+     *
+     * The new `$id` is built from a short numeric fingerprint of the
+     * stringified content. A fingerprint (rather than the content itself)
+     * keeps the value short and URI-safe — `$id` is parsed as a URI by
+     * the validator and must not contain JSON-shaped characters.
+     *
+     * @param schema - the schema to prepare
+     */
+    private prepareSchema(schema: FormSchema): FormSchema {
+        const { $id, ...rest } = schema;
+        const json = JSON.stringify(rest);
+
+        let fingerprint = 5381;
+        for (let i = 0; i < json.length; i++) {
+            fingerprint =
+                ((fingerprint << 5) + fingerprint + json.codePointAt(i)) &
+                0xff_ff_ff_ff;
+        }
+        const contentId = (fingerprint >>> 0).toString(36);
+
+        return {
+            ...schema,
+            $id: $id ? `${$id}-${contentId}` : contentId,
+        };
     }
 
     private hasExtraErrors(): boolean {


### PR DESCRIPTION
## Summary

When a consumer renders `limel-form` with a schema that reuses the same `$id` while its content changes between renders (e.g. a server schema whose `properties` get filtered based on user input), the form's `validate` event would fire with errors that don't match the schema's actual content — most visibly, fields would be reported as "additional properties" even though they're declared in `properties`.

The root cause is that the validator caches compiled validators by `$id`. The first variant compiled under a given `$id` is reused for every later variant with the same `$id`, so swapping the schema's content silently has no effect on validation.

This fix wraps the schema in a copy whose `$id` becomes `<original-$id>-<fingerprint>`, where the fingerprint is a short hash of the stringified content (sans `$id`), before handing it to RJSF and the validator. Distinct content produces a distinct cache entry; identical content still hits the cache. The fingerprint — rather than the raw content — keeps `$id` short and URI-safe, since the validator parses it as a URI and chokes on JSON-shaped characters. The consumer's original schema is left untouched.

Fixes Lundalogik/crm-client#971.

## Test plan

- [x] New regression test in `form.e2e.tsx` covers the scenario (same `$id`, schema gains a required property, value updates to satisfy it).
- [x] Existing form e2e suite still passes (42/42).
- [x] Existing form spec suite still passes (56/56).
- [x] Manual verification: open the bulk-edit dialog, pick a text field, type — the Update button enables. Lime Admin loads schemas without URI-malformed errors and at expected speed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where form validation would not properly update when schema requirements changed dynamically while maintaining the same schema identifier. Forms now correctly re-validate against updated requirements.

* **Tests**
  * Added end-to-end validation test covering dynamic schema requirement changes at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->