### PR TITLE
fix(color-picker): better render swatches in small containers

### DIFF
--- a/src/components/color-picker/color-picker-palette.scss
+++ b/src/components/color-picker/color-picker-palette.scss
@@ -29,7 +29,7 @@
             var(--color-picker-column-count),
             var(--limel-color-palette-max-column-count)
         ),
-        1fr
+        minmax(0.5rem, 3rem)
     );
     width: 100%;
     max-width: 58rem;
@@ -83,23 +83,9 @@ button.swatch {
     justify-content: center;
     align-items: center;
 
+    width: 100%;
     max-width: 3rem;
-    min-width: max(
-        2rem,
-        100% /
-            min(
-                var(--color-picker-column-count),
-                var(--limel-color-palette-max-column-count)
-            ) -
-            (
-                min(
-                        var(--color-picker-column-count),
-                        var(--limel-color-palette-max-column-count)
-                    ) -
-                    1
-            ) *
-            var(--limel-color-palette-gap)
-    );
+    min-width: 0;
     aspect-ratio: 1;
     border-radius: 0.1875rem;
 


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/4091

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced color picker palette layout with refined grid column width constraints and improved swatch button styling. The palette now delivers better visual consistency, optimized layout efficiency, and more predictable rendering behavior across various configurations, screen sizes, and zoom levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
