### PR TITLE
fix(markdown): reset image height correctly

### DIFF
--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -41,7 +41,7 @@ hr {
     // added fixed heights to images that appear in the activity feed.
     #markdown {
         img {
-            height: auto;
+            height: auto !important;
         }
     }
 }


### PR DESCRIPTION
We've gotten multiple bug reports that images in emails are scaled incorrectly and "squashed", i.e they take up the full width but has a set height causing them to render incorrectly. 

It was initially thought to be fixed in [#409](https://github.com/Lundalogik/crm-client/issues/409
) but didn't work for emails specifically when they have a fixed height. Due to css rules the inline styling will take precedence over our class `reset-img-height`, hence the `!important` to make sure that the auto height is always prioritized.

To reproduce this for emails you can do the following steps:

1. Build your local lime-elements
2. Link lime-elements to your local instance running email integration
3. Compose an email in Outlook and attach an inline image. Click the image and in the side panel that opens to the right, increase the height by 1 px, then decrease it again. Sounds confusing, but it's the only way I've managed to reproduce that the inline style height is actually sent.
4. Image should not be squashed in the conversation view, but use the correct aspect ratio.

Closes: [#625](https://github.com/Lundalogik/crm-client/issues/625)

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved markdown image rendering so the reset styling more reliably preserves images’ natural height by increasing the CSS override precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
