### PR TITLE
refactor(table): expose table state on the host element

### DIFF
--- a/src/components/table/partial-styles/_row-drag-handle.scss
+++ b/src/components/table/partial-styles/_row-drag-handle.scss
@@ -11,7 +11,7 @@
     z-index: calc(var(--limel-table-row-selector-z-index) + 1) !important;
     background-color: transparent !important;
 
-    .has-rowselector & {
+    :host([selectable]:not([selectable='false'])) & {
         background-image: none !important;
         background-color: rgb(
             var(--limel-table-row-background-color)

--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -16,7 +16,7 @@
     left: 0.375rem;
     top: 0.1875rem;
 
-    .has-movable-rows & {
+    :host([movable-rows]:not([movable-rows='false'])) & {
         left: calc(var(--limel-table-drag-handle-width) + 0.375rem);
     }
 }
@@ -24,7 +24,7 @@
 .limel-table--row-selector {
     left: 0;
 
-    .has-movable-rows & {
+    :host([movable-rows]:not([movable-rows='false'])) & {
         left: var(--limel-table-drag-handle-width);
     }
 
@@ -83,7 +83,7 @@
     }
 }
 
-.has-movable-columns .tabulator-header {
+:host([movable-columns]:not([movable-columns='false'])) .tabulator-header {
     .tabulator-col.limel-table--row-selector,
     .tabulator-col.limel-table-drag-handle {
         border: none;
@@ -99,7 +99,12 @@
     }
 }
 
-.has-movable-columns.has-movable-rows .tabulator-header {
+:host(
+        [movable-columns]:not([movable-columns='false'])[movable-rows]:not(
+                [movable-rows='false']
+            )
+    )
+    .tabulator-header {
     .tabulator-col.limel-table--row-selector {
         left: var(--limel-table-drag-handle-width);
     }

--- a/src/components/table/partial-styles/_row-selection.scss
+++ b/src/components/table/partial-styles/_row-selection.scss
@@ -64,7 +64,7 @@
             opacity: 1;
         }
 
-        .has-selection & {
+        :host(.has-selection) & {
             opacity: 1;
         }
     }
@@ -112,7 +112,7 @@
 
 .tabulator-calcs {
     .tabulator-cell {
-        .has-selection & {
+        :host(.has-selection) & {
             color: var(
                 --table-arrow-color--active
             ); // to indicate that aggregated numbers are coming from the selcted rows not all rows

--- a/src/components/table/partial-styles/movable-columns.scss
+++ b/src/components/table/partial-styles/movable-columns.scss
@@ -9,7 +9,7 @@
     }
 }
 
-.has-movable-columns {
+:host([movable-columns]:not([movable-columns='false'])) {
     .tabulator-header {
         overflow-y: visible;
 

--- a/src/components/table/partial-styles/tabulator-paginator.scss
+++ b/src/components/table/partial-styles/tabulator-paginator.scss
@@ -1,16 +1,14 @@
 @use '../../../style/mixins';
 @use '../../../style/functions';
 
-#tabulator-container {
-    &:not(.has-pagination) {
-        // When there is no pagination, Tabulator still displays the pagination bar,
-        // but with only 1 page in it. This is why we may want to hide it visually.
-        // @private
-        // We use this in the CRM for very particular use cases, such as small
-        // explorer widgets with single-page tables on the start pages.
-        .tabulator-paginator {
-            display: var(--limel-table-single-page-paginator-display, grid);
-        }
+// When there is no pagination, Tabulator still displays the pagination bar,
+// but with only 1 page in it. This is why we may want to hide it visually.
+// @private
+// We use this in the CRM for very particular use cases, such as small
+// explorer widgets with single-page tables on the start pages.
+:host(:not(.has-pagination)) #tabulator-container {
+    .tabulator-paginator {
+        display: var(--limel-table-single-page-paginator-display, grid);
     }
 }
 

--- a/src/components/table/table.e2e.tsx
+++ b/src/components/table/table.e2e.tsx
@@ -262,4 +262,30 @@ describe('limel-table', () => {
             );
         });
     });
+
+    describe('aggregation row', () => {
+        // The `has-aggregation` class is exposed on the host so consumers and
+        // ancestor components can react to the totals row without piercing the
+        // shadow DOM — e.g. a floating action bar that must sit clear of it.
+        it('marks the host with `has-aggregation` when a column has an aggregator', async () => {
+            const columns = [
+                { field: 'amount', title: 'Amount', aggregator: () => 30 },
+            ];
+            const data = [
+                { id: 1, amount: 10 },
+                { id: 2, amount: 20 },
+            ];
+            const { root } = await renderTable({ data, columns });
+
+            expect(root.classList.contains('has-aggregation')).toBe(true);
+        });
+
+        it('does not mark the host without an aggregating column', async () => {
+            const columns = [{ field: 'amount', title: 'Amount' }];
+            const data = [{ id: 1, amount: 10 }];
+            const { root } = await renderTable({ data, columns });
+
+            expect(root.classList.contains('has-aggregation')).toBe(false);
+        });
+    });
 });

--- a/src/components/table/table.e2e.tsx
+++ b/src/components/table/table.e2e.tsx
@@ -288,4 +288,27 @@ describe('limel-table', () => {
             expect(root.classList.contains('has-aggregation')).toBe(false);
         });
     });
+
+    describe('pagination state', () => {
+        // `has-pagination` is exposed on the host so consumers can react to a
+        // multi-page table without piercing the shadow DOM.
+        it('marks the host with `has-pagination` when there is more than one page', async () => {
+            const columns = [{ field: 'name', title: 'Name' }];
+            const data = [
+                { id: 1, name: 'A' },
+                { id: 2, name: 'B' },
+            ];
+            const { root } = await renderTable({ columns, data, pageSize: 1 });
+
+            expect(root.classList.contains('has-pagination')).toBe(true);
+        });
+
+        it('does not mark the host for a single-page table', async () => {
+            const columns = [{ field: 'name', title: 'Name' }];
+            const data = [{ id: 1, name: 'A' }];
+            const { root } = await renderTable({ columns, data, pageSize: 10 });
+
+            expect(root.classList.contains('has-pagination')).toBe(false);
+        });
+    });
 });

--- a/src/components/table/table.e2e.tsx
+++ b/src/components/table/table.e2e.tsx
@@ -311,4 +311,40 @@ describe('limel-table', () => {
             expect(root.classList.contains('has-pagination')).toBe(false);
         });
     });
