### PR TITLE
ci: cache npm and Sonar downloads with a split restore/save strategy

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,60 @@
+name: 'Install npm dependencies'
+description: >-
+  Runs `npm ci` wrapped in a split cache strategy (actions/cache/restore and
+  actions/cache/save as separate steps). Compared to setup-node's built-in
+  `cache: npm`, this (1) saves the cache as soon as the install has succeeded,
+  so it survives a later job step failing — setup-node only saves in a
+  post-job step gated on `post-if: success()` — and (2) uses restore-keys, so
+  a package-lock.json change gets a partial restore instead of a full registry
+  download (npm's cache is content-addressed, so a stale cache still serves
+  every package the change didn't touch). Also usable in container jobs that
+  have no setup-node at all (the Playwright-image test jobs).
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve npm cache location
+      id: npm-cache-dir
+      shell: bash
+      # npm keeps its cache under $HOME, which differs between host runners
+      # (/home/runner) and the Playwright container jobs (/github/home).
+      # actions/cache archives ~/.npm with absolute paths, so a cache saved by a
+      # host job restores into a directory the container's npm never reads (and
+      # vice versa) — silently defeating the container-caching win. Cache the
+      # resolved directory and fold $HOME into the key so host and container
+      # each keep their own effective cache.
+      run: |
+        dir="$(npm config get cache)"
+        home_tag="${HOME//\//_}"
+        # Echo to the step log too — this step exists to disambiguate the
+        # host/container home split, so make a wrong home visible right here.
+        echo "npm cache dir=$dir home-tag=$home_tag"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
+        echo "home-tag=$home_tag" >> "$GITHUB_OUTPUT"
+    - name: Restore npm cache
+      id: npm-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: npm-cache-${{ runner.os }}-${{ runner.arch }}-${{ steps.npm-cache-dir.outputs.home-tag }}-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          npm-cache-${{ runner.os }}-${{ runner.arch }}-${{ steps.npm-cache-dir.outputs.home-tag }}-
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+    - name: Save npm cache
+      # Save right here — after a successful install but before the job's real
+      # work — so the cache lands even if a later step fails. Skipped on an
+      # exact key hit (a saved cache is immutable, re-saving is a no-op). On a
+      # restore-keys (partial) hit, cache-hit is 'false' and the topped-up
+      # cache is saved under the new key. When several jobs miss on the same
+      # key at once, they race to save it: the winner uploads, the losers log
+      # an "Unable to reserve cache" warning and move on — harmless.
+      # continue-on-error keeps any other save failure (tar/upload error) from
+      # failing an otherwise-green job — a cache save should never break a check.
+      if: steps.npm-cache.outputs.cache-hit != 'true'
+      continue-on-error: true
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ steps.npm-cache.outputs.cache-primary-key }}

