### PR TITLE
Fix `limel-table`'s `has-aggregation` class going stale on re-render

### DIFF
--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -301,3 +301,38 @@ describe('limel-table aggregate updates', () => {
         expect(tabulator.recalc).not.toHaveBeenCalled();
     });
 });
+
+describe('limel-table has-aggregation detection', () => {
+    let component: Table;
+
+    beforeEach(() => {
+        component = new Table();
+    });
+
+    it('detects an aggregation from the aggregates prop when no column carries an aggregator', () => {
+        (component as any).aggregates = [{ field: 'amount', value: 100 }];
+
+        expect(
+            (component as any).hasAggregation([
+                { field: 'name' },
+                { field: 'amount' },
+            ])
+        ).toBe(true);
+    });
+
+    it('does not detect an aggregation when no column field matches an aggregate', () => {
+        (component as any).aggregates = [{ field: 'amount', value: 100 }];
+
+        expect((component as any).hasAggregation([{ field: 'name' }])).toBe(
+            false
+        );
+    });
+
+    it("detects an aggregation from a column's own aggregator", () => {
+        expect(
+            (component as any).hasAggregation([
+                { field: 'amount', aggregator: () => 0 },
+            ])
+        ).toBe(true);
+    });
+});

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1052,8 +1052,29 @@ export class Table {
         return Math.ceil(total / this.pageSize);
     }
 
+    /**
+     * Whether any of `columns` shows an aggregation — either because the column
+     * carries its own `aggregator`, or because its field has a matching entry in
+     * `aggregates`.
+     *
+     * Deriving from `aggregates` (the source of truth) rather than only from the
+     * `aggregator` that `addColumnAggregator` mutates onto the column keeps this
+     * correct even when the table is re-fed equivalent columns and aggregates
+     * without that mutation being re-applied — e.g. when only the aggregate
+     * values change, `updateAggregates` recalculates without re-running
+     * `getColumnDefinitions`.
+     *
+     * @param columns - the column definitions to inspect.
+     * @returns whether at least one column shows an aggregation.
+     */
     private hasAggregation(columns: Column[]): boolean {
-        return columns.some((column) => has(column, 'aggregator'));
+        return columns.some(
+            (column) =>
+                has(column, 'aggregator') ||
+                (this.aggregates ?? []).some(
+                    (aggregate) => aggregate.field === column.field
+                )
+        );
     }
 
     private readonly getColumnOptions = (): TabulatorOptionsColumns => {


### PR DESCRIPTION
## What

`limel-table`'s `has-aggregation` host class was derived **solely** from a `.aggregator` property that `addColumnAggregator` mutates onto the column objects. It now also derives from the `aggregates` prop — the actual source of truth.

## Why

That made the class ride on accumulated mutation state, so it could go stale. When a table is re-fed equivalent columns and aggregates **without that mutation being re-applied** — e.g. only the aggregate *values* change, so `updateAggregates` recalculates without re-running `getColumnDefinitions` — the class dropped, even though the aggregation/totals row was still rendered with its values.

This surfaced downstream: a CRM contextual action bar that uses `limel-table.has-aggregation` to sit clear of the totals row lost its offset when returning to a relation tab, despite the row still being visible with its numbers.

## How

`hasAggregation` now returns `true` for a column that **either** carries its own `aggregator` (unchanged — a consumer can still set one directly) **or** has a field with a matching entry in `aggregates`. Deriving from `aggregates` keeps the class correct regardless of whether the column object happened to be mutated.

## Tests

Unit tests assert the class is detected from the `aggregates` prop even when the column carries no `aggregator` (the regression), the no-match negative case, and the direct-`aggregator` path. The existing e2e (direct aggregator → host class) still passes.

Closes #4118
Refs Lundalogik/crm-client#1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the table component's aggregation detection logic to accurately identify when aggregation is present, considering both column-level settings and aggregate configuration properties.

* **Tests**
  * Added comprehensive test suite for aggregation detection, covering scenarios with column aggregators, matching aggregate properties, and non-matching configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->