### PR TITLE
File image resize

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -4401,8 +4401,8 @@ export function resizeImage(file: File, options: ResizeOptions): Promise<File>;
 
 // @beta
 export type ResizeOptions = {
-    width: number;
-    height: number;
+    width?: number;
+    height?: number;
     fit?: 'cover' | 'contain';
     type?: 'image/jpeg' | 'image/png';
     quality?: number;

--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -458,6 +458,8 @@ export namespace Components {
         "loading": boolean;
         "readonly": boolean;
         "required": boolean;
+        // @beta
+        "resizeImage"?: ResizeOptions;
         "value": FileInfo;
     }
     // @internal
@@ -2393,6 +2395,8 @@ export namespace JSX {
         "onInteract"?: (event: LimelFileCustomEvent<number | string>) => void;
         "readonly"?: boolean;
         "required"?: boolean;
+        // @beta
+        "resizeImage"?: ResizeOptions;
         "value"?: FileInfo;
     }
 

--- a/src/components/file/examples/file-resize-image.scss
+++ b/src/components/file/examples/file-resize-image.scss
@@ -1,0 +1,33 @@
+@use '../../../style/mixins';
+
+:host {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+limel-example-controls {
+    --example-controls-max-columns-width: 10rem;
+    gap: 1rem;
+    padding-top: 0.5rem;
+    margin-top: 0;
+}
+
+h4 {
+    font-weight: 600;
+    margin: 0;
+}
+
+.preview {
+    min-height: 10rem;
+    border-radius: 0.5rem;
+    padding: 1rem;
+
+    text-align: center;
+    @include mixins.add-chessboard-background();
+
+    img {
+        box-shadow: var(--shadow-depth-16), var(--shadow-depth-64);
+        max-width: 100%;
+    }
+}

--- a/src/components/file/examples/file-resize-image.tsx
+++ b/src/components/file/examples/file-resize-image.tsx
@@ -1,0 +1,239 @@
+import {
+    FileInfo,
+    LimelSelectCustomEvent,
+    Option,
+    type ResizeOptions,
+} from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Client-side image resize
+ *
+ * When `resizeImage` is set, a selected image is downscaled and re-encoded on the
+ * user's device *before* the `change` event fires — reducing upload size and
+ * normalizing its dimensions and format. The emitted file's `filename`,
+ * `contentType` and `size` reflect the resized file, so its extension may
+ * change (for example `.png` → `.jpg`).
+ *
+ * The options passed to `resizeImage` are:
+ *
+ * - `width` / `height`: the target box, in pixels, to fit the image into.
+ *   Clear one to derive it from the other and keep the aspect ratio; clear
+ *   both to keep the source dimensions and only re-encode.
+ * - `fit`: only matters when both `width` and `height` are set. `cover` fills
+ *   the box and center-crops the overflow; `contain` fits the whole image
+ *   inside the box, letterboxing it. Omit it for the default (`cover`).
+ * - `type`: the output format. Omit it for the default (`image/jpeg`).
+ * - `quality`: JPEG compression, `0`–`1`. Ignored for `image/png`, which is
+ *   lossless. The control below is disabled when PNG is selected.
+ *
+ * Because resize re-encodes the image, do not enable it where the original
+ * bytes must be preserved — for example security scanning, checksums, or
+ * signatures.
+ *
+ * Resize completes before `change` fires; reflect any subsequent upload with
+ * the file's `loading`, `statusText` and `progress` fields.
+ *
+ * :::note
+ * `limel-file` is a general-purpose file picker, so pair `resizeImage` with an
+ * image-restricted `accept`, as this example does. Resize only touches
+ * decodable raster images; see the next example for what happens to everything
+ * else.
+ * :::
+ *
+ * :::tip
+ * If you are specifically building an image or avatar picker, look at
+ * [limel-profile-picture](#/component/limel-profile-picture/) instead. It
+ * shares the same resize options, but additionally renders a preview of the
+ * chosen image inline, and its examples explore the `fit` strategies and
+ * fallback behavior in more depth.
+ * :::
+ *
+ * @beta
+ */
+@Component({
+    tag: 'limel-example-file-resize-image',
+    shadow: true,
+    styleUrl: 'file-resize-image.scss',
+})
+export class FileResizeImageExample {
+    @State()
+    private value?: FileInfo;
+
+    @State()
+    private previewUrl = '';
+
+    @State()
+    // Every field is optional. When omitted, `fit` defaults to `cover`, `type`
+    // to `image/jpeg` and `quality` to `0.85`; `width`/`height` fall back to the
+    // source dimensions (a missing one preserves the aspect ratio).
+    private options: ResizeOptions = {
+        width: 800,
+        height: 600,
+        fit: 'contain',
+        type: 'image/jpeg',
+        quality: 0.85,
+    };
+
+    private fitOptions: Option[] = [
+        { text: 'cover', value: 'cover' },
+        { text: 'contain', value: 'contain' },
+    ];
+
+    private typeOptions: Option[] = [
+        { text: 'image/jpeg', value: 'image/jpeg' },
+        { text: 'image/png', value: 'image/png' },
+    ];
+
+    public render() {
+        return (
+            <Host>
+                <h4>
+                    1. Set <code>ResizeOptions</code>
+                </h4>
+                <limel-example-controls>
+                    <limel-input-field
+                        label="Width"
+                        type="number"
+                        value={this.options.width?.toString() ?? ''}
+                        onChange={this.handleWidthChange}
+                    />
+                    <limel-input-field
+                        label="Height"
+                        type="number"
+                        value={this.options.height?.toString() ?? ''}
+                        onChange={this.handleHeightChange}
+                    />
+                    <limel-select
+                        label="Fit"
+                        value={this.getSelectedFit()}
+                        options={this.fitOptions}
+                        disabled={!this.options.width || !this.options.height}
+                        onChange={this.handleFitChange}
+                    />
+                    <limel-select
+                        label="Type"
+                        value={this.getSelectedType()}
+                        options={this.typeOptions}
+                        onChange={this.handleTypeChange}
+                    />
+                    <limel-slider
+                        label="JPEG quality"
+                        value={Math.round((this.options.quality ?? 0) * 100)}
+                        valuemin={1}
+                        valuemax={100}
+                        step={1}
+                        unit="%"
+                        disabled={this.options.type === 'image/png'}
+                        onChange={this.handleQualityChange}
+                    />
+                </limel-example-controls>
+                <h4>2. Select an image file</h4>
+                <limel-file
+                    label="Upload an image"
+                    accept="image/jpeg,image/png,.jpg,.jpeg,.png"
+                    value={this.value}
+                    resizeImage={this.options}
+                    onChange={this.handleChange}
+                />
+                <h4>3. See your resized image</h4>
+                <div class="preview">{this.renderPreview()}</div>
+                <limel-example-value value={this.value} />
+            </Host>
+        );
+    }
+
+    private renderPreview() {
+        if (!this.previewUrl) {
+            return <span>No image selected yet.</span>;
+        }
+
+        return <img src={this.previewUrl} alt="Preview of the resized image" />;
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.value = event.detail;
+
+        if (this.previewUrl) {
+            URL.revokeObjectURL(this.previewUrl);
+            this.previewUrl = '';
+        }
+
+        if (!this.value?.fileContent) {
+            return;
+        }
+
+        this.previewUrl = URL.createObjectURL(this.value.fileContent);
+    };
+
+    private getSelectedFit = (): Option | undefined => {
+        return this.fitOptions.find(
+            (option) => option.value === this.options.fit
+        );
+    };
+
+    private getSelectedType = (): Option | undefined => {
+        return this.typeOptions.find(
+            (option) => option.value === this.options.type
+        );
+    };
+
+    private handleWidthChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.updateNumericOption('width', event.detail);
+    };
+
+    private handleHeightChange = (event: CustomEvent<string>) => {
+        event.stopPropagation();
+        this.updateNumericOption('height', event.detail);
+    };
+
+    private handleQualityChange = (event: CustomEvent<number>) => {
+        event.stopPropagation();
+        const quality = Math.max(0, Math.min(1, event.detail / 100));
+        this.updateOption('quality', quality);
+    };
+
+    private handleFitChange = (event: LimelSelectCustomEvent<Option>) => {
+        event.stopPropagation();
+        this.updateOption('fit', event.detail.value as 'cover' | 'contain');
+    };
+
+    private handleTypeChange = (event: LimelSelectCustomEvent<Option>) => {
+        event.stopPropagation();
+        this.updateOption(
+            'type',
+            event.detail.value as 'image/jpeg' | 'image/png'
+        );
+    };
+
+    private updateNumericOption = (
+        key: 'width' | 'height' | 'quality',
+        value: string
+    ) => {
+        // A cleared field means "not set": leave the dimension out so the
+        // resize keeps the source's own value. `Number('')` is `0`, so guard
+        // the empty string explicitly rather than relying on the parse.
+        const trimmed = value.trim();
+        const parsed = Number(trimmed);
+        const isSet = trimmed !== '' && Number.isFinite(parsed);
+
+        this.updateOption(key, isSet ? parsed : undefined);
+    };
+
+    private updateOption = <K extends keyof ResizeOptions>(
+        key: K,
+        value: ResizeOptions[K]
+    ) => {
+        this.options = {
+            ...this.options,
+            [key]: value,
+        };
+    };
+
+    public componentWillUnload() {
+        if (this.previewUrl) {
+            URL.revokeObjectURL(this.previewUrl);
+        }
+    }
+}

--- a/src/components/file/examples/file-resize-mixed.tsx
+++ b/src/components/file/examples/file-resize-mixed.tsx
@@ -1,0 +1,101 @@
+import { FileInfo, type ResizeOptions } from '@limetech/lime-elements';
+import { Component, h, Host, State } from '@stencil/core';
+
+/**
+ * Resize in a general file picker
+ *
+ * The same `resizeImage` options with the default `accept="*"` — the scenario
+ * unique to a general-purpose picker. Resize degrades gracefully:
+ *
+ * - selecting an image resizes and re-encodes it;
+ * - selecting a PDF, archive, document, or SVG passes through untouched —
+ *   only decodable raster images are resized;
+ * - selecting a HEIC/HEIF off Safari emits the original unchanged, because the
+ *   browser cannot decode it.
+ *
+ * Inspect the emitted value below: its `filename`, `contentType` and `size`
+ * change only when the file was actually resized.
+ *
+ * :::note
+ * HEIC/HEIF images (common from iPhones) cannot be decoded outside Safari, so
+ * they are emitted unchanged. Detect this in your app — for example from the
+ * emitted filename extension, as below — and convert or reject server-side if
+ * needed.
+ * :::
+ *
+ * @beta
+ */
+@Component({
+    tag: 'limel-example-file-resize-mixed',
+    shadow: true,
+})
+export class FileResizeMixedExample {
+    @State()
+    private value?: FileInfo;
+
+    @State()
+    private notResized = false;
+
+    // Every field is optional. When omitted, `fit` defaults to `cover`, `type`
+    // to `image/jpeg` and `quality` to `0.85`; `width`/`height` fall back to the
+    // source dimensions (a missing one preserves the aspect ratio).
+    private options: ResizeOptions = {
+        width: 1024,
+        height: 1024,
+        fit: 'contain',
+        type: 'image/jpeg',
+        quality: 0.85,
+    };
+
+    public render() {
+        return (
+            <Host>
+                <limel-file
+                    label="Attach a file"
+                    value={this.value}
+                    resizeImage={this.options}
+                    onChange={this.handleChange}
+                />
+                {this.renderCallout()}
+                <limel-example-value value={this.value} />
+            </Host>
+        );
+    }
+
+    private renderCallout() {
+        if (!this.notResized) {
+            return;
+        }
+
+        return [
+            <hr key="divider" style={{ margin: '2rem 0' }} />,
+            <limel-callout
+                key="callout"
+                aria-live="polite"
+                heading="Uploaded as-is"
+            >
+                This file was not resized — either it is not an image, or its
+                format cannot be decoded in this browser (for example HEIC
+                outside Safari). The original file will be used.
+            </limel-callout>,
+        ];
+    }
+
+    private handleChange = (event: CustomEvent<FileInfo>) => {
+        this.value = event.detail;
+
+        if (this.value) {
+            const name = this.value.filename?.toLowerCase?.() ?? '';
+            const looksLikeImage =
+                /\.(jpe?g|png|gif|webp|bmp|heic|heif|avif|tiff?)$/.test(name);
+            const gotJpeg = name.endsWith('.jpg') || name.endsWith('.jpeg');
+            // We request `image/jpeg` output, so an image-looking file that did
+            // not come back as `.jpg` means resize was skipped (non-decodable).
+            this.notResized = looksLikeImage && !gotJpeg;
+
+            return;
+        }
+
+        this.notResized = false;
+    };
+}

--- a/src/components/file/file.e2e.tsx
+++ b/src/components/file/file.e2e.tsx
@@ -1,0 +1,109 @@
+import { render, h } from '@stencil/vitest';
+import { FileInfo } from '../../global/shared-types/file.types';
+
+// Browser tests: a real canvas / `createImageBitmap` is available here, so the
+// actual client-side resize runs. These cover the two behaviors that cannot be
+// exercised in the mock-doc `spec` environment (see file.spec.tsx): the resize
+// round-trip, and cancelling a resize that is still in flight.
+
+const RESIZE_OPTIONS = { width: 50, height: 50 };
+
+// Draw a solid PNG of the given size so it is a genuinely decodable raster.
+const makeImageFile = async (
+    filename: string,
+    width: number,
+    height: number
+): Promise<File> => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#3366cc';
+    context.fillRect(0, 0, width, height);
+
+    const blob = await new Promise<Blob>((resolve) => {
+        canvas.toBlob((result) => resolve(result), 'image/png');
+    });
+
+    return new File([blob], filename, { type: 'image/png' });
+};
+
+const asFileInfo = (file: File): FileInfo => ({
+    id: 1,
+    filename: file.name,
+    fileContent: file,
+});
+
+const selectFile = (root: HTMLElement, file: File) => {
+    const dropzone = root.shadowRoot?.querySelector('limel-file-dropzone');
+    dropzone?.dispatchEvent(
+        new CustomEvent('filesSelected', { detail: [asFileInfo(file)] })
+    );
+};
+
+const removeChip = (root: HTMLElement) => {
+    const chipSet = root.shadowRoot?.querySelector('limel-chip-set');
+    chipSet?.dispatchEvent(new CustomEvent('change', { detail: [] }));
+};
+
+const captureChanges = (root: HTMLElement): FileInfo[] => {
+    const changes: FileInfo[] = [];
+    root.addEventListener('change', (event: Event) => {
+        changes.push((event as CustomEvent<FileInfo>).detail);
+    });
+
+    return changes;
+};
+
+const setup = async () => {
+    const { root, waitForChanges } = await render(
+        <limel-file label="Attach a file" />
+    );
+    (root as any).resizeImage = RESIZE_OPTIONS;
+    await waitForChanges();
+
+    return { root, waitForChanges, changes: captureChanges(root) };
+};
+
+describe('limel-file (client-side resize)', () => {
+    it('resizes and re-encodes a selected image before emitting change', async () => {
+        const { root, changes } = await setup();
+
+        selectFile(root, await makeImageFile('photo.png', 200, 120));
+
+        await vi.waitFor(() => expect(changes).toHaveLength(1));
+
+        const emitted = changes[0];
+        // Re-encoded to the default JPEG output, with the extension updated.
+        expect(emitted.filename).toBe('photo.jpg');
+        expect(emitted.contentType).toBe('image/jpeg');
+
+        // Actually downscaled to the requested box.
+        const bitmap = await createImageBitmap(emitted.fileContent);
+        expect(bitmap.width).toBe(50);
+        expect(bitmap.height).toBe(50);
+    });
+
+    it('does not re-emit the file when the chip is removed mid-resize', async () => {
+        const { root, changes } = await setup();
+
+        // Start the resize, then remove the chip before it can finish. The
+        // synchronous ordering guarantees the removal lands while the async
+        // resize is still pending.
+        selectFile(root, await makeImageFile('photo.png', 800, 600));
+        removeChip(root);
+
+        // Wait for the removal, then give the abandoned resize time to settle.
+        await vi.waitFor(() =>
+            expect(changes.length).toBeGreaterThanOrEqual(1)
+        );
+        await new Promise((resolve) => setTimeout(resolve, 150));
+
+        // The stale resized image must never be emitted after removal.
+        expect(
+            changes.some((change) => change?.contentType === 'image/jpeg')
+        ).toBe(false);
+        // The last thing the consumer heard was the removal.
+        expect(changes.at(-1)).toBeFalsy();
+    });
+});

--- a/src/components/file/file.spec.tsx
+++ b/src/components/file/file.spec.tsx
@@ -1,0 +1,91 @@
+import { render, h } from '@stencil/vitest';
+import { FileInfo } from '../../global/shared-types/file.types';
+
+// These tests run in the mock-doc `spec` environment, which has no canvas or
+// `createImageBitmap` and renders `limel-file` from the built bundle (so its
+// `resizeImage` utility cannot be mocked). They therefore cover the parts of
+// the resize feature that don't need a working decoder: which selections are
+// eligible for resizing, and the single-file chrome. The successful resize
+// round-trip and cancelling a resize mid-flight need a real browser and are
+// covered by e2e tests.
+
+const fileWith = (filename: string, type: string): FileInfo => ({
+    id: 1,
+    filename,
+    fileContent: new File([new Blob(['data'])], filename, { type }),
+});
+
+const selectFile = async (
+    root: HTMLElement,
+    waitForChanges: () => Promise<void>,
+    file: FileInfo
+) => {
+    const dropzone = root.shadowRoot?.querySelector('limel-file-dropzone');
+    dropzone?.dispatchEvent(
+        new CustomEvent('filesSelected', { detail: [file] })
+    );
+    await waitForChanges();
+};
+
+const setup = async (props: Record<string, unknown> = {}) => {
+    const { root, waitForChanges } = await render(
+        <limel-file label="Attach a file" {...props} />
+    );
+    await waitForChanges();
+
+    const changes: FileInfo[] = [];
+    root.addEventListener('change', (event: Event) => {
+        changes.push((event as CustomEvent<FileInfo>).detail);
+    });
+
+    return { root, waitForChanges, changes };
+};
+
+test('disables the chip set clear-all button (single-file picker)', async () => {
+    const { root } = await setup();
+
+    const chipSet = root.shadowRoot?.querySelector('limel-chip-set') as any;
+    expect(chipSet).toBeTruthy();
+    expect(chipSet.clearAllButton).toBe(false);
+});
+
+test('emits a non-image file unchanged when resizeImage is set', async () => {
+    const { root, waitForChanges, changes } = await setup({
+        resizeImage: { width: 100, height: 100 },
+    });
+
+    await selectFile(
+        root,
+        waitForChanges,
+        fileWith('report.pdf', 'application/pdf')
+    );
+
+    // Not a raster image, so it is passed through untouched.
+    expect(changes.at(-1)?.filename).toBe('report.pdf');
+    expect(changes.at(-1)?.contentType).toBeUndefined();
+});
+
+test('emits an SVG unchanged when resizeImage is set', async () => {
+    const { root, waitForChanges, changes } = await setup({
+        resizeImage: { width: 100, height: 100 },
+    });
+
+    await selectFile(
+        root,
+        waitForChanges,
+        fileWith('icon.svg', 'image/svg+xml')
+    );
+
+    // SVG is excluded from resizing.
+    expect(changes.at(-1)?.filename).toBe('icon.svg');
+    expect(changes.at(-1)?.contentType).toBeUndefined();
+});
+
+test('emits an image unchanged when resizeImage is not set', async () => {
+    const { root, waitForChanges, changes } = await setup();
+
+    await selectFile(root, waitForChanges, fileWith('photo.png', 'image/png'));
+
+    expect(changes.at(-1)?.filename).toBe('photo.png');
+    expect(changes.at(-1)?.contentType).toBeUndefined();
+});

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -1,7 +1,16 @@
 import translate from '../../global/translations';
 import { Chip } from '../chip-set/chip.types';
 import { Languages } from '../date-picker/date.types';
-import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+import {
+    Component,
+    Event,
+    EventEmitter,
+    h,
+    Host,
+    Prop,
+    State,
+    Watch,
+} from '@stencil/core';
 import {
     getFileBackgroundColor,
     getFileColor,
@@ -156,11 +165,33 @@ export class File {
     @Event()
     private interact: EventEmitter<number | string>;
 
+    /**
+     * The selected file held while it is being resized, shown as a chip with a
+     * loading badge so the field is not idle during the resize.
+     */
+    @State()
+    private resizingFile?: FileInfo;
+
+    /** The committed `value`, or the file currently being resized. */
+    private get displayedFile(): FileInfo | undefined {
+        return this.value ?? this.resizingFile;
+    }
+
+    // Clear the transient file once `value` reflects the selection, keeping the
+    // same chip mounted across the hand-off (see file.spec.tsx) so only its
+    // badge changes instead of the field flashing empty.
+    @Watch('value')
+    protected handleValueChange() {
+        this.resizingFile = undefined;
+    }
+
     public render() {
         return (
             <Host aria-busy={this.isBusy ? 'true' : 'false'}>
                 <limel-file-dropzone
-                    disabled={this.disabled || this.readonly || !!this.value}
+                    disabled={
+                        this.disabled || this.readonly || !!this.displayedFile
+                    }
                     accept={this.accept}
                     onFilesSelected={this.handleNewFiles}
                 >
@@ -173,7 +204,7 @@ export class File {
     }
 
     private get statusText(): string {
-        return this.value?.statusText?.trim() ?? '';
+        return this.displayedFile?.statusText?.trim() ?? '';
     }
 
     /**
@@ -185,8 +216,8 @@ export class File {
     private get isBusy(): boolean {
         return (
             this.loading ||
-            Boolean(this.value?.loading) ||
-            this.value?.progress !== undefined
+            Boolean(this.displayedFile?.loading) ||
+            this.displayedFile?.progress !== undefined
         );
     }
 
@@ -199,7 +230,12 @@ export class File {
     }
 
     private renderDragAndDropTip() {
-        if (this.value || this.disabled || this.readonly || this.isBusy) {
+        if (
+            this.displayedFile ||
+            this.disabled ||
+            this.readonly ||
+            this.isBusy
+        ) {
             return;
         }
 
@@ -231,6 +267,17 @@ export class File {
             content instanceof Blob &&
             this.isResizableImage(content)
         ) {
+            // Show the selected file with a loading badge while it resizes.
+            // This object doubles as the in-flight token: if it is cleared or
+            // replaced during the await (e.g. the file is removed), the resize
+            // result is stale and must be dropped.
+            const pending: FileInfo = {
+                ...file,
+                loading: true,
+                statusText: this.getTranslation('file.optimizing'),
+            };
+            this.resizingFile = pending;
+
             try {
                 const processed = await resizeImageFile(
                     content,
@@ -247,6 +294,15 @@ export class File {
                 // Best-effort: on any decode or encode failure emit the
                 // original file unchanged.
             }
+
+            // Bail if the selection changed while we were resizing, so a
+            // removed or superseded file is neither re-shown nor re-emitted.
+            if (this.resizingFile !== pending) {
+                return;
+            }
+
+            // Keep the result on the same chip until `value` catches up.
+            this.resizingFile = out;
         }
 
         this.change.emit(out);
@@ -262,27 +318,28 @@ export class File {
     }
 
     private getChipArray(): Chip[] {
-        if (!this.value) {
+        const file = this.displayedFile;
+        if (!file) {
             return [];
         }
 
         return [
             {
                 ...DEFAULT_FILE_CHIP,
-                text: this.value.filename,
-                id: this.value.id,
+                text: file.filename,
+                id: file.id,
                 icon: {
-                    name: getFileIcon(this.value),
-                    title: getFileExtensionTitle(this.value),
-                    color: getFileColor(this.value),
-                    backgroundColor: getFileBackgroundColor(this.value),
+                    name: getFileIcon(file),
+                    title: getFileExtensionTitle(file),
+                    color: getFileColor(file),
+                    backgroundColor: getFileBackgroundColor(file),
                 },
                 badge: this.getBadge(),
-                href: this.value.href,
-                menuItems: this.value.menuItems,
-                loading: this.value.loading,
-                progress: this.value.progress,
-                invalid: this.value.invalid,
+                href: file.href,
+                menuItems: file.menuItems,
+                loading: file.loading,
+                progress: file.progress,
+                invalid: file.invalid,
             },
         ];
     }
@@ -292,8 +349,8 @@ export class File {
             return this.statusText;
         }
 
-        if (typeof this.value.size === 'number') {
-            return formatBytes(this.value.size);
+        if (typeof this.displayedFile?.size === 'number') {
+            return formatBytes(this.displayedFile.size);
         }
 
         return undefined;
@@ -335,6 +392,13 @@ export class File {
         event.stopPropagation();
         const file = event.detail.length === 0 ? event.detail[0] : null;
         if (!file) {
+            // Removing the chip cancels any in-flight resize: drop the
+            // transient so the chip disappears immediately, and the token
+            // guard in `handleNewFiles` discards the resize result instead of
+            // re-emitting the removed file once it finishes. Without this, a
+            // removal during resize is swallowed, because `value` is already
+            // `undefined` so the `@Watch('value')` clear never fires.
+            this.resizingFile = undefined;
             this.change.emit(file);
         }
     };

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -362,6 +362,7 @@ export class File {
                 disabled={this.disabled}
                 readonly={this.readonly}
                 invalid={this.invalid}
+                clearAllButton={false}
                 label={this.label}
                 helperText={this.helperText}
                 leadingIcon="upload_to_cloud"

--- a/src/components/file/file.tsx
+++ b/src/components/file/file.tsx
@@ -10,6 +10,10 @@ import {
 } from '../../util/file-metadata';
 import { FileInfo } from '../../global/shared-types/file.types';
 import { formatBytes } from '../../util/format-bytes';
+import {
+    resizeImage as resizeImageFile,
+    ResizeOptions,
+} from '../../util/image-resize';
 
 const DEFAULT_FILE_CHIP: Chip = {
     id: null,
@@ -56,6 +60,8 @@ const DEFAULT_FILE_CHIP: Chip = {
  * @exampleComponent limel-example-file-per-file-status
  * @exampleComponent limel-example-file-menu-items
  * @exampleComponent limel-example-file-accepted-types
+ * @exampleComponent limel-example-file-resize-image
+ * @exampleComponent limel-example-file-resize-mixed
  * @exampleComponent limel-example-file-composite
  */
 @Component({
@@ -121,6 +127,16 @@ export class File {
      */
     @Prop({ reflect: true })
     public accept: string = '*';
+
+    /**
+     * Optional client-side image resize, applied before the `change` event is
+     * emitted: a selected image is downscaled and re-encoded on the user's
+     * device. Only decodable raster images are resized; all other files pass
+     * through unchanged. See the examples for details and caveats.
+     * @beta
+     */
+    @Prop()
+    public resizeImage?: ResizeOptions;
 
     /**
      * Defines the localisation for translations.
@@ -201,10 +217,49 @@ export class File {
         return this.getTranslation('file.drag-and-drop-tips');
     };
 
-    private handleNewFiles = (event: CustomEvent<FileInfo[]>) => {
+    private handleNewFiles = async (event: CustomEvent<FileInfo[]>) => {
         this.preventAndStop(event);
-        this.change.emit(event.detail[0]);
+
+        const file = event.detail[0];
+        let out = file;
+        const content = file?.fileContent;
+
+        // `instanceof Blob` (not `File`) guards against a value with no real
+        // binary and narrows to the DOM file type; `File` here is the class.
+        if (
+            this.resizeImage &&
+            content instanceof Blob &&
+            this.isResizableImage(content)
+        ) {
+            try {
+                const processed = await resizeImageFile(
+                    content,
+                    this.resizeImage
+                );
+                out = {
+                    ...file,
+                    filename: processed.name,
+                    size: processed.size,
+                    contentType: processed.type,
+                    fileContent: processed,
+                };
+            } catch {
+                // Best-effort: on any decode or encode failure emit the
+                // original file unchanged.
+            }
+        }
+
+        this.change.emit(out);
     };
+
+    // Cheap pre-filter; the decode inside `resizeImage` is the authoritative
+    // check and throws (caught above) for anything that does not decode.
+    private isResizableImage(file: Blob): boolean {
+        return (
+            Boolean(file.type?.startsWith('image/')) &&
+            file.type !== 'image/svg+xml'
+        );
+    }
 
     private getChipArray(): Chip[] {
         if (!this.value) {

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -31,6 +31,7 @@ export default {
     'snackbar.dismiss': 'Luk',
     'file.drag-and-drop-tips':
         'Træk & slip filen her, eller klik for at gennemse.',
+    'file.optimizing': 'Optimerer…',
     'file-viewer.message.unsupported-filetype':
         'Kan ikke vise en forhåndsvisning af denne filtype.',
     'file-viewer.message.try-other-options':

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -31,6 +31,7 @@ export default {
     'snackbar.dismiss': 'Schließen',
     'file.drag-and-drop-tips':
         'Ziehen Sie Ihre Datei hierher oder klicken Sie, um zu durchsuchen.',
+    'file.optimizing': 'Optimieren…',
     'file-viewer.message.unsupported-filetype':
         'Für diesen Dateityp kann keine Vorschau angezeigt werden.',
     'file-viewer.message.try-other-options':

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -30,6 +30,7 @@ export default {
     'snackbar.dismiss': 'Dismiss',
     'file.drag-and-drop-tips':
         'Drag & drop your file here, or click to browse.',
+    'file.optimizing': 'Optimizing…',
     'file-viewer.message.unsupported-filetype':
         'Cannot display a preview for this file type.',
     'file-viewer.message.try-other-options':

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -31,6 +31,7 @@ export default {
     'snackbar.dismiss': 'Sulje',
     'file.drag-and-drop-tips':
         'Vedä & pudota tiedostosi tähän, tai napsauta selataksesi.',
+    'file.optimizing': 'Optimoidaan…',
     'file-viewer.message.unsupported-filetype':
         'Esikatselua ei voi näyttää tälle tiedostotyypille.',
     'file-viewer.message.try-other-options':

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -31,6 +31,7 @@ export default {
     'snackbar.dismiss': 'Fermer',
     'file.drag-and-drop-tips':
         'Glissez-déposez votre fichier ici, ou cliquez pour parcourir.',
+    'file.optimizing': 'Optimisation…',
     'file-viewer.message.unsupported-filetype':
         "Impossible d'afficher un aperçu pour ce type de fichier.",
     'file-viewer.message.try-other-options':

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -30,6 +30,7 @@ export default {
     'snackbar.dismiss': 'Sluiten',
     'file.drag-and-drop-tips':
         'Sleep een bestand hierheen of klik om te bladeren.',
+    'file.optimizing': 'Optimaliseren…',
     'file-viewer.message.unsupported-filetype':
         'Kan geen voorbeeld weergeven voor dit bestandstype.',
     'file-viewer.message.try-other-options':

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -30,6 +30,7 @@ export default {
     'chip-set.clear-all': 'Fjern alle',
     'file.drag-and-drop-tips':
         'Dra & slipp filen her, eller klikk for å bla gjennom.',
+    'file.optimizing': 'Optimaliserer…',
     'file-viewer.message.unsupported-filetype':
         'Kan ikke vise en forhåndsvisning av denne filtypen.',
     'file-viewer.message.try-other-options':

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -31,6 +31,7 @@ export default {
     'snackbar.dismiss': 'Stäng',
     'file.drag-and-drop-tips':
         'Dra & släpp filen här eller klicka om du vill bläddra.',
+    'file.optimizing': 'Optimerar…',
     'file-viewer.message.unsupported-filetype':
         'Kan inte visa en förhandsvisning för denna filtyp.',
     'file-viewer.message.try-other-options':

--- a/src/util/image-resize.ts
+++ b/src/util/image-resize.ts
@@ -110,10 +110,18 @@
  * @beta
  */
 export type ResizeOptions = {
-    /** Target width in CSS pixels. */
-    width: number;
-    /** Target height in CSS pixels. */
-    height: number;
+    /**
+     * Target width in CSS pixels. Omit to derive it from `height` while
+     * preserving the source aspect ratio; omit both `width` and `height` to
+     * keep the source dimensions and only re-encode.
+     */
+    width?: number;
+    /**
+     * Target height in CSS pixels. Omit to derive it from `width` while
+     * preserving the source aspect ratio; omit both `width` and `height` to
+     * keep the source dimensions and only re-encode.
+     */
+    height?: number;
     /** Fit strategy; defaults to 'cover'. */
     fit?: 'cover' | 'contain';
     /** Output MIME type; 'image/jpeg' by default. */
@@ -144,8 +152,6 @@ export async function resizeImage(
     options: ResizeOptions
 ): Promise<File> {
     const {
-        width,
-        height,
         fit = 'cover',
         type = 'image/jpeg',
         quality = 0.85,
@@ -153,9 +159,18 @@ export async function resizeImage(
     } = options;
 
     const source = await loadSource(file);
+    const sourceWidth = source.width;
+    const sourceHeight = source.height;
+    const { width, height } = resolveTargetSize(
+        sourceWidth,
+        sourceHeight,
+        options.width,
+        options.height
+    );
+
     const { sx, sy, sw, sh, dx, dy, dw, dh } = computeRects(
-        source.width as number,
-        source.height as number,
+        sourceWidth,
+        sourceHeight,
         width,
         height,
         fit
@@ -169,6 +184,53 @@ export async function resizeImage(
     const blob = await canvasToBlob(canvas, type, quality);
     const name = rename(file.name);
     return new File([blob], name, { type });
+}
+
+/**
+ * Resolve the target dimensions from the requested options, falling back to the
+ * source. A missing dimension is derived from the given one to preserve the
+ * source aspect ratio; when both are missing the source size is kept, so the
+ * image is only re-encoded. Non-positive requests are treated as missing.
+ *
+ * @param sourceWidth - Decoded source width
+ * @param sourceHeight - Decoded source height
+ * @param width - Requested target width, if any
+ * @param height - Requested target height, if any
+ */
+function resolveTargetSize(
+    sourceWidth: number,
+    sourceHeight: number,
+    width?: number,
+    height?: number
+): { width: number; height: number } {
+    // A dimension counts as "requested" only when it's a positive number;
+    // `undefined`, `0`, negatives and `NaN` are all treated as missing.
+    const hasWidth = typeof width === 'number' && width > 0;
+    const hasHeight = typeof height === 'number' && height > 0;
+
+    // Both requested: use them as-is.
+    if (hasWidth && hasHeight) {
+        return { width, height };
+    }
+
+    // Only width requested: derive the height to keep the aspect ratio.
+    if (hasWidth) {
+        return {
+            width,
+            height: Math.round(width * (sourceHeight / sourceWidth)),
+        };
+    }
+
+    // Only height requested: derive the width to keep the aspect ratio.
+    if (hasHeight) {
+        return {
+            width: Math.round(height * (sourceWidth / sourceHeight)),
+            height,
+        };
+    }
+
+    // Neither requested: keep the source size and only re-encode.
+    return { width: sourceWidth, height: sourceHeight };
 }
 
 /** Whether OffscreenCanvas is available in the current environment. */


### PR DESCRIPTION
fix https://github.com/Lundalogik/lime-webclient/issues/7902

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional client-side image resizing to the file picker (dimensions, fit, output type, JPEG quality) with in-progress UI and responsive preview.
  * Added new image resize example(s), including a mixed best-effort scenario.
* **Bug Fixes**
  * Improved resizing feedback with an “optimizing” state, synchronized selection, and safer handling when users cancel mid-process.
  * If resizing fails, the original file is emitted unchanged.
* **Documentation**
  * Added “optimizing” progress text translations for supported languages.
* **Tests**
  * Added end-to-end and unit coverage for the image resize behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
