### PR TITLE
fix(chip-set): don't enter edit mode on chip click

### DIFF
--- a/src/components/chip-set/chip-set.e2e.tsx
+++ b/src/components/chip-set/chip-set.e2e.tsx
@@ -259,6 +259,40 @@ describe('limel-chip-set', () => {
             });
         });
 
+        it('emits startEdit event when input receives focus', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-chip-set
+                    type="input"
+                    value={getValue()}
+                ></limel-chip-set>
+            );
+            const startEditSpy = spyOnEvent('startEdit');
+            await waitForChanges();
+
+            const input = root.shadowRoot!.querySelector('input');
+            input!.focus();
+            await waitForChanges();
+
+            expect(startEditSpy).toHaveReceivedEventTimes(1);
+        });
+
+        it('does not emit startEdit event when a chip is clicked', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-chip-set
+                    type="input"
+                    value={getValue()}
+                ></limel-chip-set>
+            );
+            const startEditSpy = spyOnEvent('startEdit');
+            await waitForChanges();
+
+            const chips = root.shadowRoot!.querySelectorAll('limel-chip');
+            (chips[0] as HTMLElement).click();
+            await waitForChanges();
+
+            expect(startEditSpy).toHaveReceivedEventTimes(0);
+        });
+
         describe('when disabled', () => {
             it('hides the remove button on removable chips', async () => {
                 const { root, waitForChanges } = await render(

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -21,6 +21,14 @@ import { LimelChipCustomEvent } from '../../components';
 import { createRandomString } from '../../util/random-string';
 import { IconName } from '../../global/shared-types/icon.types';
 
+type ChipAnnotatedEvent = Event & { Lime: { chip: Chip } };
+
+function isChipAnnotatedEvent(
+    event: Event | undefined
+): event is ChipAnnotatedEvent {
+    return !!(event as ChipAnnotatedEvent | undefined)?.Lime?.chip;
+}
+
 /**
  * :::note
  * **Regarding `click` and `interact` events:**
@@ -500,13 +508,22 @@ export class ChipSet {
 
     /**
      * Enter edit mode when the text field receives focus. When editMode is true, the input element will be visible
+     * @param event - The originating click or focus event, if any. When a
+     * click originates from a chip body (marked by
+     * {@link catchInputChipClicks} as `event.Lime.chip`), edit mode is
+     * not entered: the chip's `interact` event is the consumer's signal
+     * and the input should not steal focus alongside it.
      */
-    private handleTextFieldFocus() {
+    private handleTextFieldFocus(event?: Event) {
         if (this.disabled || this.readonly) {
             return;
         }
 
         if (this.editMode) {
+            return;
+        }
+
+        if (isChipAnnotatedEvent(event)) {
             return;
         }
 


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents edit mode from entering when interacting with a chip; edit mode now only starts on direct input focus.

* **Tests**
  * Added end-to-end tests verifying the input-style chip set emits the edit-start event on input focus and not when a chip is clicked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

A click on a chip in an input chip-set bubbled up to the container's
`onClick`, which called `handleTextFieldFocus` and entered edit mode.
The input stole focus and emitted `startEdit` alongside the chip's
own `interact` event, so consumers received two competing signals
for one click.

`catchInputChipClicks` already annotates chip-originated events with
`Lime.chip`. `handleTextFieldFocus` now checks for that marker and
skips the edit-mode transition when present. Added a regression test
that clicking a chip emits zero `startEdit` events, plus a sanity
test that focusing the input still emits one.

## Review:
- [x] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS