### PR TITLE
fix(file): remove baked-in defaults from the image-resize util

### DIFF
--- a/src/components/file/examples/file-resize-image.tsx
+++ b/src/components/file/examples/file-resize-image.tsx
@@ -22,8 +22,10 @@ import { Component, h, Host, State } from '@stencil/core';
  *   both to keep the source dimensions and only re-encode.
  * - `fit`: only matters when both `width` and `height` are set. `cover` fills
  *   the box and center-crops the overflow; `contain` fits the whole image
- *   inside the box, letterboxing it. Omit it for the default (`cover`).
- * - `type`: the output format. Omit it for the default (`image/jpeg`).
+ *   inside the box, letterboxing it. Omit it to scale the whole image to fit
+ *   without cropping.
+ * - `type`: the output format. Omit it to keep the source format when the
+ *   canvas can encode it (PNG stays PNG; everything else becomes JPEG).
  * - `quality`: JPEG compression, `0`–`1`. Ignored for `image/png`, which is
  *   lossless. The control below is disabled when PNG is selected.
  *
@@ -64,9 +66,12 @@ export class FileResizeImageExample {
     private previewUrl = '';
 
     @State()
-    // Every field is optional. When omitted, `fit` defaults to `cover`, `type`
-    // to `image/jpeg` and `quality` to `0.85`; `width`/`height` fall back to the
-    // source dimensions (a missing one preserves the aspect ratio).
+    // Every field is optional, and the util imposes no defaults of its own:
+    // when omitted, `type` keeps the source format when the canvas can encode
+    // it (PNG stays PNG, otherwise JPEG); `fit` scales the whole image to fit
+    // without cropping; `quality` (JPEG only) uses the browser's native
+    // quality; `width`/`height` fall back to the source dimensions (a missing
+    // one preserves the aspect ratio).
     private options: ResizeOptions = {
         width: 800,
         height: 600,

--- a/src/components/file/examples/file-resize-mixed.tsx
+++ b/src/components/file/examples/file-resize-mixed.tsx
@@ -36,9 +36,11 @@ export class FileResizeMixedExample {
     @State()
     private notResized = false;
 
-    // Every field is optional. When omitted, `fit` defaults to `cover`, `type`
-    // to `image/jpeg` and `quality` to `0.85`; `width`/`height` fall back to the
-    // source dimensions (a missing one preserves the aspect ratio).
+    // This example pins every field. In particular it forces `type:
+    // 'image/jpeg'` so the "Uploaded as-is" detection below can tell a resized
+    // image (always re-encoded to `.jpg`) from one that was passed through
+    // untouched. For what each option does when omitted, see the
+    // `file-resize-image` example, which exposes controls for them.
     private options: ResizeOptions = {
         width: 1024,
         height: 1024,

--- a/src/components/file/file.e2e.tsx
+++ b/src/components/file/file.e2e.tsx
@@ -1,5 +1,6 @@
 import { render, h } from '@stencil/vitest';
 import { FileInfo } from '../../global/shared-types/file.types';
+import { ResizeOptions } from '../../util/image-resize';
 
 // Browser tests: a real canvas / `createImageBitmap` is available here, so the
 // actual client-side resize runs. These cover the two behaviors that cannot be
@@ -8,11 +9,12 @@ import { FileInfo } from '../../global/shared-types/file.types';
 
 const RESIZE_OPTIONS = { width: 50, height: 50 };
 
-// Draw a solid PNG of the given size so it is a genuinely decodable raster.
+// Draw a solid image of the given size so it is a genuinely decodable raster.
 const makeImageFile = async (
     filename: string,
     width: number,
-    height: number
+    height: number,
+    type: 'image/png' | 'image/jpeg' = 'image/png'
 ): Promise<File> => {
     const canvas = document.createElement('canvas');
     canvas.width = width;
@@ -22,10 +24,10 @@ const makeImageFile = async (
     context.fillRect(0, 0, width, height);
 
     const blob = await new Promise<Blob>((resolve) => {
-        canvas.toBlob((result) => resolve(result), 'image/png');
+        canvas.toBlob((result) => resolve(result), type);
     });
 
-    return new File([blob], filename, { type: 'image/png' });
+    return new File([blob], filename, { type });
 };
 
 const asFileInfo = (file: File): FileInfo => ({
@@ -55,18 +57,18 @@ const captureChanges = (root: HTMLElement): FileInfo[] => {
     return changes;
 };
 
-const setup = async () => {
+const setup = async (resizeImage: ResizeOptions = RESIZE_OPTIONS) => {
     const { root, waitForChanges } = await render(
         <limel-file label="Attach a file" />
     );
-    (root as any).resizeImage = RESIZE_OPTIONS;
+    (root as any).resizeImage = resizeImage;
     await waitForChanges();
 
     return { root, waitForChanges, changes: captureChanges(root) };
 };
 
 describe('limel-file (client-side resize)', () => {
-    it('resizes and re-encodes a selected image before emitting change', async () => {
+    it('resizes and keeps the source format when no type is set', async () => {
         const { root, changes } = await setup();
 
         selectFile(root, await makeImageFile('photo.png', 200, 120));
@@ -74,14 +76,50 @@ describe('limel-file (client-side resize)', () => {
         await vi.waitFor(() => expect(changes).toHaveLength(1));
 
         const emitted = changes[0];
-        // Re-encoded to the default JPEG output, with the extension updated.
-        expect(emitted.filename).toBe('photo.jpg');
-        expect(emitted.contentType).toBe('image/jpeg');
+        // No output type requested, so the source PNG is preserved rather than
+        // silently flattened to JPEG.
+        expect(emitted.filename).toBe('photo.png');
+        expect(emitted.contentType).toBe('image/png');
 
         // Actually downscaled to the requested box.
         const bitmap = await createImageBitmap(emitted.fileContent);
         expect(bitmap.width).toBe(50);
         expect(bitmap.height).toBe(50);
+    });
+
+    it('keeps a non-PNG source format when no type is set', async () => {
+        const { root, changes } = await setup();
+
+        selectFile(
+            root,
+            await makeImageFile('photo.jpg', 200, 120, 'image/jpeg')
+        );
+
+        await vi.waitFor(() => expect(changes).toHaveLength(1));
+
+        const emitted = changes[0];
+        // A JPEG source with no requested type stays JPEG — the branch every
+        // non-PNG upload hits — rather than being forced to another format.
+        expect(emitted.filename).toBe('photo.jpg');
+        expect(emitted.contentType).toBe('image/jpeg');
+    });
+
+    it('re-encodes to an explicitly requested output type', async () => {
+        const { root, changes } = await setup({
+            width: 50,
+            height: 50,
+            type: 'image/jpeg',
+        });
+
+        selectFile(root, await makeImageFile('photo.png', 200, 120));
+
+        await vi.waitFor(() => expect(changes).toHaveLength(1));
+
+        const emitted = changes[0];
+        // An explicit type wins, converting the PNG to JPEG and updating the
+        // extension.
+        expect(emitted.filename).toBe('photo.jpg');
+        expect(emitted.contentType).toBe('image/jpeg');
     });
 
     it('does not re-emit the file when the chip is removed mid-resize', async () => {
@@ -99,9 +137,11 @@ describe('limel-file (client-side resize)', () => {
         );
         await new Promise((resolve) => setTimeout(resolve, 150));
 
-        // The stale resized image must never be emitted after removal.
+        // The stale resized image must never be emitted after removal. The
+        // resized PNG keeps its source format, so that is what a leaked result
+        // would look like.
         expect(
-            changes.some((change) => change?.contentType === 'image/jpeg')
+            changes.some((change) => change?.contentType === 'image/png')
         ).toBe(false);
         // The last thing the consumer heard was the removal.
         expect(changes.at(-1)).toBeFalsy();

--- a/src/components/profile-picture/examples/profile-picture-basic.tsx
+++ b/src/components/profile-picture/examples/profile-picture-basic.tsx
@@ -1,4 +1,4 @@
-import { FileInfo } from '@limetech/lime-elements';
+import { FileInfo, type ResizeOptions } from '@limetech/lime-elements';
 import { Component, h, Host, State } from '@stencil/core';
 
 /**
@@ -7,6 +7,12 @@ import { Component, h, Host, State } from '@stencil/core';
  * This component can be both used as a placeholder for an avatar,
  * and in the same time act as an interactive element that enables
  * users to upload a new profile picture.
+ *
+ * This example enables client-side resizing with only `width` and `height`
+ * set on `resize`. Every other option is left to the component's
+ * avatar-oriented defaults: the file is emitted as an `image/jpeg` at
+ * `quality` `0.85`, cropped to the `imageFit` (`cover` here). Set `type`,
+ * `quality` or `fit` on `resize` to override any of them.
  *
  * :::note
  * You must add a proper `width` and `height` to the component.
@@ -21,12 +27,17 @@ export class ProfilePictureExample {
     @State()
     private value?: FileInfo | string = undefined;
 
+    // Only width and height are set; type, quality and fit fall back to the
+    // component's avatar defaults (image/jpeg, 0.85, and imageFit).
+    private resize: ResizeOptions = { width: 400, height: 400 };
+
     public render() {
         return (
             <Host>
                 <limel-profile-picture
                     label="Profile picture"
                     value={this.value}
+                    resize={this.resize}
                     onChange={this.handleChange}
                 />
                 <limel-example-value value={this.value} />

--- a/src/components/profile-picture/profile-picture.tsx
+++ b/src/components/profile-picture/profile-picture.tsx
@@ -134,6 +134,8 @@ export class ProfilePicture {
     /**
      * Optional client-side resize before emitting the file.
      * If provided, the selected image will be resized on the client device.
+     * Omitted options fall back to avatar defaults: `image/jpeg`, `quality`
+     * `0.85`, and the component's `imageFit`.
      * :::note
      * HEIC may not decode in all browsers; when decoding fails, the original
      * file will be emitted. See the examples for more info.

--- a/src/components/profile-picture/profile-picture.tsx
+++ b/src/components/profile-picture/profile-picture.tsx
@@ -19,6 +19,14 @@ import { resizeImage, ResizeOptions } from '../../util/image-resize';
 import { ImageTemplate } from '../../util/image.template';
 
 /**
+ * Avatar output defaults. These live in the component rather than in the shared
+ * `resizeImage` util (which is deliberately unopinionated): avatars are stored
+ * as a compact JPEG at a fixed quality. Callers can override them via `resize`.
+ */
+const AVATAR_OUTPUT_TYPE = 'image/jpeg' as const;
+const AVATAR_JPEG_QUALITY = 0.85;
+
+/**
  * This component displays a profile picture, while allowing the user
  * to change it via a file input or drag-and-drop.
  *
@@ -412,6 +420,8 @@ export class ProfilePicture {
                 const processed = await resizeImage(file.fileContent, {
                     ...this.resize,
                     fit: this.resize.fit ?? this.imageFit,
+                    type: this.resize.type ?? AVATAR_OUTPUT_TYPE,
+                    quality: this.resize.quality ?? AVATAR_JPEG_QUALITY,
                 });
                 out = {
                     ...file,

--- a/src/util/image-resize.ts
+++ b/src/util/image-resize.ts
@@ -16,11 +16,13 @@
  * - No server-side transformation required for common cases
  *
  * Fit strategies
- * - `cover` (default): The image is scaled to cover the target rectangle, and
- *   the excess parts are center-cropped. Good for avatars.
+ * - `cover`: The image is scaled to cover the target rectangle, and the excess
+ *   parts are center-cropped. Good for avatars.
  * - `contain`: The image is scaled to fit entirely within the target rectangle
  *   without cropping, letterboxing if needed. Good when you must preserve the
  *   entire image.
+ * - omitted: scales the whole image to fit without cropping (no pixels are
+ *   discarded).
  *
  * Decoding & EXIF orientation
  * EXIF orientation is a piece of metadata stored inside image files
@@ -46,9 +48,11 @@
  *   library or WASM module; this utility intentionally avoids extra dependencies.
  *
  * Output type & quality
- * - Default output is `image/jpeg` with `quality=0.85`, which is typically
- *   appropriate for avatars. You can switch to `image/png` to preserve
- *   transparency.
+ * - When `type` is omitted the source format is kept if the canvas can encode
+ *   it: a PNG stays a PNG (preserving transparency) and everything else is
+ *   encoded as `image/jpeg`. Set `type` explicitly to force a format.
+ * - JPEG `quality` is optional; when omitted the browser's native encoding
+ *   quality is used rather than an imposed value.
  * - The output filename extension is adjusted to match the chosen MIME type by
  *   default (e.g., `.jpg` or `.png`). You can override naming via the `rename`
  *   option.
@@ -73,9 +77,9 @@
  * const processed = await resizeImage(file, {
  *   width: 400,
  *   height: 400,
- *   fit: 'cover',         // default; center-crops
- *   type: 'image/jpeg',   // default
- *   quality: 0.85,        // default
+ *   fit: 'cover',         // center-crops; omit to fit without cropping
+ *   type: 'image/jpeg',   // omit to keep the source format
+ *   quality: 0.85,        // omit to use the browser's native quality
  * });
  * // Upload `processed` instead of the original file
  * ```
@@ -122,11 +126,24 @@ export type ResizeOptions = {
      * keep the source dimensions and only re-encode.
      */
     height?: number;
-    /** Fit strategy; defaults to 'cover'. */
+    /**
+     * How the image is fitted into the target box when its aspect ratio
+     * differs. `cover` scales to fill and center-crops the overflow; `contain`
+     * scales to fit the whole image inside the box. Omit to scale the whole
+     * image to fit without cropping (no pixels are discarded). Only relevant
+     * when both `width` and `height` are set.
+     */
     fit?: 'cover' | 'contain';
-    /** Output MIME type; 'image/jpeg' by default. */
+    /**
+     * Output MIME type. Omit to keep the source file's format when the canvas
+     * can encode it: a PNG stays a PNG (preserving transparency), otherwise
+     * the output is JPEG. Set explicitly to force a format.
+     */
     type?: 'image/jpeg' | 'image/png';
-    /** JPEG quality (0..1); used only for 'image/jpeg'. Defaults to 0.85. */
+    /**
+     * JPEG quality (0..1); used only for 'image/jpeg'. Omit to let the browser
+     * use its native encoding quality rather than imposing a value.
+     */
     quality?: number;
     /** Optional renaming function. Defaults to changing extension to match MIME. */
     rename?: (originalName: string) => string;
@@ -151,12 +168,17 @@ export async function resizeImage(
     file: File,
     options: ResizeOptions
 ): Promise<File> {
-    const {
-        fit = 'cover',
-        type = 'image/jpeg',
-        quality = 0.85,
-        rename = (name: string) => renameWithType(name, type),
-    } = options;
+    // This shared utility carries no opinionated defaults: an omitted option
+    // preserves the source file's own property rather than imposing a value.
+    // Consumers that want a specific default (e.g. limel-profile-picture) apply
+    // it themselves. See the `ResizeOptions` doc for the per-option behavior.
+    const { fit, quality } = options;
+    // When no output type is requested, keep the source file's format if the
+    // canvas can encode it (PNG stays PNG, preserving transparency); anything
+    // else falls back to JPEG.
+    const type = resolveOutputType(file.type, options.type);
+    const rename =
+        options.rename ?? ((name: string) => renameWithType(name, type));
 
     const source = await loadSource(file);
     const sourceWidth = source.width;
@@ -278,12 +300,12 @@ function get2dContext(canvas: HTMLCanvasElement | OffscreenCanvas) {
  * Convert the canvas content to a Blob, supporting both canvas types.
  * @param canvas - The source canvas
  * @param type - Output MIME type
- * @param quality - JPEG quality (0..1)
+ * @param quality - JPEG quality (0..1); omit to use the browser default
  */
 function canvasToBlob(
     canvas: HTMLCanvasElement | OffscreenCanvas,
     type: string,
-    quality: number
+    quality?: number
 ): Promise<Blob> {
     if ('convertToBlob' in canvas) {
         return (canvas as OffscreenCanvas).convertToBlob({ type, quality });
@@ -383,14 +405,15 @@ async function loadImageElement(file: File): Promise<HTMLImageElement> {
  * @param sh - Source height
  * @param tw - Target width
  * @param th - Target height
- * @param fit - Fit mode (cover/contain)
+ * @param fit - Fit mode; `cover` center-crops, anything else (including
+ * omitted) scales the whole image to fit without cropping
  */
 function computeRects(
     sw: number,
     sh: number,
     tw: number,
     th: number,
-    fit: 'cover' | 'contain'
+    fit?: 'cover' | 'contain'
 ) {
     const sRatio = sw / sh;
     const tRatio = tw / th;
@@ -427,6 +450,26 @@ function computeRects(
     const dy = (th - drawH) / 2;
 
     return { sx: 0, sy: 0, sw, sh, dx, dy, dw: drawW, dh: drawH };
+}
+
+/**
+ * Resolve the output MIME type. An explicit request wins; otherwise the source
+ * file's format is kept when the canvas can encode it. The canvas can only
+ * reliably encode PNG and JPEG, so PNG is preserved (keeping transparency) and
+ * every other input (JPEG, WebP, HEIC, …) is encoded as JPEG.
+ *
+ * @param sourceType - MIME type of the input file
+ * @param requested - Explicitly requested output type, if any
+ */
+function resolveOutputType(
+    sourceType: string,
+    requested?: 'image/jpeg' | 'image/png'
+): 'image/jpeg' | 'image/png' {
+    if (requested) {
+        return requested;
+    }
+
+    return sourceType === 'image/png' ? 'image/png' : 'image/jpeg';
 }
 
 /**

--- a/src/util/image-resize.ts
+++ b/src/util/image-resize.ts
@@ -12,7 +12,7 @@
  *
  * Why resize client-side?
  * - Faster perceived uploads and lower bandwidth usage
- * - Consistent avatar sizes and formats (e.g., JPEG 400x400)
+ * - Consistent output sizes and formats (e.g., a 400x400 thumbnail)
  * - No server-side transformation required for common cases
  *
  * Fit strategies

--- a/src/util/image-resize.ts
+++ b/src/util/image-resize.ts
@@ -110,6 +110,21 @@
 // (Removed exported ResizeFit to avoid forcing a public symbol.)
 
 /**
+ * The image formats the canvas can reliably encode, mapped to their filename
+ * extension. Single source of truth for what this util can output: both the
+ * output-type resolution and the output filename extension derive from it. The
+ * `ResizeOptions.type` union below mirrors these keys — keep the two in sync
+ * when adding a format.
+ */
+const ENCODABLE_TYPES = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+} as const;
+
+/** An image MIME type the canvas can encode (a key of `ENCODABLE_TYPES`). */
+type EncodableImageType = keyof typeof ENCODABLE_TYPES;
+
+/**
  * Options for client-side image resizing.
  * @beta
  */
@@ -454,22 +469,28 @@ function computeRects(
 
 /**
  * Resolve the output MIME type. An explicit request wins; otherwise the source
- * file's format is kept when the canvas can encode it. The canvas can only
- * reliably encode PNG and JPEG, so PNG is preserved (keeping transparency) and
- * every other input (JPEG, WebP, HEIC, …) is encoded as JPEG.
+ * file's format is kept when the canvas can encode it (see `ENCODABLE_TYPES`),
+ * so a PNG stays a PNG (preserving transparency) while every other input
+ * (WebP, HEIC, …) falls back to JPEG.
  *
  * @param sourceType - MIME type of the input file
  * @param requested - Explicitly requested output type, if any
  */
 function resolveOutputType(
     sourceType: string,
-    requested?: 'image/jpeg' | 'image/png'
-): 'image/jpeg' | 'image/png' {
+    requested?: EncodableImageType
+): EncodableImageType {
     if (requested) {
         return requested;
     }
 
-    return sourceType === 'image/png' ? 'image/png' : 'image/jpeg';
+    // Keep the source format when the canvas can encode it; otherwise JPEG.
+    const canEncodeSource = Object.prototype.hasOwnProperty.call(
+        ENCODABLE_TYPES,
+        sourceType
+    );
+
+    return canEncodeSource ? (sourceType as EncodableImageType) : 'image/jpeg';
 }
 
 /**
@@ -477,8 +498,8 @@ function resolveOutputType(
  * @param name - Original filename
  * @param type - Output MIME type
  */
-function renameWithType(name: string, type: string): string {
-    const ext = type === 'image/png' ? 'png' : 'jpg';
+function renameWithType(name: string, type: EncodableImageType): string {
+    const ext = ENCODABLE_TYPES[type];
     const idx = name.lastIndexOf('.');
     const base = idx > 0 ? name.slice(0, idx) : name;
     return `${base}.${ext}`;


### PR DESCRIPTION
Closes #4177
fix https://github.com/Lundalogik/lime-webclient/issues/7902

## What

The shared `resizeImage` util (`src/util/image-resize.ts`) was written for `limel-profile-picture` and baked in defaults tuned for avatars — `fit=cover`, `type=image/jpeg`, `quality=0.85`. Because the util is shared, those defaults silently applied to every consumer. The visible symptom: `limel-file` resizing a PNG with only a `width` set silently flattened it to JPEG and lost transparency.

This removes all baked-in defaults from the util. An omitted option now preserves the source file's own property; consumers that want a specific default apply it themselves.

## Changes

- **`image-resize.ts`** — no defaults imposed by the util:
  - `type` omitted → keep the source format when the canvas can encode it (PNG→PNG, otherwise JPEG), via a new `resolveOutputType` helper.
  - `quality` omitted → pass through to the browser's native encoding quality instead of `0.85`.
  - `fit` omitted → scale the whole image to fit without cropping instead of center-cropping.
  - Updated the type docs, module doc and usage example accordingly.
- **`profile-picture.tsx`** — applies its historical defaults (`cover` / `image/jpeg` / `0.85`) in the component, so avatars are unchanged. Callers can still override via `resize`.
- **`file.e2e.tsx`** — updated the round-trip test to assert the source PNG is preserved, added tests that a non-PNG source keeps its format and that an explicit `type` still forces the format, and fixed the mid-resize sentinel.
- **Examples** — corrected the "omit → image/jpeg / cover / 0.85" comments to describe the new source-preserving behaviour.

## Behaviour change for existing `limel-file` configs

Because the util no longer supplies defaults, a `limel-file` whose `resizeImage` omits an option now behaves differently from the previous release. Beyond the headline PNG fix:

- **`type` omitted** — a PNG stays a PNG instead of being flattened to JPEG (the bug fixed here). A lossless PNG can be larger than the old JPEG.
- **`fit` omitted** (only when both `width` and `height` are set) — scales the whole image to fit without cropping instead of center-cropping to `cover`.
- **`quality` omitted** — JPEG output uses the browser's native quality (~0.92 in Chrome) instead of `0.85`, so files are somewhat larger.

This is safe in practice: the `resizeImage` prop only shipped in 39.42.0 (the previous release) and has no real consumers yet — these behaviours were found while integrating the first one.

## Why it's safe

`resizeImage` is `@beta`, so changing its defaults is not a breaking change. `limel-profile-picture`'s output is unchanged because it now sets those values explicitly.

## Testing

- `file` + `profile-picture` spec: 83 passed
- `file` e2e (real canvas / `createImageBitmap`): 4 passed
- lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated client-side image resizing: omitted options now preserve the source format when possible, scale without cropping, and use browser-native JPEG quality.
  * Profile picture resizing now applies consistent default output settings when callers omit resize `type`/`quality`.

* **Documentation**
  * Clarified resize option semantics to reflect actual omit behavior (no implied `cover`/default JPEG assumptions).

* **Tests**
  * Strengthened end-to-end coverage for format preservation, explicit JPEG re-encoding, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

