### PR TITLE
ci(release): don't block releases on SonarCloud failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # SonarCloud intermittently rejects requests from GitHub-hosted runners
+    # with HTTP 403 (AWS IP reputation blocking, confirmed by SonarSource:
+    # https://community.sonarsource.com/t/-/138939). Don't let that block
+    # releases — the quality gate still guards every PR via pr-checks.yml;
+    # this scan only refreshes the analysis baseline on main.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
SonarCloud intermittently returns HTTP 403 to GitHub-hosted runners because AWS blocks runner IPs based on IP reputation, a known issue confirmed by SonarSource staff with no fix on our side: https://community.sonarsource.com/t/github-ci-cd-getting-inconsistent-403-errors-on-jre-metadata/138939

These transient failures have repeatedly blocked releases even though the failure has nothing to do with code quality. Mark the sonarcloud job as continue-on-error so semantic-release proceeds regardless. The quality gate still guards every PR via pr-checks.yml; the scan on main only refreshes the SonarCloud analysis baseline.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened release automation resilience by allowing the deployment pipeline to continue despite intermittent failures during code quality verification. The workflow now gracefully handles temporary service connectivity disruptions, preventing unexpected release delays and ensuring more reliable delivery cycles. This enhances operational stability and reduces deployment friction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
