### PR TITLE
Fix/4060 download button

### DIFF
--- a/src/components/file-viewer/file-viewer.tsx
+++ b/src/components/file-viewer/file-viewer.tsx
@@ -269,7 +269,7 @@ export class FileViewer {
     };
 
     private renderText = () => {
-        const fallbackContent = [this.renderNoFileSupportMessage()];
+        const fallbackContent = [this.renderNoFileSupportMessage(false)];
 
         return [
             this.renderButtons(),
@@ -291,7 +291,9 @@ export class FileViewer {
                 fallbackUrl={this.sanitizeUrl(this.fileUrl)}
                 language={this.language}
             >
-                <div slot="fallback">{this.renderNoFileSupportMessage()}</div>
+                <div slot="fallback">
+                    {this.renderNoFileSupportMessage(false)}
+                </div>
             </limel-email-viewer>,
         ];
     };
@@ -332,7 +334,15 @@ export class FileViewer {
         return officeViewers[this.officeViewer];
     };
 
-    private renderNoFileSupportMessage = () => {
+    /**
+     * @param withDownloadButton whether to render a download button as a
+     * recovery option. Should be `false` when the message is shown as
+     * fallback content alongside the buttons bar, which already renders the
+     * download button when enabled, to avoid showing two download buttons.
+     */
+    private readonly renderNoFileSupportMessage = (
+        withDownloadButton = true
+    ) => {
         return (
             <div class="no-support" role="alert">
                 <h1>⚠️</h1>
@@ -346,7 +356,7 @@ export class FileViewer {
                         'file-viewer.message.try-other-options'
                     )}
                 </p>
-                {this.renderDownloadButton()}
+                {withDownloadButton && this.renderDownloadButton()}
             </div>
         );
     };

--- a/src/components/file-viewer/partial-styles/ui-controls.scss
+++ b/src/components/file-viewer/partial-styles/ui-controls.scss
@@ -4,7 +4,7 @@
 .buttons {
     position: absolute;
     z-index: 1;
-    top: 0.25rem;
+    bottom: 0.25rem;
     right: 0.25rem;
 
     display: flex;


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/lime-elements/issues/4070

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Prevented duplicate download buttons in the file viewer when unsupported content is shown within other UI that already includes a download button bar.
- Updated unsupported-file fallback rendering so the download button is only displayed when appropriate.
- Adjusted file viewer control button positioning for better layout alignment (moved vertical offset from top to bottom).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
