### PR TITLE
feat(chip-set): non-removable chips in input chip-sets

### DIFF
--- a/src/components/chip-set/chip-set-input-helpers.ts
+++ b/src/components/chip-set/chip-set-input-helpers.ts
@@ -119,8 +119,15 @@ function handleBackspace(host, event) {
 }
 
 function removeChip(host) {
-    if (host.inputChipIndexSelected !== null) {
-        host.removeChip(host.value[host.inputChipIndexSelected].id);
-        host.inputChipIndexSelected = null;
+    if (host.inputChipIndexSelected === null) {
+        return;
     }
+
+    const chip = host.value[host.inputChipIndexSelected];
+    if (chip.removable === false) {
+        return;
+    }
+
+    host.removeChip(chip.id);
+    host.inputChipIndexSelected = null;
 }

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -69,6 +69,7 @@ function isChipAnnotatedEvent(
  * @exampleComponent limel-example-chip-set-input-type-with-menu-items
  * @exampleComponent limel-example-chip-set-input-type-text
  * @exampleComponent limel-example-chip-set-input-type-search
+ * @exampleComponent limel-example-chip-set-input-non-removable
  * @exampleComponent limel-example-chip-icon-color
  * @exampleComponent limel-example-chip-set-image
  * @exampleComponent limel-example-chip-set-composite

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -752,6 +752,11 @@ export class ChipSet {
             return;
         }
 
+        if (!this.value.some((chip) => chip.removable !== false)) {
+            // Nothing to clear if every chip is locked.
+            return;
+        }
+
         return (
             <a
                 href=""
@@ -771,7 +776,10 @@ export class ChipSet {
 
     private handleDeleteAllIconClick(event: Event) {
         event.preventDefault();
-        this.change.emit([]);
+        const lockedChips = this.value.filter(
+            (chip) => chip.removable === false
+        );
+        this.change.emit(lockedChips);
     }
 
     private renderDelimiter() {

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -631,7 +631,7 @@ export class ChipSet {
 
     private getChipProps(chip: Chip, chipType: ChipType) {
         const removable =
-            this.type === 'input' && chip.removable && !this.readonly;
+            this.type === 'input' && chip.removable !== false && !this.readonly;
         const readonly = this.readonly && this.type !== 'input';
 
         return {

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -75,6 +75,15 @@ export interface Chip<T = any> {
 
     /**
      * Whether the chip should be removable. Not valid for `choice`.
+     *
+     * For chip-sets of `type="input"`, chips are removable by default.
+     * Set this to `false` to "lock" an individual chip so that it cannot
+     * be removed by the user — neither via the remove button, nor with
+     * Backspace/Delete, nor by the "Clear all" button. Locked chips
+     * remain fully interactive (clicks still emit `interact` events).
+     *
+     * If the entire chip-set is `disabled` or `readonly`, the remove
+     * button is hidden on all chips regardless of this flag.
      */
     removable?: boolean;
 

--- a/src/components/chip-set/examples/chip-set-input-non-removable.tsx
+++ b/src/components/chip-set/examples/chip-set-input-non-removable.tsx
@@ -1,0 +1,106 @@
+import { Chip, LimelChipSetCustomEvent } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+import { ENTER } from '../../../util/keycodes';
+
+/**
+ * Input chip set with non-removable chips
+ *
+ * In a chip-set of `type="input"`, chips are removable by default.
+ * To "lock" an individual chip so the user cannot remove it,
+ * set `removable: false` on that chip.
+ *
+ * A non-removable chip:
+ *
+ * - has no remove button
+ * - cannot be deleted with <kbd>Backspace</kbd> or <kbd>Delete</kbd>
+ * - is left untouched by the "Clear all" button (which hides itself
+ *   when every remaining chip is locked)
+ *
+ * :::note
+ * The non-removable chips remain fully interactive. It means clicking them still emits
+ * the `interact` event. This is the right tool for pre-filled values
+ * that the consumer always wants present (for example, the current
+ * user in a list of meeting participants, or a mandatory tag on a
+ * record), while still letting the user add and remove other chips
+ * freely. If you want to disable interaction entirely, use the
+ * chip-set's `readonly` or `disabled` props instead.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-chip-set-input-non-removable',
+    shadow: true,
+})
+export class ChipSetInputNonRemovableExample {
+    @State()
+    private value: Chip[] = [
+        {
+            id: 'me',
+            text: 'You',
+            icon: 'user_shield',
+            removable: false,
+        },
+        {
+            id: 'lucy',
+            text: 'Lucy',
+            icon: 'person_female',
+        },
+        {
+            id: 'befkadu',
+            text: 'Befkadu',
+            icon: 'person_male',
+        },
+    ];
+
+    @State()
+    private textValue = '';
+
+    public render() {
+        return (
+            <Host>
+                <limel-chip-set
+                    type="input"
+                    label="Meeting participants"
+                    helperText="You are always a participant and cannot be removed."
+                    searchLabel="Add a participant & press Enter"
+                    value={this.value}
+                    onChange={this.handleChange}
+                    onInput={this.handleInput}
+                    onInteract={this.handleInteraction}
+                    onKeyUp={this.onKeyUp}
+                />
+                <limel-example-value value={this.value} />
+            </Host>
+        );
+    }
+
+    private handleInput = (
+        event: LimelChipSetCustomEvent<string> | InputEvent
+    ) => {
+        if (event instanceof CustomEvent) {
+            this.textValue = event.detail;
+        }
+    };
+
+    private onKeyUp = (event: KeyboardEvent) => {
+        if (event.key === ENTER && this.textValue.trim()) {
+            const name = this.textValue.trim();
+            this.value = [
+                ...this.value,
+                {
+                    id: name,
+                    text: name,
+                    icon: 'person_male',
+                },
+            ];
+            this.textValue = '';
+        }
+    };
+
+    private handleChange = (event: LimelChipSetCustomEvent<Chip[]>) => {
+        this.value = event.detail;
+    };
+
+    private handleInteraction = (event: CustomEvent<Chip>) => {
+        console.log('Chip interacted with:', event.detail);
+    };
+}


### PR DESCRIPTION
## Summary
<img width="706" height="543" alt="image" src="https://github.com/user-attachments/assets/50bc4ead-aeb3-4c05-a8c5-4dc8c46ef81f" />

This branch lets consumers pin individual chips in a chip-set of `type="input"` so they cannot be removed by the user — useful for pre-filled values like the current user in a meeting-participants picker, or a mandatory tag on a record. The pinned chip stays fully interactive (clicks still emit `interact`); it just cannot be deleted.

The chip-set already exposed a per-chip `removable` flag, but it was only half-wired: it controlled whether the X button rendered, while Backspace/Delete and the "Clear all" button ignored it. The flag was effectively a UI hint, not a contract. This PR turns it into a real lock and flips its default to match the natural mental model.

## What's in each commit

1. **`fix(chip-set): make `removable: false` actually lock the chip`** — the robustness fix. `removeChip` in the keyboard helpers now bails out when the selected chip has `removable === false`, and `handleDeleteAllIconClick` filters locked chips out of the wipe. The "Clear all" button also hides itself when nothing remains to clear.
2. **`feat(chip-set): default input chips to removable`** — flips the default. Chips are removable unless the consumer sets `removable: false`. The check changes from `chip.removable` to `chip.removable !== false`. The `Chip.removable` JSDoc is rewritten to spell out the new default and what "locked" means.
3. **`docs(chip-set): add non-removable input chip-set example`** — a meeting-participants example where "You" is pinned while the other participants can be added/removed freely.

## Backward compatibility note

The default flip is technically a visible change: any consumer who previously relied on **omitting** `removable` to hide the remove button will now see the X appear on those chips. The fix is one line — set `removable: false` explicitly. All in-repo examples already set the flag explicitly so they're unaffected.

## Test plan

- [x] All 16 existing chip-set e2e tests pass
- [x] Lint clean on touched files
- [ ] Manually verify in the docs site: locked chip has no X, Backspace/Delete don't remove it, "Clear all" leaves it, clicking it still fires `interact`
- [ ] Verify the new example renders and behaves as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chips can be locked as non-removable; locked chips remain interactive but cannot be deleted.

* **Bug Fixes**
  * Removal now respects chip lock state and handles no-selection edge cases.
  * "Clear all" only appears when removable chips exist and preserves locked chips when used.

* **Documentation**
  * Added an example demonstrating input-mode chip sets with a locked (non-removable) chip.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->