### PR TITLE
fix(markdown): keep id/name attributes unprefixed in sanitizer

### DIFF
--- a/src/components/markdown/examples/markdown-built-in-component.tsx
+++ b/src/components/markdown/examples/markdown-built-in-component.tsx
@@ -1,0 +1,27 @@
+import { Component, h } from '@stencil/core';
+
+const markdown = `
+## Built-in whitelisted components
+
+A set of lime-elements components is whitelisted by default, so they can be
+used directly in markdown content without configuring the \`whitelist\` prop.
+
+For example, \`limel-icon\` is whitelisted, so you can render an icon inline: <limel-icon size="small" name="globe"></limel-icon>
+`;
+
+/**
+ * Built-in whitelisted component
+ *
+ * Some lime-elements components, such as `limel-icon`, are whitelisted by
+ * default. They can be used directly in markdown content without specifying
+ * them in the `whitelist` prop.
+ */
+@Component({
+    tag: 'limel-example-markdown-built-in-component',
+    shadow: true,
+})
+export class MarkdownBuiltInComponentExample {
+    public render() {
+        return <limel-markdown value={markdown} />;
+    }
+}

--- a/src/components/markdown/markdown-parser.spec.ts
+++ b/src/components/markdown/markdown-parser.spec.ts
@@ -1,4 +1,5 @@
 import { markdownToHTML, sanitizeHTML } from './markdown-parser';
+import { DEFAULT_MARKDOWN_WHITELIST } from './default-whitelist';
 
 /**
  * Normalize HTML for comparison: collapse whitespace between tags,
@@ -431,6 +432,83 @@ describe('markdownToHTML', () => {
             expect(result).toEqualHtml(
                 '<p><my-component allowed="ok">Content</my-component></p>'
             );
+        });
+    });
+
+    describe('clobberPrefix (DOM-clobbering prefix)', () => {
+        it('should keep name attributes on whitelisted custom elements unprefixed', async () => {
+            // Regression test for #4135. `limel-icon` uses the `name`
+            // attribute to select which icon to render. `name` is a
+            // DOM-clobber attribute, so the sanitizer's default prefix
+            // rewrote `name="globe"` to `name="user-content-globe"`, and the
+            // icon then looked up an icon that does not exist.
+            const result = await markdownToHTML(
+                '<limel-icon size="small" name="globe"></limel-icon>',
+                {
+                    whitelist: [
+                        { tagName: 'limel-icon', attributes: ['name', 'size'] },
+                    ],
+                }
+            );
+
+            expect(result).not.toContain('user-content-');
+            expect(result).toEqualHtml(
+                '<p><limel-icon size="small" name="globe"></limel-icon></p>'
+            );
+        });
+
+        it('should render limel-icon from the default whitelist with its name intact', async () => {
+            // Complements the test above by exercising the real
+            // DEFAULT_MARKDOWN_WHITELIST rather than an inline whitelist, so
+            // that dropping `name` from `limel-icon` in default-whitelist.ts
+            // would re-break #4135 and be caught here.
+            const result = await markdownToHTML(
+                '<limel-icon size="small" name="globe"></limel-icon>',
+                { whitelist: DEFAULT_MARKDOWN_WHITELIST }
+            );
+
+            expect(result).not.toContain('user-content-');
+            expect(result).toEqualHtml(
+                '<p><limel-icon size="small" name="globe"></limel-icon></p>'
+            );
+        });
+
+        it('should keep id attributes unprefixed', async () => {
+            // By default rehype-sanitize prepends `user-content-` to `id`
+            // attributes to guard against DOM clobbering. We disable that so
+            // ids stay as authored.
+            const result = await markdownToHTML('<div id="my-section">x</div>');
+            expect(result).toEqualHtml('<div id="my-section">x</div>');
+        });
+
+        it('should keep name/fragment links in sync', async () => {
+            // The `name` anchor and the `#fragment` link must keep matching
+            // values, otherwise in-page navigation breaks.
+            const result = await markdownToHTML(
+                '<a name="anchor">target</a> <a href="#anchor">go</a>'
+            );
+            expect(result).toEqualHtml(
+                '<p><a name="anchor">target</a> <a href="#anchor">go</a></p>'
+            );
+        });
+
+        it('should not double-prefix footnote ids and references', async () => {
+            // remark-rehype already namespaces footnote ids/links with
+            // `user-content-`. Without disabling the sanitizer's own prefix,
+            // the id would become `user-content-user-content-fn-1` and no
+            // longer match the `#user-content-fn-1` link.
+            const result = await markdownToHTML(
+                'Here is a footnote[^1].\n\n[^1]: My reference.'
+            );
+
+            expect(result).not.toContain('user-content-user-content-');
+
+            // The reference link must be an anchor pointing at the footnote
+            // item, and the footnote item must be an `<li>` carrying the
+            // matching id — asserting the values sit on the expected nodes,
+            // not merely that the strings appear somewhere in the output.
+            expect(result).toMatch(/<a[^>]*\bhref="#user-content-fn-1"[^>]*>/);
+            expect(result).toMatch(/<li[^>]*\bid="user-content-fn-1"[^>]*>/);
         });
     });
 

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -43,9 +43,7 @@ export async function markdownToHTML(
         .use(remarkRehype, { allowDangerousHtml: true })
         .use(rehypeRaw)
         .use(createLinksPlugin())
-        .use(rehypeSanitize, {
-            ...getWhiteList(options?.whitelist ?? []),
-        })
+        .use(rehypeSanitize, getWhiteList(options?.whitelist ?? []))
         .use(() => {
             return (tree: Node) => {
                 // Run the sanitizeStyle function on all elements, to sanitize
@@ -74,9 +72,7 @@ export async function sanitizeHTML(
 ): Promise<string> {
     const file = await unified()
         .use(rehypeParse)
-        .use(rehypeSanitize, {
-            ...getWhiteList(whitelist ?? []),
-        })
+        .use(rehypeSanitize, getWhiteList(whitelist ?? []))
         .use(() => {
             return (tree: Node) => {
                 // Run the sanitizeStyle function on all elements, to sanitize
@@ -99,6 +95,32 @@ function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
 
     const whitelist: Schema = {
         ...defaultSchema,
+        // Disable rehype-sanitize's default `user-content-` prefix, which it
+        // otherwise prepends to the DOM-clobber attributes (`id`, `name`,
+        // `aria-describedby`, `aria-labelledby`).
+        //
+        // Without this, whitelisted custom elements break: e.g.
+        // `<limel-icon name="globe">` becomes `name="user-content-globe"` and
+        // the icon no longer resolves. It also keeps GFM footnote ids
+        // consistent with the links that reference them — remark-rehype already
+        // namespaces those with `user-content-`, and a second prefix here would
+        // desync the id (`user-content-user-content-fn-1`) from its link
+        // (`#user-content-fn-1`).
+        //
+        // Set here, in the shared schema, so that both `markdownToHTML` and
+        // `sanitizeHTML` behave identically — the same content must not be
+        // prefixed on one path and left unprefixed on the other.
+        //
+        // Safe to disable here because every current consumer renders this
+        // output inside a shadow root (`limel-markdown` and `limel-text-editor`
+        // are both `shadow: true`). Unprefixed `id`/`name` attributes inside a
+        // shadow root cannot clobber document-level globals
+        // (`document.getElementById`, `window.<name>`, `document.forms`), which
+        // is what the prefix guards against. If a future consumer renders this
+        // output into the light DOM — or these functions become public exports
+        // — reinstate the prefix or scope its removal to whitelisted custom
+        // elements only.
+        clobberPrefix: '',
         strip: [...(defaultSchema.strip ?? []), 'style'],
         tagNames: [
             ...(defaultSchema.tagNames || []),

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -34,6 +34,7 @@ import { adaptColorContrast } from '../../util/adapt-color-contrast';
  * @exampleComponent limel-example-markdown-keys
  * @exampleComponent limel-example-markdown-blockquotes
  * @exampleComponent limel-example-markdown-horizontal-rule
+ * @exampleComponent limel-example-markdown-built-in-component
  * @exampleComponent limel-example-markdown-custom-component
  * @exampleComponent limel-example-markdown-custom-component-with-json-props
  * @exampleComponent limel-example-markdown-remove-empty-paragraphs


### PR DESCRIPTION
## Description

`limel-markdown` uses `rehype-sanitize`, which by default guards against [DOM clobbering](https://github.com/syntax-tree/hast-util-sanitize#clobber) by prefixing the clobber-prone attributes (`id`, `name`, `aria-describedby`, `aria-labelledby`) with `user-content-`.

This broke whitelisted `limel-icon` elements written directly in markdown: `name="globe"` was rewritten to `name="user-content-globe"`, so `limel-icon` looked up an icon that does not exist and nothing rendered.

Setting `clobberPrefix: ''` disables this prefixing, so authored `id`/`name` attributes are preserved as-is.

Closes #4135

## Footnotes — a related improvement

GFM footnote ids and links are already namespaced with `user-content-` by `remark-rehype`. The sanitizer's own prefix was being applied *on top* of that, but only to the clobber attributes (not to hrefs), so the two desynced:

```
Before:  <li id="user-content-user-content-fn-1">   ← link points at #user-content-fn-1 (no match)
After:   <li id="user-content-fn-1">                ← matches the link
```

This change makes the footnote ids consistent with the links (and aria attributes) that reference them.

> [!NOTE]
> This only makes the ids/links **consistent** — it does not, by itself, make footnotes scroll. `limel-markdown` renders inside a shadow root, and native URL-fragment navigation does not resolve targets inside shadow DOM. Actually scrolling to a footnote requires a click handler that scrolls within the shadow root, tracked in #4137. The consistency fixed here is a prerequisite for that handler to find its target.

## Changes

- `markdown-parser.ts`: set `clobberPrefix: ''` on `rehype-sanitize`, with a comment explaining why.
- `markdown-parser.spec.ts`: tests for unprefixed `id`, in-sync `name`/fragment links, and footnote ids not being double-prefixed.
- New example `limel-example-markdown-built-in-component` demonstrating `limel-icon` rendered from markdown via the default whitelist.

## How to test

- Run the spec: `npm run test:spec -- markdown-parser`
- View the new "Built-in whitelisted component" example and confirm the globe icon renders.
- Inspect the footnotes example DOM and confirm the footnote `id` matches the reference `href` (no `user-content-user-content-` double prefix).

## Follow-up

- #4137 — make in-page anchor links (footnotes) actually scroll inside the shadow root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown output to properly handle footnote IDs and custom element attribute references, ensuring correct synchronization between generated anchors and their targets.

* **Documentation**
  * Added example component demonstrating markdown support for built-in elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->