### PR TITLE
ci(publish-docs): fetch gh-pages via URL userinfo

### DIFF
--- a/publish-docs.cjs
+++ b/publish-docs.cjs
@@ -157,28 +157,33 @@ function setupDocsWorktree() {
     // `git worktree add docsDist` may fail with "already registered".
     shell.exec('git worktree prune');
 
-    // Some workflows run `actions/checkout` with
-    // `persist-credentials: false`, so `origin` carries no extraheader
-    // and an unauthenticated fetch hits 401/403 on a private repo. In
-    // that case, inject an authenticating extraheader for this single
-    // command. When the workflow's checkout already set an extraheader
-    // (the usual `persist-credentials: true` default), we must NOT add
-    // a second one — git/curl would send two `Authorization` headers
-    // and GitHub returns HTTP 400 ("Duplicate header: Authorization").
-    // The literal `$GH_TOKEN` is expanded by /bin/sh at exec time, so
+    // In CI, fetch via URL userinfo so auth doesn't depend on whether
+    // `actions/checkout` happened to persist an extraheader on `origin`
+    // (it doesn't for `cleanup.yml`, which uses
+    // `persist-credentials: false`; on a private repo that would mean
+    // an unauthenticated fetch via `origin` hits "could not read
+    // Username" when git falls back to interactive credential prompts).
+    // Clearing any inherited `http.<github>.extraheader` for this
+    // single command avoids git sending two `Authorization` headers —
+    // GitHub rejects those with HTTP 400 "Duplicate header:
+    // Authorization". Locally we just use `origin` so the user's
+    // normal SSH/HTTPS credentials apply. The literal `$GH_TOKEN` and
+    // `$GITHUB_REPOSITORY` are expanded by /bin/sh at exec time, so
     // shelljs never echoes the secret.
-    const hasExtraheader =
-        shell.exec(
-            'git config --get-all http.https://github.com/.extraheader',
-            { silent: true }
-        ).code === 0;
-    const fetchAuth =
-        !hasExtraheader && process.env.GH_TOKEN
-            ? '-c http.https://github.com/.extraheader="AUTHORIZATION: bearer $GH_TOKEN"'
-            : '';
+    const inCI = process.env.GITHUB_ACTIONS === 'true';
+    const fetchUrl = inCI
+        ? 'https://$GH_TOKEN@github.com/$GITHUB_REPOSITORY.git'
+        : 'origin';
+    const clearExtraHeader = inCI
+        ? '-c http.https://github.com/.extraheader='
+        : '';
+    const refspec = '+refs/heads/gh-pages:refs/remotes/origin/gh-pages';
 
-    if (shell.exec(`git ${fetchAuth} fetch origin gh-pages`).code !== 0) {
-        shell.echo('git fetch origin gh-pages failed!');
+    if (
+        shell.exec(`git ${clearExtraHeader} fetch ${fetchUrl} ${refspec}`)
+            .code !== 0
+    ) {
+        shell.echo('git fetch gh-pages failed!');
         teardown();
         shell.exit(1);
     }


### PR DESCRIPTION
## Summary

- Port the same fix that was just landed in `lime-crm-building-blocks` (PR #1460). The `setupDocsWorktree()` "detect existing extraheader, otherwise inject one" path is latent broken: it relies on `git config --get-all http.<github>.extraheader` to detect whether `actions/checkout` left an extraheader on `origin`, but in CI (with `actions/checkout@v6.0.2` and `persist-credentials: false`) no authentication is actually applied to the fetch. The reason it doesn't surface in `lime-elements` is that this is a public repo — `git fetch origin gh-pages` succeeds without auth.
- Replace that path with the URL-userinfo + cleared `http.<github>.extraheader` pattern that `push()` already uses. Same shape in both repos, robust if `lime-elements` ever goes private, and one less branch in the script.
- `pullAndRebase` is intentionally not changed: it only runs in the full publish flow, where the parent checkout's default `persist-credentials: true` leaves `origin` authenticated against `github.com` for the duration of the script.

## Test plan

- [x] Confirm this PR's own `Docs` build/publish job succeeds (it calls `setupDocsWorktree()`).
- [ ] On merge/close of this PR, watch the `Cleanup` workflow run and confirm the matching `PR-N` version is removed from `gh-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the documentation publishing workflow to improve reliability and ensure consistent authentication handling across continuous integration and local development environments.
  * Streamlined the documentation deployment process with enhanced credential management and refined fetch operations to support seamless, consistent publishing across various deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->