### PR TITLE
feat(picker): preserve typed query, Esc handling, and search-results header, and improve UX details

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -690,6 +690,7 @@ export namespace Components {
         "helperText": string;
         "invalid": boolean;
         "label": string;
+        "language": Languages;
         "leadingIcon": IconName;
         "multiple": boolean;
         "readonly": boolean;
@@ -2989,6 +2990,7 @@ export namespace JSX {
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
+        "language"?: Languages;
         "leadingIcon"?: IconName;
         "multiple"?: boolean;
         "onAction"?: (event: LimelPickerCustomEvent<Action>) => void;
@@ -3021,6 +3023,8 @@ export namespace JSX {
         "invalid": boolean;
         // (undocumented)
         "label": string;
+        // (undocumented)
+        "language": Languages;
         // (undocumented)
         "leadingIcon": IconName;
         // (undocumented)

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -288,6 +288,7 @@ export namespace Components {
         "disabled": boolean;
         "emptyInput": () => Promise<void>;
         "emptyInputOnBlur": boolean;
+        "emptyInputOnChange": boolean;
         "getEditMode": () => Promise<boolean>;
         "helperText": string;
         "inputType": 'search' | 'text';
@@ -1886,6 +1887,7 @@ export namespace JSX {
         "delimiter"?: string;
         "disabled"?: boolean;
         "emptyInputOnBlur"?: boolean;
+        "emptyInputOnChange"?: boolean;
         "helperText"?: string;
         "inputType"?: 'search' | 'text';
         "invalid"?: boolean;
@@ -1917,6 +1919,8 @@ export namespace JSX {
         "disabled": boolean;
         // (undocumented)
         "emptyInputOnBlur": boolean;
+        // (undocumented)
+        "emptyInputOnChange": boolean;
         // (undocumented)
         "helperText": string;
         // (undocumented)

--- a/src/components/chip-set/chip-set.e2e.tsx
+++ b/src/components/chip-set/chip-set.e2e.tsx
@@ -330,5 +330,55 @@ describe('limel-chip-set', () => {
                 expect(removeButton).toBeNull();
             });
         });
+
+        describe('emptyInputOnChange', () => {
+            async function typeIntoInput(
+                root: HTMLLimelChipSetElement,
+                text: string,
+                waitForChanges: () => Promise<void>
+            ) {
+                const input = root.shadowRoot!.querySelector('input')!;
+                input.value = text;
+                input.dispatchEvent(
+                    new Event('input', { bubbles: true, composed: true })
+                );
+                await waitForChanges();
+            }
+
+            it('clears the input when chips change (default)', async () => {
+                const { root, waitForChanges } = await render(
+                    <limel-chip-set
+                        type="input"
+                        value={getValue()}
+                    ></limel-chip-set>
+                );
+                await waitForChanges();
+
+                await typeIntoInput(root, 'pending', waitForChanges);
+                root.value = [...getValue(), { id: '3', text: 'Cherry' }];
+                await waitForChanges();
+
+                const input = root.shadowRoot!.querySelector('input')!;
+                expect(input.value).toEqual('');
+            });
+
+            it('preserves the input when chips change and emptyInputOnChange is false', async () => {
+                const { root, waitForChanges } = await render(
+                    <limel-chip-set
+                        type="input"
+                        value={getValue()}
+                        emptyInputOnChange={false}
+                    ></limel-chip-set>
+                );
+                await waitForChanges();
+
+                await typeIntoInput(root, 'pending', waitForChanges);
+                root.value = [...getValue(), { id: '3', text: 'Cherry' }];
+                await waitForChanges();
+
+                const input = root.shadowRoot!.querySelector('input')!;
+                expect(input.value).toEqual('pending');
+            });
+        });
     });
 });

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -170,6 +170,24 @@ export class ChipSet {
     public emptyInputOnBlur: boolean = true;
 
     /**
+     * Whether the input field should be emptied when the set of chips
+     * changes (i.e. when the `value` prop is updated — a chip is added,
+     * removed, or the array is replaced).
+     *
+     * Defaults to `true`, which is the right behavior for a standalone
+     * input chip-set where the typed text *becomes* the next chip on
+     * <kbd>Enter</kbd>. The input is then cleared to make room for the
+     * next chip, and help user type a new keyword from scratch.
+     *
+     * Set to `false` when the input represents a search query over an
+     * external suggestion list (as in `limel-picker`), so the typed keyword
+     * survives while chips are added or removed (when user selects items from
+     * the search results list, while it is open).
+     */
+    @Prop({ reflect: true })
+    public emptyInputOnChange: boolean = true;
+
+    /**
      * Whether the "Clear all" buttons should be shown
      */
     @Prop()
@@ -434,7 +452,9 @@ export class ChipSet {
             return;
         }
 
-        this.syncEmptyInput();
+        if (this.emptyInputOnChange) {
+            this.syncEmptyInput();
+        }
         this.initialize();
     }
 

