### PR TITLE
feat(picker): support per-item removable flag on selected chips

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -681,7 +681,7 @@ export namespace Components {
         "actionPosition": ActionPosition;
         "actions": Array<ListItem<Action>>;
         "actionScrollBehavior": ActionScrollBehavior;
-        "allItems"?: Array<ListItem<PickerValue>>;
+        "allItems"?: PickerItem[];
         "badgeIcons": boolean;
         "delimiter": string;
         "disabled": boolean;
@@ -695,7 +695,7 @@ export namespace Components {
         "required": boolean;
         "searcher"?: Searcher;
         "searchLabel": string;
-        "value": ListItem<PickerValue> | Array<ListItem<PickerValue>>;
+        "value": PickerItem | PickerItem[];
     }
     export interface LimelPopover {
         "open": boolean;
@@ -2977,7 +2977,7 @@ export namespace JSX {
         "actionPosition"?: ActionPosition;
         "actions"?: Array<ListItem<Action>>;
         "actionScrollBehavior"?: ActionScrollBehavior;
-        "allItems"?: Array<ListItem<PickerValue>>;
+        "allItems"?: PickerItem[];
         "badgeIcons"?: boolean;
         "delimiter"?: string;
         "disabled"?: boolean;
@@ -2988,13 +2988,13 @@ export namespace JSX {
         "leadingIcon"?: IconName;
         "multiple"?: boolean;
         "onAction"?: (event: LimelPickerCustomEvent<Action>) => void;
-        "onChange"?: (event: LimelPickerCustomEvent<ListItem<PickerValue> | Array<ListItem<PickerValue>>>) => void;
-        "onInteract"?: (event: LimelPickerCustomEvent<ListItem<PickerValue>>) => void;
+        "onChange"?: (event: LimelPickerCustomEvent<PickerItem | PickerItem[]>) => void;
+        "onInteract"?: (event: LimelPickerCustomEvent<PickerItem>) => void;
         "readonly"?: boolean;
         "required"?: boolean;
         "searcher"?: Searcher;
         "searchLabel"?: string;
-        "value"?: ListItem<PickerValue> | Array<ListItem<PickerValue>>;
+        "value"?: PickerItem | PickerItem[];
     }
 
     // (undocumented)
@@ -4281,6 +4281,11 @@ interface Option_2<T extends string = string> {
 export { Option_2 as Option }
 
 // @public
+export interface PickerItem<T = PickerValue> extends ListItem<T> {
+    removable?: boolean;
+}
+
+// @public
 export type PickerValue = number | string | {
     id: string | number;
     [key: string]: any;
@@ -4330,7 +4335,7 @@ export interface RowReorderEvent<T> {
 }
 
 // @public
-export type Searcher = (query: string) => Promise<Array<ListItem | ListSeparator>>;
+export type Searcher = (query: string) => Promise<Array<PickerItem | ListSeparator>>;
 
 // @public
 export type SpinnerSize = 'mini' | 'x-small' | 'small' | 'medium' | 'large';

--- a/src/components/picker/examples/picker-non-removable.tsx
+++ b/src/components/picker/examples/picker-non-removable.tsx
@@ -1,0 +1,98 @@
+import { LimelPickerCustomEvent, PickerItem } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Picker with non-removable values
+ *
+ * When `multiple={true}`, picked items become chips that are
+ * removable by default. To "lock" an individual item so the user
+ * cannot remove it, set `removable: false` on that item.
+ *
+ * A non-removable picked item:
+ *
+ * - has no remove button on its chip
+ * - cannot be deleted with <kbd>Backspace</kbd> or <kbd>Delete</kbd>
+ * - is left untouched by the "Clear all" button (which hides itself
+ *   when every remaining chip is locked)
+ *
+ * :::note
+ * Non-removable chips remain fully interactive. Clicking them still
+ * emits the `interact` event. This is the right tool for pre-filled
+ * values that the consumer always wants present (for example, the
+ * current user in a list of meeting participants, or a mandatory
+ * tag on a record), while still letting the user add and remove
+ * other items freely. If you want to disable interaction entirely,
+ * use the picker's `readonly` or `disabled` props instead.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-picker-non-removable',
+    shadow: true,
+})
+export class PickerNonRemovableExample {
+    @State()
+    private selectedItems: Array<PickerItem<number>> = [
+        {
+            text: 'You',
+            value: 0,
+            icon: 'user_shield',
+            removable: false,
+        },
+    ];
+
+    private allItems: Array<PickerItem<number>> = [
+        { text: 'Admiral Swiggins', value: 1, icon: 'person_male' },
+        { text: 'Ayla', value: 2, icon: 'person_female' },
+        { text: 'Clunk', value: 3, icon: 'person_male' },
+        { text: 'Coco', value: 4, icon: 'person_female' },
+        { text: 'Derpl', value: 5, icon: 'person_male' },
+        { text: 'Froggy G', value: 6, icon: 'person_male' },
+        { text: 'Lonestar', value: 8, icon: 'person_male' },
+        { text: 'Lucy', value: 14, icon: 'person_female' },
+        { text: 'Raelynn', value: 10, icon: 'person_female' },
+        { text: 'Voltar', value: 12, icon: 'person_male' },
+        { text: 'Yuri', value: 13, icon: 'person_male' },
+    ];
+
+    private availableItems: Array<PickerItem<number>> = [...this.allItems];
+
+    public render() {
+        return (
+            <Host>
+                <limel-picker
+                    label="Meeting participants"
+                    helperText="You are always a participant and cannot be removed."
+                    searchLabel="Add a participant"
+                    value={this.selectedItems}
+                    multiple={true}
+                    allItems={this.availableItems}
+                    emptyResultMessage="No matching participants found"
+                    onChange={this.onChange}
+                    onInteract={this.onInteract}
+                />
+                <limel-example-value value={this.selectedItems} />
+            </Host>
+        );
+    }
+
+    private onChange = (
+        event: LimelPickerCustomEvent<Array<PickerItem<number>>>
+    ) => {
+        this.selectedItems = [...event.detail];
+        this.updateAvailableItems();
+    };
+
+    private updateAvailableItems = () => {
+        this.availableItems = this.allItems.filter((item) => {
+            return !this.selectedItems.some((selectedItem) => {
+                return item.value === selectedItem.value;
+            });
+        });
+    };
+
+    private onInteract = (
+        event: LimelPickerCustomEvent<PickerItem<number>>
+    ) => {
+        console.log('Value interacted with:', event.detail);
+    };
+}

--- a/src/components/picker/picker-item.types.ts
+++ b/src/components/picker/picker-item.types.ts
@@ -1,0 +1,28 @@
+import { ListItem } from '../list-item/list-item.types';
+import { PickerValue } from './value.types';
+
+/**
+ * An item that can be picked by `limel-picker`.
+ *
+ * Extends `ListItem` with picker-specific flags that only make sense
+ * once the item has been selected and rendered as a chip.
+ *
+ * @public
+ */
+export interface PickerItem<T = PickerValue> extends ListItem<T> {
+    /**
+     * Whether the item should be removable once it has been picked
+     * and rendered as a chip. Most useful when `multiple={true}`,
+     * but also locks the single chip when `multiple={false}`.
+     *
+     * Picked items are removable by default. Set this to `false` to
+     * "lock" an individual item so that the user cannot remove it —
+     * neither via the remove button, nor with Backspace/Delete, nor
+     * by the "Clear all" button. Locked items remain fully interactive
+     * (clicks still emit `interact` events).
+     *
+     * If the entire picker is `disabled` or `readonly`, the remove
+     * button is hidden on all chips regardless of this flag.
+     */
+    removable?: boolean;
+}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -2,6 +2,7 @@ import { Action } from '../collapsible-section/action';
 import { ActionPosition, ActionScrollBehavior } from '../picker/actions.types';
 import { Chip } from '../chip-set/chip.types';
 import { ListItem } from '../list-item/list-item.types';
+import { PickerItem } from '../picker/picker-item.types';
 import { Searcher } from '../picker/searcher.types';
 import {
     Component,
@@ -32,6 +33,7 @@ const DEFAULT_SEARCHER_MAX_RESULTS = 20;
 /**
  * @exampleComponent limel-example-picker-basic
  * @exampleComponent limel-example-picker-multiple
+ * @exampleComponent limel-example-picker-non-removable
  * @exampleComponent limel-example-picker-icons
  * @exampleComponent limel-example-picker-pictures
  * @exampleComponent limel-example-picker-value-as-object
@@ -108,7 +110,7 @@ export class Picker {
      * Currently selected value or values. Where the value can be an object.
      */
     @Prop()
-    public value: ListItem<PickerValue> | Array<ListItem<PickerValue>>;
+    public value: PickerItem | PickerItem[];
 
     /**
      * A search function that takes a search-string as an argument,
@@ -132,7 +134,7 @@ export class Picker {
      * found by typing more characters in the search field.
      */
     @Prop()
-    public allItems?: Array<ListItem<PickerValue>> = [];
+    public allItems?: PickerItem[] = [];
 
     /**
      * True if multiple values are allowed
@@ -179,15 +181,13 @@ export class Picker {
      * Fired when a new value has been selected from the picker
      */
     @Event()
-    private change: EventEmitter<
-        ListItem<PickerValue> | Array<ListItem<PickerValue>>
-    >;
+    private change: EventEmitter<PickerItem | PickerItem[]>;
 
     /**
      * Fired when clicking on a selected value
      */
     @Event()
-    private interact: EventEmitter<ListItem<PickerValue>>;
+    private interact: EventEmitter<PickerItem>;
 
     /**
      * Emitted when the user selects an action.
@@ -196,7 +196,7 @@ export class Picker {
     private action: EventEmitter<Action>;
 
     @State()
-    private items: Array<ListItem<number | string>>;
+    private items: PickerItem[];
 
     @State()
     private textValue: string = '';
@@ -328,23 +328,23 @@ export class Picker {
         return value;
     };
 
-    private createChips = (value: ListItem | ListItem[]): Chip[] => {
+    private createChips = (value: PickerItem | PickerItem[]): Chip[] => {
         if (!value) {
             return [];
         }
 
         if (this.multiple) {
-            const listItems: ListItem[] = value as ListItem[];
+            const listItems: PickerItem[] = value as PickerItem[];
 
             return listItems.map(this.createChip);
         }
 
-        const listItem: ListItem = value as ListItem;
+        const listItem: PickerItem = value as PickerItem;
 
         return [this.createChip(listItem)];
     };
 
-    private createChip = (listItem: ListItem): Chip => {
+    private createChip = (listItem: PickerItem): Chip => {
         const name = getIconName(listItem.icon);
 
         const color = getIconFillColor(listItem.icon, listItem.iconColor);
@@ -353,7 +353,7 @@ export class Picker {
         return {
             id: `${valueId}`,
             text: listItem.text,
-            removable: true,
+            removable: listItem.removable !== false,
             icon: name ? { name: name, color: color } : undefined,
             image: listItem.image,
             value: listItem,
@@ -575,9 +575,7 @@ export class Picker {
             this.loading = true;
         });
         const searcher = this.searcher || this.defaultSearcher;
-        const result = (await searcher(this.textValue)) as Array<
-            ListItem<PickerValue>
-        >;
+        const result = (await searcher(this.textValue)) as PickerItem[];
 
         // If the search function resolves immediately,
         // the loading spinner will not be shown.
@@ -588,7 +586,7 @@ export class Picker {
 
     private defaultSearcher: Searcher = async (
         query: string
-    ): Promise<ListItem[]> => {
+    ): Promise<PickerItem[]> => {
         if (query === '') {
             return this.allItems.slice(0, DEFAULT_SEARCHER_MAX_RESULTS);
         }
@@ -616,13 +614,10 @@ export class Picker {
     ) {
         event.stopPropagation();
         if (!this.value || this.value !== event.detail) {
-            let newValue: ListItem<PickerValue> | Array<ListItem<PickerValue>> =
-                event.detail;
+            let newValue: PickerItem | PickerItem[] = event.detail;
             if (this.multiple) {
-                newValue = [
-                    ...(this.value as Array<ListItem<PickerValue>>),
-                    event.detail,
-                ];
+                const currentValue = (this.value as PickerItem[]) ?? [];
+                newValue = [...currentValue, event.detail];
             }
 
             this.change.emit(newValue);
@@ -669,7 +664,7 @@ export class Picker {
         if (this.multiple) {
             const chips = event.detail as Chip[];
             newValue = chips.map((chip) => {
-                return (this.value as ListItem[]).find((item) => {
+                return (this.value as PickerItem[]).find((item) => {
                     const valueId = this.getValueId(item);
 
                     return `${valueId}` === chip.id;
@@ -677,7 +672,7 @@ export class Picker {
             });
         }
 
-        this.change.emit(newValue);
+        this.change.emit(newValue as PickerItem | PickerItem[]);
     }
 
     private handleInteract(event: LimelChipSetCustomEvent<Chip>) {
@@ -754,11 +749,11 @@ export class Picker {
         }
     }
 
-    private handleSearchResult(query: string, result: ListItem[]) {
+    private handleSearchResult(query: string, result: PickerItem[]) {
         if (query === this.textValue) {
             this.items = result;
             if (this.multiple) {
-                const values = this.value as ListItem[];
+                const values = (this.value as PickerItem[]) ?? [];
                 this.items = result.filter((item) => {
                     return !values.includes(item);
                 });

--- a/src/components/picker/searcher.types.ts
+++ b/src/components/picker/searcher.types.ts
@@ -1,9 +1,9 @@
-import { ListItem } from '../list-item/list-item.types';
 import { ListSeparator } from '../../global/shared-types/separator.types';
+import { PickerItem } from './picker-item.types';
 
 /**
  * A search function that takes a search-string as an argument, and returns
- * a promise that will eventually be resolved with an array of `ListItem`:s.
+ * a promise that will eventually be resolved with an array of `PickerItem`:s.
  *
  * @param query - A search query. Typically what the user has written
  * in the input field of a limel-picker.
@@ -12,4 +12,4 @@ import { ListSeparator } from '../../global/shared-types/separator.types';
  */
 export type Searcher = (
     query: string
-) => Promise<Array<ListItem | ListSeparator>>;
+) => Promise<Array<PickerItem | ListSeparator>>;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -49,6 +49,7 @@ export * from './components/dynamic-label/label.types';
 export * from './components/list/list.types';
 export * from './components/menu/menu.types';
 export * from './components/picker/actions.types';
+export * from './components/picker/picker-item.types';
 export * from './components/picker/searcher.types';
 export * from './components/picker/value.types';
 export * from './components/progress-flow/progress-flow.types';


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-client/issues/1036
## Summary
- Add `PickerItem` type (extends `ListItem`) with optional `removable` flag, and export it from the package entry.
- Honor `removable: false` when rendering picked chips so individual items can be locked from removal.
- Retype public `value`, `allItems`, `change`, and `interact` to use `PickerItem` (backward compatible — `removable` is optional).
- Add `limel-example-picker-non-removable` demonstrating the feature.

## Test plan
- [ ] Run `npm run watch` and open the new "Picker with non-removable values" example.
- [ ] Verify the pre-selected "You" chip has no remove button.
- [ ] Verify Backspace/Delete do not remove "You".
- [ ] Verify "Clear all" removes other chips but leaves "You" in place (and hides itself once only "You" remains).
- [ ] Verify clicking "You" still emits an `interact` event (visible via `<limel-example-value>`).
- [ ] Verify other participants can be added and removed normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Picker supports non-removable (locked) selected items so users can prevent specific chips from being removed.

* **Behavior Changes**
  * Picker selection and search now consistently handle items with removable flags, improving UX for locked items.

* **Documentation**
  * Added an example showing how to configure and use non-removable items in the picker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->