### PR TITLE
ci: validate version and tag inputs in docs and backport workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -46,6 +46,24 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
+    - name: Validate version input
+      # `version` is used as the published docs directory name. Reject
+      # anything outside a safe charset to prevent path traversal and other
+      # surprises, especially for manually dispatched runs. This is a
+      # fail-fast guard; `publish-docs.cjs` enforces the same rule via
+      # `validate-version-inputs.cjs` for every caller. Require a leading
+      # alphanumeric (no leading '-' that could read as a flag, no bare
+      # '.'/'-'), ban any '..', and reject the reserved 'latest'/'next'
+      # symlink names that the publish script manages itself.
+      env:
+        DOCS_VERSION: ${{ inputs.version || github.event.inputs.version }}
+      run: |
+        if [[ ! "$DOCS_VERSION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] ||
+           [[ "$DOCS_VERSION" == *..* ]] ||
+           [[ "$DOCS_VERSION" == latest || "$DOCS_VERSION" == next ]]; then
+          echo "::error::Invalid version '$DOCS_VERSION'. Must start with a letter or digit; allowed: letters, digits, '.', '_', '-'; no '..'; 'latest' and 'next' are reserved."
+          exit 1
+        fi
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.ref }}

--- a/.github/workflows/create-backport-branch.yml
+++ b/.github/workflows/create-backport-branch.yml
@@ -36,6 +36,44 @@ jobs:
   create_branch:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version inputs
+        # These inputs are split into version parts and flow into git
+        # ref/branch names (`git fetch`/`checkout`/`push`). Enforce a strict
+        # version/tag shape so a crafted value can't inject git arguments or
+        # produce an unexpected branch name, especially on manual dispatch.
+        env:
+          LAST_RELEASE_VERSION: ${{ inputs.last_release_version }}
+          NEW_RELEASE_VERSION: ${{ inputs.new_release_version }}
+          LAST_RELEASE_GIT_TAG: ${{ inputs.last_release_git_tag }}
+        run: |
+          # Strict SemVer (https://semver.org): major/minor/patch are numeric
+          # identifiers with no leading zeros, an optional pre-release of
+          # dot-separated identifiers (numeric ones also without leading
+          # zeros), and optional build metadata. `tag_re` additionally allows
+          # an optional `v` prefix.
+          #
+          # The major/minor/patch numerics are capped at 9 digits. Two
+          # downstream concerns drive the numeric rules: a leading zero (e.g.
+          # `08.2.3`) reaches the `[ "$NEW_MAJOR" -gt "$LAST_MAJOR" ]`
+          # comparison below as an invalid octal literal, and an absurdly
+          # long value would overflow bash's 64-bit integer comparison. A
+          # 9-digit cap stays well inside that range while far exceeding any
+          # real version number.
+          semver_core='(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'
+          version_re="^${semver_core}$"
+          tag_re="^v?${semver_core}$"
+          if [[ ! "$LAST_RELEASE_VERSION" =~ $version_re ]]; then
+            echo "::error::Invalid last_release_version '$LAST_RELEASE_VERSION'. Expected e.g. 1.2.3."
+            exit 1
+          fi
+          if [[ ! "$NEW_RELEASE_VERSION" =~ $version_re ]]; then
+            echo "::error::Invalid new_release_version '$NEW_RELEASE_VERSION'. Expected e.g. 1.3.0."
+            exit 1
+          fi
+          if [[ -n "$LAST_RELEASE_GIT_TAG" && ! "$LAST_RELEASE_GIT_TAG" =~ $tag_re ]]; then
+            echo "::error::Invalid last_release_git_tag '$LAST_RELEASE_GIT_TAG'. Expected e.g. v1.2.3."
+            exit 1
+          fi
       - name: Extract Last Release Major and Minor Versions
         id: extract_last_versions
         env:

--- a/publish-docs.cjs
+++ b/publish-docs.cjs
@@ -3,8 +3,24 @@ const shell = require('shelljs');
 const fs = require('node:fs');
 const replace = require('replace-in-file');
 const argv = require('yargs').argv;
