### PR TITLE
ci: scope down sonarcloud job token permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -288,6 +288,8 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## What

Add an explicit `permissions: contents: read` block to the `sonarcloud` job in `.github/workflows/pr-checks.yml`.

## Why

The `sonarcloud` job had no `permissions:` block, so it inherited the broad default `GITHUB_TOKEN` permissions — unlike its sibling container jobs (`test`, `runtime-tests`, `accessibility-tests`, `build-example-docs`), which all declare `contents: read`. zizmor flags this as `excessive-permissions`.

The job only checks out, restores/saves the Sonar cache, and runs the scan, so read access is sufficient.

Addresses a CodeRabbit finding from #4158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)