### PR TITLE
fix(form): mark collapsible sections as invalid when they contain invalid fields

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -502,6 +502,7 @@ export namespace Components {
         "disabled": boolean;
         "errors": ValidationError;
         "propsFactory"?: (schema: FormSchema) => Record<string, any>;
+        "revealErrors": boolean;
         "schema": FormSchema;
         "transformErrors"?: (errors: FormError[]) => FormError[];
         "value": object;
@@ -2496,6 +2497,7 @@ export namespace JSX {
         "onChange"?: (event: LimelFormCustomEvent<object>) => void;
         "onValidate"?: (event: LimelFormCustomEvent<ValidationStatus>) => void;
         "propsFactory"?: (schema: FormSchema) => Record<string, any>;
+        "revealErrors"?: boolean;
         "schema"?: FormSchema;
         "transformErrors"?: (errors: FormError[]) => FormError[];
         "value"?: object;
@@ -2505,6 +2507,8 @@ export namespace JSX {
     export interface LimelFormAttributes {
         // (undocumented)
         "disabled": boolean;
+        // (undocumented)
+        "revealErrors": boolean;
     }
 
     // @internal @deprecated

--- a/example-tests/axe-baseline.json
+++ b/example-tests/axe-baseline.json
@@ -531,6 +531,12 @@
         "color-contrast",
         "label"
     ],
+    "limel-example-form-invalid-section": [
+        "aria-hidden-focus",
+        "button-name",
+        "color-contrast",
+        "label"
+    ],
     "limel-example-form-layout": [
         "aria-hidden-focus"
     ],

--- a/src/components/form/adapters/widget-adapter.ts
+++ b/src/components/form/adapters/widget-adapter.ts
@@ -61,13 +61,15 @@ export class LimeElementsWidgetAdapter extends React.Component<WidgetAdapterProp
 
     private isInvalid() {
         const { modified } = this.state;
-        const { rawErrors, required, schema } = this.props.widgetProps;
+        const { rawErrors, required, schema, registry } =
+            this.props.widgetProps;
 
         return isFieldInvalid({
             hasErrors: !!rawErrors,
             modified: modified,
             hasValue: hasValue(this.getValue()),
             required: isFieldRequired({ required, minItems: schema.minItems }),
+            revealErrors: registry?.formContext?.revealErrors === true,
         });
     }
 

--- a/src/components/form/examples/invalid-section-form.scss
+++ b/src/components/form/examples/invalid-section-form.scss
@@ -1,0 +1,16 @@
+:host(limel-example-form-invalid-section) {
+    --example-controls-column-layout: auto-fit;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+footer {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
+limel-button.save-has-errors {
+    --lime-primary-color: var(--limel-theme-error-color);
+}

--- a/src/components/form/examples/invalid-section-form.tsx
+++ b/src/components/form/examples/invalid-section-form.tsx
@@ -1,0 +1,164 @@
+import { ValidationError, ValidationStatus } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+import { isEqual } from 'lodash-es';
+import {
+    InvalidSectionFormData,
+    schema,
+    serverErrors,
+} from './invalid-section-schema';
+
+const createInitialFormData = (): InvalidSectionFormData => ({
+    personal: {
+        name: 'Bruce Wayne',
+        email: '', // empty on purpose
+    },
+    work: {
+        company: 'Wayne Enterprises',
+        jobTitle: '', // empty on purpose, hidden behind a collapsed section
+        startYear: 1939,
+    },
+    contacts: [
+        { name: 'Alfred Pennyworth', phone: '+44 7700 900123' },
+        { name: 'Lucius Fox', phone: '' }, // empty on purpose, inside a collapsed array item
+    ],
+});
+
+/**
+ * Visualizing errors in forms
+ * Collapsible sections reflect the validity of their nested fields.
+ *
+ * The form is pre-filled the way the user would receive it from a backend:
+ * most values present, but three required fields intentionally empty, for
+ * example because those properties were made `required` after the
+ * record was saved: `Email` in the first section, `Job title` in the
+ * collapsed `Work` section, and `Phone` for the `Lucius Fox` entry in the
+ * `Emergency contacts` array (whose item is also collapsed). Neither field
+ * is flagged as invalid on load, to avoid pestering the user before they've
+ * decided to save. The empty fields hidden behind a collapsed section or a
+ * collapsed array item are the interesting ones; because the user can't see
+ * them without expanding, which is why those headers need to surface the
+ * problem too.
+ *
+ * As soon as the user changes any field, the `Save` button becomes
+ * enabled. If the form has problems, the button shows an error icon
+ * and a red background — but it stays clickable. Clicking it sets
+ * `revealErrors` on `limel-form` to `true`, which lights up every
+ * required-empty / invalid field and every section that contains one.
+ * From there the user can follow the red thread to find what to fix.
+ *
+ * `Discard` resets both the data and `revealErrors`, so the form goes
+ * silent again as if the page had just loaded.
+ *
+ * The toggle below also forces a server-side validation error on
+ * `Email`, demonstrating the same behaviour driven by the `errors`
+ * prop instead of by user interaction.
+ *
+ * @sourceFile invalid-section-schema.ts
+ */
+@Component({
+    tag: 'limel-example-form-invalid-section',
+    shadow: true,
+    styleUrl: 'invalid-section-form.scss',
+})
+export class InvalidSectionFormExample {
+    @State()
+    private formData: InvalidSectionFormData = createInitialFormData();
+
+    @State()
+    private valid = false;
+
+    @State()
+    private revealErrors = false;
+
+    @State()
+    private withServerErrors = false;
+
+    public render() {
+        const errors: ValidationError | undefined = this.withServerErrors
+            ? serverErrors
+            : undefined;
+        const dirty = !isEqual(this.formData, createInitialFormData());
+        const hasProblems = !this.valid || this.withServerErrors;
+        const saveLooksBroken = dirty && hasProblems;
+
+        return (
+            <Host>
+                <limel-form
+                    schema={schema}
+                    value={this.formData}
+                    errors={errors}
+                    revealErrors={this.revealErrors}
+                    onChange={this.handleFormChange}
+                    onValidate={this.handleFormValidate}
+                />
+                <footer>
+                    <limel-button
+                        label="Discard"
+                        disabled={!dirty}
+                        onClick={this.handleDiscard}
+                    />
+                    <limel-button
+                        id="invalid-section-save"
+                        class={{ 'save-has-errors': saveLooksBroken }}
+                        label="Save"
+                        primary={true}
+                        icon={saveLooksBroken ? 'error' : undefined}
+                        disabled={!dirty}
+                        onClick={this.handleSave}
+                    />
+                    {this.renderSaveTooltip(saveLooksBroken)}
+                </footer>
+                <limel-example-controls>
+                    <limel-checkbox
+                        label="Simulate a server-side error on Email"
+                        checked={this.withServerErrors}
+                        onChange={this.handleToggleServerErrors}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private renderSaveTooltip(show: boolean) {
+        if (!show) {
+            return null;
+        }
+
+        return (
+            <limel-tooltip
+                elementId="invalid-section-save"
+                label="Form has errors. Click to reveal."
+            />
+        );
+    }
+
+    private handleFormChange = (event: CustomEvent<InvalidSectionFormData>) => {
+        this.formData = event.detail;
+    };
+
+    private handleFormValidate = (event: CustomEvent<ValidationStatus>) => {
+        this.valid = event.detail.valid;
+    };
+
+    private handleToggleServerErrors = (event: CustomEvent<boolean>) => {
+        this.withServerErrors = event.detail;
+    };
+
+    private handleSave = () => {
+        const hasProblems = !this.valid || this.withServerErrors;
+        if (hasProblems) {
+            this.revealErrors = true;
+
+            return;
+        }
+
+        const json = JSON.stringify(this.formData, null, '    ');
+        alert(`Saving:\n\n${json}`);
+        this.revealErrors = false;
+    };
+
+    private handleDiscard = () => {
+        this.formData = createInitialFormData();
+        this.revealErrors = false;
+    };
+}

--- a/src/components/form/examples/invalid-section-schema.ts
+++ b/src/components/form/examples/invalid-section-schema.ts
@@ -1,0 +1,92 @@
+import { FormSchema, ValidationError } from '@limetech/lime-elements';
+
+export interface InvalidSectionFormData {
+    personal?: {
+        name?: string;
+        email?: string;
+    };
+    work?: {
+        company?: string;
+        jobTitle?: string;
+        startYear?: number;
+    };
+    contacts?: Array<{
+        name?: string;
+        phone?: string;
+    }>;
+}
+
+export const schema: FormSchema<InvalidSectionFormData> = {
+    type: 'object',
+    properties: {
+        personal: {
+            type: 'object',
+            title: 'Personal information',
+            properties: {
+                name: {
+                    type: 'string',
+                    title: 'Name',
+                    minLength: 1,
+                },
+                email: {
+                    type: 'string',
+                    title: 'Email',
+                    format: 'email',
+                    minLength: 1,
+                },
+            },
+            required: ['name', 'email'],
+            lime: {
+                collapsible: true,
+                collapsed: false,
+            },
+        },
+        work: {
+            type: 'object',
+            title: 'Work',
+            properties: {
+                company: {
+                    type: 'string',
+                    title: 'Company',
+                    minLength: 1,
+                },
+                jobTitle: {
+                    type: 'string',
+                    title: 'Job title',
+                    minLength: 1,
+                },
+                startYear: {
+                    type: 'integer',
+                    title: 'Start year',
+                    minimum: 1900,
+                    description: 'The start year must be 1900 or later.',
+                },
+            },
+            required: ['company', 'jobTitle'],
+            lime: {
+                collapsible: true,
+                collapsed: true,
+            },
+        },
+        contacts: {
+            type: 'array',
+            title: 'Emergency contacts',
+            items: {
+                type: 'object',
+                title: 'Contact',
+                properties: {
+                    name: { type: 'string', title: 'Name', minLength: 1 },
+                    phone: { type: 'string', title: 'Phone', minLength: 1 },
+                },
+                required: ['name', 'phone'],
+            },
+            lime: {},
+        },
+    },
+};
+
+export const serverErrors: ValidationError = {
+    personal: {
+        email: ['This email is already registered'],
+    },
+};

--- a/src/components/form/fields/array-field.ts
+++ b/src/components/form/fields/array-field.ts
@@ -4,6 +4,7 @@ import { FieldProps, FieldPathList } from '@rjsf/utils';
 import { cloneDeep, isPlainObject, set } from 'lodash-es';
 import { resetDependentFields, schemaAllowsNull } from './field-helpers';
 import { ARRAY_REORDER_EVENT } from '../templates/array-field';
+import { ArrayItemErrorsContext } from '../templates/array-context';
 import { FormSchema } from '../form.types';
 
 const { fields: defaultFields } = getDefaultRegistry();
@@ -210,10 +211,18 @@ export class ArrayField extends React.Component<FieldProps> {
             onChange: this.handleChange,
         };
 
+        // Share the array's `errorSchema` (keyed by item index) with the
+        // item templates rendered below. RJSF does not forward it to a
+        // non-fixed array's `ArrayFieldItemTemplate`, so a collapsed item
+        // would otherwise have no way to tell it contains invalid fields.
         return React.createElement(
             'div',
             { ref: this.setWrapper },
-            React.createElement(BaseArrayField as any, arrayProps)
+            React.createElement(
+                ArrayItemErrorsContext.Provider,
+                { value: this.props.errorSchema ?? null },
+                React.createElement(BaseArrayField as any, arrayProps)
+            )
         );
     }
 }

--- a/src/components/form/fields/schema-field.ts
+++ b/src/components/form/fields/schema-field.ts
@@ -120,13 +120,14 @@ export class SchemaField extends React.Component<FieldProps> {
 
     private isInvalid() {
         const { modified } = this.state;
-        const { errorSchema, required, schema } = this.props;
+        const { errorSchema, required, schema, registry } = this.props;
 
         return isFieldInvalid({
             hasErrors: !isEmpty(errorSchema),
             modified: modified,
             hasValue: hasValue(this.props.formData),
             required: isFieldRequired({ required, minItems: schema.minItems }),
+            revealErrors: registry.formContext?.revealErrors === true,
         });
     }
 

--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -6,6 +6,7 @@ import {
     booleanSchema,
     enumSchema,
     requiredFieldSchema,
+    twoRequiredFieldsSchema,
     emailFormatSchema,
     arraySchema,
     nestedObjectSchema,
@@ -162,6 +163,54 @@ test('does not emit validate on mount when value is already valid', async () => 
         (call) => call[0].detail.valid === true
     );
     expect(validCalls).toEqual([]);
+});
+
+test('does not flag untouched required-empty fields by default', async () => {
+    const { formContent } = await renderForm({
+        schema: twoRequiredFieldsSchema,
+        value: {},
+    });
+
+    const inputs = formContent.querySelectorAll('limel-input-field');
+    expect([...inputs].every((el: any) => el.invalid === false)).toBe(true);
+});
+
+test('flags untouched required-empty siblings when `revealErrors` is set to true', async () => {
+    const { formContent, change, root, waitForChanges, setProps } =
+        await renderForm({
+            schema: twoRequiredFieldsSchema,
+            value: {},
+        });
+
+    // A change first, so RJSF has propagated its per-field error state.
+    await change('Name', 'Alice');
+    await setProps({ revealErrors: true });
+    await waitForReactRender(root, waitForChanges);
+
+    const nickname = [
+        ...formContent.querySelectorAll('limel-input-field'),
+    ].find((el) => el.getAttribute('label') === 'Nickname') as any;
+
+    expect(nickname.invalid).toBe(true);
+});
+
+test('unflags untouched required-empty siblings when `revealErrors` is reset', async () => {
+    const { formContent, change, root, waitForChanges, setProps } =
+        await renderForm({
+            schema: twoRequiredFieldsSchema,
+            value: {},
+            revealErrors: true,
+        });
+
+    await change('Name', 'Alice');
+    await setProps({ revealErrors: false, value: {} });
+    await waitForReactRender(root, waitForChanges);
+
+    const nickname = [
+        ...formContent.querySelectorAll('limel-input-field'),
+    ].find((el) => el.getAttribute('label') === 'Nickname') as any;
+
+    expect(nickname.invalid).toBe(false);
 });
 
 test('validates against new schema after schema changes at runtime', async () => {

--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -11,11 +11,13 @@ import {
     arraySchema,
     nestedObjectSchema,
     arrayOfObjectsSchema,
+    arrayOfObjectsSchemaWithRequired,
     dynamicSchema,
     dynamicSchemaUpdated,
     helpSchema,
     gridLayoutSchema,
     collapsibleSchema,
+    collapsibleSchemaWithRequired,
     dateSchema,
     integerSchema,
     serverErrorsSchema,
@@ -370,6 +372,74 @@ test('renders collapsible section when schema has lime.collapsible', async () =>
     const collapsible = formContent.querySelector('limel-collapsible-section');
     expect(collapsible).toBeTruthy();
     expect(collapsible.getAttribute('header')).toEqual('Details');
+});
+
+test('does not mark collapsible section as invalid when all nested fields are valid', async () => {
+    const { formContent } = await renderForm({
+        schema: collapsibleSchema,
+        value: { details: { info: 'ok' } },
+        revealErrors: true,
+    });
+
+    const collapsible = formContent.querySelector('limel-collapsible-section');
+    expect(collapsible.invalid).toBe(false);
+});
+
+test('keeps collapsible section silent until `revealErrors` is true, even with server errors', async () => {
+    const { formContent, root, waitForChanges, setProps } = await renderForm({
+        schema: collapsibleSchema,
+        value: { details: { info: 'value' } },
+        errors: { details: { info: ['Something is wrong'] } },
+    });
+
+    const collapsible = formContent.querySelector('limel-collapsible-section');
+    expect(collapsible.invalid).toBe(false);
+
+    await setProps({ revealErrors: true });
+    await waitForReactRender(root, waitForChanges);
+
+    expect(collapsible.invalid).toBe(true);
+});
+
+test('marks collapsible section as invalid when a nested field fails schema validation and `revealErrors` is true', async () => {
+    const { formContent, change, root, waitForChanges, setProps } =
+        await renderForm({
+            schema: collapsibleSchemaWithRequired,
+            value: { details: { info: 'something' } },
+        });
+
+    await change('Info', '');
+    await setProps({ revealErrors: true });
+    await waitForReactRender(root, waitForChanges);
+
+    const collapsible = formContent.querySelector('limel-collapsible-section');
+    expect(collapsible.invalid).toBe(true);
+});
+
+test('marks a collapsed array-of-objects item as invalid when it contains errors and `revealErrors` is true', async () => {
+    // Both items stay collapsed because their data is non-empty, so the
+    // invalid field inside the second item is never rendered. The header
+    // must still surface the problem, which it can only do by reading the
+    // `errorSchema` rather than walking its (unrendered) children.
+    const { formContent, root, waitForChanges, setProps } = await renderForm({
+        schema: arrayOfObjectsSchemaWithRequired,
+        value: { heroes: [{ name: 'Batman' }, { name: 'Robin' }] },
+        errors: { heroes: { 1: { name: ['This hero is already taken'] } } },
+    });
+
+    const items = formContent.querySelectorAll('limel-collapsible-section');
+    expect(items.length).toBe(2);
+
+    // Silent until errors are revealed, even though item 2 has an error.
+    expect((items[1] as any).invalid).toBe(false);
+
+    await setProps({ revealErrors: true });
+    await waitForReactRender(root, waitForChanges);
+
+    // The invalid item reflects the error on its still-collapsed header,
+    // while the valid item stays silent.
+    expect((items[0] as any).invalid).toBe(false);
+    expect((items[1] as any).invalid).toBe(true);
 });
 
 test('renders custom component when schema has lime.component', async () => {

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -40,6 +40,15 @@ export const requiredFieldSchema: FormSchema = {
     required: ['name'],
 };
 
+export const twoRequiredFieldsSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        name: { type: 'string', title: 'Name' },
+        nickname: { type: 'string', title: 'Nickname' },
+    },
+    required: ['name', 'nickname'],
+};
+
 export const emailFormatSchema: FormSchema = {
     type: 'object',
     properties: {

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -99,6 +99,24 @@ export const arrayOfObjectsSchema: FormSchema = {
     },
 };
 
+export const arrayOfObjectsSchemaWithRequired: FormSchema = {
+    type: 'object',
+    properties: {
+        heroes: {
+            type: 'array',
+            title: 'Heroes',
+            items: {
+                type: 'object',
+                title: 'Hero',
+                properties: {
+                    name: { type: 'string', title: 'Name', minLength: 1 },
+                },
+                required: ['name'],
+            },
+        },
+    },
+};
+
 export const dynamicSchema: FormSchema = {
     type: 'object',
     properties: {
@@ -152,6 +170,23 @@ export const collapsibleSchema: FormSchema = {
             properties: {
                 info: { type: 'string', title: 'Info' },
             },
+            lime: {
+                collapsible: true,
+            },
+        },
+    },
+};
+
+export const collapsibleSchemaWithRequired: FormSchema = {
+    type: 'object',
+    properties: {
+        details: {
+            type: 'object',
+            title: 'Details',
+            properties: {
+                info: { type: 'string', title: 'Info' },
+            },
+            required: ['info'],
             lime: {
                 collapsible: true,
             },

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -96,6 +96,15 @@ export class Form {
     public errors: ValidationError;
 
     /**
+     * Set to `true` to render every field with a validation error as
+     * invalid, even untouched ones, and to reflect that on each
+     * containing collapsible section's header. Defaults to `false`,
+     * which keeps untouched required-empty fields silent.
+     */
+    @Prop()
+    public revealErrors: boolean = false;
+
+    /**
      * Emitted when a change is made within the form
      */
     @Event()
@@ -190,6 +199,7 @@ export class Form {
                         schema: this.schema,
                         rootValue: this.value,
                         propsFactory: this.propsFactory,
+                        revealErrors: this.revealErrors,
                     },
                     fields: {
                         SchemaField: CustomSchemaField,

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -38,6 +38,7 @@ import { mapValues } from 'lodash-es';
  * @exampleComponent limel-example-props-factory-form
  * @exampleComponent limel-example-form-layout
  * @exampleComponent limel-example-form-span-fields
+ * @exampleComponent limel-example-form-invalid-section
  * @exampleComponent limel-example-custom-error-message
  * @exampleComponent limel-example-server-errors
  * @exampleComponent limel-example-form-array-item-controls

--- a/src/components/form/templates/array-context.ts
+++ b/src/components/form/templates/array-context.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+import { ErrorSchema } from '@rjsf/utils';
 import { FormSchema } from '../form.types';
 
 export interface ArrayFieldOptions {
@@ -7,3 +8,15 @@ export interface ArrayFieldOptions {
 }
 
 export const ArrayFieldContext = createContext<ArrayFieldOptions | null>(null);
+
+/**
+ * The array's validation errors as an RJSF `errorSchema`, keyed by item
+ * index (e.g. `{ 1: { phone: { __errors: [...] } } }`).
+ *
+ * RJSF passes `errorSchema` to the array *field* (`FieldProps`) but, for
+ * non-fixed arrays, does not forward it to `ArrayFieldItemTemplate` — so
+ * the custom `ArrayField` shares it here for each item to read its own
+ * slice (`errorSchema[index]`). This lets a collapsed item flag itself as
+ * invalid without rendering (and DOM-walking) its hidden children.
+ */
+export const ArrayItemErrorsContext = createContext<ErrorSchema | null>(null);

--- a/src/components/form/templates/array-field-collapsible-item.ts
+++ b/src/components/form/templates/array-field-collapsible-item.ts
@@ -1,7 +1,7 @@
 import { Action } from '../../collapsible-section/action';
 import React, { PropsWithChildren, ReactNode } from 'react';
-import { findTitle } from './common';
-import { ArrayFieldItemButtonsTemplateProps } from '@rjsf/utils';
+import { findTitle, hasNestedErrors } from './common';
+import { ArrayFieldItemButtonsTemplateProps, ErrorSchema } from '@rjsf/utils';
 import { Runnable } from './types';
 import { isEmpty } from 'lodash-es';
 import { JSONSchema7 } from 'json-schema';
@@ -38,6 +38,20 @@ export interface CollapsibleItemProps {
      * Whether this particular item can be reordered.
      */
     allowItemReorder: boolean;
+
+    /**
+     * Validation errors for this item, as an RJSF `errorSchema` subtree.
+     * Used to flag the item's header when it contains invalid fields,
+     * even while the item is collapsed and its fields are not rendered.
+     */
+    errorSchema?: ErrorSchema;
+
+    /**
+     * Whether the form has been asked to reveal all validation errors
+     * (typically on a save attempt). The header only reflects nested
+     * errors when this is `true`, keeping a freshly loaded form silent.
+     */
+    revealErrors?: boolean;
 }
 
 export class CollapsibleItemTemplate extends React.Component<
@@ -78,7 +92,8 @@ export class CollapsibleItemTemplate extends React.Component<
     }
 
     public render() {
-        const { data, schema, formSchema } = this.props;
+        const { data, schema, formSchema, errorSchema, revealErrors } =
+            this.props;
         let children: ReactNode;
         if (this.state.isOpen) {
             children = this.props.children;
@@ -90,6 +105,8 @@ export class CollapsibleItemTemplate extends React.Component<
                   class: 'drag-handle',
               })
             : null;
+
+        const invalid = revealErrors === true && hasNestedErrors(errorSchema);
 
         return React.createElement(
             'limel-collapsible-section',
@@ -104,6 +121,7 @@ export class CollapsibleItemTemplate extends React.Component<
                 'data-reorderable': this.props.allowItemReorder
                     ? 'true'
                     : 'false',
+                invalid: invalid,
             },
             dragHandle,
             children

--- a/src/components/form/templates/array-field-item.ts
+++ b/src/components/form/templates/array-field-item.ts
@@ -4,10 +4,11 @@ import { isObjectType } from '../schema';
 import { FormSchema } from '../form.types';
 import { CollapsibleItemTemplate } from './array-field-collapsible-item';
 import { SimpleItemTemplate } from './array-field-simple-item';
-import { ArrayFieldContext } from './array-context';
+import { ArrayFieldContext, ArrayItemErrorsContext } from './array-context';
 
 export const ArrayFieldItemTemplate = (props: ArrayFieldItemTemplateProps) => {
     const arrayContext = useContext(ArrayFieldContext);
+    const itemErrors = useContext(ArrayItemErrorsContext);
     const schema = arrayContext?.arraySchema;
     const formData = arrayContext?.formData;
     const formContext = props.registry.formContext;
@@ -30,6 +31,8 @@ export const ArrayFieldItemTemplate = (props: ArrayFieldItemTemplateProps) => {
                 formSchema: formContext?.schema,
                 allowItemRemoval: allowItemRemoval,
                 allowItemReorder: allowItemReorder,
+                errorSchema: itemErrors?.[props.index],
+                revealErrors: formContext?.revealErrors === true,
             },
             props.children
         );

--- a/src/components/form/templates/common.ts
+++ b/src/components/form/templates/common.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { isArrayType, isObjectType } from '../schema';
 import { FormSchema } from '../form.types';
 import { JSONSchema7 } from 'json-schema';
+import { ErrorSchema } from '@rjsf/utils';
 
 /**
  *
@@ -159,4 +160,29 @@ function findSchemaTitle(value: any, schema: JSONSchema7) {
     }
 
     return value;
+}
+
+/**
+ * Recursively check whether an RJSF `errorSchema` subtree contains any
+ * field with validation errors.
+ *
+ * Used to reflect the validity of nested fields onto a containing
+ * collapsible section's header, so a collapsed section with invalid
+ * contents is still flagged in the UI.
+ *
+ * @param errorSchema - the RJSF error schema subtree to inspect
+ * @returns `true` when any nested field has one or more errors
+ */
+export function hasNestedErrors(errorSchema?: ErrorSchema): boolean {
+    if (!errorSchema) {
+        return false;
+    }
+
+    return Object.entries(errorSchema).some(([key, value]) => {
+        if (key === '__errors') {
+            return Array.isArray(value) && value.length > 0;
+        }
+
+        return hasNestedErrors(value as ErrorSchema);
+    });
 }

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -5,7 +5,7 @@ import {
     FormLayoutOptions,
     FormSchema,
 } from '../form.types';
-import { renderDescription, renderTitle } from './common';
+import { hasNestedErrors, renderDescription, renderTitle } from './common';
 import { GridLayout } from './grid-layout';
 import { RowLayout } from './row-layout';
 import { LimeObjectFieldTemplateProps, ObjectFieldProperty } from './types';
@@ -62,6 +62,8 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
     const helpElement = getHelpComponent(props.schema as FormSchema, {
         slot: 'header',
     });
+    const revealErrors = props.registry.formContext?.revealErrors === true;
+    const invalid = revealErrors && hasNestedErrors(props.errorSchema);
 
     return React.createElement(
         'limel-collapsible-section',
@@ -72,6 +74,7 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
                 props.fieldPathId
             ),
             'is-open': defaultOpen,
+            invalid: invalid,
         },
         helpElement,
         renderDescription(props.description as string),

--- a/src/components/form/validation-display.spec.ts
+++ b/src/components/form/validation-display.spec.ts
@@ -34,6 +34,7 @@ it.each([
         modified: true,
         hasValue: false,
         required: true,
+        revealErrors: false,
         expected: true,
     },
     {
@@ -41,6 +42,7 @@ it.each([
         modified: false,
         hasValue: true,
         required: true,
+        revealErrors: false,
         expected: true,
     },
     {
@@ -48,6 +50,7 @@ it.each([
         modified: false,
         hasValue: false,
         required: false,
+        revealErrors: false,
         expected: true,
     },
     {
@@ -55,6 +58,7 @@ it.each([
         modified: true,
         hasValue: true,
         required: false,
+        revealErrors: false,
         expected: false,
     },
     {
@@ -62,13 +66,39 @@ it.each([
         modified: false,
         hasValue: false,
         required: true,
+        revealErrors: false,
+        expected: false,
+    },
+    {
+        // Untouched required-empty field becomes invalid when the form
+        // is asked to reveal all errors (e.g. on a save attempt).
+        hasErrors: true,
+        modified: false,
+        hasValue: false,
+        required: true,
+        revealErrors: true,
+        expected: true,
+    },
+    {
+        // `revealErrors` never flags fields that have no errors.
+        hasErrors: false,
+        modified: false,
+        hasValue: false,
+        required: true,
+        revealErrors: true,
         expected: false,
     },
 ])(
-    'isFieldInvalid returns $expected when hasErrors=$hasErrors, modified=$modified, hasValue=$hasValue, required=$required',
-    ({ hasErrors, modified, hasValue, required, expected }) => {
+    'isFieldInvalid returns $expected when hasErrors=$hasErrors, modified=$modified, hasValue=$hasValue, required=$required, revealErrors=$revealErrors',
+    ({ hasErrors, modified, hasValue, required, revealErrors, expected }) => {
         expect(
-            isFieldInvalid({ hasErrors, modified, hasValue, required })
+            isFieldInvalid({
+                hasErrors,
+                modified,
+                hasValue,
+                required,
+                revealErrors,
+            })
         ).toBe(expected);
     }
 );

--- a/src/components/form/validation-display.ts
+++ b/src/components/form/validation-display.ts
@@ -31,16 +31,13 @@ export function hasValue(value: unknown): boolean {
 /**
  * Determine whether a field should be displayed as invalid.
  *
- * A field with errors is shown as invalid only when the user has
- * interacted with it, it already contains a value, or it is optional.
- * This avoids showing errors on untouched required fields before the
- * user has had a chance to fill them in.
- *
  * @param field - the current field state
  * @param field.hasErrors - whether the field currently has validation errors
  * @param field.modified - whether the user has interacted with the field
  * @param field.hasValue - whether the field holds a non-empty value
  * @param field.required - whether the field is required
+ * @param field.revealErrors - whether the form has been asked to reveal
+ *   all errors at once (typically on a save attempt)
  * @returns `true` when the field should render in an invalid state
  */
 export function isFieldInvalid(field: {
@@ -48,9 +45,14 @@ export function isFieldInvalid(field: {
     modified: boolean;
     hasValue: boolean;
     required: boolean;
+    revealErrors?: boolean;
 }): boolean {
     return (
-        field.hasErrors && (field.modified || field.hasValue || !field.required)
+        field.hasErrors &&
+        (field.modified ||
+            field.hasValue ||
+            !field.required ||
+            !!field.revealErrors)
     );
 }
 

--- a/src/components/input-field/input-field.tsx
+++ b/src/components/input-field/input-field.tsx
@@ -291,6 +291,11 @@ export class InputField {
     public componentDidUpdate() {
         if (this.invalid) {
             this.mdcTextField.valid = false;
+        } else if (!this.wasInvalid) {
+            // Reset MDC's internal validity once the consumer no longer
+            // considers the field invalid and our own check hasn't
+            // flagged it either.
+            this.mdcTextField.valid = true;
         }
 
         this.mdcTextField.disabled = this.disabled || this.readonly;


### PR DESCRIPTION
partially -
fix https://github.com/Lundalogik/lime-elements/issues/3528
## Summary

Solves the discoverability problem for forms with collapsible sections: a user editing a form can't tell that a collapsed section contains an invalid or required-empty field. The final design adds a single declarative prop on `limel-form` — `revealErrors: boolean` — that the consumer flips on a save attempt to surface every blocking error at once: red fields, red section headers, red array-item headers. The user follows the red thread to find what to fix.

## Why this approach

We shouldn't try to auto-detect "form is dirty" and lit everything up as soon as the user starts filling-in the form. That is wrong for the common case of an empty form being filled in from scratch, the user gets yelled at before they've had a chance to type into the next field. As explained in the parent issue, the actual problem is about *pre-filled* forms where something has gone invalid after the fact (e.g. an admin made a property `required` after the record was saved), not about empty forms being filled from scratch.

The fix has to:

- Stay silent on a freshly loaded form, no matter how many invalid fields it contains.
- Make the obstacles to saving discoverable the moment the user tries to save — including ones behind a collapsed section.
- Be plug-and-play: a consumer that doesn't opt in keeps the existing behaviour bit-for-bit.
- Have a clean reset path on Discard or successful Save.

A consumer-controlled boolean prop ticks all four. The recommended pattern: Save stays enabled even when the form is invalid; clicking it sets `revealErrors=true` and the consumer updates the Save button to show an error affordance. Discard or successful Save resets the prop. The companion CRM-side wiring lives in a separate PR.

## Commits

Split into four atomic, independently-testable units. Each builds on the previous so reviewers can focus on one concern at a time.

### 1. `fix(input-field): reset MDC's internal validity when the consumer clears the invalid prop`

Pre-existing bug, surfaced once we started toggling `invalid` back from `true` to `false`. `componentDidUpdate` set `mdcTextField.valid = false` when `invalid` became `true`, but never set it back. MDC then kept painting the field red even after the consumer cleared `invalid`. Adds the symmetric reset. Benefits any consumer of `limel-input-field`, not just our form work (`limel-chip-set`, `limel-picker`, `limel-date-picker` all delegate to it).

### 2. `feat(form): add revealErrors prop to opt into showing all validation errors`

New boolean prop on `limel-form`, default `false`. When `true`, every field with a validation error renders as invalid even if the user hasn't touched it. The gate in `isFieldInvalid` is extended with an optional `revealErrors` parameter, read from RJSF's `formContext` by both `SchemaField` and the default widget adapter. Default `false` preserves the existing "stay silent on untouched required-empty" behaviour for every existing consumer that doesn't pass the prop.

### 3. `feat(form): mark collapsible sections and array items as invalid when revealErrors is true`

When `revealErrors` is `true` and a collapsible section contains a nested field with errors, the section header's `invalid` prop turns on. Same for items inside an array-of-objects field — those go through DOM detection because RJSF does not pass `errorSchema` down to `ArrayFieldItemTemplate`. The section indicator stays silent when `revealErrors` is `false`, keeping freshly-loaded forms quiet.

### 4. `docs(form): add example for revealing validation errors on save`

`limel-example-form-invalid-section` demonstrates the recommended Save/Discard flow: form loaded pre-filled with required-empty fields (one of them behind a collapsed section), Save button enables on dirty, click reveals all errors, Discard resets everything.

## Known constraints (kept intentionally)

- **Pre-existing `hasValue` gate is unchanged.** If a field has a non-empty value that fails its own validation (e.g. `multipleOf: 100` violated by `12345`), the field will turn red as soon as RJSF propagates per-field `rawErrors` — typically after the first change anywhere in the form. This predates the PR. Changing it would be a breaking UX change for every existing consumer of `limel-form` and is out of scope.
- **RJSF v6 + `liveValidate: 'onChange'` defers per-field `rawErrors` propagation until the first change.** In practice this is invisible to the user because the recommended consumer pattern keeps Save disabled until the form is dirty. The new e2e tests in commit #2 trigger a no-op change before asserting visibility, which matches the realistic flow.

## Test plan

- [ ] Open the new `limel-example-form-invalid-section`. Form loads with two empty required fields (`Email` visible, `Job title` behind a collapsed section). Neither is flagged. Save is disabled.
- [ ] Change `Name`. Save button enables and shows the error icon plus a tooltip "Form has errors. Click to reveal."
- [ ] Click Save. `Email` lights up red. The collapsed `Work` section header also turns red — expand it and `Job title` is also red.
- [ ] Fill both required fields. Save's error indicator goes away. Click Save — alert fires, form returns to a clean silent state.
- [ ] Repeat the edit, but this time click Discard. The form data resets, every red marker goes away.
- [ ] Toggle the "Simulate a server-side error on Email" checkbox. The `Email` field and the `Personal information` section header light up; untoggle and they go silent.
- [ ] Run `npm test` — 58 form spec + 48 form e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a revealErrors option to forms to surface validation on untouched fields and reflect invalid state in collapsible sections and collapsed array items.
  * Array templates expose per-item error context and a helper to detect nested errors.

* **Bug Fixes**
  * Input fields now reliably reset their visual validity when errors are cleared.

* **Documentation**
  * Added an interactive example demonstrating validation, server-error simulation, save/discard behavior.

* **Tests**
  * Expanded e2e/tests for revealErrors and collapsible/array invalid-state scenarios.

* **Style**
  * Added styling for the invalid-section example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->