--- a/src/components/picker/examples/picker-basic.tsx
+++ b/src/components/picker/examples/picker-basic.tsx
@@ -45,7 +45,6 @@ export class PickerBasicExample {
                 label="Favorite awesomenaut"
                 value={this.selectedItem}
                 allItems={this.allItems}
-                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,

--- a/src/components/picker/examples/picker-composite.tsx
+++ b/src/components/picker/examples/picker-composite.tsx
@@ -28,7 +28,6 @@ export class PickerCompositeExample {
         searchLabel: 'My search label',
         helperText: 'My helper text',
         leadingIcon: 'search',
-        emptyResultMessage: 'No matches found',
         delimiter: '',
         value: [],
         required: false,

--- a/src/components/picker/examples/picker-empty-result-message.tsx
+++ b/src/components/picker/examples/picker-empty-result-message.tsx
@@ -1,0 +1,64 @@
+import { LimelPickerCustomEvent, PickerItem } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * With a custom empty-result message
+ *
+ * When the user's query returns no matches, the picker shows a
+ * generic translated message (`No results matching "X"` in English,
+ * where `X` is the typed query). To replace it with a more
+ * domain-specific phrase, set `emptyResultMessage`.
+ *
+ * :::note
+ * Most pickers do **not** need to set this prop. The default already
+ * reads naturally for any domain. Customize only when the picker's
+ * content has a name worth mentioning — for example, a participants
+ * picker that should say "No matching participants found" instead of
+ * the generic default.
+ * :::
+ *
+ * Type something that doesn't match any of the items below (e.g.,
+ * `xyz`) to see the custom message appear.
+ */
+@Component({
+    tag: 'limel-example-picker-empty-result-message',
+    shadow: true,
+})
+export class PickerEmptyResultMessageExample {
+    @State()
+    private selectedItems: Array<PickerItem<number>> = [];
+
+    private readonly allItems: Array<PickerItem<number>> = [
+        { text: 'Admiral Swiggins', value: 1, icon: 'person_male' },
+        { text: 'Ayla', value: 2, icon: 'person_female' },
+        { text: 'Clunk', value: 3, icon: 'person_male' },
+        { text: 'Coco', value: 4, icon: 'person_female' },
+        { text: 'Derpl', value: 5, icon: 'person_male' },
+        { text: 'Lonestar', value: 8, icon: 'person_male' },
+        { text: 'Raelynn', value: 10, icon: 'person_female' },
+        { text: 'Voltar', value: 12, icon: 'person_male' },
+    ];
+
+    public render() {
+        return (
+            <Host>
+                <limel-picker
+                    label="Meeting participants"
+                    searchLabel="Search for a participant"
+                    value={this.selectedItems}
+                    multiple={true}
+                    allItems={this.allItems}
+                    emptyResultMessage="No matching participants found"
+                    onChange={this.onChange}
+                />
+                <limel-example-value value={this.selectedItems} />
+            </Host>
+        );
+    }
+
+    private readonly onChange = (
+        event: LimelPickerCustomEvent<Array<PickerItem<number>>>
+    ) => {
+        this.selectedItems = [...event.detail];
+    };
+}

--- a/src/components/picker/examples/picker-empty-suggestions.tsx
+++ b/src/components/picker/examples/picker-empty-suggestions.tsx
@@ -46,7 +46,6 @@ export class PickerExample {
                 label="Favorite awesomenaut"
                 value={this.selectedItem}
                 searcher={this.search}
-                emptyResultMessage="No results"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,

--- a/src/components/picker/examples/picker-icons.tsx
+++ b/src/components/picker/examples/picker-icons.tsx
@@ -145,7 +145,6 @@ export class PickerIconsExample {
                 searchLabel={'Search your awesomenaut'}
                 multiple={true}
                 allItems={this.allItems}
-                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,

--- a/src/components/picker/examples/picker-leading-icon-example.tsx
+++ b/src/components/picker/examples/picker-leading-icon-example.tsx
@@ -35,7 +35,6 @@ export class PickerLeadingIconExample {
                 leadingIcon="search"
                 value={this.selectedItem}
                 allItems={this.allItems}
-                emptyResultMessage="No results"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,

--- a/src/components/picker/examples/picker-multiple.tsx
+++ b/src/components/picker/examples/picker-multiple.tsx
@@ -39,7 +39,6 @@ export class PickerMultipleExample {
                 value={this.selectedItems}
                 multiple={true}
                 allItems={this.availableItems}
-                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,

--- a/src/components/picker/examples/picker-non-removable.tsx
+++ b/src/components/picker/examples/picker-non-removable.tsx
@@ -66,7 +66,6 @@ export class PickerNonRemovableExample {
                     value={this.selectedItems}
                     multiple={true}
                     allItems={this.availableItems}
-                    emptyResultMessage="No matching participants found"
                     onChange={this.onChange}
                     onInteract={this.onInteract}
                 />

--- a/src/components/picker/examples/picker-pictures.tsx
+++ b/src/components/picker/examples/picker-pictures.tsx
@@ -68,7 +68,6 @@ export class PickerPicturesExample {
                 searchLabel={'Search your awesomenaut'}
                 multiple={true}
                 allItems={this.allItems}
-                emptyResultMessage="No matching awesomenauts found"
                 onChange={this.onChange}
                 onInteract={this.onInteract}
             />,

--- a/src/components/picker/examples/picker-sections.tsx
+++ b/src/components/picker/examples/picker-sections.tsx
@@ -43,7 +43,6 @@ export class PickerSectionsExample {
                     label="Pick an awesomenaut"
                     value={this.selectedItem}
                     searcher={this.search}
-                    emptyResultMessage="No matching awesomenauts"
                     onChange={this.onChange}
                 />
                 <limel-example-value value={this.selectedItem} />

--- a/src/components/picker/examples/picker-value-as-object-with-actions.tsx
+++ b/src/components/picker/examples/picker-value-as-object-with-actions.tsx
@@ -71,7 +71,6 @@ export class PickerValueAsObjectWithActionsExample {
                     label="Favorite authors"
                     value={this.selectedItems}
                     searchLabel={'Find your favorite authors'}
-                    emptyResultMessage="No matching authors found"
                     multiple={true}
                     allItems={this.allItems}
                     onChange={this.onChange}

--- a/src/components/picker/examples/picker-value-as-object.tsx
+++ b/src/components/picker/examples/picker-value-as-object.tsx
@@ -23,7 +23,6 @@ export class PickerValueAsObjectExample {
                 label="Favorite authors"
                 value={this.selectedItems}
                 searchLabel="Search your favorite authors"
-                emptyResultMessage="No matching authors found"
                 multiple={true}
                 allItems={this.allItems}
                 onChange={this.onChange}

--- a/src/components/picker/picker.e2e.tsx
+++ b/src/components/picker/picker.e2e.tsx
@@ -1,0 +1,56 @@
+import { render, h } from '@stencil/vitest';
+
+const allItems = [
+    { text: 'Apple', value: 1 },
+    { text: 'Banana', value: 2 },
+];
+
+async function focusAndType(
+    root: HTMLLimelPickerElement,
+    text: string,
+    waitForChanges: () => Promise<void>
+) {
+    const chipSet = root.shadowRoot!.querySelector('limel-chip-set')!;
+    const input = chipSet.shadowRoot!.querySelector('input')!;
+    input.focus();
+    input.value = text;
+    input.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    // Wait for the picker's 300ms search debounce plus a small margin.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    await waitForChanges();
+}
+
+describe('limel-picker', () => {
+    describe('when no items match the typed query', () => {
+        it('shows the default translated empty-result message', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-picker label="Pick" allItems={allItems}></limel-picker>
+            );
+            await waitForChanges();
+            await focusAndType(root, 'xyz', waitForChanges);
+
+            expect(document.body.textContent).toContain(
+                'No results matching "xyz"'
+            );
+        });
+
+        it('shows the consumer override when `emptyResultMessage` is set, and the default text is gone', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-picker
+                    label="Pick"
+                    allItems={allItems}
+                    emptyResultMessage="No participants found"
+                ></limel-picker>
+            );
+            await waitForChanges();
+            await focusAndType(root, 'xyz', waitForChanges);
+
+            expect(document.body.textContent).toContain(
+                'No participants found'
+            );
+            expect(document.body.textContent).not.toContain(
+                'No results matching'
+            );
+        });
+    });
+});

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -510,8 +510,17 @@ export class Picker {
     }
 
     private onListKeyDown(event: KeyboardEvent) {
-        const keyFound = [TAB, ESCAPE, ENTER].includes(event.key);
-        if (keyFound) {
+        if (event.key === ESCAPE) {
+            // Stop bubble; otherwise menu-surface also emits `dismiss`
+            // and triggers a duplicate clearInputField via handleCloseMenu.
+            event.preventDefault();
+            event.stopPropagation();
+            this.clearInputField();
+            this.chipSet.setFocus();
+
+            return;
+        }
+        if ([TAB, ENTER].includes(event.key)) {
             this.chipSet.setFocus();
         }
     }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -451,7 +451,15 @@ export class Picker {
         }
 
         if (!this.items?.length) {
-            return this.renderEmptyMessage();
+            // Only show "no matching results" when the user actually has
+            // a query in flight. Without this guard, the message would
+            // also render right after Esc clears the input, leaving the
+            // dropdown stuck in an "empty result" state.
+            if (this.textValue !== '') {
+                return this.renderEmptyMessage();
+            }
+
+            return;
         }
 
         return this.renderListResult();
@@ -512,10 +520,10 @@ export class Picker {
     private onListKeyDown(event: KeyboardEvent) {
         if (event.key === ESCAPE) {
             // Stop bubble; otherwise menu-surface also emits `dismiss`
-            // and triggers a duplicate clearInputField via handleCloseMenu.
+            // and triggers a duplicate clear via handleCloseMenu.
             event.preventDefault();
             event.stopPropagation();
-            this.clearInputField();
+            this.handleEscape();
             this.chipSet.setFocus();
 
             return;
@@ -728,7 +736,7 @@ export class Picker {
         if (isEscape) {
             event.preventDefault();
             event.stopPropagation();
-            this.clearInputField();
+            this.handleEscape();
 
             return;
         }
@@ -821,10 +829,41 @@ export class Picker {
         this.clearInputField();
     }
 
-    private clearInputField() {
+    /**
+     * Shared prelude for any flow that ends the current search session:
+     * wipe the chip-set's visible text, reset the picker's `textValue`,
+     * and cancel any in-flight debounced search.
+     *
+     * Used by `clearInputField` (which then drops the dropdown
+     * entirely) and `resetSearchToDefault` (which re-runs the searcher
+     * with an empty query to repopulate the dropdown with defaults).
+     */
+    private clearTextValue() {
         this.chipSet.emptyInput();
         this.textValue = '';
-        this.handleSearchResult('', []);
         this.debouncedSearch.cancel();
+    }
+
+    private clearInputField() {
+        this.clearTextValue();
+        this.handleSearchResult('', []);
+    }
+
+    private resetSearchToDefault() {
+        this.clearTextValue();
+        this.search('');
+    }
+
+    /**
+     * Two-stage Esc: first press clears the typed query but keeps the
+     * dropdown open showing the default suggestions; a second press
+     * (with the query already empty) closes the dropdown.
+     */
+    private handleEscape() {
+        if (this.textValue === '') {
+            this.clearInputField();
+        } else {
+            this.resetSearchToDefault();
+        }
     }
 }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -41,6 +41,7 @@ const DEFAULT_SEARCHER_MAX_RESULTS = 20;
  * @exampleComponent limel-example-picker-value-as-object
  * @exampleComponent limel-example-picker-value-as-object-with-actions
  * @exampleComponent limel-example-picker-empty-suggestions
+ * @exampleComponent limel-example-picker-empty-result-message
  * @exampleComponent limel-example-picker-leading-icon
  * @exampleComponent limel-example-picker-static-actions
  * @exampleComponent limel-example-picker-sections
@@ -90,7 +91,14 @@ export class Picker {
     public leadingIcon: IconName;
 
     /**
-     * A message to display when the search returned an empty result
+     * A message to display when the search returned an empty result.
+     *
+     * If unset (or set to an empty string), the picker shows a
+     * default translated message (`No results matching "X"` in
+     * English, where `X` is the current query) chosen by the
+     * `language` prop. Set this to override the default with custom
+     * text — for example, when the picker's domain calls for more
+     * specific wording like "No matching participants found".
      */
     @Prop()
     public emptyResultMessage: string;
@@ -492,9 +500,11 @@ export class Picker {
     }
 
     private renderEmptyMessage() {
-        if (!this.emptyResultMessage) {
-            return;
-        }
+        const text =
+            this.emptyResultMessage ||
+            translate.get('picker.no-matching-results', this.language, {
+                query: this.textValue,
+            });
 
         const style = {
             color: 'rgb(var(--contrast-1100))',
@@ -502,7 +512,7 @@ export class Picker {
             margin: '0.5rem 1rem',
         };
 
-        return <p style={style}>{this.emptyResultMessage}</p>;
+        return <p style={style}>{text}</p>;
     }
 
     private renderListResult() {

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -231,7 +231,6 @@ export class Picker {
     constructor() {
         this.handleTextInput = this.handleTextInput.bind(this);
         this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
-        this.handleDropdownKeyDown = this.handleDropdownKeyDown.bind(this);
         this.handleInputFieldFocus = this.handleInputFieldFocus.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.handleInteract = this.handleInteract.bind(this);
@@ -761,21 +760,6 @@ export class Picker {
 
             event.preventDefault();
             listElement.focus();
-        }
-    }
-
-    /**
-     * Key handler for the dropdown
-     *
-     * @param event - event
-     */
-    private handleDropdownKeyDown(event: KeyboardEvent) {
-        const isEscape = event.key === ESCAPE;
-
-        if (isEscape) {
-            event.preventDefault();
-            this.textValue = '';
-            this.chipSet.setFocus(true);
         }
     }
 

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -57,14 +57,14 @@ export class Picker {
      * True if the picker should be disabled
      */
     @Prop()
-    public disabled: boolean = false;
+    public disabled = false;
 
     /**
      * Set to `true` to disable adding and removing items,
      * but allow interaction with existing items.
      */
     @Prop({ reflect: true })
-    public readonly: boolean = false;
+    public readonly = false;
 
     /**
      * Text to display for the input field of the picker
@@ -115,7 +115,7 @@ export class Picker {
      * True if the control requires a value
      */
     @Prop()
-    public required: boolean = false;
+    public required = false;
 
     /**
      * Set to `true` to indicate that the current value of the input field is
@@ -158,7 +158,7 @@ export class Picker {
      * True if multiple values are allowed
      */
     @Prop()
-    public multiple: boolean = false;
+    public multiple = false;
 
     /**
      * Sets delimiters between chips. Works only when `multiple` is `true`.
@@ -193,7 +193,7 @@ export class Picker {
      * Whether badge icons should be used in the result list or not
      */
     @Prop({ reflect: true })
-    public badgeIcons: boolean = false;
+    public badgeIcons = false;
 
     /**
      * Fired when a new value has been selected from the picker

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -508,7 +508,8 @@ export class Picker {
 
         const style = {
             color: 'rgb(var(--contrast-1100))',
-            'text-align': 'center',
+            textAlign: 'center',
+            fontSize: 'var(--limel-theme-default-font-size)',
             margin: '0.5rem 1rem',
         };
 

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -1,9 +1,12 @@
 import { Action } from '../collapsible-section/action';
 import { ActionPosition, ActionScrollBehavior } from '../picker/actions.types';
 import { Chip } from '../chip-set/chip.types';
+import { Languages } from '../date-picker/date.types';
 import { ListItem } from '../list-item/list-item.types';
+import { ListSeparator } from '../../global/shared-types/separator.types';
 import { PickerItem } from '../picker/picker-item.types';
 import { Searcher } from '../picker/searcher.types';
+import translate from '../../global/translations';
 import {
     Component,
     Element,
@@ -91,6 +94,14 @@ export class Picker {
      */
     @Prop()
     public emptyResultMessage: string;
+
+    /**
+     * Defines the language for translations. Affects the labels
+     * rendered by the picker itself, such as the "Results matching"
+     * header shown above the suggestion list while the user is typing.
+     */
+    @Prop()
+    public language: Languages = 'en';
 
     /**
      * True if the control requires a value
@@ -195,7 +206,7 @@ export class Picker {
     private action: EventEmitter<Action>;
 
     @State()
-    private items: PickerItem[];
+    private items: Array<PickerItem | ListSeparator>;
 
     @State()
     private textValue: string = '';
@@ -291,6 +302,7 @@ export class Picker {
                 readonly={this.readonly}
                 required={this.required}
                 searchLabel={this.searchLabel}
+                language={this.language}
                 onInput={this.handleTextInput}
                 onKeyDown={this.handleInputKeyDown}
                 onChange={this.handleChange}
@@ -575,7 +587,7 @@ export class Picker {
             this.loading = true;
         });
         const searcher = this.searcher || this.defaultSearcher;
-        const result = (await searcher(this.textValue)) as PickerItem[];
+        const result = await searcher(this.textValue);
 
         // If the search function resolves immediately,
         // the loading spinner will not be shown.
@@ -620,9 +632,10 @@ export class Picker {
 
             this.change.emit(newValue);
             if (this.multiple) {
-                this.items = this.items.filter(
+                const remaining = this.items.filter(
                     (item) => item !== event.detail
                 );
+                this.items = this.hasPickableItems(remaining) ? remaining : [];
             } else {
                 // Single-pick: the search session ends with the pick, so
                 // wipe the input. (In multi-pick we deliberately keep the
@@ -766,18 +779,49 @@ export class Picker {
         }
     }
 
-    private handleSearchResult(query: string, result: PickerItem[]) {
+    private handleSearchResult(
+        query: string,
+        result: Array<PickerItem | ListSeparator>
+    ) {
         if (query === this.textValue) {
-            this.items = result;
+            let nextItems = result;
             if (this.multiple) {
                 const values = (this.value as PickerItem[]) ?? [];
-                this.items = result.filter((item) => {
+                nextItems = result.filter((item) => {
+                    if ('separator' in item) {
+                        return true;
+                    }
+
                     return !values.includes(item);
                 });
             }
 
+            this.items = this.prependSearchHeader(query, nextItems);
             this.loading = false;
         }
+    }
+
+    private hasPickableItems(
+        items: Array<PickerItem | ListSeparator>
+    ): boolean {
+        return items.some((item) => !('separator' in item));
+    }
+
+    private prependSearchHeader(
+        query: string,
+        items: Array<PickerItem | ListSeparator>
+    ): Array<PickerItem | ListSeparator> {
+        if (query === '') {
+            return items;
+        }
+        if (!this.hasPickableItems(items)) {
+            return items;
+        }
+        const text = translate.get('picker.results-matching', this.language, {
+            query: query,
+        });
+
+        return [{ separator: true, text: text }, ...items];
     }
 
     private handleCloseMenu() {

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -22,7 +22,6 @@ import {
     LimelListCustomEvent,
 } from '../../components';
 import { getIconFillColor, getIconName } from '../icon/get-icon-props';
-import { PickerValue } from './value.types';
 import { DebouncedFunc, debounce } from 'lodash-es';
 import { IconName } from '../../global/shared-types/icon.types';
 
@@ -299,6 +298,7 @@ export class Picker {
                 onStartEdit={this.handleInputFieldFocus}
                 onStopEdit={this.handleStopEditAndBlur}
                 emptyInputOnBlur={false}
+                emptyInputOnChange={false}
                 clearAllButton={this.multiple && !this.chipSetEditMode}
                 {...props}
             />,
@@ -609,9 +609,7 @@ export class Picker {
      *
      * @param event - event
      */
-    private handleListChange(
-        event: LimelListCustomEvent<ListItem<PickerValue>>
-    ) {
+    private handleListChange(event: LimelListCustomEvent<PickerItem>) {
         event.stopPropagation();
         if (!this.value || this.value !== event.detail) {
             let newValue: PickerItem | PickerItem[] = event.detail;
@@ -621,12 +619,22 @@ export class Picker {
             }
 
             this.change.emit(newValue);
-            this.items = [];
+            if (this.multiple) {
+                this.items = this.items.filter(
+                    (item) => item !== event.detail
+                );
+            } else {
+                // Single-pick: the search session ends with the pick, so
+                // wipe the input. (In multi-pick we deliberately keep the
+                // typed query so the user can keep adding matches.)
+                this.items = [];
+                this.textValue = '';
+                this.chipSet?.emptyInput();
+            }
         }
 
         if (this.multiple) {
-            this.textValue = '';
-            this.chipSet?.setFocus(true);
+            this.chipSet?.setFocus();
         }
     }
 
@@ -764,10 +772,6 @@ export class Picker {
     }
 
     private handleCloseMenu() {
-        if (this.items.length > 0) {
-            return;
-        }
-
         this.clearInputField();
     }
 

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -702,6 +702,15 @@ export class Picker {
             !event.shiftKey;
         const isUp = event.key === ARROW_UP;
         const isDown = event.key === ARROW_DOWN;
+        const isEscape = event.key === ESCAPE;
+
+        if (isEscape) {
+            event.preventDefault();
+            event.stopPropagation();
+            this.clearInputField();
+
+            return;
+        }
 
         if (!isForwardTab && !isUp && !isDown) {
             return;

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -115,4 +115,5 @@ Du kan fortsætte med at blokere billeder (e-mailen kan se ufuldstændig ud) ell
         'Ikke-understøttet billedformat',
     'profile-picture.unsupported-preview.description':
         'Vi kan ikke vise det valgte billede i denne browser. Vælg venligst en anden billedfil.',
+    'picker.results-matching': 'Resultater der matcher "{ query }"',
 };

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -116,4 +116,5 @@ Du kan fortsætte med at blokere billeder (e-mailen kan se ufuldstændig ud) ell
     'profile-picture.unsupported-preview.description':
         'Vi kan ikke vise det valgte billede i denne browser. Vælg venligst en anden billedfil.',
     'picker.results-matching': 'Resultater der matcher "{ query }"',
+    'picker.no-matching-results': 'Ingen resultater der matcher "{ query }"',
 };

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -117,4 +117,5 @@ Sie können Bilder weiterhin blockieren (die E-Mail kann unvollständig aussehen
     'profile-picture.unsupported-preview.description':
         'Wir können das ausgewählte Bild in diesem Browser nicht anzeigen. Bitte wählen Sie eine andere Bilddatei.',
     'picker.results-matching': 'Ergebnisse passend zu "{ query }"',
+    'picker.no-matching-results': 'Keine Ergebnisse passend zu "{ query }"',
 };

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -116,4 +116,5 @@ Sie können Bilder weiterhin blockieren (die E-Mail kann unvollständig aussehen
         'Nicht unterstütztes Bildformat',
     'profile-picture.unsupported-preview.description':
         'Wir können das ausgewählte Bild in diesem Browser nicht anzeigen. Bitte wählen Sie eine andere Bilddatei.',
+    'picker.results-matching': 'Ergebnisse passend zu "{ query }"',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -114,4 +114,5 @@ You can keep images blocked (the email may look incomplete), or load them if you
     'profile-picture.unsupported-preview.description':
         'We cannot display the selected image in this browser. Please select a different image file.',
     'picker.results-matching': 'Results matching "{ query }"',
+    'picker.no-matching-results': 'No results matching "{ query }"',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -113,4 +113,5 @@ You can keep images blocked (the email may look incomplete), or load them if you
     'profile-picture.unsupported-preview.title': 'Unsupported image format',
     'profile-picture.unsupported-preview.description':
         'We cannot display the selected image in this browser. Please select a different image file.',
+    'picker.results-matching': 'Results matching "{ query }"',
 };

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -115,4 +115,5 @@ Voit pitää kuvat estettyinä (sähköposti voi näyttää puutteelliselta) tai
     'profile-picture.unsupported-preview.description':
         'Emme voi näyttää valittua kuvaa tässä selaimessa. Valitse jokin toinen kuvatiedosto.',
     'picker.results-matching': 'Hakua "{ query }" vastaavat tulokset',
+    'picker.no-matching-results': 'Ei hakua "{ query }" vastaavia tuloksia',
 };

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -114,4 +114,5 @@ Voit pitää kuvat estettyinä (sähköposti voi näyttää puutteelliselta) tai
     'profile-picture.unsupported-preview.title': 'Tiedostomuoto ei ole tuettu',
     'profile-picture.unsupported-preview.description':
         'Emme voi näyttää valittua kuvaa tässä selaimessa. Valitse jokin toinen kuvatiedosto.',
+    'picker.results-matching': 'Hakua "{ query }" vastaavat tulokset',
 };

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -119,4 +119,6 @@ Vous pouvez laisser les images bloquées (l'e-mail peut sembler incomplet) ou le
     'profile-picture.unsupported-preview.description':
         "Nous ne pouvons pas afficher l'image sélectionnée dans ce navigateur. Veuillez sélectionner un autre fichier image.",
     'picker.results-matching': 'Résultats correspondant à « { query } »',
+    'picker.no-matching-results':
+        'Aucun résultat correspondant à « { query } »',
 };

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -118,4 +118,5 @@ Vous pouvez laisser les images bloquées (l'e-mail peut sembler incomplet) ou le
         "Format d'image non pris en charge",
     'profile-picture.unsupported-preview.description':
         "Nous ne pouvons pas afficher l'image sélectionnée dans ce navigateur. Veuillez sélectionner un autre fichier image.",
+    'picker.results-matching': 'Résultats correspondant à « { query } »',
 };

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -117,4 +117,6 @@ Je kunt afbeeldingen geblokkeerd houden (de e-mail kan er onvolledig uitzien) of
     'profile-picture.unsupported-preview.description':
         'We kunnen de geselecteerde afbeelding niet weergeven in deze browser. Selecteer een ander afbeeldingsbestand.',
     'picker.results-matching': 'Resultaten die overeenkomen met "{ query }"',
+    'picker.no-matching-results':
+        'Geen resultaten die overeenkomen met "{ query }"',
 };

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -116,4 +116,5 @@ Je kunt afbeeldingen geblokkeerd houden (de e-mail kan er onvolledig uitzien) of
         'Niet-ondersteund afbeeldingsformaat',
     'profile-picture.unsupported-preview.description':
         'We kunnen de geselecteerde afbeelding niet weergeven in deze browser. Selecteer een ander afbeeldingsbestand.',
+    'picker.results-matching': 'Resultaten die overeenkomen met "{ query }"',
 };

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -115,4 +115,5 @@ Du kan fortsette å blokkere bilder (e-posten kan se ufullstendig ut), eller las
     'profile-picture.unsupported-preview.description':
         'Vi kan ikke vise det valgte bildet i denne nettleseren. Vennligst velg en annen bildefil.',
     'picker.results-matching': 'Resultater som matcher "{ query }"',
+    'picker.no-matching-results': 'Ingen resultater som matcher "{ query }"',
 };

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -114,4 +114,5 @@ Du kan fortsette å blokkere bilder (e-posten kan se ufullstendig ut), eller las
     'profile-picture.unsupported-preview.title': 'Ustøttet bildeformat',
     'profile-picture.unsupported-preview.description':
         'Vi kan ikke vise det valgte bildet i denne nettleseren. Vennligst velg en annen bildefil.',
+    'picker.results-matching': 'Resultater som matcher "{ query }"',
 };

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -114,4 +114,5 @@ Du kan fortsätta blockera bilder (e-posten kan se ofullständig ut) eller ladda
     'profile-picture.unsupported-preview.title': 'Formatet stöds inte',
     'profile-picture.unsupported-preview.description':
         'Vi kan inte visa den valda bilden i den här webbläsaren. Välj en annan bildfil.',
+    'picker.results-matching': 'Resultat som matchar "{ query }"',
 };

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -115,4 +115,5 @@ Du kan fortsätta blockera bilder (e-posten kan se ofullständig ut) eller ladda
     'profile-picture.unsupported-preview.description':
         'Vi kan inte visa den valda bilden i den här webbläsaren. Välj en annan bildfil.',
     'picker.results-matching': 'Resultat som matchar "{ query }"',
+    'picker.no-matching-results': 'Inga resultat som matchar "{ query }"',
 };


### PR DESCRIPTION
Follow-up UX work discovered during review of #4081 (now merged). The original PR's scope was per-item removable chips; this branch addresses several rough edges in the surrounding picker UX, plus a small cleanup.

This is a better design for a search bar, integrated in a picker component which allows the user to select multiple items. Clearing what the user has typed on every selection means in many cases that they should type the same thing again. That’s way more annoying than keeping the letters that they have typed.

Note that the the user can easily press the `Esc` key, or click elsewhere to clear the letters.

In reality, users don’t always search for names. They may search for company name, or prefixes, etc… Let’s say they want to Email a few people from lime in an email composer UI. They type the word “lime” and the suggestion list will show all contacts form Lime. They can keep clicking and selecting those they want. If we clear the list every time they pick a contact, they have to type the word “lime” over and over again.


## Test plan

- [ ] Open `limel-example-picker-non-removable`, search for `a`, pick Ayla — verify dropdown stays open with `a` still in the input and `Results matching "a"` header visible above the remaining matches.
- [ ] In the same example, press <kbd>Esc</kbd> while the input has focus — verify the typed text is cleared, the dropdown stays open showing the default suggestions, and focus remains in the input.
- [ ] Press <kbd>Esc</kbd> again — verify the dropdown closes.
- [ ] Press <kbd>Esc</kbd> while the dropdown list has focus (after Tab into it) — verify same two-stage behavior, with focus returning to the input.
- [ ] Click outside the dropdown — verify the dropdown closes and the typed text is cleared.
- [ ] Search for a query that returns no matches — verify the default `No results matching "{query}"` message appears, with the typed query interpolated.
- [ ] Open `limel-example-picker-empty-result-message` — verify the custom `emptyResultMessage` overrides the default.
- [ ] Switch `language="sv"` (or any other supported locale) on a picker and verify the header text and empty-result text are both translated.
- [ ] Open `limel-example-chip-set-input` (standalone chip-set, no `emptyInputOnChange` set) — verify typing a value, pressing Enter still clears the input as before.

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such
- [ ] Non-English translations (fi in particular) reviewed by a native speaker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Picker shows translated empty-result messages based on language and displays a "results matching" header when searching
  * ChipSet adds a configurable option to preserve or clear typed input when chips change
  * Improved Picker Esc key behavior for clearing query and closing the list

* **Documentation / Examples**
  * Added an example demonstrating custom empty-result messaging

* **Chores**
  * Added translations for picker messages in multiple languages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->