### PR TITLE
ci: drop obsolete Stencil double-build workaround

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,7 +34,6 @@ jobs:
           exit 1
         fi
     - run: npm run build
-    - run: npm run build # Needed to avoid incremental build quirks
     - run: npm run api:verify
 
   test:

--- a/publish-docs.cjs
+++ b/publish-docs.cjs
@@ -269,9 +269,7 @@ function build() {
         shell.exit(1);
     }
 
-    // Run docs build twice to ensure no type errors.
-    // (Known bug in Stencil, see https://github.com/stenciljs/core/issues/3534)
-    if (shell.exec('npm run docs:build && npm run docs:build').code !== 0) {
+    if (shell.exec('npm run docs:build').code !== 0) {
         shell.echo('docs:build failed!');
         teardown();
         shell.exit(1);


### PR DESCRIPTION
A long-standing Stencil bug meant TypeScript errors were not reported on the first build when `components.d.ts` was missing or outdated, so the build was run twice to surface them. That bug is fixed in `@stencil/core` 4.43.2 ([stenciljs/core#6616](https://github.com/stenciljs/core/pull/6616), closing [#3534](https://github.com/stenciljs/core/issues/3534)).

This repo resolves `@stencil/core` 4.43.5, so the second build is removed in both places it appeared:

- `pr-checks.yml` (before `npm run api:verify`).
- `publish-docs.cjs` (the `docs:build` step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build validation to catch mismatched core package versions before running the app build.
  * Simplified the documentation build process so it runs once instead of twice, reducing unnecessary build time while keeping failure handling intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->