### PR TITLE
fix(checkbox): rename internal id field to avoid createElement error

### DIFF
--- a/src/components/checkbox/checkbox.spec.tsx
+++ b/src/components/checkbox/checkbox.spec.tsx
@@ -71,3 +71,42 @@ describe('limel-checkbox (aria semantics)', () => {
         expect(input.getAttribute('aria-checked')).toBe('true');
     });
 });
+
+describe('limel-checkbox (host element id handling)', () => {
+    async function setup(props: Record<string, any> = {}) {
+        const { root, waitForChanges } = await render(
+            <limel-checkbox {...props}></limel-checkbox>
+        );
+        await waitForChanges();
+
+        return { root, waitForChanges };
+    }
+
+    // Regression test for the internal id token colliding with the native
+    // `HTMLElement.id` property. Previously the component held a private field
+    // named `id`, whose initializer ran in the constructor as `this.id = …`,
+    // invoking the native `id` setter and stamping an attribute onto the host.
+    // That both polluted the host's `id` and made the element non-pristine after
+    // construction, which throws `NotSupportedError: The result must not have
+    // attributes` when a framework creates it synchronously via
+    // `document.createElement()` (e.g. Vue).
+    it('does not stamp a generated id onto the host element', async () => {
+        const { root } = await setup();
+        expect(root.getAttribute('id')).toBeNull();
+    });
+
+    it('leaves a consumer-provided host id untouched', async () => {
+        const { root } = await setup({ id: 'my-checkbox' });
+        expect(root.getAttribute('id')).toBe('my-checkbox');
+    });
+
+    it('still associates the internal input with its label', async () => {
+        const { root } = await setup();
+        const input = root.shadowRoot?.querySelector(
+            'input[type="checkbox"]'
+        ) as HTMLInputElement;
+        const label = root.shadowRoot?.querySelector('label');
+        expect(input.id).toBeTruthy();
+        expect(label?.getAttribute('for')).toBe(input.id);
+    });
+});

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -113,7 +113,7 @@ export class Checkbox {
 
     @Element()
     private limelCheckbox: HTMLLimelCheckboxElement;
-    private id: string = createRandomString();
+    private inputId: string = createRandomString();
     private helperTextId: string = createRandomString();
 
     @Watch('checked')
@@ -184,7 +184,7 @@ export class Checkbox {
                 readonly={this.readonly}
                 invalid={this.isInvalid()}
                 onChange={this.onChange}
-                id={this.id}
+                id={this.inputId}
             />
         );
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatically generated IDs from being added to the checkbox host element.
  * Preserved consumer-provided checkbox IDs.
  * Maintained correct association between the checkbox input and its label for accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #4190

## What

`limel-checkbox` held a `private` field literally named `id`:

```ts
private id: string = createRandomString();
```

Because the component extends `HTMLElement`, `id` shadows the native
`HTMLElement.prototype.id` accessor. Compiled with the default
`useDefineForClassFields: false`, the field initializer runs in the
**constructor** as `this.id = …`, invoking the native `id` setter, which adds an
`id` attribute to the element during construction.

Per the [DOM "create an element" algorithm](https://dom.spec.whatwg.org/#concept-create-element),
an already-defined custom element constructed **synchronously**
(`document.createElement`/`createElementNS`) must be pristine — no attributes,
no children — or the browser throws
`NotSupportedError: The result must not have attributes`
([HTML custom-element requirement](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance)).

Frameworks that construct elements eagerly hit this. Vue's renderer calls
`document.createElement('limel-checkbox')` on the already-registered tag, so it
upgrades synchronously, the constructor adds `id`, and it throws — the checkbox
never hydrates (no shadow root, no `hydrated` class). Sibling components
(`limel-button`, `limel-input-field`, …) don't assign `this.id`, so they're
unaffected. The Stencil lazy-load / HTML-parser path never trips the check,
which is why this wasn't caught before.

## Fix

Rename the field to `inputId` (consistent with the sibling `helperTextId`) so it
no longer shadows the native property, and update its read in `render()`.
`checkbox.template.tsx` is unchanged — its `id` prop is a key on a plain props
object, not on an `HTMLElement`.

No behaviour change to the internal `<input>`/`<label>` wiring. Bonus: the host
element no longer gets a stray generated `id`, and a consumer-set
`<limel-checkbox id="…">` is now left untouched (previously the constructor
overwrote it).

## Tests

Added spec coverage in `checkbox.spec.tsx`:
- host element is not given a generated `id` (the regression);
- a consumer-provided host `id` is preserved;
- the internal input still gets an id and the label's `for` still matches it.

> Note: I couldn't run the suite locally (fresh clone without installed
> dependencies) — relying on CI to validate.

## Related (not in this PR)

The same `private id` pattern exists in `dialog/dialog.tsx`, but there it's
assigned in `componentWillLoad()` rather than a field initializer, so it dodges
the crash — though it still stamps a generated `id` onto the host. Worth the
same rename as a follow-up. `radio-button-group/radio-button.tsx` exposes a
deliberate `@Prop() id` (Stencil accessors shadow the native setter; no
constructor assignment) and is not affected.
