### PR TITLE
docs(examples): fix listbox and color-contrast axe violations in example markup

### DIFF
--- a/example-tests/axe-baseline.json
+++ b/example-tests/axe-baseline.json
@@ -43,7 +43,6 @@
   "limel-example-file-viewer-basic": ["heading-order"],
   "limel-example-file-viewer-eml": ["heading-order"],
   "limel-example-markdown-adapt-color-contrast": ["heading-order"],
-  "limel-example-markdown-composite": ["color-contrast"],
   "limel-example-placement": ["heading-order"],
   "limel-example-select-with-empty-option": ["heading-order"],
   "limel-file-input": ["button-name"],

--- a/example-tests/axe-baseline.json
+++ b/example-tests/axe-baseline.json
@@ -42,7 +42,6 @@
   "limel-example-drag-handle-horizontal": ["heading-order"],
   "limel-example-file-viewer-basic": ["heading-order"],
   "limel-example-file-viewer-eml": ["heading-order"],
-  "limel-example-list-item-actions": ["list"],
   "limel-example-markdown-adapt-color-contrast": ["heading-order"],
   "limel-example-markdown-composite": ["color-contrast"],
   "limel-example-placement": ["heading-order"],

--- a/src/components/action-bar/examples/action-bar-as-list-component.tsx
+++ b/src/components/action-bar/examples/action-bar-as-list-component.tsx
@@ -1,5 +1,5 @@
 import { ListItem } from '@limetech/lime-elements';
