### PR TITLE
feat(text-editor): add clear method to clear content imperatively

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -762,6 +762,7 @@ export namespace Components {
     //
     // @beta
     export interface LimelProsemirrorAdapter {
+        "clear": () => Promise<void>;
         "contentType": 'markdown' | 'html';
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //
@@ -894,6 +895,7 @@ export namespace Components {
     // @beta
     export interface LimelTextEditor {
         "allowResize": boolean;
+        "clear": () => Promise<void>;
         "contentType": 'markdown' | 'html';
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -222,6 +222,45 @@ export class ProsemirrorAdapter {
         this.changeEmitter.flush();
     }
 
+    /**
+     * Clear the editor's content imperatively.
+     *
+     * Assigning an empty `value` prop only clears the editor when the value
+     * changes. The editor debounces its `change` event, so a consumer's
+     * bound value can lag the live document; assigning `''` when the prop was
+     * already `''` is skipped by change detection and would leave the typed
+     * content untouched — for example, clearing the editor right after a
+     * send. Use this to empty the editor regardless of the prop's change
+     * detection.
+     *
+     * Does not emit a `change` event. Consumers that mirror the editor
+     * content on `change` (drafts, validation, dirty state) should reset
+     * their own copy when calling this.
+     */
+    @Method()
+    public async clear(): Promise<void> {
+        if (!this.view) {
+            return;
+        }
+
+        // Drop any pending debounced change so it cannot fire after this
+        // clear and resurrect the old content.
+        if (this.changeWaiting) {
+            this.changeEmitter.cancel();
+            this.changeWaiting = false;
+        }
+
+        const currentContent = this.contentConverter.serialize(
+            this.view,
+            this.schema
+        );
+        if (currentContent === '') {
+            return;
+        }
+
+        await this.updateView('');
+    }
+
     @Watch('value')
     protected watchValue(newValue: string) {
         if (!this.view) {

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -532,35 +532,40 @@ export class ProsemirrorAdapter {
     };
 
     private async updateView(content: string) {
+        // Reset in a `finally` so a rejection from `parseAsHTML` (or any
+        // failure below) cannot leave the flag stuck `true`, which would
+        // silently suppress every future `change` event for this instance.
         this.suppressChangeEvent = true;
-        const html = await this.contentConverter.parseAsHTML(
-            content,
-            this.schema
-        );
-        const prosemirrorDOMparser = DOMParser.fromSchema(
-            this.view.state.schema
-        );
-        const domParser = new window.DOMParser();
-        const doc = domParser.parseFromString(html, 'text/html');
-        const prosemirrorDoc = prosemirrorDOMparser.parse(doc.body);
-        const tr = this.view.state.tr;
-        tr.replaceWith(0, tr.doc.content.size, prosemirrorDoc.content);
-        this.view.dispatch(tr);
+        try {
+            const html = await this.contentConverter.parseAsHTML(
+                content,
+                this.schema
+            );
+            const prosemirrorDOMparser = DOMParser.fromSchema(
+                this.view.state.schema
+            );
+            const domParser = new window.DOMParser();
+            const doc = domParser.parseFromString(html, 'text/html');
+            const prosemirrorDoc = prosemirrorDOMparser.parse(doc.body);
+            const tr = this.view.state.tr;
+            tr.replaceWith(0, tr.doc.content.size, prosemirrorDoc.content);
+            this.view.dispatch(tr);
 
-        // Keep the change-dedup baseline in sync with programmatically-set
-        // content. Without this, `lastEmittedValue` would still reflect the
-        // pre-update content, so a later user edit back to that old value
-        // (e.g. clearing a seeded value) would be wrongly suppressed and no
-        // `change` event would be emitted.
-        this.lastEmittedValue = this.contentConverter.serialize(
-            this.view,
-            this.schema
-        );
+            // Keep the change-dedup baseline in sync with programmatically-set
+            // content. Without this, `lastEmittedValue` would still reflect
+            // the pre-update content, so a later user edit back to that old
+            // value (e.g. clearing a seeded value) would be wrongly suppressed
+            // and no `change` event would be emitted.
+            this.lastEmittedValue = this.contentConverter.serialize(
+                this.view,
+                this.schema
+            );
 
-        const metadata = getMetadataFromDoc(this.view.state.doc);
-        this.metadataEmitter(metadata);
-
-        this.suppressChangeEvent = false;
+            const metadata = getMetadataFromDoc(this.view.state.doc);
+            this.metadataEmitter(metadata);
+        } finally {
+            this.suppressChangeEvent = false;
+        }
     }
 
     private handleTransaction = (transaction: Transaction) => {

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -279,5 +279,72 @@ describe('limel-text-editor', () => {
             expect(changes).toHaveLength(2);
             expect(changes[1].trim()).toBe('first second');
         });
+
+        test('clear empties content when re-assigning value="" cannot', async () => {
+            const { root, waitForChanges, setProps, editor, typeText } =
+                await createEditor({ value: '' });
+
+            typeText('hello');
+            await vi.waitFor(() => {
+                expect(editor.textContent).toBe('hello');
+            });
+
+            // '' -> '' is skipped by change detection, so the value watch
+            // never fires and the prop path cannot clear. Closing that gap
+            // is the whole reason clear() exists.
+            await setProps({ value: '' });
+            await waitForChanges();
+            expect(editor.textContent).toBe('hello');
+
+            await root.clear();
+            await vi.waitFor(() => {
+                expect(editor.textContent).toBe('');
+            });
+        });
+
+        test('clear empties content the value prop never caught up to', async () => {
+            const { root, editor, typeText } = await createEditor({
+                value: '',
+            });
+
+            // Type without letting the debounce emit, so the `value` prop
+            // (still '') never reflects the typed text — the scenario that
+            // defeats a prop-based clear.
+            typeText('hello');
+
+            await root.clear();
+
+            await vi.waitFor(() => {
+                expect(editor.textContent).toBe('');
+            });
+        });
+
+        test('clear discards the pending change so no stale change is emitted', async () => {
+            const { root, editor, typeText, changes } = await createEditor({
+                value: '',
+            });
+
+            typeText('hello');
+
+            await root.clear();
+
+            await vi.waitFor(() => {
+                expect(editor.textContent).toBe('');
+            });
+
+            await sleep(DEBOUNCE_WAIT);
+            expect(changes.some((change) => change.includes('hello'))).toBe(
+                false
+            );
+        });
+
+        test('clear does not emit a change event', async () => {
+            const { root, changes } = await createEditor({ value: 'hello' });
+
+            await root.clear();
+            await sleep(DEBOUNCE_WAIT);
+
+            expect(changes).toHaveLength(0);
+        });
     });
 });

--- a/src/components/text-editor/text-editor.spec.tsx
+++ b/src/components/text-editor/text-editor.spec.tsx
@@ -124,6 +124,20 @@ describe('limel-text-editor', () => {
         });
     });
 
+    describe('clear', () => {
+        test('it resolves', async () => {
+            const { root } = await createComponent();
+
+            await expect(root.clear()).resolves.toBeUndefined();
+        });
+
+        test('it resolves in readonly mode, where no adapter is rendered', async () => {
+            const { root } = await createComponent({ readonly: true });
+
+            await expect(root.clear()).resolves.toBeUndefined();
+        });
+    });
+
     describe('label', () => {
         test('it renders the label', async () => {
             const { root } = await createComponent({ label: 'my label' });

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -263,6 +263,27 @@ export class TextEditor implements FormComponent<string> {
         await this.adapterElement?.flushPendingChanges();
     }
 
+    /**
+     * Clear the editor's content imperatively, bypassing the `value` prop's
+     * change detection.
+     *
+     * Assigning an empty `value` prop only clears the editor when the value
+     * changes. Because the editor debounces its `change` event, a consumer's
+     * bound value can lag the live content, so assigning `''` when the prop
+     * was already `''` is skipped and the content is left untouched — for
+     * example, clearing the editor immediately after a send. Use this to
+     * empty the editor regardless of the prop's change detection.
+     *
+     * Does not emit a `change` event. If you mirror the editor content on
+     * `change` (drafts, validation, dirty state), reset your own copy when
+     * calling this. In readonly mode no editor is rendered, so this is a
+     * silent no-op.
+     */
+    @Method()
+    public async clear(): Promise<void> {
+        await this.adapterElement?.clear();
+    }
+
     public render() {
         return (
             <Host>


### PR DESCRIPTION
## Problem

`limel-text-editor` is a controlled component (it has a `value` prop), but assigning `value` only updates the editor when Stencil detects the prop **changed**. Because the editor debounces its `change` event, a consumer's bound value can legitimately lag the live document. That produces a case the prop can't express: clearing the editor by assigning `''` when the previously rendered prop was already `''`.

The clearest example is a chat-style "send box":

1. The user types fast and presses send.
2. The composer flushes, captures the text, emits the message, then sets its bound value back to `''` to clear.
3. Stencil batches the "catch-up" value and the clear into one render and commits only the final `''`. Since the previously rendered value was already `''`, the prop goes `'' → ''` — **no change** — so the editor never re-renders, `@Watch('value')` never fires, and the document keeps the sent text on screen.

The editor receives no signal at all in this case, so it cannot be fixed reactively from inside the component. `flushPendingChanges()` (added in #4128) solved the symmetric **read** problem for this same use case; this adds the **write** counterpart.

## Change

Add an imperative `clear()` method to `limel-text-editor` (and its ProseMirror adapter) that empties the editor's document **regardless of the prop's change detection**:

- discards any pending debounced `change` so it can't fire afterward and resurrect old content;
- does nothing if the document is already empty (preserves the caret);
- does **not** emit a `change` event (the caller cleared it, so no echo / re-entrancy).

Consumers that previously needed timing workarounds to clear (e.g. deferring by a frame) can call `await editor.clear()` instead.

```ts
// on send:
await editor.flushPendingChanges();        // read: make sure we have the full text
this.converseRequest.emit(this.value);
await editor.clear();                       // write: reliably empty, no timing hack
```

Backwards compatible (additive method only).

## Tests

- Spec: `clear` resolves, including readonly mode where no adapter is rendered.
- E2E: `clear` empties content the `value` prop never caught up to; discards the pending change so no stale `change` is emitted; does not emit a `change` event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The text editor component now provides a public `clear()` method to immediately remove all editor content, including when updates are pending/debounced.
  * `clear()` is designed to avoid emitting the editor’s `change` event.

* **Bug Fixes**
  * Improved handling to ensure clearing doesn’t leave the editor in a state where future change notifications could be incorrectly suppressed.

* **Tests**
  * Added/extended e2e and unit tests covering `clear()` in default and `readonly` modes, including discarding pending typed input and preventing stale change payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->