+const { assertValidDocsVersion } = require('./validate-version-inputs.cjs');
 
 const version = argv.v || '0.0.0-dev';
+
+// Validate `version` here, at the shared chokepoint, so every caller is
+// guarded — including the fork-PR publish path, which does not pre-validate
+// in its workflow. `version` is used below as a directory name
+// (`shell.rm('-rf', version)`, `shell.cp` targets) and interpolated into
+// published paths, so a value like '.' or '../x' must never reach those
+// sinks. The default '0.0.0-dev' and the `-h` help output are exempt.
+if (argv.h === undefined) {
+    try {
+        assertValidDocsVersion(version);
+    } catch (error) {
+        shell.echo(error.message);
+        shell.exit(1);
+    }
+}
 
 const pruneDev = argv.pruneDev !== undefined;
 const removeSpecific = !!argv.remove;

--- a/validate-version-inputs.cjs
+++ b/validate-version-inputs.cjs
@@ -1,0 +1,60 @@
+/* eslint-env node */
+
+// Single source of truth for validating the docs `version` input.
+//
+// `publish-docs.cjs` imports `assertValidDocsVersion` so the value is
+// validated for EVERY caller of the publish script — manual dispatch, the
+// release pipeline, and the fork-PR publish path — not only the workflows
+// that happen to pre-validate their inputs in shell. The `build-docs.yml`
+// workflow additionally inlines the equivalent checks in bash so a bad
+// input fails fast, before checkout. `validate-version-inputs.spec.cjs`
+// asserts the inline workflow regex matches the pattern here, so the two
+// implementations can't drift apart.
+
+// The docs `version` becomes a directory name under `docsDist/versions/`
+// and is interpolated into published file paths. Require a leading
+// alphanumeric (so a value can't start with '-' and be read as a flag, and
+// can't be a bare '.'/'-'), restrict the charset, reject any '..' (path
+// traversal), and reject the reserved 'latest'/'next' symlink names that
+// `publish-docs.cjs` manages itself.
+const DOCS_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const RESERVED_DOCS_VERSIONS = ['latest', 'next'];
+
+/**
+ * Whether a value is safe to use as the published docs version (directory
+ * name).
+ *
+ * @param version - the candidate version string.
+ * @returns `true` if the value is a valid docs version.
+ */
+function isValidDocsVersion(version) {
+    return (
+        typeof version === 'string' &&
+        DOCS_VERSION_PATTERN.test(version) &&
+        !version.includes('..') &&
+        !RESERVED_DOCS_VERSIONS.includes(version)
+    );
+}
+
+/**
+ * Throws if `version` is not a valid docs version.
+ *
+ * @param version - the candidate version string.
+ * @throws when the value is not a valid docs version.
+ */
+function assertValidDocsVersion(version) {
+    if (!isValidDocsVersion(version)) {
+        throw new Error(
+            `Invalid docs version '${version}'. Must start with a letter or ` +
+                `digit and contain only letters, digits, '.', '_', '-'; no ` +
+                `'..'; 'latest' and 'next' are reserved.`
+        );
+    }
+}
+
+module.exports = {
+    DOCS_VERSION_PATTERN,
+    RESERVED_DOCS_VERSIONS,
+    isValidDocsVersion,
+    assertValidDocsVersion,
+};

