### PR TITLE
feat(code-diff): add interactive playground example

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -112,6 +112,9 @@ export interface ClosingActions {
     scrimClick: boolean;
 }
 
+// @public
+export type CodeDiffLayout = 'unified' | 'split';
+
 // Warning: (ae-incompatible-release-tags) The symbol "Color" is marked as @public, but its signature references "_Internal" which is marked as @internal
 //
 // @public
@@ -325,7 +328,7 @@ export namespace Components {
     export interface LimelCodeDiff {
         "contextLines": number;
         "language"?: string;
-        "layout": 'unified' | 'split';
+        "layout": CodeDiffLayout;
         "lineWrapping": boolean;
         "newHeading"?: string;
         "newValue": string | object;
@@ -1999,7 +2002,7 @@ export namespace JSX {
     export interface LimelCodeDiff {
         "contextLines"?: number;
         "language"?: string;
-        "layout"?: 'unified' | 'split';
+        "layout"?: CodeDiffLayout;
         "lineWrapping"?: boolean;
         "newHeading"?: string;
         "newValue"?: string | object;
@@ -2016,7 +2019,7 @@ export namespace JSX {
         // (undocumented)
         "language": string;
         // (undocumented)
-        "layout": 'unified' | 'split';
+        "layout": CodeDiffLayout;
         // (undocumented)
         "lineWrapping": boolean;
         // (undocumented)

--- a/src/components/code-diff/code-diff.tsx
+++ b/src/components/code-diff/code-diff.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Prop, State, Watch, Host } from '@stencil/core';
 
 import { Languages } from '../date-picker/date.types';
+import { CodeDiffLayout } from './code-diff.types';
 import translate from '../../global/translations';
 import {
     DiffHunk,
@@ -74,7 +75,7 @@ export class CodeDiff {
      * - `split` — side-by-side comparison with old on left, new on right
      */
     @Prop({ reflect: true })
-    public layout: 'unified' | 'split' = 'unified';
+    public layout: CodeDiffLayout = 'unified';
 
     /**
      * Number of unchanged context lines to display around each change.

--- a/src/components/code-diff/code-diff.tsx
+++ b/src/components/code-diff/code-diff.tsx
@@ -34,6 +34,7 @@ import {
  * @exampleComponent limel-example-code-diff-split
  * @exampleComponent limel-example-code-diff-line-wrap
  * @exampleComponent limel-example-code-diff-expand
+ * @exampleComponent limel-example-code-diff-interactive
  */
 @Component({
     tag: 'limel-code-diff',

--- a/src/components/code-diff/code-diff.types.ts
+++ b/src/components/code-diff/code-diff.types.ts
@@ -1,0 +1,8 @@
+/**
+ * The layout of the code diff view.
+ * - `unified` — single column with interleaved additions and removals
+ * - `split` — side-by-side comparison with old on left, new on right
+ *
+ * @public
+ */
+export type CodeDiffLayout = 'unified' | 'split';

--- a/src/components/code-diff/examples/code-diff-interactive.scss
+++ b/src/components/code-diff/examples/code-diff-interactive.scss
@@ -1,0 +1,19 @@
+:host {
+    --code-editor-max-height: 16rem;
+}
+
+.editors {
+    display: flex;
+    gap: 1rem;
+
+    limel-code-editor {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+}
+
+@media (max-width: 40rem) {
+    .editors {
+        flex-direction: column;
+    }
+}

--- a/src/components/code-diff/examples/code-diff-interactive.tsx
+++ b/src/components/code-diff/examples/code-diff-interactive.tsx
@@ -1,0 +1,133 @@
+import {
+    CodeDiffLayout,
+    LimelSelectCustomEvent,
+    Option,
+} from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+const INITIAL_OLD_VALUE = `{
+    "name": "acme-dashboard",
+    "version": "1.4.0",
+    "private": true,
+    "scripts": {
+        "build": "vite build",
+        "test": "vitest"
+    },
+    "dependencies": {
+        "react": "18.2.0",
+        "lodash": "4.17.21"
+    }
+}`;
+
+const INITIAL_NEW_VALUE = `{
+    "name": "acme-dashboard",
+    "version": "2.0.0",
+    "private": true,
+    "scripts": {
+        "build": "vite build --mode production",
+        "test": "vitest",
+        "lint": "eslint ."
+    },
+    "dependencies": {
+        "react": "18.2.0",
+        "zustand": "4.5.0"
+    }
+}`;
+
+const LAYOUT_OPTIONS: Array<Option<CodeDiffLayout>> = [
+    { text: 'unified', value: 'unified' },
+    { text: 'split', value: 'split' },
+];
+
+/**
+ * Interactive playground
+ *
+ * Edit either side and watch the diff update live. Use the controls
+ * to switch between `unified` and `split` layouts, and to toggle
+ * `lineWrapping` on and off.
+ */
+@Component({
+    tag: 'limel-example-code-diff-interactive',
+    shadow: true,
+    styleUrl: 'code-diff-interactive.scss',
+})
+export class CodeDiffInteractiveExample {
+    @State()
+    private oldValue: string = INITIAL_OLD_VALUE;
+
+    @State()
+    private newValue: string = INITIAL_NEW_VALUE;
+
+    @State()
+    private layout: Option<CodeDiffLayout> = LAYOUT_OPTIONS[1];
+
+    @State()
+    private lineWrapping = true;
+
+    public render() {
+        return (
+            <Host>
+                <div class="editors">
+                    <limel-code-editor
+                        label="Old value"
+                        language="json"
+                        lineNumbers={true}
+                        value={this.oldValue}
+                        onChange={this.handleOldValueChange}
+                    />
+                    <limel-code-editor
+                        label="New value"
+                        language="json"
+                        lineNumbers={true}
+                        value={this.newValue}
+                        onChange={this.handleNewValueChange}
+                    />
+                </div>
+                <limel-example-controls style={{ margin: '1rem 0' }}>
+                    <limel-select
+                        label="layout"
+                        options={LAYOUT_OPTIONS}
+                        value={this.layout}
+                        onChange={this.handleLayoutChange}
+                    />
+                    <limel-switch
+                        label="lineWrapping"
+                        value={this.lineWrapping}
+                        onChange={this.handleLineWrappingChange}
+                    />
+                </limel-example-controls>
+                <limel-code-diff
+                    oldValue={this.oldValue}
+                    newValue={this.newValue}
+                    language="json"
+                    layout={this.layout.value}
+                    lineWrapping={this.lineWrapping}
+                />
+            </Host>
+        );
+    }
+
+    private readonly handleOldValueChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.oldValue = event.detail;
+    };
+
+    private readonly handleNewValueChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.newValue = event.detail;
+    };
+
+    private readonly handleLayoutChange = (
+        event: LimelSelectCustomEvent<Option<CodeDiffLayout>>
+    ) => {
+        event.stopPropagation();
+        this.layout = event.detail;
+    };
+
+    private readonly handleLineWrappingChange = (
+        event: CustomEvent<boolean>
+    ) => {
+        event.stopPropagation();
+        this.lineWrapping = event.detail;
+    };
+}

--- a/src/components/code-diff/examples/code-diff-line-wrap.tsx
+++ b/src/components/code-diff/examples/code-diff-line-wrap.tsx
@@ -1,4 +1,8 @@
-import { LimelSelectCustomEvent, Option } from '@limetech/lime-elements';
+import {
+    CodeDiffLayout,
+    LimelSelectCustomEvent,
+    Option,
+} from '@limetech/lime-elements';
 import { Component, Host, State, h } from '@stencil/core';
 
 const OLD_VALUE = `{
@@ -24,7 +28,7 @@ const NEW_VALUE = `{
     }
 }`;
 
-const LAYOUT_OPTIONS: Array<Option<'unified' | 'split'>> = [
+const LAYOUT_OPTIONS: Array<Option<CodeDiffLayout>> = [
     { text: 'unified', value: 'unified' },
     { text: 'split', value: 'split' },
 ];
@@ -48,7 +52,7 @@ export class CodeDiffLineWrappingExample {
     private lineWrapping = false;
 
     @State()
-    private layout: Option<'unified' | 'split'> = LAYOUT_OPTIONS[0];
+    private layout: Option<CodeDiffLayout> = LAYOUT_OPTIONS[0];
 
     public render() {
         return (
@@ -86,7 +90,7 @@ export class CodeDiffLineWrappingExample {
     };
 
     private readonly handleLayoutChange = (
-        event: LimelSelectCustomEvent<Option<'unified' | 'split'>>
+        event: LimelSelectCustomEvent<Option<CodeDiffLayout>>
     ) => {
         event.stopPropagation();
         this.layout = event.detail;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -4,6 +4,7 @@ export * from './components/button/button.types';
 export * from './components/callout/callout.types';
 export * from './components/chip-set/chip.types';
 export * from './components/circular-progress/circular-progress.types';
+export * from './components/code-diff/code-diff.types';
 export * from './components/code-editor/code-editor.types';
 export * from './components/collapsible-section/action';
 export * from './components/chart/chart.types';


### PR DESCRIPTION
Closes #4133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new interactive code diff playground example to switch between unified and split layouts, toggle line wrapping, and preview changes live with customizable code samples.

* **Refactor**
  * Improved code diff layout typing by introducing a shared `CodeDiffLayout` type and updating component/example props and selections to use it.

* **Style**
  * Enhanced the interactive example layout responsiveness and editor sizing behavior for better viewing on different screen widths.

* **Documentation**
  * Updated component JSDoc to include an additional example reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Adds an interactive playground to the top of the `limel-code-diff` examples page: two editable `limel-code-editor` boxes feeding a live `limel-code-diff`, with controls for `unified`/`split` layout and `lineWrapping`. Also extracts the `layout` prop's inline union into a named, public `CodeDiffLayout` type.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS