### PR TITLE
feat(info-tile): add reducePresence prop for de-emphasized tiles

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -565,6 +565,7 @@ export namespace Components {
         "loading"?: boolean;
         "prefix"?: string;
         "progress"?: InfoTileProgress;
+        "reducedPresence"?: boolean;
         "suffix"?: string;
         "value": number | string;
     }
@@ -2651,6 +2652,7 @@ export namespace JSX {
         "loading"?: boolean;
         "prefix"?: string;
         "progress"?: InfoTileProgress;
+        "reducedPresence"?: boolean;
         "suffix"?: string;
         "value"?: number | string;
     }
@@ -2669,6 +2671,8 @@ export namespace JSX {
         "loading": boolean;
         // (undocumented)
         "prefix": string;
+        // (undocumented)
+        "reducedPresence": boolean;
         // (undocumented)
         "suffix": string;
         // (undocumented)

--- a/src/components/info-tile/examples/info-tile-reduced-presence.scss
+++ b/src/components/info-tile/examples/info-tile-reduced-presence.scss
@@ -1,0 +1,42 @@
+:host {
+    --example-controls-column-layout: auto-fit;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 1rem;
+}
+
+limel-info-tile {
+    height: 7rem;
+    --info-tile-icon-color: rgb(var(--color-white));
+    --info-tile-text-color: rgb(var(--color-white));
+
+    &.open-bugs {
+        --info-tile-background-color: rgb(var(--color-red-default));
+    }
+
+    &.active-tickets {
+        --info-tile-background-color: rgb(var(--color-amber-default));
+    }
+
+    &.failed-automations {
+        --info-tile-background-color: rgb(var(--color-pink-default));
+    }
+
+    &.overdue-todos {
+        --info-tile-background-color: rgb(var(--color-sky-default));
+    }
+
+    &.next-customer-meeting {
+        --info-tile-background-color: rgb(var(--color-green-default));
+    }
+
+    &.critical-alerts {
+        --info-tile-background-color: rgb(var(--color-orange-default));
+    }
+}

--- a/src/components/info-tile/examples/info-tile-reduced-presence.tsx
+++ b/src/components/info-tile/examples/info-tile-reduced-presence.tsx
@@ -1,0 +1,105 @@
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Reducing visual presence
+ *
+ * Info tiles can have bright colors that draw attention. When several
+ * tiles sit on the same dashboard, the equally-loud visual styling can
+ * overwhelm the user even though most tiles report nothing noteworthy.
+ * For example: "zero customers need your attention today"
+ *
+ * :::tip
+ * An info tile should tell the user:
+ * > Hey 👋! Look at me. Here's something you should know about your
+ * > business right now!
+ *
+ * not:
+ * > Hey 👋! Look at me. I'm here to show you that nothing important is
+ * > happening right now. Carry on with your work, and check on me
+ * > later if you like.
+ * :::
+ *
+ * Set `reducedPresence` to `true` on the tiles whose values are not
+ * currently noteworthy. This is better than hiding the individual tiles.
+ * This way, the tile keeps its position in a grid layout, and also remains
+ * interactive. But is rendered with reduced saturation and opacity,
+ * so the eye is drawn to the tiles that actually warrant attention.
+ * The dimming clears on hover and keyboard focus, so the tile is
+ * still fully readable when the user looks at it.
+ *
+ * The example below shows a typical operations dashboard. Four of the
+ * six tiles report something unimportant; the other two report something the
+ * user should look at. Toggle the switch to see how reducing the
+ * presence of the four benign tiles makes the two tiles that actually
+ * need attention stand out.
+ */
+@Component({
+    tag: 'limel-example-info-tile-reduced-presence',
+    shadow: true,
+    styleUrl: 'info-tile-reduced-presence.scss',
+})
+export class InfoTileReducedPresenceExample {
+    @State()
+    private reducedPresence = false;
+
+    public render() {
+        return (
+            <Host>
+                <div class="tiles">
+                    <limel-info-tile
+                        class="open-bugs"
+                        icon="bug"
+                        label="Open bugs"
+                        value="0"
+                        reducedPresence={this.reducedPresence}
+                    />
+                    <limel-info-tile
+                        class="active-tickets"
+                        icon="ticket"
+                        label="Active tickets"
+                        value="0"
+                        reducedPresence={this.reducedPresence}
+                    />
+                    <limel-info-tile
+                        class="failed-automations"
+                        icon="robot"
+                        label="Failed automations"
+                        value={3}
+                    />
+                    <limel-info-tile
+                        class="overdue-todos"
+                        icon="tasklist"
+                        label="Overdue todos"
+                        value="0"
+                        reducedPresence={this.reducedPresence}
+                    />
+                    <limel-info-tile
+                        class="critical-alerts"
+                        icon="fire_alarm"
+                        label="Critical alerts"
+                        value={7}
+                    />
+                    <limel-info-tile
+                        class="next-customer-meeting"
+                        icon="meeting"
+                        label="Next customer meeting"
+                        prefix="in"
+                        value="30 days"
+                        reducedPresence={this.reducedPresence}
+                    />
+                </div>
+                <limel-example-controls>
+                    <limel-switch
+                        label="Reduce presence on the non-noteworthy tiles"
+                        value={this.reducedPresence}
+                        onChange={this.handleToggle}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private readonly handleToggle = (event: CustomEvent<boolean>) => {
+        this.reducedPresence = event.detail;
+    };
+}

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -60,14 +60,29 @@
     width: 100%;
     height: 100%;
 
+    transition:
+        filter 0.4s ease,
+        opacity 0.25s ease;
+
     * {
         box-sizing: border-box;
     }
 }
 
+:host(limel-info-tile[reduced-presence]) {
+    filter: saturate(0.1);
+    opacity: 0.4;
+}
+
+:host(limel-info-tile[reduced-presence]:hover),
+:host(limel-info-tile[reduced-presence]:focus-within) {
+    filter: none;
+    opacity: 1;
+}
+
 :host(limel-info-tile[disabled]) {
     a {
-        opacity: 0.5;
+        opacity: 0.4;
         cursor: not-allowed;
     }
 }

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -19,6 +19,7 @@ import { getRel } from '../../util/link-helper';
  * @exampleComponent limel-example-info-tile-loading
  * @exampleComponent limel-example-info-tile-primary-slot
  * @exampleComponent limel-example-info-tile-styling
+ * @exampleComponent limel-example-info-tile-reduced-presence
  */
 @Component({
     tag: 'limel-info-tile',
@@ -62,6 +63,13 @@ export class InfoTile {
      */
     @Prop({ reflect: true })
     public disabled? = false;
+
+    /**
+     * Set to `true` to render the tile with a reduced visual presence —
+     * lower saturation and opacity, so the tile draws less attention.
+     */
+    @Prop({ reflect: true })
+    public reducedPresence? = false;
 
     /**
      * If supplied, the info tile will display a notification badge.


### PR DESCRIPTION
When several tiles sit on the same dashboard, the equally-loud visual styling can overwhelm the user even though most of them report nothing noteworthy (a zero counter, a metric inside its expected range). Setting `reducePresence` dims the tile (lower saturation + opacity) so the eye is drawn to the tiles that actually warrant attention; the dimming clears on hover and keyboard focus, so the tile is still fully readable when the user looks at it.

#### Before: 
<img width="656" height="351" alt="image" src="https://github.com/user-attachments/assets/085b08b2-50ea-4351-914c-5d72fa8d44f1" />

#### after
https://github.com/user-attachments/assets/1de9e0d2-9c9d-4762-bfcd-bb1872562453


<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Info tiles now support a reduced visual presence mode that dims tiles while maintaining full clarity on interaction—tiles desaturate and lower opacity by default, then restore full visibility when hovered or focused.
  * Added new example demonstrating the reduce presence feature with a toggle control for easy testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
