### PR TITLE
fix(list): ensure dividers are visually separating items more

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -47,7 +47,15 @@ ul {
     align-items: center;
     gap: 0.75rem;
     height: auto;
-    padding: 0 0.5rem;
+    padding: 0 0.25rem;
+
+    margin-bottom: 0.5rem;
+    &:not(:first-child) {
+        margin-top: 0.75rem;
+    }
+    :host(.has-striped-rows) & {
+        margin-top: 0.5rem;
+    }
 }
 
 .limel-list-divider-line {


### PR DESCRIPTION
The list dividers were hard to notice since they were visually too close to their pervious and next list items. It made the UI a bit too noisy, while making it hard to quickly notice the dividers.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced list divider spacing and alignment for improved visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lundalogik/lime-elements/pull/4104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