--- a/.github/actions/set-up-node/action.yml
+++ b/.github/actions/set-up-node/action.yml
@@ -23,7 +23,13 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
-        cache: 'npm'
+        # npm caching is handled by the install-dependencies action instead,
+        # which saves the cache as soon as npm ci succeeds; setup-node's
+        # built-in cache only saves when the whole job succeeds (post-if:
+        # success()) and restores on exact lock-file match only. Explicitly
+        # disabled here because package.json has a `packageManager` field,
+        # which would otherwise auto-enable the built-in cache.
+        package-manager-cache: false
     - name: Verify Node.js setup
       shell: bash
       run: echo "✅ Node $(node -v), npm $(npm -v)"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         ref: ${{ inputs.ref }}
     - uses: ./.github/actions/set-up-node
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     - run: git config --global user.email "93315277+lime-opensource@users.noreply.github.com"
     - run: git config --global user.name "Lime Technologies OSS"
     - name: Publish docs

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         persist-credentials: false
     - uses: ./.github/actions/set-up-node
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     - run: git config --global user.email "93315277+lime-opensource@users.noreply.github.com"
     - run: git config --global user.name "Lime Technologies OSS"
     - name: Remove PR docs

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -292,11 +292,50 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+      # Cache the Sonar downloads: the scan action installs the scanner CLI
+      # into the runner tool cache, and the scanner fills ~/.sonar/cache with
+      # the JRE and analyzers at scan time. Both downloads have been flaky in
+      # the past (scanner binaries served from IPs on GitHub's blocklist), so
+      # a cache hit also removes a failure source, not just ~30s of overhead.
+      # The key hashes both workflow files, so it rotates whenever either file
+      # changes (including a scan-action bump, which changes the scanner CLI
+      # version); between rotations the restore-keys prefix serves the newest
+      # saved cache. The hashFiles list must stay identical to the one in
+      # release.yml, or the shared cache silently splits in two.
+      # These caches hold executable content (scanner CLI, JRE, analyzer JARs)
+      # restored without integrity checks; that is safe only because this job's
+      # `head.repo.full_name == github.repository` guard keeps forks — i.e.
+      # untrusted actors — off the write side.
+      - name: Restore Sonar caches
+        id: sonar-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.sonar/cache
+            ${{ runner.tool_cache }}/sonar-scanner-cli
+          key: sonar-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/pr-checks.yml', '.github/workflows/release.yml') }}
+          restore-keys: |
+            sonar-cache-${{ runner.os }}-${{ runner.arch }}-
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      # Split save (rather than plain actions/cache, whose post-job save is
+      # gated on job success) so the downloads are kept even when the scan
+      # fails — scan failures (quality gate, SonarCloud 403 flakes) say
+      # nothing about the cached files. Best-effort: never fail the job over
+      # a cache save (e.g. paths missing because the scan died before
+      # downloading anything).
+      - name: Save Sonar caches
+        if: ${{ !cancelled() && steps.sonar-cache.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.sonar/cache
+            ${{ runner.tool_cache }}/sonar-scanner-cli
+          key: ${{ steps.sonar-cache.outputs.cache-primary-key }}
   autosquash:
     name: Block Autosquash Commits
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -67,7 +67,7 @@ jobs:
         persist-credentials: false
     # No set-up-node: the image bundles a Node whose major is asserted against
     # .nvmrc by verify-playwright-container (below), so npm ci runs under it.
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     # Fail fast if the pinned image has drifted from the project (Node major vs
     # .nvmrc, and the image's Chromium build vs @playwright/test). See the action.
     - uses: ./.github/actions/verify-playwright-container
@@ -129,7 +129,7 @@ jobs:
         persist-credentials: false
     # No set-up-node: the image bundles a Node whose major is asserted against
     # .nvmrc by verify-playwright-container (below), so npm ci runs under it.
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     # Fail fast if the pinned image has drifted from the project (Node major vs
     # .nvmrc, and the image's Chromium build vs @playwright/test). See the action.
     - uses: ./.github/actions/verify-playwright-container
@@ -184,7 +184,7 @@ jobs:
         persist-credentials: false
     # No set-up-node: the image bundles a Node whose major is asserted against
     # .nvmrc by verify-playwright-container (below), so npm ci runs under it.
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     # Fail fast if the pinned image has drifted from the project (Node major vs
     # .nvmrc, and the image's Chromium build vs @playwright/test). See the action.
     - uses: ./.github/actions/verify-playwright-container
@@ -238,7 +238,7 @@ jobs:
         persist-credentials: false
     # No set-up-node: the image bundles a Node whose major is asserted against
     # .nvmrc by verify-playwright-container (below), so npm ci runs under it.
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     # Fail fast if the pinned image has drifted from the project (Node major vs
     # .nvmrc, and the image's Chromium build vs @playwright/test). See the action.
     - uses: ./.github/actions/verify-playwright-container

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: ./.github/actions/set-up-node
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     - run: npm run lint
 
   build:
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: ./.github/actions/set-up-node
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     - name: Ensure installed React and React-DOM versions match
       run: |
         REACT_VERSION=$(npm ls react --depth=0 --json | jq -r '.dependencies.react.version')
@@ -83,7 +83,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: ./.github/actions/set-up-node
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     # The example tests run against these docs. We build them once here and share
     # the result via an artifact so each (sharded) test job doesn't rebuild. We
     # build our own rather than reuse the `docs` job's artifact: that one only

--- a/.github/workflows/publish-fork-pr-docs.yml
+++ b/.github/workflows/publish-fork-pr-docs.yml
@@ -71,7 +71,7 @@ jobs:
     - uses: ./.github/actions/set-up-node
       if: steps.download.outcome == 'success' && steps.metadata.outputs.skip != 'true'
 
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
       if: steps.download.outcome == 'success' && steps.metadata.outputs.skip != 'true'
 
     - name: Configure git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,22 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+      # Cache the Sonar downloads (scanner CLI in the runner tool cache, JRE +
+      # analyzers in ~/.sonar/cache). Same key as the PR-checks sonarcloud job,
+      # so releases and PR runs share one cache; a save from main is readable
+      # by every PR. The hashFiles list must stay identical to the one in
+      # pr-checks.yml, or the shared cache silently splits. See pr-checks.yml
+      # for the full rationale.
+      - name: Restore Sonar caches
+        id: sonar-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.sonar/cache
+            ${{ runner.tool_cache }}/sonar-scanner-cli
+          key: sonar-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/pr-checks.yml', '.github/workflows/release.yml') }}
+          restore-keys: |
+            sonar-cache-${{ runner.os }}-${{ runner.arch }}-
       - name: SonarCloud Scan
         id: scan
         # SonarCloud intermittently rejects requests from GitHub-hosted
@@ -40,6 +56,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      # Split save so the downloads are kept even when the scan or the quality
+      # gate fails. Best-effort: never block a release over a cache save.
+      - name: Save Sonar caches
+        if: ${{ !cancelled() && steps.sonar-cache.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.sonar/cache
+            ${{ runner.tool_cache }}/sonar-scanner-cli
+          key: ${{ steps.sonar-cache.outputs.cache-primary-key }}
       - name: Check quality gate status
         if: steps.scan.outcome == 'failure'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         persist-credentials: false
     - uses: ./.github/actions/set-up-node
-    - run: npm ci
+    - uses: ./.github/actions/install-dependencies
     - run: npm run build
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0


### PR DESCRIPTION
## What this does

Makes CI runs faster and less flaky by caching downloads that were previously re-fetched on every run, and by making the caches survive failed runs.

**The wins:**

- **The 8 container test jobs now cache npm packages.** The `test`, `runtime-tests` (2 shards), `accessibility-tests` (4 shards) and `component-tests` jobs run inside the Playwright image and had no caching at all — every PR push downloaded every package from the registry 8 times.
- **The npm cache now survives a failed job.** Previously (via setup-node's built-in cache) the cache was only saved if the *whole job* succeeded. So a PR that changed `package-lock.json` and failed lint re-downloaded everything on every push until the job went green. Now the cache is saved as soon as `npm ci` succeeds.
- **A lock-file change no longer means a full re-download.** The built-in cache only restored on an exact lock-file match. The new setup falls back to the newest previous cache, which still contains every package the change didn't touch.
- **The Sonar scanner and analyzers are now cached.** We have a history of intermittent scanner-download failures (binaries served from IPs on GitHub's blocklist), so a cache hit removes a flake source, not just ~30 s of overhead. The cache is saved even when the scan or quality gate fails — those failures say nothing about the downloaded files.

## How

A new `install-dependencies` composite action wraps `npm ci` in the split cache pattern: `actions/cache/restore` → `npm ci` → `actions/cache/save`. Saving in a regular step right after the install (instead of a success-gated post-job step) is what makes the cache survive later failures. All jobs — host and container — now use it; `set-up-node` keeps handling only the Node version. The Sonar jobs use the same split pattern inline, with a save step that is best-effort (`continue-on-error`) so a cache problem can never block a PR check or a release.

## Notes for reviewers

- When several jobs miss on the same key simultaneously they race to save it; the losers log an "Unable to reserve cache" warning and continue. Expected, harmless.
- setup-node v6 auto-enables its built-in cache when `package.json` has a `packageManager` field (ours does), so it's now explicitly disabled with `package-manager-cache: false`.
- The Sonar cache key hashes the two workflow files, so it rotates whenever the pinned scan action (and with it the scanner version) is bumped by Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dependency setup across CI and release workflows for more consistent and reliable builds.
  * Added smarter cache handling to speed up repeated runs and reduce unnecessary downloads.
  * Enabled shared caching for code quality checks to improve performance.

* **Bug Fixes**
  * Reduced cache mismatches between different runner environments, helping avoid setup issues.
  * Made cache saving best-effort so cache-related problems are less likely to interrupt jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->