### PR TITLE
fix(file-viewer): guard Fullscreen against missing browser API

### DIFF
--- a/src/components/file-viewer/fullscreen.spec.ts
+++ b/src/components/file-viewer/fullscreen.spec.ts
@@ -1,0 +1,59 @@
+import { Fullscreen } from './fullscreen';
+
+describe('Fullscreen', () => {
+    describe('when the browser supports the Fullscreen API', () => {
+        let element: any;
+        let requestFullscreenSpy: ReturnType<typeof vi.fn>;
+        let fullscreen: Fullscreen;
+
+        beforeEach(() => {
+            requestFullscreenSpy = vi.fn();
+            element = { requestFullscreen: requestFullscreenSpy };
+            fullscreen = new Fullscreen(element);
+        });
+
+        it('reports as supported', () => {
+            expect(fullscreen.isSupported()).toBe(true);
+        });
+
+        it('calls the native method with the element bound as `this`', () => {
+            fullscreen.requestFullscreen();
+
+            expect(requestFullscreenSpy).toHaveBeenCalledTimes(1);
+            expect(requestFullscreenSpy.mock.contexts[0]).toBe(element);
+        });
+    });
+
+    describe('when the browser supports a vendor-prefixed Fullscreen API', () => {
+        it('uses webkitRequestFullscreen when available', () => {
+            const webkitRequestFullscreen = vi.fn();
+            const fullscreen = new Fullscreen({ webkitRequestFullscreen });
+
+            expect(fullscreen.isSupported()).toBe(true);
+
+            fullscreen.requestFullscreen();
+            expect(webkitRequestFullscreen).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('when the browser does not support the Fullscreen API (e.g., iPhone Safari)', () => {
+        let fullscreen: Fullscreen;
+
+        beforeEach(() => {
+            // Construction must not throw — this is the regression we're guarding against.
+            fullscreen = new Fullscreen({});
+        });
+
+        it('reports as not supported', () => {
+            expect(fullscreen.isSupported()).toBe(false);
+        });
+
+        it('is a no-op when requestFullscreen is called', () => {
+            expect(() => fullscreen.requestFullscreen()).not.toThrow();
+        });
+
+        it('is a no-op when toggle is called', () => {
+            expect(() => fullscreen.toggle()).not.toThrow();
+        });
+    });
+});

--- a/src/components/file-viewer/fullscreen.ts
+++ b/src/components/file-viewer/fullscreen.ts
@@ -1,5 +1,5 @@
 export class Fullscreen {
-    private enter: () => void;
+    private enter: (() => void) | undefined;
     private exit: () => void;
 
     constructor(element: any) {
@@ -8,7 +8,9 @@ export class Fullscreen {
             element.msRequestFullscreen ||
             element.mozRequestFullScreen ||
             element.webkitRequestFullscreen;
-        this.enter = this.enter.bind(element);
+        if (this.enter) {
+            this.enter = this.enter.bind(element);
+        }
         const doc: any = window.document;
         this.exit =
             doc.exitFullscreen ||
@@ -45,6 +47,6 @@ export class Fullscreen {
     };
 
     public isSupported(): boolean {
-        return !!this.requestFullscreen;
+        return !!this.enter;
     }
 }


### PR DESCRIPTION
 ## Fix: guard `Fullscreen` against missing browser API

iPhone Safari does not expose `requestFullscreen` (or any vendor-prefixed variant) on regular `HTMLElement`s. The `Fullscreen` constructor unconditionally called `.bind(element)` on the resolved method, which threw a `TypeError` when none of the variants existed. The throw propagated up through `limel-file-viewer`'s constructor, leaving the component with an empty shadow DOM whenever `allowFullscreen` was set.

This was particularly visible for images: `renderPdf` doesn't touch `this.fullscreen`, so PDFs rendered fine, but `renderImage` → `renderButtons` → `renderToggleFullscreenButton` calls `this.fullscreen.isSupported()`, which then crashed `render()` entirely — and the user saw nothing.

### Changes

- `fullscreen.ts`: guard `.bind` behind an `if (this.enter)` check; type `enter` as `(() => void) | undefined`. 
- `fullscreen.ts`: `isSupported()` now returns `!!this.enter` instead of `!!this.requestFullscreen`. The previous implementation checked the class's own arrow-function property, so it always returned `true` — which is why callers' `isSupported()` guards never prevented the crash.
- `fullscreen.spec.ts`: new unit tests covering supported, vendor-prefixed, and unsupported (iPhone Safari) cases.

### Impact

All consumers passing `allowFullscreen` to `limel-file-viewer` will now render images correctly on iPhone Safari. The fullscreen button is simply hidden where the API is unavailable.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering fullscreen support detection and behavior across standard, vendor-prefixed, and unsupported environments.

* **Refactor**
  * Improved fullscreen stability: detection logic refined, vendor-prefixed APIs handled, and operations become safe no-ops when fullscreen isn’t available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://seesparkbox.com/foundry/atomic_commits_with_git)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [x] Firefox
- [x] Safari

Mobile:
- [ ] Chrome on Android
- [x] iOS
