### PR TITLE
fix(table): preserve page and scroll position on data refresh

### DIFF
--- a/src/components/table/table.e2e.tsx
+++ b/src/components/table/table.e2e.tsx
@@ -27,6 +27,13 @@ describe('limel-table', () => {
         return root.shadowRoot.querySelector('#tabulator-container');
     }
 
+    // Tabulator's data pipeline is async and the `updateData` watcher defers via
+    // `setTimeout`, and there is no public "settled" signal to await. Wait a
+    // bounded time for the row rebuild and any paginator round-trip to complete.
+    // Used by tests that assert the *absence* of an event, where polling on a
+    // condition is not possible.
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 300));
+
     describe('column headers', () => {
         it('renders the correct column headers', async () => {
             const columns = [
@@ -346,5 +353,107 @@ describe('limel-table', () => {
 
             expect(root.classList.contains('has-selection')).toBe(false);
         });
+    });
+
+    test('stays on the current page when a row is deleted (data + totalRows shrink)', async () => {
+        const columns = [{ field: 'name', title: 'Name' }];
+        // pageSize 2, 6 rows total -> 3 pages. Start on page 3.
+        const page3Data = [
+            { id: 5, name: 'E' },
+            { id: 6, name: 'F' },
+        ];
+
+        const { waitForChanges, spyOnEvent, setProps } = await renderTable({
+            mode: 'remote',
+            data: page3Data,
+            columns,
+            totalRows: 6,
+            pageSize: 2,
+            page: 3,
+        });
+
+        const changePageSpy = spyOnEvent('changePage');
+        const loadSpy = spyOnEvent('load');
+
+        // Simulate deleting row F: page 3 now has one row, 5 total (still 3 pages).
+        setProps({ totalRows: 5, data: [{ id: 5, name: 'E' }] });
+        await waitForChanges();
+        await settle();
+        await waitForChanges();
+
+        const changePageToFirst = changePageSpy.events.filter(
+            (event: CustomEvent) => event.detail === 1
+        );
+        expect(changePageToFirst.length).toBe(0);
+
+        // The URL offset in the consumer is driven by the `load` event, not
+        // `changePage`, so a `load` for page 1 would also snap the list back.
+        const loadForFirstPage = loadSpy.events.filter(
+            (event: CustomEvent) => event.detail?.page === 1
+        );
+        expect(loadForFirstPage.length).toBe(0);
+    });
+
+    test('keeps the scroll position when totalRows changes (deferred totals) on a later page', async () => {
+        const columns = [{ field: 'name', title: 'Name' }];
+        // A full page of rows so the row container overflows and is scrollable.
+        const pageData = Array.from({ length: 50 }, (_, i) => ({
+            id: 100 + i,
+            name: `Row ${i}`,
+        }));
+
+        const { root, waitForChanges, setProps } = await renderTable({
+            mode: 'remote',
+            data: pageData,
+            columns,
+            totalRows: 150, // 3 pages
+            pageSize: 50,
+            page: 2,
+        });
+
+        const scrollContainer = root.shadowRoot.querySelector(
+            '.tabulator-tableholder'
+        ) as HTMLElement;
+        scrollContainer.scrollTop = 300;
+        await waitForChanges();
+
+        // Deferred totals arrive: totalRows is corrected, data and page unchanged.
+        setProps({ totalRows: 200 });
+        await waitForChanges();
+        await settle();
+        await waitForChanges();
+
+        expect(scrollContainer.scrollTop).toBe(300);
+    });
+
+    test('keeps the scroll position when a row is deleted (data changes) on a scrolled page', async () => {
+        const columns = [{ field: 'name', title: 'Name' }];
+        const pageData = Array.from({ length: 50 }, (_, i) => ({
+            id: 100 + i,
+            name: `Row ${i}`,
+        }));
+
+        const { root, waitForChanges, setProps } = await renderTable({
+            mode: 'remote',
+            data: pageData,
+            columns,
+            totalRows: 150,
+            pageSize: 50,
+            page: 2,
+        });
+
+        const scrollContainer = root.shadowRoot.querySelector(
+            '.tabulator-tableholder'
+        ) as HTMLElement;
+        scrollContainer.scrollTop = 300;
+        await waitForChanges();
+
+        // Delete a row: data shrinks by one, totalRows drops, page unchanged.
+        setProps({ data: pageData.slice(0, 49), totalRows: 149 });
+        await waitForChanges();
+        await settle();
+        await waitForChanges();
+
+        expect(scrollContainer.scrollTop).toBe(300);
     });
 });

--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -25,7 +25,7 @@ describe('limel-table data updates', () => {
     beforeEach(() => {
         component = new Table();
         (component as any).tabulator = {
-            replaceData: vi.fn(),
+            replaceData: vi.fn().mockResolvedValue(undefined),
             updateData: vi.fn().mockResolvedValue(undefined),
             updateOrAddData: vi.fn(),
             getRow: vi.fn().mockReturnValue({ reformat: vi.fn() }),
@@ -169,6 +169,9 @@ describe('limel-table remote paginator refresh', () => {
         (component as any).tabulator = {
             replaceData: vi.fn().mockResolvedValue(undefined),
             setMaxPage: vi.fn(),
+            // Tabulator resets to the first page after replaceData().
+            getPage: vi.fn().mockReturnValue(1),
+            setPage: vi.fn().mockResolvedValue(undefined),
         };
         (component as any).initialized = true;
         (component as any).pageSize = 10;
@@ -237,6 +240,114 @@ describe('limel-table remote paginator refresh', () => {
             (component as any).refreshRemotePaginator()
         ).resolves.toBeUndefined();
     });
+});
+
+// The raw component class is tested as a white box, poking private members and
+// mock events, so `component` is typed loosely to avoid casting on every access.
+function setupRemotePreservationTable() {
+    const component: any = new Table();
+    const changePage = { emit: vi.fn() };
+    const load = { emit: vi.fn() };
+    component.mode = 'remote';
+    component.pageSize = 10;
+    component.page = 3;
+    component.columns = [];
+    component.changePage = changePage;
+    component.load = load;
+
+    return { component, changePage, load };
+}
+
+function setupRemoteClampingTable() {
+    const component: any = new Table();
+    const changePage = { emit: vi.fn() };
+    component.mode = 'remote';
+    component.initialized = true;
+    component.pageSize = 10;
+    component.changePage = changePage;
+    component.getRowScrollContainer = () => null;
+    component.tabulator = {
+        replaceData: vi.fn().mockResolvedValue(undefined),
+        setMaxPage: vi.fn(),
+        // Tabulator resets to the first page after replaceData().
+        getPage: vi.fn().mockReturnValue(1),
+        setPage: vi.fn().mockResolvedValue(undefined),
+    };
+
+    return { component, changePage };
+}
+
+test('does not emit changePage or load during a paginator refresh even when Tabulator requests page 1', () => {
+    const { component, changePage, load } = setupRemotePreservationTable();
+    component.paginatorRefreshDepth = 1;
+
+    component.requestData(null, null, { page: 1, sorters: [] });
+
+    expect(changePage.emit).not.toHaveBeenCalled();
+    expect(load.emit).not.toHaveBeenCalled();
+});
+
+test('emits changePage for a genuine user page change outside a refresh', () => {
+    const { component, changePage } = setupRemotePreservationTable();
+
+    component.requestData(null, null, { page: 2, sorters: [] });
+
+    expect(changePage.emit).toHaveBeenCalledWith(2);
+});
+
+test('keeps the current page when Tabulator omits the page param', () => {
+    const { component, changePage } = setupRemotePreservationTable();
+
+    component.requestData(null, null, { sorters: [] });
+
+    expect(changePage.emit).not.toHaveBeenCalled();
+});
+
+test('clamps to the last page when the current page no longer exists after rows shrink', async () => {
+    const { component, changePage } = setupRemoteClampingTable();
+    component.page = 3;
+    component.totalRows = 15; // maxPage = 2
+
+    await component.refreshRemotePaginator();
+
+    expect(changePage.emit).toHaveBeenCalledWith(2);
+});
+
+test('does not clamp when the current page is still valid', async () => {
+    const { component, changePage } = setupRemoteClampingTable();
+    component.page = 2;
+    component.totalRows = 100; // maxPage = 10
+
+    await component.refreshRemotePaginator();
+
+    expect(changePage.emit).not.toHaveBeenCalled();
+});
+
+test('restores the current page after replaceData resets it', async () => {
+    const { component, changePage } = setupRemoteClampingTable();
+    component.page = 3;
+    component.totalRows = 100; // maxPage = 10, page 3 still valid
+
+    await component.refreshRemotePaginator();
+
+    // getPage() mocked to return 1 (Tabulator's post-replaceData reset),
+    // so the page must be restored to the controlled page without emitting
+    // a spurious changePage.
+    expect(component.tabulator.setPage).toHaveBeenCalledWith(3);
+    expect(changePage.emit).not.toHaveBeenCalled();
+});
+
+test('skips the row-rebuild round-trip when the page count is unchanged', async () => {
+    const { component } = setupRemoteClampingTable();
+    component.page = 2;
+    component.totalRows = 100; // maxPage = 10
+
+    await component.refreshRemotePaginator(); // first run: count 10, does the work
+    component.tabulator.replaceData.mockClear();
+
+    await component.refreshRemotePaginator(); // same count -> skipped
+
+    expect(component.tabulator.replaceData).not.toHaveBeenCalled();
 });
 
 describe('limel-table aggregate updates', () => {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -267,6 +267,26 @@ export class Table {
     private shouldSort = false;
     private hasWarnedOnConflictingMovableAndSortable = false;
 
+    /**
+     * Depth of in-flight `refreshRemotePaginator` round-trips. While
+     * `isRefreshingPaginator` is true, `requestData`/`handleDataSorting` must
+     * not emit `changePage`/`load`, since the round-trip is not a user-initiated
+     * page change and the consumer's page state is authoritative. A counter
+     * rather than a boolean so overlapping refreshes (e.g. `totalRows` and
+     * `pageSize` changing in the same tick) don't clear the guard early.
+     */
+    private paginatorRefreshDepth = 0;
+
+    private get isRefreshingPaginator(): boolean {
+        return this.paginatorRefreshDepth > 0;
+    }
+
+    /**
+     * Page count reflected by the paginator UI at the last refresh. Used to skip
+     * the (row-rebuilding) refresh round-trip when the count hasn't changed.
+     */
+    private lastPaginatorPageCount: number | undefined;
+
     constructor() {
         this.handleDataSorting = this.handleDataSorting.bind(this);
         this.handlePageLoaded = this.handlePageLoaded.bind(this);
@@ -364,7 +384,10 @@ export class Table {
 
             if (shouldReplace) {
                 this.pool.releaseAll();
-                this.tabulator.replaceData(newData);
+                const restoreScroll = this.preserveScroll();
+                this.tabulator
+                    .replaceData(newData)
+                    .then(restoreScroll, () => {});
                 this.setSelection();
 
                 return;
@@ -725,23 +748,33 @@ export class Table {
             return;
         }
 
-        const scrollContainer = this.getRowScrollContainer();
-        const scrollTop = scrollContainer?.scrollTop ?? 0;
-        const scrollLeft = scrollContainer?.scrollLeft ?? 0;
+        const maxPage = this.calculatePageCount();
 
-        // `replaceData` resolves through `requestData`, which rejects when the
-        // component is destroyed, and Tabulator's ajax pipeline can reject too.
-        // Since the watchers call this without awaiting, swallow rejections here
-        // to avoid an unhandled promise rejection.
-        try {
-            await this.tabulator.replaceData();
-        } catch {
+        if (maxPage === this.lastPaginatorPageCount) {
             return;
         }
 
-        if (scrollContainer) {
-            scrollContainer.scrollTop = scrollTop;
-            scrollContainer.scrollLeft = scrollLeft;
+        const restoreScroll = this.preserveScroll();
+
+        const targetPage = Math.min(this.page, Math.max(maxPage, FIRST_PAGE));
+
+        this.paginatorRefreshDepth++;
+        try {
+            await this.tabulator.replaceData();
+            if (this.tabulator.getPage?.() !== targetPage) {
+                await this.tabulator.setPage(targetPage);
+            }
+        } catch {
+            return;
+        } finally {
+            this.paginatorRefreshDepth--;
+        }
+
+        this.lastPaginatorPageCount = maxPage;
+        restoreScroll();
+
+        if (targetPage !== this.page) {
+            this.changePage.emit(targetPage);
         }
     }
 
@@ -751,8 +784,28 @@ export class Table {
      * the table lives on this element's `scrollTop` / `scrollLeft`.
      */
     private getRowScrollContainer(): HTMLElement | null {
-        return (this.host.shadowRoot?.querySelector('.tabulator-tableholder') ??
-            null) as HTMLElement | null;
+        return (this.host?.shadowRoot?.querySelector(
+            '.tabulator-tableholder'
+        ) ?? null) as HTMLElement | null;
+    }
+
+    /**
+     * Snapshot the current scroll position and return a callback that restores
+     * it. Tabulator resets the row container to top-left whenever it rebuilds
+     * all row elements (e.g. `replaceData`), so wrap such operations with this
+     * and invoke the returned callback once the rebuild has settled.
+     */
+    private preserveScroll(): () => void {
+        const scrollContainer = this.getRowScrollContainer();
+        const scrollTop = scrollContainer?.scrollTop ?? 0;
+        const scrollLeft = scrollContainer?.scrollLeft ?? 0;
+
+        return () => {
+            if (scrollContainer) {
+                scrollContainer.scrollTop = scrollTop;
+                scrollContainer.scrollLeft = scrollLeft;
+            }
+        };
     }
 
     private getOptions(): TabulatorOptions {
@@ -877,9 +930,9 @@ export class Table {
         }
 
         const sorters = params.sorters ?? [];
-        const currentPage = params.page ?? FIRST_PAGE;
+        const currentPage = params.page ?? this.page ?? FIRST_PAGE;
 
-        if (this.page !== currentPage) {
+        if (!this.isRefreshingPaginator && this.page !== currentPage) {
             this.changePage.emit(currentPage);
         }
 
@@ -905,7 +958,7 @@ export class Table {
               })
             : Promise.resolve(this.data);
 
-        if (!isEqual(this.currentLoad, load)) {
+        if (!this.isRefreshingPaginator && !isEqual(this.currentLoad, load)) {
             this.currentSorting = columnSorters;
             this.currentLoad = load;
             this.load.emit(load);
@@ -930,7 +983,10 @@ export class Table {
                 sorters: columnSorters,
             };
 
-            if (!isEqual(this.currentLoad, load)) {
+            if (
+                !this.isRefreshingPaginator &&
+                !isEqual(this.currentLoad, load)
+            ) {
                 this.currentSorting = columnSorters;
                 this.currentLoad = load;
                 this.load.emit(load);


### PR DESCRIPTION
## What & why

In remote mode, `limel-table` snapped a paginated list back to page 1 and lost its scroll position whenever the rows were rebuilt — for example when a row was deleted or two objects were merged while the user was on a later page (e.g. page 3 of a list). The root cause is that `replaceData()` resets Tabulator's internal pagination to the first page and scrolls the row container to top-left, and re-entering the ajax pipeline then emitted `changePage`/`load` for page 1 back to the consumer.

This regressed after the remote-paginator refresh was added, and affected any consumer of `limel-table` in remote mode (the object list in lime-webclient being the visible one).

## Changes

All changes are scoped to remote mode.

- Guard the internal `changePage`/`load` emissions in `requestData` and `handleDataSorting` while a paginator refresh is in flight, using a depth counter so overlapping refreshes (`totalRows` and `pageSize` changing in the same tick) can't clear the guard early. The returned `last_page` still updates the paginator UI.
- After `replaceData()`, restore Tabulator to the controlled `page` (clamped to the new page count) so `getPage()` and the paginator UI stay in sync. When the current page no longer exists (the last row on the last page was removed), the clamp is emitted as a genuine `changePage`.
- Snapshot and restore the scroll position around the row rebuilds, on both the data-change path and the paginator-refresh path.
- Skip the paginator-refresh round-trip entirely when the page count is unchanged (the common case, e.g. removing one row of many), which avoids two redundant full row rebuilds per data change.

## Testing
1. Go to an explorer with many pages 
2. Go to a page > 1 
3. Scroll down 
4. Delete one item
5. You should stay on the same page, scrolled to the same position

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary page-change and data-load events during table refreshes.
  * Preserved the current page when rows are deleted or data totals change.
  * Correctly clamped pagination to the last available page when needed.
  * Preserved table scroll position during data updates and pagination refreshes.
  * Improved handling of asynchronous data replacement and sorting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