+
+    describe('selection state', () => {
+        // `has-selection` is exposed on the host so consumers can react to an
+        // active row selection without piercing the shadow DOM.
+        it('marks the host with `has-selection` when rows are selected', async () => {
+            const columns = [{ field: 'name', title: 'Name' }];
+            const data = [
+                { id: 1, name: 'A' },
+                { id: 2, name: 'B' },
+            ];
+            const { root, setProps, waitForChanges } = await renderTable({
+                columns,
+                data,
+                selectable: true,
+            });
+
+            setProps({ selection: [data[0]] });
+            await waitForChanges();
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            await waitForChanges();
+
+            expect(root.classList.contains('has-selection')).toBe(true);
+        });
+
+        it('does not mark the host without a selection', async () => {
+            const columns = [{ field: 'name', title: 'Name' }];
+            const data = [{ id: 1, name: 'A' }];
+            const { root } = await renderTable({
+                columns,
+                data,
+                selectable: true,
+            });
+
+            expect(root.classList.contains('has-selection')).toBe(false);
+        });
+    });
 });

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1113,12 +1113,12 @@ export class Table {
                     'has-low-density': this.layout === 'lowDensity',
                     'has-pagination-on-top': this.paginationLocation === 'top',
                     'has-aggregation': this.hasAggregation(this.columns),
+                    'has-pagination': totalRows > this.pageSize,
                 }}
             >
                 <div
                     id="tabulator-container"
                     class={{
-                        'has-pagination': totalRows > this.pageSize,
                         'has-selection': this.tableSelection?.hasSelection,
                     }}
                 >

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1114,14 +1114,10 @@ export class Table {
                     'has-pagination-on-top': this.paginationLocation === 'top',
                     'has-aggregation': this.hasAggregation(this.columns),
                     'has-pagination': totalRows > this.pageSize,
+                    'has-selection': this.tableSelection?.hasSelection,
                 }}
             >
-                <div
-                    id="tabulator-container"
-                    class={{
-                        'has-selection': this.tableSelection?.hasSelection,
-                    }}
-                >
+                <div id="tabulator-container">
                     {/* Toggle style instead of removing the loader
                     because removing the element will cause a rerender, breaking the
                     tabulator table */}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1112,13 +1112,13 @@ export class Table {
                 class={{
                     'has-low-density': this.layout === 'lowDensity',
                     'has-pagination-on-top': this.paginationLocation === 'top',
+                    'has-aggregation': this.hasAggregation(this.columns),
                 }}
             >
                 <div
                     id="tabulator-container"
                     class={{
                         'has-pagination': totalRows > this.pageSize,
-                        'has-aggregation': this.hasAggregation(this.columns),
                         'has-selection': this.tableSelection?.hasSelection,
                     }}
                 >

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1119,7 +1119,6 @@ export class Table {
                     class={{
                         'has-pagination': totalRows > this.pageSize,
                         'has-aggregation': this.hasAggregation(this.columns),
-                        'has-rowselector': this.selectable,
                         'has-selection': this.tableSelection?.hasSelection,
                     }}
                 >

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1119,8 +1119,6 @@ export class Table {
                     class={{
                         'has-pagination': totalRows > this.pageSize,
                         'has-aggregation': this.hasAggregation(this.columns),
-                        'has-movable-columns': this.movableColumns,
-                        'has-movable-rows': !!this.rowDragManager,
                         'has-rowselector': this.selectable,
                         'has-selection': this.tableSelection?.hasSelection,
                     }}


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-elements/issues/4116

Refactors how `limel-table` surfaces its rendered state so consumers/ancestors can rely on **host-level** state instead of piercing the shadow DOM. Landed commit-by-commit.

Part of #4116 (full rationale there — including the floating contextual action bar that needs `limel-table.has-aggregation`).

### State already covered by a reflected `@Prop` → style via the host attribute, drop the duplicate class (`refactor`)

- [x] `movableColumns` / `movableRows` → `:host([movable-columns])` / `:host([movable-rows])` (dropped `has-movable-columns` / `has-movable-rows`)
- [x] `selectable` → `:host([selectable])` (dropped `has-rowselector`)

No new tests — these are existing reflected props.

### Derived state with no prop equivalent → expose on the host as a class (`feat`, with e2e tests)

- [x] `has-aggregation` → host (no internal style users; pure move)
- [x] `has-pagination` → host (internal single-page-paginator rule rewritten to read the host)
- [x] `has-selection` → host (internal row-selector / calc-cell rules rewritten to read the host)

Each is a new public marker consumers can target (`limel-table.has-…`), covered by an e2e assertion on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal styling architecture by restructuring CSS class application and selector management for better maintainability across table components.

* **Tests**
  * Extended end-to-end test coverage with new test suites validating table state behavior for aggregation, pagination, and selection features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->