### PR TITLE
fix(form): keep optional oneOf enums clearable

### DIFF
--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -8,6 +8,7 @@ import {
     requiredFieldSchema,
     twoRequiredFieldsSchema,
     emailFormatSchema,
+    optionalOneOfSchema,
     arraySchema,
     nestedObjectSchema,
     arrayOfObjectsSchema,
@@ -100,6 +101,23 @@ test('emits change event with updated form data', async () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0].detail).toEqual({ name: 'Alice' });
+});
+
+test('does not auto-select a const from an optional oneOf, but keeps real defaults', async () => {
+    const onChange = vi.fn();
+    const { change } = await renderForm({
+        schema: optionalOneOfSchema,
+        onChange,
+    });
+
+    await change('Name', 'Alice');
+
+    // `choice` is an optional oneOf and must stay empty (the user can leave it
+    // blank), while `withDefault` still gets its declared default applied.
+    expect(onChange.mock.lastCall[0].detail).toEqual({
+        name: 'Alice',
+        withDefault: 'preset',
+    });
 });
 
 const validationTests = [

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -32,6 +32,26 @@ export const enumSchema: FormSchema = {
     },
 };
 
+export const optionalOneOfSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        name: { type: 'string', title: 'Name' },
+        choice: {
+            type: 'string',
+            title: 'Choice',
+            oneOf: [
+                { type: 'string', const: 'a', title: 'A' },
+                { type: 'string', const: 'b', title: 'B' },
+            ],
+        },
+        withDefault: {
+            type: 'string',
+            title: 'With default',
+            default: 'preset',
+        },
+    },
+};
+
 export const requiredFieldSchema: FormSchema = {
     type: 'object',
     properties: {

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -186,6 +186,15 @@ export class Form {
                     widgets: widgets,
                     validator: rjsfValidator,
                     liveValidate: 'onChange',
+                    // `@rjsf/core` v6 treats a `const` inside `oneOf`/`anyOf`
+                    // as a default and auto-selects the first option, so an
+                    // optional enum can never be left empty (clearing it just
+                    // gets repopulated on the next render). `skipOneOf` keeps
+                    // this off for enums while still applying genuine
+                    // `default` values, matching the pre-v6 behavior.
+                    experimental_defaultFormStateBehavior: {
+                        constAsDefaults: 'skipOneOf',
+                    },
                     showErrorList: false,
                     extraErrors: this.getExtraErrors(this.errors),
                     templates: {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optional fields with `oneOf` constraints no longer auto-populate with defaults; other fields with explicit defaults continue to be applied as expected.

* **Tests**
  * Added test coverage for optional `oneOf` field behavior with default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## What's going on

After the `@rjsf/core` v2 → v6 upgrade, an optional enum field rendered as a `oneOf` of `const` values can no longer be left empty. RJSF v6 defaults `constAsDefaults` to `'always'`, which treats each `const` as a default and auto-selects the first option. Clearing the field in the UI does nothing useful — the next render just repopulates it with the first option.

This surfaced in `limepkg-email`: its admin config has a "Use data from message" dropdown (`messageProperty`) that is meant to be optional — you're supposed to be able to leave it blank and configure a search path instead. Since lime-crm 3.10.0 (which is where the v6 upgrade landed) that field always comes back pre-filled with the first option, so customers can't save the empty/blank configuration the feature documents.

## The fix

Set `experimental_defaultFormStateBehavior.constAsDefaults: 'skipOneOf'`. That stops RJSF from treating `oneOf`/`anyOf` `const` options as defaults, so optional enums stay empty until the user picks something. Genuine `default` values are still applied — verified both ways in the test and against RJSF's own `getDefaultFormState`:

- `'always'` → `{ property: 'foo', messageProperty: 'fromAddress', relation: 'conversation' }`
- `'skipOneOf'` → `{ property: 'foo', relation: 'conversation' }`  ← enum left empty, real default kept

`'skipOneOf'` is the conservative choice over `'never'` since it still defaults a standalone `const` field (a field with a single fixed value), it only stops the auto-pick inside `oneOf`/`anyOf`.

Heads up for reviewers: this changes default-population behavior for every `limel-form` consumer, not just the package that hit it — worth a deliberate look, though it's restoring the behavior forms had before v6.

## Tests

Added `optionalOneOfSchema` plus an e2e test asserting an optional `oneOf` stays empty while a sibling with a declared `default` is still populated. Confirmed it fails with the old `'always'` behavior and passes with the fix. Full form suite green (52 e2e + 58 spec).

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
macOS:
- [x] Chrome (automated e2e via Chromium)