### PR TITLE
fix(table): refresh remote paginator when totalRows or pageSize change

### DIFF
--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -159,6 +159,86 @@ describe('limel-table remote mode options', () => {
     });
 });
 
+describe('limel-table remote paginator refresh', () => {
+    let component: Table;
+    let scrollContainer: HTMLElement;
+
+    beforeEach(() => {
+        component = new Table();
+        scrollContainer = document.createElement('div');
+        (component as any).tabulator = {
+            replaceData: vi.fn().mockResolvedValue(undefined),
+            setMaxPage: vi.fn(),
+        };
+        (component as any).initialized = true;
+        (component as any).pageSize = 10;
+        (component as any).getRowScrollContainer = () => scrollContainer;
+    });
+
+    it('replaces data with no args when totalRows changes in remote mode', async () => {
+        (component as any).mode = 'remote';
+
+        (component as any).totalRowsChanged();
+        await Promise.resolve();
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.replaceData).toHaveBeenCalledWith();
+    });
+
+    it('replaces data with no args when pageSize changes in remote mode', async () => {
+        (component as any).mode = 'remote';
+
+        (component as any).pageSizeChanged();
+        await Promise.resolve();
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.replaceData).toHaveBeenCalledWith();
+    });
+
+    it('does not replace data in local mode', async () => {
+        (component as any).mode = 'local';
+
+        (component as any).totalRowsChanged();
+        (component as any).pageSizeChanged();
+        await Promise.resolve();
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.replaceData).not.toHaveBeenCalled();
+    });
+
+    it('restores scroll position after replacing data', async () => {
+        (component as any).mode = 'remote';
+        scrollContainer.scrollTop = 120;
+        scrollContainer.scrollLeft = 40;
+
+        // Simulate Tabulator resetting scroll during the data rebuild.
+        (component as any).tabulator.replaceData = vi
+            .fn()
+            .mockImplementation(() => {
+                scrollContainer.scrollTop = 0;
+                scrollContainer.scrollLeft = 0;
+
+                return Promise.resolve();
+            });
+
+        await (component as any).refreshRemotePaginator();
+
+        expect(scrollContainer.scrollTop).toBe(120);
+        expect(scrollContainer.scrollLeft).toBe(40);
+    });
+
+    it('swallows replaceData rejection without restoring scroll', async () => {
+        (component as any).mode = 'remote';
+        (component as any).tabulator.replaceData = vi
+            .fn()
+            .mockRejectedValue(new Error('destroyed'));
+
+        await expect(
+            (component as any).refreshRemotePaginator()
+        ).resolves.toBeUndefined();
+    });
+});
+
 describe('limel-table aggregate updates', () => {
     let component: Table;
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -318,11 +318,13 @@ export class Table {
     @Watch('totalRows')
     protected totalRowsChanged() {
         this.updateMaxPage();
+        this.refreshRemotePaginator();
     }
 
     @Watch('pageSize')
     protected pageSizeChanged() {
         this.updateMaxPage();
+        this.refreshRemotePaginator();
     }
 
     @Watch('page')
@@ -701,6 +703,56 @@ export class Table {
 
     private updateMaxPage() {
         this.tabulator?.setMaxPage(this.calculatePageCount());
+    }
+
+    /**
+     * In remote mode the visible paginator buttons are rendered from the
+     * `last_page` value returned by `ajaxRequestFunc`, not from
+     * `setMaxPage`. When `totalRows` or `pageSize` change after init, force
+     * Tabulator to re-invoke the ajax callback so the paginator UI picks up
+     * the new page count.
+     *
+     * `replaceData` rather than `setData` because the latter calls
+     * `rowManager.resetScroll()` (visible as the table snapping to
+     * top-left every refresh). `replaceData` still wipes and rebuilds
+     * the row elements as a side-effect of going through the data
+     * pipeline (causing a brief flicker), so save and restore the scroll
+     * position explicitly: Tabulator's `renderInPosition` path doesn't
+     * fully preserve vertical scroll across the row rebuild.
+     */
+    private async refreshRemotePaginator() {
+        if (!this.isRemoteMode() || !this.tabulator || !this.initialized) {
+            return;
+        }
+
+        const scrollContainer = this.getRowScrollContainer();
+        const scrollTop = scrollContainer?.scrollTop ?? 0;
+        const scrollLeft = scrollContainer?.scrollLeft ?? 0;
+
+        // `replaceData` resolves through `requestData`, which rejects when the
+        // component is destroyed, and Tabulator's ajax pipeline can reject too.
+        // Since the watchers call this without awaiting, swallow rejections here
+        // to avoid an unhandled promise rejection.
+        try {
+            await this.tabulator.replaceData();
+        } catch {
+            return;
+        }
+
+        if (scrollContainer) {
+            scrollContainer.scrollTop = scrollTop;
+            scrollContainer.scrollLeft = scrollLeft;
+        }
+    }
+
+    /**
+     * Tabulator's scrollable row container, inside `<limel-table>`'s
+     * shadow DOM. The user's vertical/horizontal scroll position within
+     * the table lives on this element's `scrollTop` / `scrollLeft`.
+     */
+    private getRowScrollContainer(): HTMLElement | null {
+        return (this.host.shadowRoot?.querySelector('.tabulator-tableholder') ??
+            null) as HTMLElement | null;
     }
 
     private getOptions(): TabulatorOptions {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote-mode pagination now refreshes when total rows or page size change: paginator UI updates, the table re-requests data, current scroll position is preserved after refresh, and transient failures during refresh are handled gracefully.

* **Tests**
  * Added tests covering remote paginator refresh, scroll restoration, and graceful failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary
- In remote (ajax) mode, Tabulator's visible paginator buttons are driven by the `last_page` returned from `ajaxRequestFunc`, not by `setMaxPage`. As a result, changing `totalRows` or `pageSize` after init updated the internal max page but left the rendered paginator UI stale.
- The `totalRows` and `pageSize` watchers now also call a new `refreshRemotePaginator()`, which triggers `tabulator.replaceData()` so Tabulator re-invokes the ajax callback and the paginator picks up the new page count. Local mode is unaffected (guarded by `isRemoteMode()`).
- `replaceData()` rather than `setData()` because the latter calls `rowManager.resetScroll()` — visible as the table snapping to top-left on every totals refresh. `replaceData()` still rebuilds the row elements as a side-effect of going through the data pipeline (Tabulator's `renderInPosition` doesn't fully preserve vertical scroll across the rebuild), so the user's scroll position is saved and restored explicitly around the call.
- A small `getRowScrollContainer()` helper names the `.tabulator-tableholder` lookup so the magic selector lives in one place.

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

## Test plan
- [ ] In remote mode, mount a table and update `totalRows` after init — paginator buttons reflect the new page count.
- [ ] In remote mode, change `pageSize` after init — paginator buttons reflect the new page count, current page is preserved (or clamped if it exceeds the new max).
- [ ] In remote mode, scroll the table vertically and horizontally, then update `totalRows` — scroll position is preserved (no snap to top-left).
- [ ] In local (non-remote) mode, changing `totalRows` / `pageSize` behaves as before (no extra data fetch).

### Browsers tested:
Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
