### PR TITLE
feat(text-editor): add change flushing and fix pending value writes

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -768,6 +768,7 @@ export namespace Components {
         // @alpha
         "customElements": CustomElementDefinition[];
         "disabled"?: boolean;
+        "flushPendingChanges": () => Promise<void>;
         "language": Languages;
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //
@@ -899,6 +900,7 @@ export namespace Components {
         // @alpha
         "customElements": CustomElementDefinition[];
         "disabled"?: boolean;
+        "flushPendingChanges": () => Promise<void>;
         "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -4,6 +4,7 @@ import {
     Event,
     EventEmitter,
     Host,
+    Method,
     Prop,
     State,
     Watch,
@@ -155,6 +156,16 @@ export class ProsemirrorAdapter {
     private contentConverter: ContentTypeConverter;
     private actionBarElement: HTMLElement;
     private lastEmittedValue: string;
+
+    /**
+     * The value most recently delivered to the consumer via the `change`
+     * event. Unlike `lastEmittedValue`, which is updated already when a
+     * change is queued for the debounced emit, this is only updated when
+     * the event is actually dispatched. It is used to tell a consumer's
+     * echo of an emitted value apart from an intentional external update.
+     * `undefined` until the first `change` event is dispatched.
+     */
+    private lastDispatchedValue: string;
     private changeWaiting = false;
     private transactionFired = false;
     private lastClickedPos: number | null = null;
@@ -202,6 +213,15 @@ export class ProsemirrorAdapter {
         this.portalId = createRandomString();
     }
 
+    /**
+     * Emits any pending debounced `change` event immediately.
+     * Does nothing if no change is pending.
+     */
+    @Method()
+    public async flushPendingChanges(): Promise<void> {
+        this.changeEmitter.flush();
+    }
+
     @Watch('value')
     protected watchValue(newValue: string) {
         if (!this.view) {
@@ -209,8 +229,17 @@ export class ProsemirrorAdapter {
         }
 
         if (this.changeWaiting) {
-            // A change is pending; do not update the editor's content
-            return;
+            if (newValue === this.lastDispatchedValue) {
+                // The consumer is echoing back a value we emitted, while a
+                // newer change is still pending. Ignore the echo so it does
+                // not clobber the newer content in the editor.
+                return;
+            }
+
+            // The consumer is intentionally setting a different value.
+            // Discard the pending change and apply the new value.
+            this.changeEmitter.cancel();
+            this.changeWaiting = false;
         }
 
         const currentContent = this.contentConverter.serialize(
@@ -630,6 +659,9 @@ export class ProsemirrorAdapter {
     };
 
     private changeEmitter = debounce((value: string) => {
+        // Record the dispatched value before emitting, so that a consumer
+        // that synchronously echoes the value back is correctly ignored.
+        this.lastDispatchedValue = value;
         this.change.emit(value);
         this.changeWaiting = false;
     }, DEBOUNCE_TIMEOUT);

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -1,4 +1,5 @@
 import { render, h } from '@stencil/vitest';
+import { vi } from 'vitest';
 
 describe('limel-text-editor', () => {
     async function createComponent(props: any = {}) {
@@ -154,5 +155,129 @@ describe('limel-text-editor', () => {
         const labelId = notchedOutline.labelId;
         expect(labelId).toBeTruthy();
         expect(adapter.getAttribute('id')).toBe(labelId);
+    });
+
+    describe('change event handling', () => {
+        // Comfortably longer than the editor's 300 ms change debounce.
+        const DEBOUNCE_WAIT = 500;
+
+        const sleep = (ms: number) =>
+            new Promise((resolve) => setTimeout(resolve, ms));
+
+        async function createEditor(props: any = {}) {
+            const { root, waitForChanges, setProps } = await render(
+                <limel-text-editor value={props.value} />
+            );
+            await waitForChanges();
+
+            const editor = await vi.waitFor(() => {
+                const contentEditable = getAdapter(
+                    root
+                )?.shadowRoot?.querySelector('.ProseMirror') as HTMLElement;
+                expect(contentEditable).toBeTruthy();
+
+                return contentEditable;
+            });
+
+            const changes: string[] = [];
+            root.addEventListener('change', (event: CustomEvent<string>) => {
+                changes.push(event.detail);
+            });
+
+            const typeText = (text: string) => {
+                editor.focus();
+                document.execCommand('insertText', false, text);
+            };
+
+            return {
+                root: root as HTMLLimelTextEditorElement,
+                waitForChanges,
+                setProps,
+                editor,
+                typeText,
+                changes,
+            };
+        }
+
+        test('typing emits a single change event after the debounce delay', async () => {
+            const { typeText, changes } = await createEditor();
+
+            typeText('hello');
+            expect(changes).toHaveLength(0);
+
+            await sleep(DEBOUNCE_WAIT);
+            expect(changes).toHaveLength(1);
+            expect(changes[0].trim()).toBe('hello');
+        });
+
+        test('flushPendingChanges emits a pending change immediately, without a duplicate later', async () => {
+            const { root, typeText, changes } = await createEditor();
+
+            typeText('hello');
+            expect(changes).toHaveLength(0);
+
+            await root.flushPendingChanges();
+            expect(changes).toHaveLength(1);
+            expect(changes[0].trim()).toBe('hello');
+
+            await sleep(DEBOUNCE_WAIT);
+            expect(changes).toHaveLength(1);
+        });
+
+        test('flushPendingChanges emits nothing when no change is pending', async () => {
+            const { root, changes } = await createEditor({ value: 'hello' });
+
+            await root.flushPendingChanges();
+            await sleep(DEBOUNCE_WAIT);
+            expect(changes).toHaveLength(0);
+        });
+
+        test('an echoed value during a pending change is ignored', async () => {
+            const { root, setProps, editor, typeText, changes } =
+                await createEditor();
+
+            typeText('first');
+            await root.flushPendingChanges();
+            expect(changes).toHaveLength(1);
+
+            typeText(' second');
+            // Echo the previously emitted value back, like a controlled
+            // parent component catching up late.
+            await setProps({ value: changes[0] });
+
+            await root.flushPendingChanges();
+            expect(changes).toHaveLength(2);
+            expect(changes[1].trim()).toBe('first second');
+            expect(editor.textContent).toBe('first second');
+        });
+
+        test('a differing value during a pending change replaces the content and discards the pending change', async () => {
+            const { root, setProps, editor, typeText, changes } =
+                await createEditor();
+
+            typeText('first');
+            await root.flushPendingChanges();
+            expect(changes).toHaveLength(1);
+
+            typeText(' second');
+            // Intentionally clear the editor while the change is pending,
+            // like a chat composer being reset after sending.
+            await setProps({ value: '' });
+
+            await vi.waitFor(() => {
+                expect(editor.textContent).toBe('');
+            });
+
+            await sleep(DEBOUNCE_WAIT);
+            expect(changes).toHaveLength(1);
+
+            // Recreating the discarded content must emit a change; the
+            // baseline is the externally set value, not the content from
+            // before the external update.
+            typeText('first second');
+            await root.flushPendingChanges();
+            expect(changes).toHaveLength(2);
+            expect(changes[1].trim()).toBe('first second');
+        });
     });
 });

--- a/src/components/text-editor/text-editor.spec.tsx
+++ b/src/components/text-editor/text-editor.spec.tsx
@@ -110,6 +110,20 @@ describe('limel-text-editor', () => {
         });
     });
 
+    describe('flushPendingChanges', () => {
+        test('it resolves when no change is pending', async () => {
+            const { root } = await createComponent();
+
+            await expect(root.flushPendingChanges()).resolves.toBeUndefined();
+        });
+
+        test('it resolves in readonly mode, where no adapter is rendered', async () => {
+            const { root } = await createComponent({ readonly: true });
+
+            await expect(root.flushPendingChanges()).resolves.toBeUndefined();
+        });
+    });
+
     describe('label', () => {
         test('it renders the label', async () => {
             const { root } = await createComponent({ label: 'my label' });

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -1,4 +1,12 @@
-import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
+import {
+    Component,
+    Event,
+    EventEmitter,
+    Host,
+    Method,
+    Prop,
+    h,
+} from '@stencil/core';
 import { FormComponent } from '../form/form.types';
 import { Languages } from '../date-picker/date.types';
 import { createRandomString } from '../../util/random-string';
@@ -234,10 +242,25 @@ export class TextEditor implements FormComponent<string> {
 
     private readonly helperTextId: string;
     private readonly editorId: string;
+    private adapterElement?: HTMLLimelProsemirrorAdapterElement;
 
     public constructor() {
         this.helperTextId = createRandomString();
         this.editorId = createRandomString();
+    }
+
+    /**
+     * Emits any pending `change` event immediately, instead of waiting
+     * for the debounce delay to elapse. Does nothing if no change is
+     * pending.
+     *
+     * Useful when the current content is needed right away, for example
+     * when the user activates a "send" or "save" action right after
+     * typing.
+     */
+    @Method()
+    public async flushPendingChanges(): Promise<void> {
+        await this.adapterElement?.flushPendingChanges();
     }
 
     public render() {
@@ -277,6 +300,7 @@ export class TextEditor implements FormComponent<string> {
 
         return (
             <limel-prosemirror-adapter
+                ref={(el) => (this.adapterElement = el)}
                 slot="content"
                 aria-placeholder={this.placeholder}
                 contentType={this.contentType}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to immediately flush pending editor changes via new `flushPendingChanges()` method.

* **Bug Fixes**
  * Improved handling of external value updates to prevent duplicate change emissions.
  * Enhanced tracking to correctly distinguish intentional external updates from echoed values.

* **Tests**
  * Expanded test coverage for change event handling and flush functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Problem

`limel-text-editor`'s ProseMirror adapter has two related defects around its debounced `change` event:

1. **No way to read or flush pending content.** The `change` event is debounced (300 ms) and only flushed early on blur. A consumer that needs the current content *now* (e.g. a chat composer's send button) is forced into a blur → `requestAnimationFrame` → read dance, and can still consume stale text.
2. **External value writes are silently dropped while a change is pending.** `watchValue` returns early whenever `changeWaiting` is set, so a parent that clears the editor (`value = ''`) right after consuming a change can fail to clear it — downstream this left a chat composer showing already-sent text after sending.

## Fix

- **`flushPendingChanges(): Promise<void>`** — new public `@Method` on `limel-text-editor` (delegating to the adapter) that emits any pending debounced `change` immediately and is a no-op when nothing is pending. This keeps a single data flow: consumers still receive content only via the `change` event, instead of a second read path like `getCurrentValue()`.
- **Dropped writes:** the `changeWaiting` guard now only ignores values equal to the last *dispatched* `change` value (a controlled-component echo). Any other value cancels the pending debounce and is applied to the editor through the normal update path, which baselines change detection on the applied content — so a subsequent edit recreating the discarded content still emits. A new `lastDispatchedValue` field is needed because `lastEmittedValue` is updated already when a change is *queued*, so during the pending window it holds the about-to-emit content, not what the parent last received; comparing against it could never classify a parent's echo as an echo.

## Design decisions & compatibility

- **Additive only.** No existing prop, event, or event payload changes. Consumers that never call `flushPendingChanges` and never write `value` during the pending window see byte-identical behavior.
- **Echo semantics preserved:** echoes of the last dispatched value during a pending window are still ignored, so a late-catching-up controlled parent cannot clobber newer typing (covered by a regression test). `lastDispatchedValue` is recorded *before* `change.emit()`, so even a parent that synchronously echoes inside its change handler is classified correctly. Before the first dispatch nothing can be an echo, so the field starts `undefined` and intentional writes during the very first pending window are honored.
- **Explicitly unchanged:** the 300 ms debounce default, blur-flush behavior, placeholder rendering, and the shapes of all events.

## Known limitations

These are deliberate tradeoffs of detecting echoes by value-equality; calling them out so the behavioral contract is explicit for consumers:

- **An intentional reset *to* the last dispatched value is indistinguishable from an echo.** If the editor dispatched `"hello"`, the user then types `"hello world"` (change pending), and the parent intentionally writes `value = "hello"`, that write is treated as an echo and ignored — the editor keeps `"hello world"` and the pending change survives. Value-equality cannot tell an intentional reset apart from a controlled-component echo, and protecting newer typing is the priority, so the echo classification wins.
- **A differing external write wins over a pending local edit.** When the parent writes any value other than the last dispatched one during the pending window, the user's in-flight (not-yet-emitted) edit is discarded in favour of the external value. This is what makes the chat-composer reset work, but it means a controlled parent that lags and writes a stale-but-different value can clobber active typing. The contract is "last differing external write wins over a pending local edit."

## Test evidence

New tests:

- e2e (`text-editor.e2e.tsx`, real Chromium):
  - `typing emits a single change event after the debounce delay`
  - `flushPendingChanges emits a pending change immediately, without a duplicate later`
  - `flushPendingChanges emits nothing when no change is pending`
  - `an echoed value during a pending change is ignored`
  - `a differing value during a pending change replaces the content and discards the pending change` (also asserts that recreating the discarded content afterwards emits a change)
- spec (`text-editor.spec.tsx`):
  - `flushPendingChanges > it resolves when no change is pending`
  - `flushPendingChanges > it resolves in readonly mode, where no adapter is rendered`

Results:

```text
✓  e2e (chromium)  src/components/text-editor/text-editor.e2e.tsx (14 tests) 3333ms
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

```text
✓  spec  src/components/text-editor/text-editor.spec.tsx (9 tests) 1499ms
 Test Files  12 passed (12)
      Tests  79 passed (79)
```

`npm run lint` passes. The unhandled-rejection stderr noise in the e2e run is preexisting on `main` (icon Cache API in the test environment) and unrelated.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such (none)

### Browsers tested:
Linux:
- [x] Chrome (headless Chromium via the e2e suite)

