### PR TITLE
docs(text-editor): document that clear discards pending changes and the flush-first pattern

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -236,9 +236,11 @@ export class ProsemirrorAdapter {
      * send. Use this to empty the editor regardless of the prop's change
      * detection.
      *
-     * Does not emit a `change` event. Consumers that mirror the editor
-     * content on `change` (drafts, validation, dirty state) should reset
-     * their own copy when calling this.
+     * Does not emit a `change` event, and discards any pending debounced
+     * `change` — consumers that need the final content must call
+     * `flushPendingChanges()` before clearing. Consumers that mirror the
+     * editor content on `change` (drafts, validation, dirty state) should
+     * reset their own copy when calling this.
      */
     @Method()
     public async clear(): Promise<void> {

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -290,6 +290,12 @@ export class TextEditor implements FormComponent<string> {
      * example, clearing the editor immediately after a send. Use this to
      * empty the editor regardless of the prop's change detection.
      *
+     * Any pending debounced `change` is also discarded, so content the user
+     * typed just before the call is never reported. To capture the final
+     * content before clearing, flush first — `await flushPendingChanges()`
+     * delivers the final content, then read the bound value, then
+     * `await clear()`.
+     *
      * Does not emit a `change` event. If you mirror the editor content on
      * `change` (drafts, validation, dirty state), reset your own copy when
      * calling this. In readonly mode no editor is rendered, so this is a


### PR DESCRIPTION
## What

Documents two facts about `clear()` that the JSDoc omits, on both
`limel-text-editor` and its ProseMirror adapter:

- clearing also discards any pending debounced `change`, so content typed just
  before the call is never reported;
- the pattern for capturing the final content anyway is to flush first:

```ts
await editor.flushPendingChanges(); // emits the final content
send(this.boundValue);
await editor.clear();
```

No behavior change.

## Why

`clear()` silently swallows a pending `change`, and the only way to learn that
today is reading the implementation. The one in-tree consumer (the AI chat
composer in lime-crm-components) depends on the flush-first pattern for
correctness, but the pattern is not discoverable from the API docs — the next
consumer would have to rediscover it.

## Verification

- Docs-only change; text-editor spec 268/268 and e2e 130/130 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that clearing the editor discards pending debounced change events.
  * Added guidance to flush pending changes before clearing when final content must be delivered.
  * Documented that mirrored editor state may need to be reset after clearing.
  * Clarified that clearing has no effect when the editor is read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->