### PR TITLE
backport: fix(form): keep optional oneOf enums clearable

### DIFF
--- a/src/components/form/form.e2e.tsx
+++ b/src/components/form/form.e2e.tsx
@@ -7,6 +7,7 @@ import {
     enumSchema,
     requiredFieldSchema,
     emailFormatSchema,
+    optionalOneOfSchema,
     arraySchema,
     nestedObjectSchema,
     arrayOfObjectsSchema,
@@ -95,6 +96,23 @@ test('emits change event with updated form data', async () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0].detail).toEqual({ name: 'Alice' });
+});
+
+test('does not auto-select a const from an optional oneOf, but keeps real defaults', async () => {
+    const onChange = vi.fn();
+    const { change } = await renderForm({
+        schema: optionalOneOfSchema,
+        onChange,
+    });
+
+    await change('Name', 'Alice');
+
+    // `choice` is an optional oneOf and must stay empty (the user can leave it
+    // blank), while `withDefault` still gets its declared default applied.
+    expect(onChange.mock.lastCall[0].detail).toEqual({
+        name: 'Alice',
+        withDefault: 'preset',
+    });
 });
 
 const validationTests = [

--- a/src/components/form/form.test-schemas.ts
+++ b/src/components/form/form.test-schemas.ts
@@ -32,6 +32,26 @@ export const enumSchema: FormSchema = {
     },
 };
 
+export const optionalOneOfSchema: FormSchema = {
+    type: 'object',
+    properties: {
+        name: { type: 'string', title: 'Name' },
+        choice: {
+            type: 'string',
+            title: 'Choice',
+            oneOf: [
+                { type: 'string', const: 'a', title: 'A' },
+                { type: 'string', const: 'b', title: 'B' },
+            ],
+        },
+        withDefault: {
+            type: 'string',
+            title: 'With default',
+            default: 'preset',
+        },
+    },
+};
+
 export const requiredFieldSchema: FormSchema = {
     type: 'object',
     properties: {

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -176,6 +176,15 @@ export class Form {
                     widgets: widgets,
                     validator: rjsfValidator,
                     liveValidate: 'onChange',
+                    // `@rjsf/core` v6 treats a `const` inside `oneOf`/`anyOf`
+                    // as a default and auto-selects the first option, so an
+                    // optional enum can never be left empty (clearing it just
+                    // gets repopulated on the next render). `skipOneOf` keeps
+                    // this off for enums while still applying genuine
+                    // `default` values, matching the pre-v6 behavior.
+                    experimental_defaultFormStateBehavior: {
+                        constAsDefaults: 'skipOneOf',
+                    },
                     showErrorList: false,
                     extraErrors: this.getExtraErrors(this.errors),
                     templates: {


### PR DESCRIPTION
`@rjsf/core` v6 defaults `constAsDefaults` to `'always'`, which treats a `const` inside `oneOf`/`anyOf` as a default and auto-selects the first option. That makes it impossible to leave an optional enum empty — clearing it just repopulates the first option on the next render.

Set `constAsDefaults: 'skipOneOf'` so enum options are no longer treated as defaults, while genuine `default` values still apply.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
