### PR TITLE
feat(form): emit data-schema-path on layout wrappers

### DIFF
--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -36,6 +36,8 @@ import {
     nestedStringCustomComponentSchema,
     arrayItemWithDependenciesSchema,
     arrayItemWithDependenciesAndCustomConfigSchema,
+    nestedSchemaPathSchema,
+    nestedLayoutSchemaPathSchema,
 } from './form.test-schemas';
 
 const fieldTypeTests = [
@@ -362,6 +364,42 @@ test('renders grid layout when schema has lime.layout.type grid', async () => {
 
     const inputFields = grid.querySelectorAll('limel-input-field');
     expect(inputFields.length).toBe(2);
+});
+
+test('emits data-schema-path on each layout wrapper', async () => {
+    const { formContent } = await renderForm({
+        schema: nestedSchemaPathSchema,
+    });
+
+    const paths = [
+        ...formContent.querySelectorAll(
+            '.limel-form-layout--default[data-schema-path]'
+        ),
+    ].map((el) => el.dataset.schemaPath);
+
+    expect(paths).toEqual([
+        '/',
+        '/section',
+        '/section/details',
+        '/section/details/contact',
+    ]);
+});
+
+test('emits data-schema-path on grid and row layout wrappers', async () => {
+    const { formContent } = await renderForm({
+        schema: nestedLayoutSchemaPathSchema,
+    });
+
+    expect(
+        formContent
+            .querySelector('.limel-form-layout--grid')
+            ?.getAttribute('data-schema-path')
+    ).toBe('/grid');
+    expect(
+        formContent
+            .querySelector('.limel-form-row--layout')
+            ?.getAttribute('data-schema-path')
+    ).toBe('/row');
 });
 
 test('renders collapsible section when schema has lime.collapsible', async () => {

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -501,3 +501,52 @@ export const nestedStringCustomComponentSchema: FormSchema = {
         },
     },
 };
+
+export const nestedSchemaPathSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        section: {
+            type: 'object',
+            title: 'Section',
+            properties: {
+                details: {
+                    type: 'object',
+                    title: 'Details',
+                    properties: {
+                        contact: {
+                            type: 'object',
+                            title: 'Contact',
+                            properties: {
+                                name: { type: 'string', title: 'Name' },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+
+export const nestedLayoutSchemaPathSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        grid: {
+            type: 'object',
+            title: 'Grid',
+            properties: {
+                first: { type: 'string', title: 'First' },
+                second: { type: 'string', title: 'Second' },
+            },
+            lime: { layout: { type: 'grid', columns: 2 } },
+        },
+        row: {
+            type: 'object',
+            title: 'Row',
+            properties: {
+                third: { type: 'string', title: 'Third' },
+                fourth: { type: 'string', title: 'Fourth' },
+            },
+            lime: { layout: { type: 'row' } },
+        },
+    },
+};

--- a/src/components/form/templates/grid-layout.ts
+++ b/src/components/form/templates/grid-layout.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormLayoutOptions, GridLayoutOptions } from '../form.types';
+import { toSchemaPath } from './object-field';
 
 const MAX_COLUMNS = 5;
 const MAX_COLUMN_WIDTH = 15;
@@ -76,6 +77,7 @@ export class GridLayout extends React.Component<LayoutProps, LayoutState> {
             'div',
             {
                 className: classes.join(' '),
+                'data-schema-path': toSchemaPath(this.props.schemaPath ?? []),
                 ref: this.elementRef,
             },
             this.props.children
@@ -97,6 +99,7 @@ export class GridLayout extends React.Component<LayoutProps, LayoutState> {
 
 interface LayoutProps {
     options: FormLayoutOptions;
+    schemaPath?: string[];
     children?: any;
 }
 

--- a/src/components/form/templates/object-field.ts
+++ b/src/components/form/templates/object-field.ts
@@ -22,7 +22,11 @@ export const ObjectFieldTemplate = (props: LimeObjectFieldTemplateProps) => {
         return React.createElement(
             ArrayFieldContext.Provider,
             { value: null },
-            renderProperties(props.properties, props.schema)
+            renderProperties(
+                props.properties,
+                props.schema,
+                props.fieldPathId.path.map(String)
+            )
         );
     }
 
@@ -39,7 +43,11 @@ function renderFieldWithTitle(props: LimeObjectFieldTemplateProps) {
         {},
         renderSectionHeader(props),
         renderDescription(props.description as string),
-        renderProperties(props.properties, props.schema)
+        renderProperties(
+            props.properties,
+            props.schema,
+            props.fieldPathId.path.map(String)
+        )
     );
 }
 
@@ -78,7 +86,11 @@ function renderCollapsibleField(props: LimeObjectFieldTemplateProps) {
         },
         helpElement,
         renderDescription(props.description as string),
-        renderProperties(props.properties, props.schema)
+        renderProperties(
+            props.properties,
+            props.schema,
+            props.fieldPathId.path.map(String)
+        )
     );
 }
 
@@ -101,16 +113,18 @@ function getSchemaObjectPropertyPath(
 
 function renderProperties(
     properties: ObjectFieldProperty[],
-    schema: JSONSchema7
+    schema: JSONSchema7,
+    schemaPath: string[]
 ) {
     const layout = schema.lime?.layout;
 
-    return renderLayout(properties, layout);
+    return renderLayout(properties, layout, schemaPath);
 }
 
 function renderLayout(
     properties: ObjectFieldProperty[],
-    layout: Partial<LimeLayoutOptions>
+    layout: Partial<LimeLayoutOptions>,
+    schemaPath: string[]
 ) {
     const type = layout?.type || 'default';
     const layouts: Record<FormLayoutType, Function> = {
@@ -119,36 +133,59 @@ function renderLayout(
         row: renderRowLayout,
     };
 
-    return layouts[type](properties, layout);
+    return layouts[type](properties, layout, schemaPath);
 }
 
-function renderDefaultLayout(properties: ObjectFieldProperty[]) {
+function renderDefaultLayout(
+    properties: ObjectFieldProperty[],
+    _layout: FormLayoutOptions | undefined,
+    schemaPath: string[]
+) {
     return React.createElement(
         'div',
         {
             className: 'limel-form-layout--default',
+            'data-schema-path': toSchemaPath(schemaPath),
         },
         properties.map((element) => element.content)
     );
 }
 
+/**
+ * Render a schema path as a leading-slash string. Root → `/`,
+ * `['rules']` → `/rules`, `['rules', 'details']` → `/rules/details`.
+ *
+ * @param path the schema-path segments (typically `fieldPathId.path`).
+ */
+export function toSchemaPath(path: string[]): string {
+    return path.length === 0 ? '/' : `/${path.join('/')}`;
+}
+
 function renderGridLayout(
     properties: ObjectFieldProperty[],
-    layout: FormLayoutOptions
+    layout: FormLayoutOptions,
+    schemaPath: string[]
 ) {
     return React.createElement(
         GridLayout,
         {
             options: layout,
+            schemaPath: schemaPath,
         },
         properties.map((element) => element.content)
     );
 }
 
-function renderRowLayout(properties: ObjectFieldProperty[]) {
+function renderRowLayout(
+    properties: ObjectFieldProperty[],
+    _layout: FormLayoutOptions | undefined,
+    schemaPath: string[]
+) {
     return React.createElement(
         RowLayout,
-        {},
+        {
+            schemaPath: schemaPath,
+        },
         properties.map((element) => element.content)
     );
 }

--- a/src/components/form/templates/row-layout.ts
+++ b/src/components/form/templates/row-layout.ts
@@ -1,22 +1,27 @@
 import React from 'react';
 import { Row } from '../row/row';
+import { toSchemaPath } from './object-field';
 import { RowProps } from './types';
-export class RowLayout extends React.Component<RowProps> {
+
+interface RowLayoutProps extends RowProps {
+    schemaPath?: string[];
+}
+
+export class RowLayout extends React.Component<RowLayoutProps> {
     private elementRef: React.RefObject<HTMLElement>;
 
-    constructor(public props: RowProps) {
+    constructor(public props: RowLayoutProps) {
         super(props);
 
         this.elementRef = React.createRef();
     }
 
     public render() {
-        const classes = ['limel-form-row--layout'];
-
         return React.createElement(
             'div',
             {
-                className: classes.join(' '),
+                className: 'limel-form-row--layout',
+                'data-schema-path': toSchemaPath(this.props.schemaPath ?? []),
                 ref: this.elementRef,
             },
             this.props.children.map((child, index) => {


### PR DESCRIPTION
Each object-field layout wrapper now carries a `data-schema-path` attribute (root as `/`, nested as `/a/b/...`). This lets a descendant web component locate a schema-scoped ancestor in the DOM without having the path prop-drilled down to it.

Foundation for the rules-visibility context work — the consuming pieces live in lime-crm-components and lime-webclient.

Closes Lundalogik/crm-client#1075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form layout components now emit `data-schema-path` attributes on rendered elements, enabling improved element identification and test coverage across nested structures.

* **Tests**
  * Added test coverage verifying schema path attribution on layout wrapper elements and nested schema structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->