-import { Component, h } from '@stencil/core';
+import { Component, h, Host } from '@stencil/core';
 
 /**
  * Creative usage
@@ -64,9 +64,11 @@ export class ActionBarAsListComponent {
     ];
 
     public render() {
-        return [
-            <h3>To-dos</h3>,
-            <limel-list items={this.items} class="has-striped-rows" />,
-        ];
+        return (
+            <Host>
+                <h3>To-dos</h3>
+                <limel-list items={this.items} class="has-striped-rows" />
+            </Host>
+        );
     }
 }

--- a/src/components/chart/examples/chart-styling.tsx
+++ b/src/components/chart/examples/chart-styling.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from '@stencil/core';
+import { Component, h, Host } from '@stencil/core';
 import { chartItems } from './chart-items-ring';
 
 /**
@@ -14,12 +14,14 @@ import { chartItems } from './chart-items-ring';
 })
 export class ChartStackedBarExample {
     public render() {
-        return [
-            <h4>Stacked-bar Chart</h4>,
-            <limel-chart items={chartItems} type="stacked-bar" />,
-            <div role="separator" />,
-            <h4>Bar Chart</h4>,
-            <limel-chart items={chartItems} axisIncrement={1} type="bar" />,
-        ];
+        return (
+            <Host>
+                <h4>Stacked-bar Chart</h4>
+                <limel-chart items={chartItems} type="stacked-bar" />
+                <div role="separator" />
+                <h4>Bar Chart</h4>
+                <limel-chart items={chartItems} axisIncrement={1} type="bar" />
+            </Host>
+        );
     }
 }

--- a/src/components/help/examples/help-placement.tsx
+++ b/src/components/help/examples/help-placement.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from '@stencil/core';
+import { Component, h, Host } from '@stencil/core';
 
 const helpAutoUpdates =
     'Automatically download and install updates, when the phone is connected to a Wi-Fi, is charging and is locked.';
@@ -27,36 +27,38 @@ const helpBetaUpdates =
 })
 export class HelpPlacementExample {
     public render() {
-        return [
-            <h4>Better layout</h4>,
-            <ul>
-                <li>
-                    <limel-help value={helpAutoUpdates} class="pull-left" />
-                    <limel-checkbox label="Automatic updates" />
-                </li>
-                <li>
-                    <limel-help value={helpBetaUpdates} class="pull-left" />
-                    <limel-checkbox label="Beta updates" />
-                </li>
-                <li>
-                    <limel-checkbox label="Notify after update" />
-                </li>
-            </ul>,
-            <hr />,
-            <h4>Worse layout</h4>,
-            <ul>
-                <li>
-                    <limel-checkbox label="Automatic updates" />
-                    <limel-help value={helpAutoUpdates} />
-                </li>
-                <li>
-                    <limel-checkbox label="Beta updates" />
-                    <limel-help value={helpBetaUpdates} />
-                </li>
-                <li>
-                    <limel-checkbox label="Notify after update" />
-                </li>
-            </ul>,
-        ];
+        return (
+            <Host>
+                <h4>Better layout</h4>
+                <ul>
+                    <li>
+                        <limel-help value={helpAutoUpdates} class="pull-left" />
+                        <limel-checkbox label="Automatic updates" />
+                    </li>
+                    <li>
+                        <limel-help value={helpBetaUpdates} class="pull-left" />
+                        <limel-checkbox label="Beta updates" />
+                    </li>
+                    <li>
+                        <limel-checkbox label="Notify after update" />
+                    </li>
+                </ul>
+                <hr />
+                <h4>Worse layout</h4>
+                <ul>
+                    <li>
+                        <limel-checkbox label="Automatic updates" />
+                        <limel-help value={helpAutoUpdates} />
+                    </li>
+                    <li>
+                        <limel-checkbox label="Beta updates" />
+                        <limel-help value={helpBetaUpdates} />
+                    </li>
+                    <li>
+                        <limel-checkbox label="Notify after update" />
+                    </li>
+                </ul>
+            </Host>
+        );
     }
 }

--- a/src/components/list-item/examples/list-item-actions.tsx
+++ b/src/components/list-item/examples/list-item-actions.tsx
@@ -46,7 +46,13 @@ export class ListItemActionsExample {
     public render() {
         return (
             <Host>
-                <ul onClick={this.onClick} onKeyDown={this.onKeyDown}>
+                <ul
+                    role="listbox"
+                    aria-label="Board games"
+                    aria-orientation="vertical"
+                    onClick={this.onClick}
+                    onKeyDown={this.onKeyDown}
+                >
                     <limel-list-item
                         tabIndex={0}
                         data-value={1}

--- a/src/components/markdown/examples/markdown-composite.scss
+++ b/src/components/markdown/examples/markdown-composite.scss
@@ -18,7 +18,7 @@
         border: 0.125rem dashed rgb(var(--contrast-700));
 
         legend {
-            color: rgb(var(--contrast-1000));
+            color: rgb(var(--contrast-1100));
             text-align: center;
         }
     }


### PR DESCRIPTION
## What

Fixes two accessibility violations in the docs **example markup** — none of these were in production components, so nothing a customer runs is affected. The axe baseline shrinks from 52 entries to 50, and since the baseline only ratchets down, these violations can never come back silently.

Also wraps three example renders in `<Host>` instead of JSX array literals, per Stencil conventions.

## How

**Named listbox.** The `list-item-actions` example wrapped `role="option"` items in a plain `<ul>`, violating axe's `list` rule (a `<ul>` may only contain `<li>` children). It now uses `role="listbox"` with an `aria-label` and `aria-orientation="vertical"`, mirroring how `limel-list` itself renders its listbox.

**Color contrast.** The `markdown-composite` example's `<legend>` had a contrast ratio of 4.21:1 (4.5:1 required by WCAG AA). Bumping `--contrast-1000` → `--contrast-1100` gives ~5.9:1, and also improves contrast in dark mode.

**`<Host>` wrappers.** Three example render methods returned sibling elements as JSX array literals. They now use `<Host>`, which adds no extra DOM node and avoids SonarCloud's missing-`key` warning for elements in arrays. (Addresses review feedback from @coderabbitai.)

## Scope note

An earlier version of this PR also changed 18 example heading captions from `<h4>`/`<h3>` to `<h2>` to fix their `heading-order` violations on the docs **debug pages**. That work was dropped: the debug pages are a proxy, and on the **real** component pages (e.g. `#/component/limel-chart/`) kompendium renders each example title as an `h5`, so `h2` captions would have made the real-page document outline *worse* than the original `h4`s. The root cause is kompendium's own heading outline (`h1` → `h3` "Examples" → `h5` example title), which will be fixed in kompendium first (jgroth/kompendium#184) — after that lands, the original `h4` captions become correct on both surfaces and the 18 remaining `heading-order` baseline entries can be ratcheted away for good.

## Verification

The two fixed entries are removed from `example-tests/axe-baseline.json`, so the accessibility suite itself enforces the fixes — it fails if either violation is still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
