### PR TITLE
Show the selected file's size as a badge on limel-file

### DIFF
--- a/src/components/file/examples/file-size-badge.tsx
+++ b/src/components/file/examples/file-size-badge.tsx
@@ -1,0 +1,71 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * File size badge
+ * When the size of the selected file is known, `limel-file` displays it as a
+ * badge on the chip, giving end-users a quick sense of how large the file is.
+ *
+ * The size is picked up automatically when a user chooses a file from their
+ * device. When a file is provided programmatically, for example when loaded
+ * from a server, the badge is only shown if the `size` property (in bytes) is
+ * set on the `FileInfo` object. Toggle the switch below to see the difference.
+ */
+@Component({
+    tag: 'limel-example-file-size-badge',
+    shadow: true,
+})
+export class FileSizeBadgeExample {
+    @State()
+    private includeSize = true;
+
+    @State()
+    private value: FileInfo = {
+        filename: 'annual-report.pdf',
+        id: 123,
+        size: 2_411_724,
+    };
+
+    public render() {
+        const value = this.getValue();
+
+        return (
+            <Host>
+                <limel-file
+                    label="Attach a file"
+                    onChange={this.handleChange}
+                    value={value}
+                />
+                <limel-example-controls>
+                    <limel-switch
+                        value={this.includeSize}
+                        label="Include file size"
+                        onChange={this.setIncludeSize}
+                    />
+                </limel-example-controls>
+                <limel-example-value value={value} />
+            </Host>
+        );
+    }
+
+    private getValue(): FileInfo {
+        if (!this.value || this.includeSize) {
+            return this.value;
+        }
+
+        const value = { ...this.value };
+        delete value.size;
+
+        return value;
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.value = event.detail;
+        console.log('onChange', this.value);
+    };
+
+    private setIncludeSize = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.includeSize = event.detail;
+    };
+}

--- a/src/components/file/file.scss
+++ b/src/components/file/file.scss
@@ -6,6 +6,7 @@
  */
 
 :host(limel-file) {
+    --badge-max-width: auto;
     position: relative;
 }
 

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -48,6 +48,7 @@ const DEFAULT_FILE_CHIP: Chip = {
  *
  * @exampleComponent limel-example-file-basic
  * @exampleComponent limel-example-file-custom-icon
+ * @exampleComponent limel-example-file-size-badge
  * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
  * @exampleComponent limel-example-file-composite

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -9,6 +9,7 @@ import {
     getFileIcon,
 } from '../../util/file-metadata';
 import { FileInfo } from '../../global/shared-types/file.types';
+import { formatBytes } from '../../util/format-bytes';
 
 const DEFAULT_FILE_CHIP: Chip = {
     id: null,
@@ -163,6 +164,11 @@ export class File {
             return [];
         }
 
+        const badge =
+            typeof this.value.size === 'number'
+                ? formatBytes(this.value.size)
+                : undefined;
+
         return [
             {
                 ...DEFAULT_FILE_CHIP,
@@ -174,6 +180,7 @@ export class File {
                     color: getFileColor(this.value),
                     backgroundColor: getFileBackgroundColor(this.value),
                 },
+                badge: badge,
                 href: this.value.href,
                 menuItems: this.value.menuItems,
             },


### PR DESCRIPTION
## Why

`limel-file` never surfaced the size of the selected file, even though `FileInfo.size` was already available — both when a user picks a file from their device (the browser gives us `File.size`) and when a consumer provides it (e.g. `limec-file-picker`, whose data source always carries a size). This shows that size as a badge on the file chip, so end-users get a quick sense of how large the attached file is — the same treatment `limel-email-viewer` already gives attachment chips.

#### Before
<img width="433" height="66" alt="image" src="https://github.com/user-attachments/assets/573b08d1-8480-4fc3-97d7-2a1e6583ffce" />


#### After
<img width="431" height="57" alt="image" src="https://github.com/user-attachments/assets/be547167-2645-4e6f-83d7-899debeb4d53" />
<img width="525" height="257" alt="image" src="https://github.com/user-attachments/assets/991c963f-c931-4c8e-88e2-39a73bace0bb" />


## What

- **`feat(file)`** — In `getChipArray()`, derive a badge from `value.size` via `formatBytes` and pass it to the chip. The badge only renders when the size is a known number, so files without a size are unaffected (a second safety net exists in `limel-chip`'s own `if (!this.badge)` guard). Sets `--badge-max-width: auto` on the host so the size text isn't truncated by the badge's default `2.75rem` max width.
- **`docs(file)`** — Adds `limel-example-file-size-badge`, with an "Include file size" toggle that strips/restores `size` so readers can see the badge is conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File attachments can now display a size badge when size information is available.
  * Added an example showing how the file size badge appears and can be toggled on or off.

* **Style**
  * Updated file display styling to better accommodate the badge layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->