### PR TITLE
feat(picker): support badges on picked chips

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -78,7 +78,7 @@ export interface ChartItem<T extends number | [number, number] = number | [numbe
 
 // @public (undocumented)
 export interface Chip<T = any> {
-    badge?: number;
+    badge?: number | string;
     href?: string;
     icon?: IconName | Icon;
     // @deprecated

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -4318,6 +4318,7 @@ export { Option_2 as Option }
 
 // @public
 export interface PickerItem<T = PickerValue> extends ListItem<T> {
+    badge?: number | string;
     removable?: boolean;
 }
 

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -98,9 +98,10 @@ export interface Chip<T = any> {
     value?: T;
 
     /**
-     * The value of the badge.
+     * The value of the badge. Accepts either a number (for counter-style
+     * badges) or a short string (e.g. a status label like "Inactive").
      */
-    badge?: number;
+    badge?: number | string;
 
     /**
      * If supplied, the chip will render a link, using the supplied href.

--- a/src/components/chip-set/examples/chip-set-filter-badge.tsx
+++ b/src/components/chip-set/examples/chip-set-filter-badge.tsx
@@ -87,7 +87,10 @@ export class ChipSetFilterBadgeExample {
     private setAllBadgeValue() {
         let badgeValue = 0;
         for (const chip of this.chips) {
-            if (chip.id !== CHIP_SELECET_ALL_ID) {
+            if (
+                chip.id !== CHIP_SELECET_ALL_ID &&
+                typeof chip.badge === 'number'
+            ) {
                 badgeValue += chip.badge;
             }
         }

--- a/src/components/picker/examples/picker-with-badges.tsx
+++ b/src/components/picker/examples/picker-with-badges.tsx
@@ -1,0 +1,107 @@
+import { LimelPickerCustomEvent, PickerItem } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Picker with badges on picked chips
+ *
+ * Set `badge` on a `PickerItem` to stamp the resulting chip with a
+ * short status label or counter. The badge accepts a string
+ * (e.g. `"Inactive"`, `"Beta"`) or a number (e.g. `12`).
+ *
+ * Use it to surface metadata about the picked value at a glance
+ * without forcing the consumer to read the chip text or open a
+ * tooltip — for example, marking deactivated users in a group
+ * picker, or flagging items that have unread notifications.
+ *
+ * :::note
+ * For long string labels you may need to override the
+ * `--badge-max-width` CSS custom property on the host element of
+ * the consuming component, since the default is tuned for short
+ * numeric counters.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-picker-with-badges',
+    shadow: true,
+})
+export class PickerWithBadgesExample {
+    @State()
+    private selectedItems: Array<PickerItem<number>> = [
+        {
+            text: 'Admiral Swiggins',
+            value: 1,
+            icon: 'person_male',
+            badge: 'Inactive',
+            secondaryText: 'Inactive',
+        },
+        {
+            text: 'Ayla',
+            value: 2,
+            icon: 'person_female',
+        },
+    ];
+
+    private allItems: Array<PickerItem<number>> = [
+        {
+            text: 'Admiral Swiggins',
+            value: 1,
+            icon: 'person_male',
+            badge: 'Inactive',
+            secondaryText: 'Inactive',
+        },
+        { text: 'Ayla', value: 2, icon: 'person_female' },
+        { text: 'Clunk', value: 3, icon: 'person_male' },
+        { text: 'Coco', value: 4, icon: 'person_female' },
+        {
+            text: 'Derpl',
+            value: 5,
+            icon: 'person_male',
+            badge: 'Inactive',
+            secondaryText: 'Inactive',
+        },
+        { text: 'Froggy G', value: 6, icon: 'person_male' },
+        { text: 'Lonestar', value: 8, icon: 'person_male' },
+        { text: 'Lucy', value: 14, icon: 'person_female' },
+        { text: 'Raelynn', value: 10, icon: 'person_female' },
+        { text: 'Voltar', value: 12, icon: 'person_male' },
+        { text: 'Yuri', value: 13, icon: 'person_male' },
+    ];
+
+    private availableItems: Array<PickerItem<number>> = this.allItems.filter(
+        (item) =>
+            !this.selectedItems.some(
+                (selected) => selected.value === item.value
+            )
+    );
+
+    public render() {
+        return (
+            <Host>
+                <limel-picker
+                    label="Meeting participants"
+                    searchLabel="Add a participant"
+                    value={this.selectedItems}
+                    multiple={true}
+                    allItems={this.availableItems}
+                    onChange={this.onChange}
+                />
+                <limel-example-value value={this.selectedItems} />
+            </Host>
+        );
+    }
+
+    private onChange = (
+        event: LimelPickerCustomEvent<Array<PickerItem<number>>>
+    ) => {
+        this.selectedItems = [...event.detail];
+        this.updateAvailableItems();
+    };
+
+    private updateAvailableItems = () => {
+        this.availableItems = this.allItems.filter((item) => {
+            return !this.selectedItems.some((selectedItem) => {
+                return item.value === selectedItem.value;
+            });
+        });
+    };
+}

--- a/src/components/picker/picker-item.types.ts
+++ b/src/components/picker/picker-item.types.ts
@@ -25,4 +25,11 @@ export interface PickerItem<T = PickerValue> extends ListItem<T> {
      * button is hidden on all chips regardless of this flag.
      */
     removable?: boolean;
+
+    /**
+     * Optional badge to display on the chip when the item is picked.
+     * Useful for marking selected items with a status indicator
+     * (e.g. "Inactive", "Beta", or a numeric counter).
+     */
+    badge?: number | string;
 }

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -36,6 +36,7 @@ const DEFAULT_SEARCHER_MAX_RESULTS = 20;
  * @exampleComponent limel-example-picker-basic
  * @exampleComponent limel-example-picker-multiple
  * @exampleComponent limel-example-picker-non-removable
+ * @exampleComponent limel-example-picker-with-badges
  * @exampleComponent limel-example-picker-icons
  * @exampleComponent limel-example-picker-pictures
  * @exampleComponent limel-example-picker-value-as-object
@@ -377,6 +378,7 @@ export class Picker {
             image: listItem.image,
             value: listItem,
             menuItems: listItem.actions,
+            badge: listItem.badge,
         };
     };
 


### PR DESCRIPTION
## Summary

Lets consumers stamp picked chips with a short status label or a numeric counter via a new optional `badge` field on `PickerItem`.

- `feat(chip-set)` — widens `Chip.badge` from `number` to `string | number`. The underlying `limel-badge.label` already accepts both, so this just exposes that capability one layer up.
- `feat(picker)` — adds `PickerItem.badge` and forwards it to the rendered chip. Includes a new `limel-example-picker-with-badges` showing string and numeric badges in use.

## Motivation

Used by [Lundalogik/crm-client#1016](https://github.com/Lundalogik/crm-client/issues/1016) to mark inactive groups in the filter-set publish-groups picker with an `Inactive` badge instead of hiding them. Generally useful anywhere selected items need a status indicator at a glance (Beta, Deprecated, unread counter, etc.).

## Test plan

- [ ] Open the new `picker-with-badges` example — chips for items with `badge: 'Inactive'` show the badge, chips without `badge` don't.
- [ ] Existing `chip-set-filter-badge` example still works (numeric counter arithmetic is now type-guarded).
- [ ] `npm run api:verify` regenerates `etc/lime-elements.api.md` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chips and picker items can show badges as numbers or short strings.
  * Added a picker example demonstrating multi-select chips with badges and live selection display.

* **Bug Fixes**
  * Badge aggregation now only sums numeric badges and ignores non-numeric badge values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->