### PR TITLE
fix(file): match extension accept specifiers by filename

### DIFF
--- a/src/util/files.spec.ts
+++ b/src/util/files.spec.ts
@@ -61,30 +61,93 @@ describe('isTypeAccepted', () => {
         (accept: string, expected: boolean[]) => {
             it(`${expected[0] ? 'accepts' : 'does not accept'} image/png`, () => {
                 expect(
-                    isTypeAccepted({ contentType: 'image/png' } as any, accept)
+                    isTypeAccepted(
+                        {
+                            contentType: 'image/png',
+                            filename: 'photo.png',
+                        } as any,
+                        accept
+                    )
                 ).toEqual(expected[0]);
             });
 
             it(`${expected[1] ? 'accepts' : 'does not accept'} image/jpg`, () => {
                 expect(
-                    isTypeAccepted({ contentType: 'image/jpg' } as any, accept)
+                    isTypeAccepted(
+                        {
+                            contentType: 'image/jpg',
+                            filename: 'photo.jpg',
+                        } as any,
+                        accept
+                    )
                 ).toEqual(expected[1]);
             });
 
             it(`${expected[2] ? 'accepts' : 'does not accept'} video/webp`, () => {
                 expect(
-                    isTypeAccepted({ contentType: 'video/webp' } as any, accept)
+                    isTypeAccepted(
+                        {
+                            contentType: 'video/webp',
+                            filename: 'clip.webp',
+                        } as any,
+                        accept
+                    )
                 ).toEqual(expected[2]);
             });
 
             it(`${expected[3] ? 'accepts' : 'does not accept'} document/pdf`, () => {
                 expect(
                     isTypeAccepted(
-                        { contentType: 'document/pdf' } as any,
+                        {
+                            contentType: 'document/pdf',
+                            filename: 'doc.pdf',
+                        } as any,
                         accept
                     )
                 ).toEqual(expected[3]);
             });
         }
     );
+});
+
+describe('isTypeAccepted matches extension specifiers by filename', () => {
+    const asFile = (filename: string, contentType = ''): any => ({
+        filename,
+        contentType,
+    });
+
+    it('accepts an extension whose MIME subtype differs (e.g. .docx)', () => {
+        // Regression: this previously matched `contentType.endsWith('/docx')`,
+        // which fails for the real docx MIME type.
+        const docx =
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+        expect(isTypeAccepted(asFile('report.docx', docx), '.docx')).toBe(true);
+    });
+
+    it('rejects a file whose extension does not match', () => {
+        expect(isTypeAccepted(asFile('report.pdf'), '.docx')).toBe(false);
+    });
+
+    it('matches multi-part extensions', () => {
+        expect(isTypeAccepted(asFile('archive.tar.gz'), '.tar.gz')).toBe(true);
+        expect(isTypeAccepted(asFile('archive.zip'), '.tar.gz')).toBe(false);
+    });
+
+    it('matches case-insensitively', () => {
+        expect(isTypeAccepted(asFile('REPORT.PDF'), '.pdf')).toBe(true);
+        expect(isTypeAccepted(asFile('report.pdf'), '.PDF')).toBe(true);
+    });
+
+    it('matches by filename even when the content type is unhelpful', () => {
+        expect(
+            isTypeAccepted(asFile('data.7z', 'application/octet-stream'), '.7z')
+        ).toBe(true);
+    });
+
+    it('matches within a comma-separated list', () => {
+        expect(isTypeAccepted(asFile('sheet.xlsx'), '.pdf,.docx,.xlsx')).toBe(
+            true
+        );
+    });
 });

--- a/src/util/files.ts
+++ b/src/util/files.ts
@@ -52,9 +52,11 @@ export function isTypeAccepted(file: FileInfo, accept?: string): boolean {
         }
 
         if (acceptedType.startsWith('.')) {
-            const fileType = acceptedType.split('.')[1];
-
-            return file.contentType.endsWith(`/${fileType}`);
+            // An extension specifier matches by file name (like the native
+            // `accept` attribute), not by MIME type.
+            return file.filename
+                .toLowerCase()
+                .endsWith(acceptedType.toLowerCase());
         }
     });
 }


### PR DESCRIPTION
## What
fix https://github.com/Lundalogik/lime-elements/issues/4183
`limel-file-dropzone` filters dropped files with `isTypeAccepted` (`src/util/files.ts`). For a `.ext` accept specifier it matched against the file's **MIME subtype** (`contentType.endsWith('/ext')`), not the filename:

```ts
if (acceptedType.startsWith('.')) {
    const fileType = acceptedType.split('.')[1]; // ".docx" -> "docx"
    return file.contentType.endsWith(`/${fileType}`);
}
```

That only works when the subtype happens to equal the extension (`.pdf` → `application/pdf`, `.csv` → `text/csv`). Files whose subtype differs were **silently rejected on drag-and-drop** — e.g. all Office/iWork/OpenDocument formats, `.txt` (`text/plain`), `.eml`/`.msg`, and most archives (`.7z`, `.rar`, `.tar`, `.gz`, …). The file *chooser* was unaffected, because the browser matches `accept` by filename. `split('.')[1]` also meant multi-part extensions like `.tar.gz` never matched.

## Change

Match `.ext` specifiers against the **filename** (case-insensitively), the way the native `accept` attribute does. MIME specifiers (`type/subtype` and `type/*`) still match `contentType` and are unchanged.

## Tests

`src/util/files.spec.ts`: the existing `describe.each` files now carry a `filename` (which keeps every existing expectation valid), plus a new block covering the fix — an extension whose MIME subtype differs (`.docx`), multi-part extensions (`.tar.gz`), case-insensitivity, an unhelpful content type (`application/octet-stream`), and matching within a comma-separated list. All spec tests pass.

## Out of scope (follow-up)

`limel-file` only wires the dropzone's `filesSelected`, not `filesRejected`, so a genuinely-unsupported dropped file is still silently ignored (no upload, no feedback). Surfacing that needs a small UX/API decision and is left as a follow-up — see the issue.

Refs #4183

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file type validation for extension-based accept rules.
  * Added support for case-insensitive filename matching, multi-part extensions, and comma-separated accept lists.
  * Fixed handling of document extensions such as `.docx`.
  * Improved validation when the content type is unavailable or unreliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->