### PR TITLE
Add loading, progress, and invalid states to limel-file (component and per-file)

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1115,6 +1115,7 @@ export interface FileInfo {
     iconColor?: Color;
     id: number | string;
     lastModified?: Date;
+    loading?: boolean;
     menuItems?: Array<MenuItem | ListSeparator>;
     size?: number;
 }

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -450,6 +450,7 @@ export namespace Components {
     export interface LimelFile {
         "accept": string;
         "disabled": boolean;
+        "helperText": string;
         "invalid": boolean;
         "label": string;
         "language": Languages;
@@ -2351,6 +2352,7 @@ export namespace JSX {
     export interface LimelFile {
         "accept"?: string;
         "disabled"?: boolean;
+        "helperText"?: string;
         "invalid"?: boolean;
         "label"?: string;
         "language"?: Languages;
@@ -2367,6 +2369,8 @@ export namespace JSX {
         "accept": string;
         // (undocumented)
         "disabled": boolean;
+        // (undocumented)
+        "helperText": string;
         // (undocumented)
         "invalid": boolean;
         // (undocumented)

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -454,6 +454,7 @@ export namespace Components {
         "invalid": boolean;
         "label": string;
         "language": Languages;
+        "loading": boolean;
         "readonly": boolean;
         "required": boolean;
         "value": FileInfo;
@@ -2356,6 +2357,7 @@ export namespace JSX {
         "invalid"?: boolean;
         "label"?: string;
         "language"?: Languages;
+        "loading"?: boolean;
         "onChange"?: (event: LimelFileCustomEvent<FileInfo>) => void;
         "onInteract"?: (event: LimelFileCustomEvent<number | string>) => void;
         "readonly"?: boolean;
@@ -2377,6 +2379,8 @@ export namespace JSX {
         "label": string;
         // (undocumented)
         "language": Languages;
+        // (undocumented)
+        "loading": boolean;
         // (undocumented)
         "readonly": boolean;
         // (undocumented)

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -92,6 +92,7 @@ export interface Chip<T = any> {
     invalid?: boolean;
     loading?: boolean;
     menuItems?: Array<MenuItem | ListSeparator>;
+    progress?: number;
     removable?: boolean;
     selected?: boolean;
     text: string;

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1118,6 +1118,7 @@ export interface FileInfo {
     lastModified?: Date;
     loading?: boolean;
     menuItems?: Array<MenuItem | ListSeparator>;
+    progress?: number;
     size?: number;
 }
 

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1115,6 +1115,7 @@ export interface FileInfo {
     // @deprecated
     iconColor?: Color;
     id: number | string;
+    invalid?: boolean;
     lastModified?: Date;
     loading?: boolean;
     menuItems?: Array<MenuItem | ListSeparator>;

--- a/src/components/chip-set/chip-set.tsx
+++ b/src/components/chip-set/chip-set.tsx
@@ -66,6 +66,7 @@ function isChipAnnotatedEvent(
  * @exampleComponent limel-example-chip-set-filter-badge
  * @exampleComponent limel-example-chip-set-input
  * @exampleComponent limel-example-chip-set-invalid-chips
+ * @exampleComponent limel-example-chip-set-progress
  * @exampleComponent limel-example-chip-set-input-type-with-menu-items
  * @exampleComponent limel-example-chip-set-input-type-text
  * @exampleComponent limel-example-chip-set-input-type-search
@@ -665,6 +666,7 @@ export class ChipSet {
             selected: chip.selected,
             disabled: this.disabled,
             loading: chip.loading,
+            progress: chip.progress,
             invalid: chip.invalid,
             readonly: readonly,
             type: chipType,

--- a/src/components/chip-set/chip.types.ts
+++ b/src/components/chip-set/chip.types.ts
@@ -120,6 +120,13 @@ export interface Chip<T = any> {
     loading?: boolean;
 
     /**
+     * Reflects the current value of a progress bar on the chip,
+     * visualizing the percentage of an ongoing process.
+     * Must be a number between `0` and `100`.
+     */
+    progress?: number;
+
+    /**
      * Set to `true` to visualize the chip in an "invalid" or "error" state.
      */
     invalid?: boolean;

--- a/src/components/chip-set/examples/chip-set-progress.tsx
+++ b/src/components/chip-set/examples/chip-set-progress.tsx
@@ -1,0 +1,56 @@
+import { Chip } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Progress on a chip
+ *
+ * A chip in the set can show a determinate progress bar by setting `progress`
+ * — a number between `0` and `100` — on the chip. This is useful for
+ * reflecting an ongoing process on a specific chip, such as an upload.
+ *
+ * For an indeterminate indicator, set `loading` on the chip instead.
+ */
+@Component({
+    tag: 'limel-example-chip-set-progress',
+    shadow: true,
+})
+export class ChipSetProgressExample {
+    @State()
+    private progress = 40;
+
+    public render() {
+        const chips: Chip[] = [
+            {
+                id: 1,
+                text: 'document.pdf',
+                removable: true,
+                progress: this.progress,
+            },
+        ];
+
+        return (
+            <Host>
+                <limel-chip-set type="input" value={chips} />
+                <limel-example-controls
+                    style={{
+                        '--example-controls-column-layout': 'auto-fit',
+                    }}
+                >
+                    <limel-slider
+                        label="Progress"
+                        value={this.progress}
+                        valuemin={0}
+                        valuemax={100}
+                        unit="%"
+                        onChange={this.setProgress}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private setProgress = (event: CustomEvent<number>) => {
+        event.stopPropagation();
+        this.progress = event.detail;
+    };
+}

--- a/src/components/file/examples/file-accepted-types.tsx
+++ b/src/components/file/examples/file-accepted-types.tsx
@@ -3,6 +3,15 @@ import { Component, h, State } from '@stencil/core';
 
 /**
  * Limit accepted file types
+ *
+ * The `accept` prop limits which file types the picker offers, using the
+ * standard [file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#unique_file_type_specifiers):
+ * a comma-separated list of MIME types (e.g. `image/png`) or extensions (e.g.
+ * `.png`). It only filters what the file dialog offers — it is a hint, not a
+ * guarantee — so validate on the server as well.
+ *
+ * Rather than listing the allowed types in the `label`, use `helperText` to
+ * describe them below the field.
  */
 @Component({
     tag: 'limel-example-file-accepted-types',
@@ -18,7 +27,8 @@ export class FileAcceptedTypesExample {
     public render() {
         return [
             <limel-file
-                label="Attach only images (png, jpeg)"
+                label="Attach an image"
+                helperText="Allowed types: PNG and JPEG"
                 onChange={this.handleChange}
                 required={this.required}
                 value={this.value}

--- a/src/components/file/examples/file-loading.tsx
+++ b/src/components/file/examples/file-loading.tsx
@@ -1,0 +1,61 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Loading
+ *
+ * Set the `loading` prop to `true` to put the whole component in an
+ * indeterminate busy state, rendering a spinner and setting `aria-busy` on the
+ * component. This is the component's own loading state, controlled entirely by
+ * the consumer: it is shown whether or not a file is selected, and stays until
+ * you set `loading` back to `false`. Use it for work that has no measurable
+ * percentage, such as reading a selected file's metadata.
+ *
+ * :::note
+ * Setting `loading` does _not_ disable the interactivity of the component. If
+ * it should be disabled meanwhile, set `disabled` separately.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-file-loading',
+    shadow: true,
+})
+export class FileLoadingExample {
+    @State()
+    private value: FileInfo = {
+        filename: 'annual-report.pdf',
+        id: 1,
+    };
+
+    @State()
+    private loading = false;
+
+    public render() {
+        return (
+            <Host>
+                <limel-file
+                    label="Attach a file"
+                    value={this.value}
+                    loading={this.loading}
+                    onChange={this.handleChange}
+                />
+                <limel-example-controls>
+                    <limel-switch
+                        label="Loading"
+                        value={this.loading}
+                        onChange={this.setLoading}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.value = event.detail;
+    };
+
+    private setLoading = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.loading = event.detail;
+    };
+}

--- a/src/components/file/examples/file-loading.tsx
+++ b/src/components/file/examples/file-loading.tsx
@@ -15,6 +15,9 @@ import { Component, h, Host, State } from '@stencil/core';
  * Setting `loading` does _not_ disable the interactivity of the component. If
  * it should be disabled meanwhile, set `disabled` separately.
  * :::
+ *
+ * To reflect a busy state on an individual file instead, set `loading` on that
+ * file — see the per-file loading example.
  */
 @Component({
     tag: 'limel-example-file-loading',

--- a/src/components/file/examples/file-per-file-invalid.tsx
+++ b/src/components/file/examples/file-per-file-invalid.tsx
@@ -1,0 +1,81 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * File invalid
+ *
+ * Set `invalid` on a file's `FileInfo` to mark that specific file as invalid,
+ * rendering its chip in an error state — for example a file that failed to
+ * upload or is of a disallowed type.
+ *
+ * :::note
+ * Unlike `loading` and `progress`, a per-file `invalid` does **not**
+ * automatically mark the whole component as invalid. Validity is a form-level
+ * decision, so it is the consumer's responsibility to set the component's own
+ * `invalid` prop when an invalid file should invalidate the whole field — as
+ * this example does.
+ * :::
+ *
+ * :::tip
+ * When a file is invalid, explain what is wrong with a `helperText`. In this
+ * example, toggling the file invalid also marks the field invalid, so the
+ * helper text is rendered as an error message describing the reason.
+ * :::
+ *
+ */
+@Component({
+    tag: 'limel-example-file-per-file-invalid',
+    shadow: true,
+})
+export class FilePerFileInvalidExample {
+    @State()
+    private file?: FileInfo = {
+        filename: 'annual-report.pdf',
+        id: 1,
+    };
+
+    @State()
+    private invalid = true;
+
+    public render() {
+        const value: FileInfo | undefined = this.file && {
+            ...this.file,
+            invalid: this.invalid,
+        };
+        const helperText = this.invalid
+            ? 'This file exceeds the maximum allowed size of 10 MB.'
+            : undefined;
+
+        return (
+            <Host>
+                <limel-file
+                    label="Attach a file"
+                    value={value}
+                    invalid={this.invalid}
+                    helperText={helperText}
+                    onChange={this.handleChange}
+                />
+                <limel-example-controls
+                    style={{
+                        '--example-controls-column-layout': 'auto-fit',
+                    }}
+                >
+                    <limel-switch
+                        label="File invalid"
+                        value={this.invalid}
+                        onChange={this.setInvalid}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.file = event.detail;
+    };
+
+    private setInvalid = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.invalid = event.detail;
+    };
+}

--- a/src/components/file/examples/file-per-file-loading.tsx
+++ b/src/components/file/examples/file-per-file-loading.tsx
@@ -1,0 +1,66 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * File loading
+ *
+ * A file can carry its own busy state via `loading` on its `FileInfo`, which
+ * renders an indeterminate indicator on that file's chip — for example while
+ * that specific file is being processed.
+ *
+ * Because a busy file means the component has work in progress, setting a
+ * file's `loading` — or its `progress` — also automatically puts the whole
+ * component into its loading state (the busy spinner shows and `aria-busy` is
+ * set), informing both users and assistive tech about the status.
+ */
+@Component({
+    tag: 'limel-example-file-per-file-loading',
+    shadow: true,
+})
+export class FilePerFileLoadingExample {
+    @State()
+    private file?: FileInfo = {
+        filename: 'annual-report.pdf',
+        id: 1,
+    };
+
+    @State()
+    private loading = false;
+
+    public render() {
+        const value: FileInfo | undefined = this.file && {
+            ...this.file,
+            loading: this.loading,
+        };
+
+        return (
+            <Host>
+                <limel-file
+                    label="Attach a file"
+                    value={value}
+                    onChange={this.handleChange}
+                />
+                <limel-example-controls
+                    style={{
+                        '--example-controls-column-layout': 'auto-fit',
+                    }}
+                >
+                    <limel-switch
+                        label="File loading"
+                        value={this.loading}
+                        onChange={this.setLoading}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.file = event.detail;
+    };
+
+    private setLoading = (event: CustomEvent<boolean>) => {
+        event.stopPropagation();
+        this.loading = event.detail;
+    };
+}

--- a/src/components/file/examples/file-per-file-progress.tsx
+++ b/src/components/file/examples/file-per-file-progress.tsx
@@ -1,0 +1,78 @@
+import { FileInfo } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * File progress
+ *
+ * Set `progress` on the file (its `FileInfo`) to a number between `0` and
+ * `100` to render a determinate progress bar on that file's chip. Use it for
+ * measurable work, such as uploading the file or resizing it on the client.
+ *
+ * `progress` is for measurable work; for indeterminate work, set `loading` on
+ * the file instead — see the per-file loading example. A file typically shows
+ * `loading` while it is queued or finalized, and `progress` while the bytes
+ * transfer.
+ *
+ * While a file has `progress` (or `loading`), the whole component is
+ * automatically put into its loading state — the busy spinner shows and
+ * `aria-busy` is set — so both users and assistive tech know work is ongoing.
+ *
+ * :::note
+ * `progress` is rendered on the file's chip, so it only has an effect while a
+ * file is selected.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-file-per-file-progress',
+    shadow: true,
+})
+export class FilePerFileProgressExample {
+    @State()
+    private file?: FileInfo = {
+        filename: 'annual-report.pdf',
+        id: 1,
+    };
+
+    @State()
+    private progress = 0;
+
+    public render() {
+        const value: FileInfo | undefined = this.file && {
+            ...this.file,
+            progress: this.progress,
+        };
+
+        return (
+            <Host>
+                <limel-file
+                    label="Attach a file"
+                    value={value}
+                    onChange={this.handleChange}
+                />
+                <limel-example-controls
+                    style={{
+                        '--example-controls-column-layout': 'auto-fit',
+                    }}
+                >
+                    <limel-slider
+                        label="Progress"
+                        value={this.progress}
+                        valuemin={0}
+                        valuemax={100}
+                        unit="%"
+                        onChange={this.setProgress}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.file = event.detail;
+    };
+
+    private setProgress = (event: CustomEvent<number>) => {
+        event.stopPropagation();
+        this.progress = event.detail;
+    };
+}

--- a/src/components/file/examples/file-size-badge.tsx
+++ b/src/components/file/examples/file-size-badge.tsx
@@ -36,7 +36,11 @@ export class FileSizeBadgeExample {
                     onChange={this.handleChange}
                     value={value}
                 />
-                <limel-example-controls>
+                <limel-example-controls
+                    style={{
+                        '--example-controls-column-layout': 'auto-fit',
+                    }}
+                >
                     <limel-switch
                         value={this.includeSize}
                         label="Include file size"

--- a/src/components/file/file.scss
+++ b/src/components/file/file.scss
@@ -46,3 +46,10 @@
         @include mixins.truncate-text-on-line(2);
     }
 }
+
+limel-spinner {
+    pointer-events: none;
+    position: absolute;
+    inset: 0 0.375rem 0 auto;
+    margin: auto;
+}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -49,6 +49,7 @@ const DEFAULT_FILE_CHIP: Chip = {
  * @exampleComponent limel-example-file-basic
  * @exampleComponent limel-example-file-custom-icon
  * @exampleComponent limel-example-file-size-badge
+ * @exampleComponent limel-example-file-loading
  * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
  * @exampleComponent limel-example-file-composite
@@ -104,6 +105,14 @@ export class File {
     public invalid = false;
 
     /**
+     * Set to `true` to put the component in the `loading` state, and render an
+     * indeterminate progress indicator. This does _not_ disable the
+     * interactivity of the component!
+     */
+    @Prop({ reflect: true })
+    public loading = false;
+
+    /**
      * The [accepted file types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers)
      */
     @Prop({ reflect: true })
@@ -129,7 +138,7 @@ export class File {
 
     public render() {
         return (
-            <Host>
+            <Host aria-busy={this.loading ? 'true' : 'false'}>
                 <limel-file-dropzone
                     disabled={this.disabled || this.readonly || !!this.value}
                     accept={this.accept}
@@ -138,12 +147,21 @@ export class File {
                     {this.renderChipset()}
                 </limel-file-dropzone>
                 {this.renderDragAndDropTip()}
+                {this.renderSpinner()}
             </Host>
         );
     }
 
+    private renderSpinner() {
+        if (!this.loading) {
+            return;
+        }
+
+        return <limel-spinner />;
+    }
+
     private renderDragAndDropTip() {
-        if (this.value || this.disabled || this.readonly) {
+        if (this.value || this.disabled || this.readonly || this.loading) {
             return;
         }
 

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -51,6 +51,7 @@ const DEFAULT_FILE_CHIP: Chip = {
  * @exampleComponent limel-example-file-size-badge
  * @exampleComponent limel-example-file-loading
  * @exampleComponent limel-example-file-per-file-loading
+ * @exampleComponent limel-example-file-per-file-progress
  * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
  * @exampleComponent limel-example-file-composite
@@ -139,7 +140,7 @@ export class File {
 
     public render() {
         return (
-            <Host aria-busy={this.isLoading ? 'true' : 'false'}>
+            <Host aria-busy={this.isBusy ? 'true' : 'false'}>
                 <limel-file-dropzone
                     disabled={this.disabled || this.readonly || !!this.value}
                     accept={this.accept}
@@ -153,12 +154,22 @@ export class File {
         );
     }
 
-    private get isLoading(): boolean {
-        return this.loading || Boolean(this.value?.loading);
+    /**
+     * The component is busy for any reason: its own `loading`, or a file that
+     * is `loading` or has `progress` (including `0`). Completion is signalled
+     * by the consumer clearing these — not by `progress` reaching `100`, since
+     * a file at `100%` may still be finalizing (e.g. awaiting the server).
+     */
+    private get isBusy(): boolean {
+        return (
+            this.loading ||
+            Boolean(this.value?.loading) ||
+            this.value?.progress !== undefined
+        );
     }
 
     private renderSpinner() {
-        if (!this.isLoading) {
+        if (!this.isBusy) {
             return;
         }
 
@@ -166,7 +177,7 @@ export class File {
     }
 
     private renderDragAndDropTip() {
-        if (this.value || this.disabled || this.readonly || this.isLoading) {
+        if (this.value || this.disabled || this.readonly || this.isBusy) {
             return;
         }
 
@@ -214,6 +225,7 @@ export class File {
                 href: this.value.href,
                 menuItems: this.value.menuItems,
                 loading: this.value.loading,
+                progress: this.value.progress,
             },
         ];
     }

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -72,6 +72,12 @@ export class File {
     public label: string;
 
     /**
+     * Optional helper text to display below the component.
+     */
+    @Prop({ reflect: true })
+    public helperText: string;
+
+    /**
      * Set to `true` to indicate that the field is required.
      */
     @Prop({ reflect: true })
@@ -195,6 +201,7 @@ export class File {
                 readonly={this.readonly}
                 invalid={this.invalid}
                 label={this.label}
+                helperText={this.helperText}
                 leadingIcon="upload_to_cloud"
                 language={this.language}
                 onChange={this.handleChipSetChange}

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -52,6 +52,7 @@ const DEFAULT_FILE_CHIP: Chip = {
  * @exampleComponent limel-example-file-loading
  * @exampleComponent limel-example-file-per-file-loading
  * @exampleComponent limel-example-file-per-file-progress
+ * @exampleComponent limel-example-file-per-file-invalid
  * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
  * @exampleComponent limel-example-file-composite
@@ -226,6 +227,7 @@ export class File {
                 menuItems: this.value.menuItems,
                 loading: this.value.loading,
                 progress: this.value.progress,
+                invalid: this.value.invalid,
             },
         ];
     }

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -50,6 +50,7 @@ const DEFAULT_FILE_CHIP: Chip = {
  * @exampleComponent limel-example-file-custom-icon
  * @exampleComponent limel-example-file-size-badge
  * @exampleComponent limel-example-file-loading
+ * @exampleComponent limel-example-file-per-file-loading
  * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
  * @exampleComponent limel-example-file-composite
@@ -138,7 +139,7 @@ export class File {
 
     public render() {
         return (
-            <Host aria-busy={this.loading ? 'true' : 'false'}>
+            <Host aria-busy={this.isLoading ? 'true' : 'false'}>
                 <limel-file-dropzone
                     disabled={this.disabled || this.readonly || !!this.value}
                     accept={this.accept}
@@ -152,8 +153,12 @@ export class File {
         );
     }
 
+    private get isLoading(): boolean {
+        return this.loading || Boolean(this.value?.loading);
+    }
+
     private renderSpinner() {
-        if (!this.loading) {
+        if (!this.isLoading) {
             return;
         }
 
@@ -161,7 +166,7 @@ export class File {
     }
 
     private renderDragAndDropTip() {
-        if (this.value || this.disabled || this.readonly || this.loading) {
+        if (this.value || this.disabled || this.readonly || this.isLoading) {
             return;
         }
 
@@ -208,6 +213,7 @@ export class File {
                 badge: badge,
                 href: this.value.href,
                 menuItems: this.value.menuItems,
+                loading: this.value.loading,
             },
         ];
     }

--- a/src/global/shared-types/file.types.ts
+++ b/src/global/shared-types/file.types.ts
@@ -101,4 +101,10 @@ export interface FileInfo {
      * upload, as a percentage. Must be a number between `0` and `100`.
      */
     progress?: number;
+
+    /**
+     * Set to `true` to mark the file as invalid, rendering it in an error
+     * state. This is independent of the component's own `invalid` state.
+     */
+    invalid?: boolean;
 }

--- a/src/global/shared-types/file.types.ts
+++ b/src/global/shared-types/file.types.ts
@@ -88,4 +88,11 @@ export interface FileInfo {
      * Custom menu items for the file.
      */
     menuItems?: Array<MenuItem | ListSeparator>;
+
+    /**
+     * Set to `true` to put the file in a `loading` state, rendering an
+     * indeterminate progress indicator on it. This also puts the parent
+     * component into its loading state.
+     */
+    loading?: boolean;
 }

--- a/src/global/shared-types/file.types.ts
+++ b/src/global/shared-types/file.types.ts
@@ -95,4 +95,10 @@ export interface FileInfo {
      * component into its loading state.
      */
     loading?: boolean;
+
+    /**
+     * Reflects the progress of an ongoing process on the file, such as an
+     * upload, as a percentage. Must be a number between `0` and `100`.
+     */
+    progress?: number;
 }


### PR DESCRIPTION
## Why

`limel-file` had no way to reflect that something is happening to the selected file — a known gap. Its consumer `limec-file-picker` can today only grey the field out via `disabled` during work, and there is no way to surface upload progress at all.

>[!important]
>Before starting the review, please note that some of the decisions in this PR may feel initially strange. This is due to two reasons:
>1. `limel-file` allows only selection of one single file. We know consumers have requested multiple file selection possibility. We want to enable this feature in future. To keep this component future-proof this means, there shouldn't be a one-on-one relationship between the file(chip) and the file picker. Each file can individually become `invalid` or be on `loading` state.
>2. An optimal `FileInfo` interface, should have a `status` prop or similar (name not decided yet). That would allow each file to reflect its own status. For example: "Uploading…", "Failed!", "43%" (progressed, loaded, or uploaded), etc… Right now in this PR, we have some accessibility issues with aria-live, and we can't properly explain to the assistive tech what is going on. But a future per-file `status` in the follow up PR will help solve this issue. Such statuses will also be reflected on the chip's badge itself, helping sighted users to understand the status of what is happening better

Two tiers of "busy" state, built up in atomic commits:

- **`feat(file): add a loading prop`** — a component-level `loading` prop: the component's own indeterminate busy state (spinner + `aria-busy`), controlled entirely by the consumer, shown whether or not a file is selected. Does not disable interactivity.
- **`feat(file): support a per-file loading state`** — `FileInfo.loading`, rendered as an indeterminate indicator on that file's chip. A loading file also puts the parent into its loading state. Independent of the component prop; the multi-file-ready per-file model.
- **`feat(chip-set): forward the progress property to the chip`** — `limel-chip` already had a determinate `progress` bar, but the `Chip` model consumed by `limel-chip-set` didn't expose it. Adds `progress` to `Chip` + forwards it (with a chip-set example).
- **`feat(file): support a per-file progress state`** — `FileInfo.progress` (0–100), a determinate bar on the file's chip, for measurable work like uploads or client-side resizing.
- **`feat(file): support a per-file invalid state`** — `FileInfo.invalid`, an error state on the file's chip, independent of the component-level `invalid` prop.

Per-file status lives on `FileInfo`, so it maps 1:1 onto the chip and is ready for a future multi-file `limel-file` — each file owns its own state, the pattern already used by `limel-chip-set`'s `Chip[]` and `limebb-document-chips`. Every field is optional and defaults to off, so this is fully backward compatible. Each feat carries its own documentation example.

## Design notes

- **Component vs. per-file.** `loading` exists both at the component level (the whole picker is busy — a spinner) and per file (`FileInfo.loading` — the chip's own indicator). A loading file bubbles up to the component's busy state (`aria-busy` + spinner); the two are otherwise independent. `progress` and per-file `invalid` are per-file only. There is intentionally **no** component-level `progress` — a cumulative/overall bar can be added later if/when the component supports multiple files.
- Per-file status only renders while a file is selected (there must be a chip to render it on).
- `loading` does not disable interactivity, matching other components' loading states.
- ARIA conveys *that* the component is busy (`aria-busy`), not *what* — announcing the specific activity ("Uploading…") is a natural fit for a future per-file status label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `loading` support to the file component, including busy behavior with a spinner.
  - Added progress support (0–100) to file/chip rendering, enabling determinate progress display.
  - Added per-file `invalid` and `helperText` handling to improve messaging in chip UI.
- **Style & Accessibility**
  - Updated busy state semantics (e.g., `aria-busy`) and adjusted UI while busy.
- **Examples & Documentation**
  - Added new examples covering file loading, per-file loading, per-file progress, per-file invalidation, and chip-set progress.
  - Extended documentation example tags for the new loading/progress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->