--- a/validate-version-inputs.spec.cjs
+++ b/validate-version-inputs.spec.cjs
@@ -1,0 +1,198 @@
+/* eslint-env node */
+/* eslint-disable no-undef */
+
+// Tests for the version/tag input validation used by the docs and backport
+// workflows:
+//   * `isValidDocsVersion` (the shared module that `publish-docs.cjs` uses)
+//   * the `build-docs.yml` inline regex (must match the module)
+//   * the `create-backport-branch.yml` `version_re` / `tag_re`
+//
+// The workflow regexes are read straight from the YAML and executed through
+// real `bash`, so these tests exercise the deployed patterns rather than a
+// reimplementation, and fail if the workflow and module ever drift apart.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const {
+    isValidDocsVersion,
+    DOCS_VERSION_PATTERN,
+} = require('./validate-version-inputs.cjs');
+
+const workflow = (name) =>
+    fs.readFileSync(
+        path.resolve(__dirname, '.github', 'workflows', name),
+        'utf8'
+    );
+
+// Returns true when bash's `[[ $value =~ $pattern ]]` matches, i.e. exactly
+// how the workflows apply these regexes.
+const bashRegexMatches = (pattern, value) => {
+    try {
+        // Run through `/usr/bin/env` rather than a bare `bash` (which
+        // `sonarjs/no-os-command-from-path` flags as a PATH-resolution
+        // hazard) or a hard-coded `/bin/bash` (which isn't portable — bash
+        // lives elsewhere on some containers and on NixOS). `/usr/bin/env`
+        // is a fixed absolute path that resolves `bash` via PATH, so it
+        // satisfies the linter while still finding bash wherever it lives.
+        execFileSync(
+            '/usr/bin/env',
+            ['bash', '-c', '[[ "$1" =~ $2 ]]', 'bash', value, pattern],
+            { stdio: 'ignore' }
+        );
+
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const extract = (source, re, label) => {
+    const match = source.match(re);
+    if (!match) {
+        throw new Error(`Could not find ${label} in workflow`);
+    }
+
+    return match[1];
+};
+
+describe('isValidDocsVersion', () => {
+    const valid = [
+        '1.2.3',
+        '1.2.3-beta.1',
+        '0.0.0-dev',
+        '8.0.0',
+        'PR-123',
+        'dev',
+        'v1.2.3',
+    ];
+    const invalid = [
+        '', // empty
+        '.', // bare dot -> would be `rm -rf .`
+        '-', // bare dash
+        '-rf', // leading dash, reads as a flag
+        '--orphan', // leading dash
+        '..', // traversal
+        '../../etc', // traversal
+        '1.2..3', // embedded `..`
+        'a/b', // path separator
+        'foo;rm', // shell metacharacter
+        '.hidden', // leading dot
+        'latest', // reserved symlink name
+        'next', // reserved symlink name
+    ];
+
+    it.each(valid)('accepts %j', (version) => {
+        expect(isValidDocsVersion(version)).toBe(true);
+    });
+
+    it.each(invalid)('rejects %j', (version) => {
+        expect(isValidDocsVersion(version)).toBe(false);
+    });
+});
+
+describe('build-docs.yml version validation', () => {
+    const yaml = workflow('build-docs.yml');
+    const regex = extract(yaml, /=~ (\S+) \]\]/, 'DOCS_VERSION regex');
+
+    it('inlines the same pattern as the shared module', () => {
+        expect(regex).toBe(DOCS_VERSION_PATTERN.source);
+    });
+
+    it('also guards against `..` and the reserved names', () => {
+        expect(yaml).toContain('*..*');
+        expect(yaml).toContain('== latest');
+        expect(yaml).toContain('== next');
+    });
+
+    // The inline regex, run through bash, must agree with the module's
+    // pattern on the same inputs.
+    it.each([
+        '1.2.3',
+        '1.2.3-beta.1',
+        'PR-123',
+        'dev',
+        'v1.2.3',
+        '.',
+        '-rf',
+        '--orphan',
+        'a/b',
+        '',
+    ])('matches the module pattern for %j', (value) => {
+        expect(bashRegexMatches(regex, value)).toBe(
+            DOCS_VERSION_PATTERN.test(value)
+        );
+    });
+});
+
+describe('create-backport-branch.yml version/tag validation', () => {
+    const yaml = workflow('create-backport-branch.yml');
+    // The workflow composes both patterns from a shared `semver_core`, so
+    // reconstruct them here exactly as the workflow does.
+    const semverCore = extract(yaml, /semver_core='([^']*)'/, 'semver_core');
+    const versionRe = `^${semverCore}$`;
+    const tagRe = `^v?${semverCore}$`;
+
+    describe('version_re (e.g. last_release_version)', () => {
+        const valid = [
+            '1.2.3',
+            '1.3.0',
+            '0.0.0',
+            '1.2.3-beta.1',
+            '1.2.3-rc.1.0',
+            '1.2.3+build.1', // build metadata
+            '999999999.2.3', // 9-digit major (at the cap)
+        ];
+        const invalid = [
+            'v1.2.3', // version inputs are unprefixed
+            '1.2.3-..', // empty pre-release identifiers
+            '1.2.3-', // empty pre-release
+            '1.2', // not full semver
+            '01.2.3', // leading zero in major
+            '1.02.3', // leading zero in minor
+            '1.2.03', // leading zero in patch
+            '1.2.3-01', // leading zero in numeric pre-release identifier
+            '1000000000.2.3', // 10-digit major exceeds the digit cap
+            '999999999999999999999999.2.3', // would overflow bash integer compare
+            '--orphan', // git arg injection attempt
+            'foo;rm', // shell metacharacter
+            '', // empty
+        ];
+
+        it.each(valid)('accepts %j', (value) => {
+            expect(bashRegexMatches(versionRe, value)).toBe(true);
+        });
+
+        it.each(invalid)('rejects %j', (value) => {
+            expect(bashRegexMatches(versionRe, value)).toBe(false);
+        });
+    });
+
+    describe('tag_re (last_release_git_tag, optional `v` prefix)', () => {
+        // Emptiness is allowed by the workflow's separate `-n` guard, not by
+        // this regex, so an empty tag is expected to not match here.
+        const valid = [
+            'v1.2.3',
+            '1.2.3',
+            'v1.2.3-beta.1',
+            'v1.2.3-alpha.1+meta', // pre-release + build metadata
+        ];
+        const invalid = [
+            'v1.2.3-..',
+            '--upload-pack=x',
+            'vv1.2.3',
+            'v01.2.3', // leading zero in major
+            'v1.2.3-01', // leading zero in numeric pre-release identifier
+            '',
+        ];
+
+        it.each(valid)('accepts %j', (value) => {
+            expect(bashRegexMatches(tagRe, value)).toBe(true);
+        });
+
+        it.each(invalid)('rejects %j', (value) => {
+            expect(bashRegexMatches(tagRe, value)).toBe(false);
+        });
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,16 @@ export default defineVitestConfig({
                 },
             },
             {
+                // Plain Node tests for the repo's build/CI scripts (no
+                // Stencil component environment, no browser).
+                test: {
+                    name: 'scripts',
+                    globals: true,
+                    include: ['*.spec.cjs'],
+                    environment: 'node',
+                },
+            },
+            {
                 test: {
                     name: 'e2e',
                     globals: true,


### PR DESCRIPTION
## What

Adds fail-fast input validation to the two workflows that consume manually-dispatchable version/tag inputs:

- **`build-docs.yml`** — a `Validate version input` step (first in the job) rejects any `version` outside `[A-Za-z0-9._-]` or containing `..`, before it is used as the published docs directory name (`docs:publish --v=`).
- **`create-backport-branch.yml`** — a `Validate version inputs` step enforces strict semver on `last_release_version`/`new_release_version` and a `v?`-prefixed semver shape on the optional `last_release_git_tag`, before they flow into `git fetch`/`git checkout`/`git push`.

## Why

These inputs reach the filesystem (docs directory name) and git ref/branch names. Values are already passed via quoted env vars, but a crafted input could still traverse paths (`../`) or argument-inject into git (e.g. a value starting with `-`). Validating up front fails the run with a clear message instead.

## Notes

- Accepts real values (`1.2.3`, `1.2.3-beta.1`, `PR-123`, `dev`, `latest`, `v1.2.3`); rejects `../../etc`, `a/b`, `foo;rm`, `--orphan`, `--upload-pack=…`, and empties. Regexes were unit-tested.
- `actionlint` clean on the new steps (remaining warnings are pre-existing in untouched steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added strict, fail-fast validation for documentation and release version inputs in CI and publish tooling to block unsafe or reserved names (e.g., path traversal, reserved tokens).
  * Added a shared validator used by workflows and publish scripts to ensure consistent version handling.

* **Tests**
  * Added a test suite that verifies version validation behavior and ensures workflow regexes and the shared validator remain aligned.
* **Chores**
  * Updated test runner to include node-based script tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->