### PR TITLE
ci: use scoped S3 upload role via s3-release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
     needs: [sonarcloud]
     if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
+    # Run in the `s3-release` environment, which holds the scoped S3 upload
+    # role and restricts which branches may use it. Its deployment branch
+    # policy mirrors this workflow's trigger branches.
+    environment: s3-release
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
@@ -69,7 +73,7 @@ jobs:
       if: steps.semantic.outputs.new_release_published == 'true'
       uses: ./.github/actions/upload-frontend-build-output-to-s3
       with:
-        aws-role: ${{ secrets.AWS_SHARED_LIMECLOUD_WRITE_STATIC_FILES_ROLE }}
+        aws-role: ${{ secrets.AWS_LIMECLOUD_WRITE_STATIC_FILES_ROLE }}
         frontend-path: ./
         package-version: ${{ steps.semantic.outputs.new_release_version }}
 


### PR DESCRIPTION
## What

Activates the dedicated, least-privilege S3 upload role for releases:
- The `semantic-release` job now runs in the **`s3-release` environment**, whose deployment branch policy (`main`, `*.x`, `*.x.x`, `dev`, `alpha`, `beta`) mirrors this workflow's trigger branches.
- The S3 upload step now assumes `AWS_LIMECLOUD_WRITE_STATIC_FILES_ROLE` (environment secret).

## Why

The new role can only write under this package's prefix and is only assumable from this environment — narrowing the blast radius of the release credentials. This is the consumer-side activation of infrastructure that's already deployed.

## Risk / notes

- This is the cutover commit: once merged, the next release uses the new environment + role.
- All release branches are covered by the environment's branch policy, so the release job runs exactly where it does today.
- The old `AWS_SHARED_LIMECLOUD_WRITE_STATIC_FILES_ROLE` repo secret becomes unused by this repo and can be removed after a confirmed successful release (other repos still use the underlying role).

## Verification

- `actionlint` passes
- Confirmed env secret name, branch policies, and OIDC trust subject all align
- Successful dev-release run: https://github.com/Lundalogik/lime-elements/actions/runs/26747671683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure configuration for AWS credentials and environment controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->