### PR TITLE
fix(text-editor): emit change when a programmatically set value is cleared

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -479,6 +479,16 @@ export class ProsemirrorAdapter {
         tr.replaceWith(0, tr.doc.content.size, prosemirrorDoc.content);
         this.view.dispatch(tr);
 
+        // Keep the change-dedup baseline in sync with programmatically-set
+        // content. Without this, `lastEmittedValue` would still reflect the
+        // pre-update content, so a later user edit back to that old value
+        // (e.g. clearing a seeded value) would be wrongly suppressed and no
+        // `change` event would be emitted.
+        this.lastEmittedValue = this.contentConverter.serialize(
+            this.view,
+            this.schema
+        );
+
         const metadata = getMetadataFromDoc(this.view.state.doc);
         this.metadataEmitter(metadata);
 

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -107,6 +107,41 @@ describe('limel-text-editor', () => {
         expect(adapter.hasAttribute('aria-disabled')).toBe(false);
     });
 
+    test('emits a change event when a programmatically seeded value is cleared by the user', async () => {
+        // Regression: seeding `value` AFTER the editor has initialised (e.g.
+        // "AI Assist" placing a prompt into an already-open chat) goes through
+        // the `watchValue`/`updateView` path. That path must keep the
+        // change-dedup baseline in sync, otherwise clearing the seeded text
+        // back to the (stale) empty baseline is wrongly suppressed and the
+        // consumer never learns the field is empty.
+        const changes: string[] = [];
+        const { root, waitForChanges } = await createComponent();
+        root.addEventListener('change', (event: Event) => {
+            changes.push((event as CustomEvent<string>).detail);
+        });
+
+        // Seed a value programmatically, post-init.
+        (root as any).value = 'hello';
+        await waitForChanges();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // The user clears the editor.
+        const adapter = getAdapter(root);
+        const editable = adapter.shadowRoot.querySelector(
+            '.ProseMirror'
+        ) as HTMLElement;
+        editable.focus();
+        const doc = editable.ownerDocument;
+        doc.execCommand('selectAll');
+        doc.execCommand('delete');
+
+        // `change` is debounced; wait it out so the emission lands.
+        await new Promise((resolve) => setTimeout(resolve, 350));
+        await waitForChanges();
+
+        expect(changes).toContain('');
+    });
+
     test('label-to-editor id linkage is correct', async () => {
         const { root } = await createComponent();
 


### PR DESCRIPTION
## Problem

When `value` is set on `limel-text-editor` **programmatically after the editor has initialised**, the update goes through `prosemirror-adapter`'s `updateView`. That method replaced the document but left `lastEmittedValue` (the change-dedup baseline) pointing at the *previous* content.

As a result, a later user edit that returns the content to that stale baseline — most notably **clearing a seeded value back to empty** — was wrongly suppressed by the `content === lastEmittedValue` guard in `handleTransaction`. No `change` event fired, so consumers kept a stale view of the field.

Concrete symptom: an "AI Assist"-style flow seeds a prompt into the composer, the user erases it, but the send button stays enabled (and will send empty/stale text), because the editor never told the consumer the field was empty. Only triggers when the value is seeded *after* init (e.g. into an already-open editor) — the init path already sets the baseline correctly.

## Fix

After a programmatic `updateView`, sync `lastEmittedValue` to the serialised content, mirroring the initialisation path. The dedup baseline now always reflects the current document, regardless of whether content arrived via user edits or programmatic set.

## Test

Added an e2e regression test: seed `value` post-init, clear it as a user, assert a `change` event with `''` is emitted. Fails before the fix (`expected [] to include ''`), passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Ensure change events fire correctly after the editor is programmatically initialized: the editor now aligns its internal baseline with seeded content so subsequent user edits (including clearing content) emit the expected change.

## Tests
* Added an end-to-end regression test that verifies debounced change events are emitted when the editor is seeded programmatically and then modified by the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->