### PR TITLE
chore(deps): switch kompendium to @limetech/kompendium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "html-escaper": "^3.0.3",
         "jsonlint-mod": "^1.7.6",
         "jsx-dom": "^8.1.6",
-        "kompendium": "^1.1.0",
+        "kompendium": "npm:@limetech/kompendium@^1.1.2",
         "lodash-es": "^4.17.23",
         "material-components-web": "^13.0.0",
         "moment": "^2.30.1",
@@ -6429,9 +6429,10 @@
       }
     },
     "node_modules/kompendium": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-1.1.1.tgz",
-      "integrity": "sha512-Zr+t1Y0gW9UjSZYAYVuSiGy51mOsYSZsSqjpWZcxNRkKvenMn3tiZ7UtqmGW2IKxDfNJ2wrY+YKwuNszZo+BOw==",
+      "name": "@limetech/kompendium",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@limetech/kompendium/-/kompendium-1.1.2.tgz",
+      "integrity": "sha512-H7/zUznXzTAU3ZtY2mAyZ706c9wfwuw9W/PAuAJMrOeg2w0WcfOgVwZxYCgZD0bCHD6AwzavDvfZSV7CKVG4wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15521,9 +15522,9 @@
       }
     },
     "kompendium": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/kompendium/-/kompendium-1.1.1.tgz",
-      "integrity": "sha512-Zr+t1Y0gW9UjSZYAYVuSiGy51mOsYSZsSqjpWZcxNRkKvenMn3tiZ7UtqmGW2IKxDfNJ2wrY+YKwuNszZo+BOw==",
+      "version": "npm:@limetech/kompendium@1.1.2",
+      "resolved": "https://registry.npmjs.org/@limetech/kompendium/-/kompendium-1.1.2.tgz",
+      "integrity": "sha512-H7/zUznXzTAU3ZtY2mAyZ706c9wfwuw9W/PAuAJMrOeg2w0WcfOgVwZxYCgZD0bCHD6AwzavDvfZSV7CKVG4wg==",
       "dev": true,
       "requires": {
         "chokidar": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "html-escaper": "^3.0.3",
     "jsonlint-mod": "^1.7.6",
     "jsx-dom": "^8.1.6",
-    "kompendium": "^1.1.0",
+    "kompendium": "npm:@limetech/kompendium@^1.1.2",
     "lodash-es": "^4.17.23",
     "material-components-web": "^13.0.0",
     "moment": "^2.30.1",


### PR DESCRIPTION
## What

Repoint the `kompendium` devDependency at the maintained fork [`@limetech/kompendium`](https://www.npmjs.com/package/@limetech/kompendium) (latest: `1.1.2`), via an npm alias:

```diff
-    "kompendium": "^1.1.0",
+    "kompendium": "npm:@limetech/kompendium@^1.1.2",
```

The alias keeps the package installed at `node_modules/kompendium`, so the `import { kompendium } from 'kompendium'` in `stencil.config.ts` / `stencil.config.docs.ts` and the `dist/` copy step are unchanged. No source edits.

## Why

`Lundalogik/kompendium` is our maintained fork of the (slow-moving, personally-maintained) upstream `jgroth/kompendium`, publishing `@limetech/kompendium` so we can ship docs-tooling fixes without waiting on upstream. `1.1.2` includes the heading-outline fix.

## Verification

- After `npm install`, `node_modules/kompendium` resolves to `@limetech/kompendium@1.1.2` (lockfile integrity matches the published tarball).
- The generator-side source the docs build actually consumes (`dist/index.ts`, `generator.ts`, `config.ts`, `source.ts`) is **byte-identical** to upstream `1.1.1`; the only deltas are in the compiled docs-UI bundle (the heading-outline fix + a new `component-title` component).
- End-to-end docs build/deploy is verified by this PR's preview-docs workflow.

`kompendium` is a devDependency (docs tooling only), so nothing published from lime-elements is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to use an updated package source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->