### PR TITLE
refactor(email-viewer): use role=list on attachment list container

### DIFF
--- a/src/components/email-viewer/email-viewer.scss
+++ b/src/components/email-viewer/email-viewer.scss
@@ -106,17 +106,11 @@
     }
 
     .attachment-list {
-        margin: 0;
-        padding: 0.5rem 0;
-        list-style: none;
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
-    }
 
-    li {
-        display: inline-flex;
-        max-width: 100%;
+        padding: 0.5rem 0;
     }
 
     limel-chip {

--- a/src/components/email-viewer/email-viewer.tsx
+++ b/src/components/email-viewer/email-viewer.tsx
@@ -233,11 +233,19 @@ export class EmailViewer {
         return (
             <div class="attachments">
                 <span id="attachments-label">{label}</span>
-                <ul class="attachment-list" aria-labelledby="attachments-label">
+                {/* NOSONAR: <ul> can only contain <li> children per the HTML
+                    spec, but our list items are <limel-chip> custom elements.
+                    Using role="list" on a <div> avoids invalid markup while
+                    preserving list semantics for assistive technologies. */}
+                <div
+                    class="attachment-list"
+                    role="list"
+                    aria-labelledby="attachments-label"
+                >
                     {attachments.map((attachment, index) =>
                         this.renderAttachment(attachment, index)
                     )}
-                </ul>
+                </div>
             </div>
         );
     }
@@ -256,21 +264,20 @@ export class EmailViewer {
                 : undefined;
 
         return (
-            <li key={`attachment-${index}`}>
-                <limel-chip
-                    title={tooltip}
-                    text={filename}
-                    icon={{
-                        name: getIconForFile(extension),
-                        color: getIconFillColorForFile(extension),
-                        backgroundColor:
-                            getIconBackgroundColorForFile(extension),
-                    }}
-                    badge={fileSize}
-                    readonly={true}
-                    language={this.language}
-                />
-            </li>
+            <limel-chip
+                key={`attachment-${index}`}
+                role="listitem"
+                title={tooltip}
+                text={filename}
+                icon={{
+                    name: getIconForFile(extension),
+                    color: getIconFillColorForFile(extension),
+                    backgroundColor: getIconBackgroundColorForFile(extension),
+                }}
+                badge={fileSize}
+                readonly={true}
+                language={this.language}
+            />
         );
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #4064. Reverts the `<ul>` + `<li>` markup back to `<div role="list">` with `role="listitem"` on each chip, which removes the no-op `<li>` wrappers.

A `NOSONAR` comment is included to suppress the SonarCloud `prefer-tag-over-role` warning. The rule's recommended fix (use `<ul>`) would require either:

- re-adding `<li>` wrappers around each `<limel-chip>` (the very markup this change reverts), or
- placing `<limel-chip>` as a direct `<ul>` child, which is invalid HTML (`<ul>` content model is "zero or more `<li>` elements").

The label association via `aria-labelledby="attachments-label"` is preserved so screen readers still announce the list as "Attachments".

## Test plan

- [ ] Open a `.eml` with multiple attachments and verify the chip list still renders identically.
- [ ] Verify the screen reader announces "Attachments, list, N items" when entering the list.
- [ ] Verify SonarCloud no longer reports the role-on-div warning for `email-viewer.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)