### PR TITLE
fix(text-editor): size inline images given bare-pixel dimensions

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/plugins/image/node.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/image/node.spec.ts
@@ -1,6 +1,7 @@
 import { NodeSpec, TagParseRule } from 'prosemirror-model';
 import { MarkdownSerializerState } from 'prosemirror-markdown';
 import {
+    applyImageStyles,
     getImageNode,
     getImageNodeMarkdownSerializer,
     ImageNodeAttrs,
@@ -191,5 +192,29 @@ describe('inline-image node', () => {
                 height: '200px',
             });
         });
+    });
+});
+
+describe('applyImageStyles', () => {
+    it('adds a px unit to bare pixel dimensions', () => {
+        const img = document.createElement('img');
+
+        applyImageStyles(img, {
+            attrs: { width: '166', height: '63' },
+        } as any);
+
+        expect(img.style.width).toBe('166px');
+        expect(img.style.height).toBe('63px');
+    });
+
+    it('leaves dimensions that already carry a unit untouched', () => {
+        const img = document.createElement('img');
+
+        applyImageStyles(img, {
+            attrs: { width: '50%', height: '300px' },
+        } as any);
+
+        expect(img.style.width).toBe('50%');
+        expect(img.style.height).toBe('300px');
     });
 });

--- a/src/components/text-editor/prosemirror-adapter/plugins/image/node.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/image/node.ts
@@ -84,11 +84,15 @@ export function getImageNodeMarkdownSerializer(
  * @param node
  */
 export function applyImageStyles(img: HTMLImageElement, node: Node) {
-    img.style.height = node.attrs.height;
-    img.style.width = node.attrs.width;
+    img.style.height = toCssLength(node.attrs.height);
+    img.style.width = toCssLength(node.attrs.width);
     img.style.minHeight = node.attrs.minHeight;
     img.style.minWidth = node.attrs.minWidth;
     img.style.maxWidth = node.attrs.maxWidth;
+}
+
+function toCssLength(value: string): string {
+    return /^\d+$/.test(value) ? `${value}px` : value;
 }
 
 /**
@@ -149,11 +153,6 @@ function escapeAttributeValue(value: string): string {
         .replaceAll('>', '&gt;');
 }
 
-// Dimensions are emitted as CSS-unit strings (e.g. `width="300px"`), matching
-// what `applyImageStyles` reads back when the tag is re-parsed inside the
-// editor. The external renderer of this microformat (the `limebb-inline-image`
-// building block) must therefore treat `width`/`height` as CSS lengths, not as
-// bare HTML pixel counts.
 function getInlineImageHTML(attrs: ImageNodeAttrs, tag: string): string {
     const attributes = [
         `${IMAGE_ID_ATTRIBUTE}="${escapeAttributeValue(attrs.imageId ?? '')}"`,


### PR DESCRIPTION
## What

Inline-image dimensions can be expressed as bare pixel counts (`166`, the HTML `<img width>` form) or as CSS lengths (`166px`, `50%`). `applyImageStyles` assigned the value straight to `style.width` / `style.height`, so a bare number was an invalid inline style and silently ignored — the image rendered at its intrinsic size (too big).

This normalizes bare pixel counts to `px`; values that already carry a unit (`166px`, `50%`) are left untouched.

Closes https://github.com/Lundalogik/crm-client/issues/1148

## Test

Added `applyImageStyles` unit tests: a bare pixel count gains a `px` unit; a value that already has a unit is left as-is.