### PR TITLE
ci: harden release workflow secret and upload-destination scoping

### DIFF
--- a/.github/actions/upload-frontend-build-output-to-s3/action.yml
+++ b/.github/actions/upload-frontend-build-output-to-s3/action.yml
@@ -26,7 +26,10 @@ runs:
     env:
       PACKAGE_VERSION: ${{ inputs.package-version }}
     run: |
-      PKG_NAME=$(npm pkg get name | tr -d '\"')
+      # Intentionally hardcoded (not derived from package.json) so the upload
+      # destination is fixed and lives in this CODEOWNERS-protected file.
+      # Do not replace with `npm pkg get name`.
+      PKG_NAME="@limetech/lime-elements"
       FILENAME=$(npm pack | tail -n1)
       tar -xvf "$FILENAME"
       aws s3 cp "package" "s3://limecloud-static-files/packages/$PKG_NAME/$PACKAGE_VERSION" --recursive --follow-symlinks

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,6 +24,10 @@ on:
         description: 'Git ref (branch, tag, or SHA) to checkout. If not specified, uses the default ref for the triggering event.'
         required: false
         type: string
+    secrets:
+      PUBLISH_DOCS:
+        description: 'Token used to push the built docs to the gh-pages branch. Only needed when publishing (buildOnly == false).'
+        required: false
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -9,9 +9,6 @@ jobs:
     name: Remove PR docs
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_USERNAME: lime-opensource
-      GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
       CI: true
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,4 +21,7 @@ jobs:
     - name: Remove PR docs
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_USERNAME: lime-opensource
+        GH_TOKEN: ${{ secrets.CREATE_RELEASE }}
       run: npm run docs:publish -- --remove="PR-$PR_NUMBER"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -105,7 +105,8 @@ jobs:
       # For same-repo PRs, publish directly. For fork PRs, build only (publishing handled by publish-pr-docs workflow).
       # For Dependabot PRs, build only (no need to publish docs for dependency updates).
       buildOnly: ${{ github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
-    secrets: inherit
+    secrets:
+      PUBLISH_DOCS: ${{ secrets.PUBLISH_DOCS }}
 
   automerge:
     needs: [lint, build, test, autosquash, docs]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,4 +83,5 @@ jobs:
       version: "${{ needs.semantic-release.outputs.new_release_version }}"
       ref: "${{ needs.semantic-release.outputs.new_release_git_tag }}"
       forcePush: true
-    secrets: inherit
+    secrets:
+      PUBLISH_DOCS: ${{ secrets.PUBLISH_DOCS }}


### PR DESCRIPTION
## What

Two small CI hardening changes:

1. **Hardcode the S3 upload destination** in the `upload-frontend-build-output-to-s3` action. The destination package name is now a fixed value in this CODEOWNERS-protected action instead of being read from `package.json` (which is not CODEOWNERS-protected).

2. **Limit workflow secret exposure:**
   - `pr-checks.yml` and `release.yml` now pass only `PUBLISH_DOCS` to the reusable `build-docs.yml` workflow, instead of `secrets: inherit` (which forwarded every repository secret). `build-docs.yml` declares the secret accordingly; `GITHUB_TOKEN` is provided to reusable workflows automatically.
   - `cleanup.yml` scopes its tokens to the single step that uses them rather than exposing them to the whole job (which also runs `npm ci`).

## Why

Tighten the blast radius of the release/cleanup workflows: keep the upload target fixed and under code-owner control, and ensure each job/step only sees the secrets it actually needs.

## Notes

- No behavioral change expected. Fork/Dependabot PRs already receive no secrets and run in `buildOnly` mode; same-repo PR and release runs still get `PUBLISH_DOCS`.
- Validated locally with `actionlint` (the only remaining warning is the pre-existing SC2086 in the React-version check, untouched here).
- Type is `ci`, so this does not trigger a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment pipeline configurations to enhance security practices in documentation publishing and artifact management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->