### PR TITLE
feat(text-editor): deprecate legacy image handling in favor of inlineImages

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -1025,7 +1025,7 @@ export interface DockMenu {
     };
 }
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export interface EditorImage {
     fileInfoId: string;
     src: string;
@@ -1066,7 +1066,7 @@ export type EditorMenuTypes = (typeof EditorMenuTypes)[keyof typeof EditorMenuTy
 // @public (undocumented)
 export const editorMenuTypesArray: EditorMenuTypes[];
 
-// @alpha
+// @alpha @deprecated
 export interface EditorMetadata {
     images: EditorImage[];
     links: EditorLink[];
@@ -1283,7 +1283,7 @@ interface Image_2 {
 }
 export { Image_2 as Image }
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ImageInserter {
     // (undocumented)
     fileInfo: FileInfo;
@@ -3628,7 +3628,7 @@ export namespace JSX {
         "onChange"?: (event: LimelTextEditorCustomEvent<string>) => void;
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //
-        // @alpha
+        // @alpha @deprecated
         "onImagePasted"?: (event: LimelTextEditorCustomEvent<ImageInserter>) => void;
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //
@@ -3636,7 +3636,7 @@ export namespace JSX {
         "onImageRemoved"?: (event: LimelTextEditorCustomEvent<EditorImage>) => void;
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //
-        // @alpha
+        // @alpha @deprecated
         "onMetadataChange"?: (event: LimelTextEditorCustomEvent<EditorMetadata>) => void;
         // Warning: (ae-extra-release-tag) The doc comment should not contain more than one release tag
         //

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -648,6 +648,9 @@ export class ProsemirrorAdapter {
         }
     }
 
+    // When the deprecated metadata events are removed, this cache eviction
+    // must be kept: re-derive the removed fileInfoIds from the node attrs so
+    // pasted images still get evicted from `imageCache` when deleted.
     private removeImagesFromCache(
         oldMetadata: EditorMetadata,
         newMetadata: EditorMetadata

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -198,6 +198,8 @@ export class TextEditor implements FormComponent<string> {
      *
      * @private
      * @alpha
+     * @deprecated Use the `inlineImages` prop instead, which lets the editor
+     * own the whole paste lifecycle. Will be removed in a future version.
      */
     @Event()
     private readonly imagePasted: EventEmitter<ImageInserter>;
@@ -207,8 +209,8 @@ export class TextEditor implements FormComponent<string> {
      *
      * @private
      * @alpha
-     * @deprecated - This event is deprecated and will be removed in a future version.
-     * Use the `metadataChange` event instead to track image removals.
+     * @deprecated Use the `inlineImages` prop instead. Will be removed in a
+     * future version.
      */
     @Event()
     private readonly imageRemoved: EventEmitter<EditorImage>;
@@ -218,6 +220,9 @@ export class TextEditor implements FormComponent<string> {
      *
      * @private
      * @alpha
+     * @deprecated Unused alpha event. Image handling now lives in the
+     * `inlineImages` prop; link changes have no direct replacement yet. Will
+     * be removed in a future version.
      */
     @Event()
     private readonly metadataChange: EventEmitter<EditorMetadata>;

--- a/src/components/text-editor/text-editor.types.ts
+++ b/src/components/text-editor/text-editor.types.ts
@@ -65,6 +65,8 @@ export type TextEditorNode = {
 
 /**
  * @alpha
+ * @deprecated Superseded by the `InlineImages` config, which lets the editor
+ * own the whole paste lifecycle. Will be removed in a future version.
  */
 export interface ImageInserter {
     fileInfo: FileInfo;
@@ -160,6 +162,8 @@ export type EditorImageState = 'loading' | 'failed' | 'success';
 
 /**
  * @alpha
+ * @deprecated Superseded by the `InlineImages` config. Will be removed in a
+ * future version.
  */
 export interface EditorImage {
     /**
@@ -231,10 +235,12 @@ export interface TriggerEventDetail {
 }
 
 /**
+ * Interface representing metadata extracted from the editor document
  *
  * @alpha
- *
- * Interface representing metadata extracted from the editor document
+ * @deprecated Unused alpha API. Image handling now lives in the `InlineImages`
+ * config; link metadata has no direct replacement yet. Will be removed in a
+ * future version.
  */
 export interface EditorMetadata {
     /**


### PR DESCRIPTION
The `inlineImages` prop now owns the whole inline-image lifecycle — paste, upload, storage format, and URL resolution — so the older event-based API it replaces is on the way out.

Marks these as deprecated, all pointing at `inlineImages`:

- `imagePasted` event and its `ImageInserter` interface (the manual paste-handling hook)
- `metadataChange` event and its `EditorMetadata` interface
- `imageRemoved` was already deprecated; its notice pointed at `metadataChange`, which is now also going away, so it's repointed at `inlineImages` too

No runtime behavior changes — this is JSDoc plus the regenerated API report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer-facing deprecation notes for legacy image and metadata-related editor events.
  * Marked older image/metadata interfaces as deprecated and clarified that inline image handling is managed via the `inlineImages` prop.
  * Clarified that deprecated metadata/link behavior has no direct replacement yet and is planned for future removal.
* **Chores**
  * Added maintenance guidance comments to support future event removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->