### PR TITLE
fix(table): stretch columns correctly when movable rows are enabled

### DIFF
--- a/src/components/chip-set/chip-set-input-helpers.ts
+++ b/src/components/chip-set/chip-set-input-helpers.ts
@@ -12,7 +12,6 @@ import {
  * Lets the user select, activate, and remove chips with the keyboard.
  *
  * @param event - event
- 
  */
 export function handleKeyboardEvent(event: KeyboardEvent) {
     if (this.textValue.length > 0) {

--- a/src/components/table/row-drag-manager.spec.ts
+++ b/src/components/table/row-drag-manager.spec.ts
@@ -50,7 +50,7 @@ describe('RowDragManager', () => {
 
     describe('getRowHeaderDefinition', () => {
         it('returns a column definition with correct properties', () => {
-            const definition = manager.getRowHeaderDefinition() as any;
+            const definition = manager.getRowHeaderDefinition(32) as any;
 
             expect(definition.headerSort).toBe(false);
             expect(definition.resizable).toBe(false);
@@ -59,8 +59,15 @@ describe('RowDragManager', () => {
             expect(definition.cssClass).toEqual('limel-table-drag-handle');
         });
 
+        it('reserves the given width so layouts do not stretch the column', () => {
+            const definition = manager.getRowHeaderDefinition(32) as any;
+
+            expect(definition.width).toBe(32);
+            expect(definition.minWidth).toBe(32);
+        });
+
         it('provides a formatter that uses the element pool', () => {
-            const definition = manager.getRowHeaderDefinition() as any;
+            const definition = manager.getRowHeaderDefinition(32) as any;
             const formatter = definition.formatter as () => HTMLElement;
 
             const element = formatter();
@@ -69,7 +76,7 @@ describe('RowDragManager', () => {
         });
 
         it('sets drag handle properties via setElementProperties', () => {
-            const definition = manager.getRowHeaderDefinition() as any;
+            const definition = manager.getRowHeaderDefinition(32) as any;
             const formatter = definition.formatter as () => HTMLElement;
 
             formatter();
@@ -80,7 +87,7 @@ describe('RowDragManager', () => {
         });
 
         it('reads language lazily so host prop changes propagate', () => {
-            const definition = manager.getRowHeaderDefinition() as any;
+            const definition = manager.getRowHeaderDefinition(32) as any;
             const formatter = definition.formatter as () => HTMLElement;
 
             language = 'sv';
@@ -93,7 +100,7 @@ describe('RowDragManager', () => {
         });
 
         it('provides a cellClick handler that stops propagation', () => {
-            const definition = manager.getRowHeaderDefinition() as any;
+            const definition = manager.getRowHeaderDefinition(32) as any;
             const event = {
                 stopPropagation: vi.fn(),
                 preventDefault: vi.fn(),

--- a/src/components/table/row-drag-manager.ts
+++ b/src/components/table/row-drag-manager.ts
@@ -59,13 +59,23 @@ export class RowDragManager {
     /**
      * Returns the Tabulator rowHeader config that renders
      * a limel-drag-handle and restricts dragging to that cell
+     *
+     * @param width - width of the column in pixels. The CSS clamps the
+     * rendered cells to `--limel-table-drag-handle-width`, so Tabulator must
+     * reserve the same width in its layout. Otherwise width-distributing
+     * layouts such as `fitColumns` hand the handle a full flex share and the
+     * difference shows up as a blank filler column.
      */
-    public getRowHeaderDefinition(): Partial<TabulatorColumnDefinition> {
+    public getRowHeaderDefinition(
+        width: number
+    ): Partial<TabulatorColumnDefinition> {
         return {
             headerSort: false,
             resizable: false,
             frozen: true,
             rowHandle: true,
+            width: width,
+            minWidth: width,
             formatter: this.getDragHandleFormatter(),
             cssClass: 'limel-table-drag-handle',
             cellClick: this.handleCellClick,

--- a/src/components/table/table.e2e.tsx
+++ b/src/components/table/table.e2e.tsx
@@ -164,6 +164,76 @@ describe('limel-table', () => {
         });
     });
 
+    describe('movable rows with stretchColumns layout', () => {
+        // The drag-handle column is rendered at a fixed CSS width. Tabulator
+        // must reserve exactly that width in its layout, otherwise the
+        // `fitColumns` algorithm hands the handle a full flex share and the
+        // difference shows up as a blank filler column (#4123).
+        it('stretches the columns to fill the full table width', async () => {
+            const columns = [
+                { field: 'name', title: 'Name' },
+                { field: 'role', title: 'Role' },
+                { field: 'city', title: 'City' },
+            ];
+            const data = [
+                { id: 1, name: 'Alice', role: 'Dev', city: 'Lund' },
+                { id: 2, name: 'Bob', role: 'QA', city: 'Malmö' },
+            ];
+            const { root } = await renderTable({
+                data,
+                columns,
+                movableRows: true,
+                sortableColumns: false,
+                layout: 'stretchColumns',
+            });
+
+            const container = getContainer(root);
+            const holder = container.querySelector('.tabulator-tableholder');
+            const row = container.querySelector(
+                '.tabulator-table .tabulator-row'
+            );
+
+            const holderWidth = holder.getBoundingClientRect().width;
+            const rowWidth = row.getBoundingClientRect().width;
+
+            expect(rowWidth).toBeGreaterThanOrEqual(holderWidth - 5);
+        });
+
+        it('keeps the drag-handle column at its fixed width', async () => {
+            const columns = [
+                { field: 'name', title: 'Name' },
+                { field: 'role', title: 'Role' },
+            ];
+            const data = [{ id: 1, name: 'Alice', role: 'Dev' }];
+            const { root } = await renderTable({
+                data,
+                columns,
+                movableRows: true,
+                sortableColumns: false,
+                layout: 'stretchColumns',
+            });
+
+            const container = getContainer(root);
+            const handleCell = container.querySelector(
+                '.tabulator-row .tabulator-cell.limel-table-drag-handle'
+            );
+            const handleHeader = container.querySelector(
+                '.tabulator-col.limel-table-drag-handle'
+            );
+
+            // 2rem at the default 16px root font size
+            const expectedWidth = 32;
+            expect(handleCell.getBoundingClientRect().width).toBeCloseTo(
+                expectedWidth,
+                0
+            );
+            expect(handleHeader.getBoundingClientRect().width).toBeCloseTo(
+                expectedWidth,
+                0
+            );
+        });
+    });
+
     describe('remote sorting', () => {
         it('displays data in the order returned by the server, without re-sorting locally', async () => {
             // Initial data is in reverse numeric order (unsorted).

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1076,10 +1076,28 @@ export class Table {
             // Tabulator's `rowHeader` inline type narrows `formatter` to a
             // string, but the runtime accepts a function (as `ColumnDefinition`
             // does). Cast bridges the incomplete upstream type.
-            rowHeader:
-                this.rowDragManager.getRowHeaderDefinition() as TabulatorOptions['rowHeader'],
+            rowHeader: this.rowDragManager.getRowHeaderDefinition(
+                this.getDragHandleWidth()
+            ) as TabulatorOptions['rowHeader'],
         };
     };
+
+    /**
+     * Resolves `--limel-table-drag-handle-width` to pixels by measuring a
+     * probe element, since the custom property may be declared in any unit.
+     */
+    private getDragHandleWidth(): number {
+        const FALLBACK_WIDTH = 32;
+        const probe = document.createElement('div');
+        probe.style.cssText =
+            'position: absolute; visibility: hidden;' +
+            'width: var(--limel-table-drag-handle-width);';
+        this.host.shadowRoot.append(probe);
+        const width = probe.getBoundingClientRect().width;
+        probe.remove();
+
+        return width || FALLBACK_WIDTH;
+    }
 
     private readonly handleMoveColumn = (
         _,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-handle column width management in tables with movable rows under stretchColumns layout, ensuring proper row stretching while maintaining consistent drag-handle width.

* **Tests**
  * Added tests verifying row width stretching and drag-handle column width behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

Fixes #4123

## What

`layout="stretchColumns"` did not stretch the columns when `movableRows` was enabled — the rows ended short of the table width, leaving a blank filler column on the right.

## Why

The drag-handle row-header column is clamped to `--limel-table-drag-handle-width` (2rem) by CSS with `!important`, but Tabulator's layout math knew nothing about that width. The `fitColumns` layout (which `stretchColumns` maps to) treated the handle as a regular flexible column and handed it a full equal flex share; the difference between the allocated share and the rendered 32px showed up as blank space, and the data columns were left narrower than they should be.

Note: the issue's suspected cause (`frozen: true` on the row header) was disproven — plain Tabulator 6.3.1 with a frozen `rowHeader` distributes `fitColumns` widths correctly. The column stays frozen.

## How

The table now resolves `--limel-table-drag-handle-width` to pixels by measuring a probe element (so any unit or consumer override works) and reserves exactly that width (`width` + `minWidth`) in the `rowHeader` column definition. Tabulator's bookkeeping and the rendered width now agree, for all layouts. Setting `minWidth` also fixes the header cell previously rendering at Tabulator's 40px default minimum instead of 32px.

Regression-tested with two new e2e tests: rows span the full table width with `stretchColumns` + `movableRows`, and the drag-handle column stays at its fixed width.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [x] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS