### PR TITLE
fix(list): focus pressed row on mousedown to keep clicks on target

### DIFF
--- a/src/components/list/list.e2e.tsx
+++ b/src/components/list/list.e2e.tsx
@@ -207,6 +207,89 @@ describe('limel-list', () => {
                     selected: true,
                 });
             });
+
+            it('focuses the pressed item, not the first one', async () => {
+                const items = [
+                    { text: 'item 1' },
+                    { text: 'item 2' },
+                    { text: 'item 3' },
+                ];
+                const { root, waitForChanges } = await render(
+                    <limel-list type="selectable" items={items}></limel-list>
+                );
+                await waitForChanges();
+
+                const itemEls =
+                    root.shadowRoot.querySelectorAll('limel-list-item');
+                const pressed = itemEls[2] as HTMLElement;
+                pressed.dispatchEvent(
+                    new MouseEvent('mousedown', {
+                        bubbles: true,
+                        composed: true,
+                        cancelable: true,
+                    })
+                );
+                await waitForChanges();
+
+                expect(root.shadowRoot.activeElement).toBe(pressed);
+            });
+        });
+
+        describe('is set as `radio`', () => {
+            it('emits change when a radio item is pressed', async () => {
+                const items = [{ text: 'item 1' }, { text: 'item 2' }];
+                const { root, waitForChanges, spyOnEvent } = await render(
+                    <limel-list type="radio" items={items}></limel-list>
+                );
+                const changeSpy = spyOnEvent('change');
+                await waitForChanges();
+
+                const itemEls =
+                    root.shadowRoot.querySelectorAll('limel-list-item');
+                const target = itemEls[1] as HTMLElement;
+                target.dispatchEvent(
+                    new MouseEvent('mousedown', {
+                        bubbles: true,
+                        composed: true,
+                        cancelable: true,
+                    })
+                );
+                target.click();
+                await waitForChanges();
+
+                expect(changeSpy).toHaveReceivedEventDetail({
+                    ...items[1],
+                    selected: true,
+                });
+            });
+        });
+
+        describe('is set as `checkbox`', () => {
+            it('emits change when a checkbox item is pressed', async () => {
+                const items = [{ text: 'item 1' }, { text: 'item 2' }];
+                const { root, waitForChanges, spyOnEvent } = await render(
+                    <limel-list type="checkbox" items={items}></limel-list>
+                );
+                const changeSpy = spyOnEvent('change');
+                await waitForChanges();
+
+                const itemEls =
+                    root.shadowRoot.querySelectorAll('limel-list-item');
+                const target = itemEls[1] as HTMLElement;
+                target.dispatchEvent(
+                    new MouseEvent('mousedown', {
+                        bubbles: true,
+                        composed: true,
+                        cancelable: true,
+                    })
+                );
+                target.click();
+                await waitForChanges();
+
+                expect(changeSpy).toHaveReceivedEventDetail([
+                    { ...items[1], selected: true },
+                ]);
+            });
         });
     });
 });

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -82,6 +82,7 @@ export class List {
     private config: ListRendererConfig;
     private listRenderer = new ListRenderer();
     private mdcList: MDCList;
+    private listElement: HTMLElement;
     private multiple: boolean;
     private selectable: boolean;
 
@@ -195,8 +196,53 @@ export class List {
             return;
         }
 
+        this.listElement = element as HTMLElement;
+        this.listElement.removeEventListener(
+            'mousedown',
+            this.handleItemMouseDown
+        );
+        this.listElement.addEventListener(
+            'mousedown',
+            this.handleItemMouseDown
+        );
+
         this.mdcList = new MDCList(element);
         this.mdcList.hasTypeahead = true;
+    };
+
+    /**
+     * Focus the pressed list item directly, without scrolling.
+     *
+     * Since the list uses `delegatesFocus`, pressing a non-focusable part of
+     * a list item (e.g. its text) would otherwise delegate focus to the first
+     * focusable row, scrolling it into view. In a scrolled list that moves the
+     * pressed row out from under the pointer before the click completes, so the
+     * click lands on empty space and no item gets selected.
+     *
+     * Bound to `mousedown` only (not `pointerdown`) so a touch-drag to scroll
+     * that starts on a row is not blocked by `preventDefault`.
+     *
+     * @param event - the mousedown event
+     */
+    private handleItemMouseDown = (event: MouseEvent) => {
+        const target = event.target as HTMLElement;
+        const itemElement = target?.closest?.(
+            '.mdc-deprecated-list-item'
+        ) as HTMLElement | null;
+        if (!itemElement) {
+            return;
+        }
+
+        // Suppress the default focus delegation (and its scroll) for any row,
+        // but only move focus to interactive (non-disabled) rows.
+        event.preventDefault();
+        if (
+            !itemElement.classList.contains(
+                'mdc-deprecated-list-item--disabled'
+            )
+        ) {
+            itemElement.focus({ preventScroll: true });
+        }
     };
 
     private setupListeners = () => {
@@ -220,6 +266,10 @@ export class List {
     };
 
     private teardown = () => {
+        this.listElement?.removeEventListener(
+            'mousedown',
+            this.handleItemMouseDown
+        );
         this.mdcList?.unlisten(ACTION_EVENT, this.handleAction);
         this.mdcList?.destroy();
     };


### PR DESCRIPTION
fix https://github.com/Lundalogik/crm-client/issues/795
## Summary
- A click on a row deep in a scrolled `limel-list` was lost: `delegatesFocus` redirected focus to the first (off-screen) row and scrolled it into view, moving the pressed row out from under the pointer so mouseup landed on empty `<ul>` space and MDC computed index `-1`. This is the cause of the object explorer widget "jumps to top instead of opening the clicked object" bug.
- Fix: on `mousedown`, suppress the default focus delegation and focus the pressed row with `{ preventScroll: true }`. Mouse-only (not `pointerdown`) so touch-drag scrolling isn't blocked; `preventDefault` for any row (so disabled rows don't scroll-jump either), but focus only moves to non-disabled rows.
- Added e2e tests for `radio`/`checkbox` toggling and pressed-row focus.

## Test plan
- [ ] `npx stencil-test --project e2e list/list.e2e` passes (15/15)
- [ ] Object explorer widget: scroll down → load more → click a deep row → it opens, list does not jump to top
- [ ] `radio` and `checkbox` list examples still toggle on click
- [ ] `limel-menu-list` still activates items (shares the pattern; not changed here)

Refs Lundalogik/crm-client#795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded E2E test coverage for the list component, including verification of focus behavior for selectable, radio, and checkbox list types.

* **Bug Fixes**
  * Improved focus management when interacting with list items via mouse, ensuring the correct item receives focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->