### PR TITLE
Type characters in limel-select to jump to a matching option

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -807,7 +807,6 @@ export namespace Components {
         "maxLinesSecondaryText": number;
         "selectedItem"?: ListItem<string | number>;
     }
-    // (undocumented)
     export interface LimelSelect {
         "disabled": boolean;
         "helperText": string;
@@ -3343,7 +3342,6 @@ export namespace JSX {
         "maxLinesSecondaryText": number;
     }
 
-    // (undocumented)
     export interface LimelSelect {
         "disabled"?: boolean;
         "helperText"?: string;

--- a/example-tests/components/select.spec.ts
+++ b/example-tests/components/select.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Per-component example test for limel-select. Unlike the generic runtime/
+// accessibility suites (which iterate every documented example), interaction
+// tests must know the component, so they live in their own file under
+// example-tests/components/.
+//
+// This file covers the typeahead: typing characters moves the highlight to the
+// option starting with them, without changing the value. That behavior needs
+// real key events and real focus, which is why it is tested here rather than in
+// select.e2e.tsx.
+//
+// Coupling (intentional, fails loudly if broken — never silently):
+//   1. drives the docs examples `limel-example-select-basic` (heroes Luke
+//      Skywalker / Han Solo (disabled) / Leia Organo),
+//      `limel-example-select-with-separators` (US states grouped by separators)
+//      and `limel-example-select-multiple`, each of which renders a
+//      `limel-example-value` reflecting the current value;
+//   2. the dropdown renders as a portal on document.body (a sibling of the
+//      example), so it is located via a top-level `limel-menu-surface` locator,
+//      not as a descendant of the example.
+
+const trigger = (page: Page) =>
+    page.locator('limel-select button.limel-select-trigger');
+
+const surface = (page: Page) => page.locator('limel-menu-surface');
+
+// Types on the trigger rather than through `page.keyboard`, so that Playwright
+// waits for the trigger to be actionable and focuses it first. Pressing through
+// the keyboard directly races the focus, and the key is then lost.
+//
+// The whole sequence goes through a single `pressSequentially`, without an
+// `await` between the characters. Anything awaited mid-sequence — a visibility
+// assertion, a poll — is a round trip to the browser, and enough of them would
+// outlast `TYPEAHEAD_BUFFER_TIMEOUT` on a loaded runner, so the characters would
+// no longer be treated as one word.
+const openByTyping = async (page: Page, characters: string) => {
+    await expect(trigger(page)).toBeVisible();
+    await trigger(page).pressSequentially(characters);
+    await expect(surface(page)).toBeVisible();
+};
+
+const openByClick = async (page: Page) => {
+    await expect(trigger(page)).toBeVisible();
+    await trigger(page).click();
+    await expect(surface(page)).toBeVisible();
+};
+
+/**
+ * The label of the option that currently has focus.
+ *
+ * Read through `evaluate` rather than a locator, because focus lives on a row
+ * inside `limel-list`'s shadow root and there is no selector for "the focused
+ * element".
+ *
+ * @param page - the page the example is rendered on
+ */
+const focusedOption = (page: Page) =>
+    page.evaluate(() => {
+        const list = document.querySelector('limel-menu-surface limel-list');
+        const row = list?.shadowRoot?.activeElement;
+
+        return row?.querySelector('.label')?.textContent ?? null;
+    });
+
+test.describe('limel-select typeahead', () => {
+    test.describe('with a plain list of options', () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/#/debug/limel-example-select-basic');
+        });
+
+        test('opens and highlights the match, without changing the value', async ({
+            page,
+        }) => {
+            await openByTyping(page, 'l');
+
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+            // The primary contract: typing highlights, it does not select.
+            await expect(page.locator('limel-example-value')).not.toContainText(
+                'luke'
+            );
+        });
+
+        test('cycles past disabled options when the same character is repeated', async ({
+            page,
+        }) => {
+            await openByTyping(page, 'l');
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+
+            // Deliberately pressed after the assertion above, so the buffer may
+            // well have been discarded by now. A lone character has to keep
+            // cycling from the highlighted row either way — a user pausing
+            // between presses expects to keep moving, not to start over.
+            await page.keyboard.press('l');
+
+            // Skips the disabled "Han Solo", which also starts with an "L"
+            // in its value but not its text — the text is what matters.
+            await expect.poll(() => focusedOption(page)).toBe('Leia Organo');
+        });
+
+        test('matches all the typed characters, not just the first', async ({
+            page,
+        }) => {
+            await openByTyping(page, 'le');
+
+            await expect.poll(() => focusedOption(page)).toBe('Leia Organo');
+        });
+
+        test('still selects the highlighted option with Enter', async ({
+            page,
+        }) => {
+            await openByTyping(page, 'le');
+            await expect.poll(() => focusedOption(page)).toBe('Leia Organo');
+
+            await page.keyboard.press('Enter');
+
+            await expect(page.locator('limel-example-value')).toContainText(
+                'leia'
+            );
+            await expect(surface(page)).toBeHidden();
+        });
+
+        test('starts over after the dropdown is dismissed', async ({
+            page,
+        }) => {
+            await openByTyping(page, 'le');
+            await expect.poll(() => focusedOption(page)).toBe('Leia Organo');
+
+            await page.keyboard.press('Escape');
+            await expect(surface(page)).toBeHidden();
+
+            // A discarded buffer is the only way this can match: "l" appended
+            // to the previous "le" would be "lel", which matches no option, so
+            // the dropdown would not even reopen.
+            await openByTyping(page, 'l');
+
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+        });
+    });
+
+    test.describe('with separators between the options', () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/#/debug/limel-example-select-with-separators');
+        });
+
+        test('counts separators when addressing an option by index', async ({
+            page,
+        }) => {
+            // "Alaska" sits after a separator, and "Arizona" after two more.
+            // Landing on either proves the indexing accounts for them.
+            await openByTyping(page, 'a');
+            await expect.poll(() => focusedOption(page)).toBe('Alaska');
+
+            await page.keyboard.press('a');
+            await expect.poll(() => focusedOption(page)).toBe('Arizona');
+        });
+
+        test('matches text containing a space', async ({ page }) => {
+            // There are four states starting with "New", so getting to
+            // "New York" is only possible if the space is matched rather than
+            // treated as a selection.
+            await openByTyping(page, 'new y');
+
+            await expect.poll(() => focusedOption(page)).toBe('New York');
+        });
+    });
+
+    test.describe('when several options can be selected', () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto('/#/debug/limel-example-select-multiple');
+        });
+
+        test('still selects the highlighted option with the space bar', async ({
+            page,
+        }) => {
+            // Opened without typing, so that the space bar keeps its usual
+            // meaning rather than continuing a typeahead.
+            await openByClick(page);
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+
+            await page.keyboard.press(' ');
+
+            await expect(page.locator('limel-example-value')).toContainText(
+                'luke'
+            );
+        });
+    });
+});

--- a/example-tests/components/select.spec.ts
+++ b/example-tests/components/select.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect, type Page } from '@playwright/test';
+import { TYPEAHEAD_BUFFER_TIMEOUT } from '../../src/util/typeahead';
 
 // Per-component example test for limel-select. Unlike the generic runtime/
 // accessibility suites (which iterate every documented example), interaction
 // tests must know the component, so they live in their own file under
 // example-tests/components/.
 //
-// This file covers the typeahead: typing characters moves the highlight to the
-// option starting with them, without changing the value. That behavior needs
-// real key events and real focus, which is why it is tested here rather than in
-// select.e2e.tsx.
+// This file covers keyboard navigation of the dropdown — the typeahead, and
+// where focus lands after picking an option. Both need real key events and real
+// focus, which is why they are tested here rather than in select.e2e.tsx.
 //
 // Coupling (intentional, fails loudly if broken — never silently):
 //   1. drives the docs examples `limel-example-select-basic` (heroes Luke
@@ -63,7 +63,7 @@ const focusedOption = (page: Page) =>
         return row?.querySelector('.label')?.textContent ?? null;
     });
 
-test.describe('limel-select typeahead', () => {
+test.describe('limel-select keyboard navigation', () => {
     test.describe('with a plain list of options', () => {
         test.beforeEach(async ({ page }) => {
             await page.goto('/#/debug/limel-example-select-basic');
@@ -183,6 +183,71 @@ test.describe('limel-select typeahead', () => {
             await expect(page.locator('limel-example-value')).toContainText(
                 'luke'
             );
+        });
+
+        test('keeps the picked option focused, so the next one is a key away', async ({
+            page,
+        }) => {
+            await openByClick(page);
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+
+            await page.keyboard.press('ArrowDown');
+            await page.keyboard.press('ArrowDown');
+            await expect.poll(() => focusedOption(page)).toBe('Obi-Wan Kenobi');
+
+            await page.keyboard.press(' ');
+            await expect(page.locator('limel-example-value')).toContainText(
+                'Obi-Wan'
+            );
+
+            // Asserted after the value has landed, so the re-render that
+            // picking triggers has already happened. Focus must survive it:
+            // picking several options in a row is the point of a multiple
+            // select, and starting over from the top after each one makes that
+            // unusable.
+            await expect.poll(() => focusedOption(page)).toBe('Obi-Wan Kenobi');
+
+            // Navigation continues from where it left off.
+            await page.keyboard.press('ArrowDown');
+            await expect.poll(() => focusedOption(page)).toBe('Yoda');
+
+            await page.keyboard.press(' ');
+            await expect(page.locator('limel-example-value')).toContainText(
+                'Yoda'
+            );
+        });
+
+        test('keeps the picked option focused even after typing earlier in the same session', async ({
+            page,
+        }) => {
+            await openByClick(page);
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+
+            // Jumps to "Yoda" by typing, then moves away from it with the
+            // arrow keys before picking a different row. The typed match must
+            // not resurface once it no longer reflects where the user is.
+            await page.keyboard.press('y');
+            await expect.poll(() => focusedOption(page)).toBe('Yoda');
+
+            // Waited out deliberately, so that the typeahead buffer has
+            // expired and the space bar below is unambiguously a pick rather
+            // than a continuation of "y" — that collision is a separate,
+            // documented trade-off, not what this test is isolating.
+            await page.waitForTimeout(TYPEAHEAD_BUFFER_TIMEOUT + 100);
+
+            await page.keyboard.press('ArrowDown');
+            await expect.poll(() => focusedOption(page)).toBe('Rey');
+
+            await page.keyboard.press(' ');
+            await expect(page.locator('limel-example-value')).toContainText(
+                'Rey'
+            );
+
+            // Asserted after the value has landed, so the re-render that
+            // picking triggers has already happened. If the typed match were
+            // still remembered, this re-render would apply it and pull focus
+            // back to "Yoda".
+            await expect.poll(() => focusedOption(page)).toBe('Rey');
         });
     });
 });

--- a/src/components/list/list.tsx
+++ b/src/components/list/list.tsx
@@ -207,6 +207,26 @@ export class List {
         );
 
         this.mdcList = new MDCList(element);
+
+        // NOTE: This has no effect. It is kept as a marker rather than
+        // removed, so that its absence isn't mistaken for an oversight.
+        //
+        // MDC indexes each row for typeahead by looking for
+        // `.mdc-deprecated-list-item__primary-text` inside it, while
+        // `limel-list-item` renders its label as `<span class="label">`. MDC
+        // therefore builds an empty index, and typing does nothing.
+        //
+        // Do not "fix" this by adding MDC's class name to `limel-list-item`.
+        // That revives MDC's typeahead along with three behaviors that cannot
+        // be configured from the outside: a hard coded 300ms buffer, `Enter`
+        // being ignored for as long as that buffer lives (its `notifyAction`
+        // is guarded by `isTypeaheadInProgress`), and the space bar being
+        // excluded from matches. It would also collide with `limel-menu`,
+        // where single characters are used as item hotkeys.
+        //
+        // `limel-select` implements its own typeahead instead, see
+        // `src/util/typeahead.ts`. It intercepts typed characters in the
+        // capture phase on this very element, so they never reach MDC.
         this.mdcList.hasTypeahead = true;
     };
 

--- a/src/components/select/select.e2e.tsx
+++ b/src/components/select/select.e2e.tsx
@@ -500,4 +500,187 @@ describe('limel-select (menu)', () => {
             expect(nativeSelect).not.toBeNull();
         });
     });
+
+    describe('typeahead', () => {
+        const doctors: Option[] = [
+            { text: 'Jodie Whittaker', value: '13' },
+            { text: 'Peter Capaldi', value: '12' },
+            { text: 'Matt Smith', value: '11' },
+            { text: 'David Tennant', value: '10' },
+        ];
+
+        // `cancelable` matches what a browser dispatches, and is what makes
+        // `preventDefault` observable through the returned event.
+        const pressKey = (
+            root: any,
+            key: string,
+            modifiers: KeyboardEventInit = {}
+        ): KeyboardEvent => {
+            const trigger = root.shadowRoot.querySelector(
+                '.limel-select-trigger'
+            );
+
+            const event = new KeyboardEvent('keydown', {
+                key: key,
+                bubbles: true,
+                cancelable: true,
+                composed: true,
+                ...modifiers,
+            });
+            trigger.dispatchEvent(event);
+
+            return event;
+        };
+
+        // Read from the class rather than `aria-expanded`, which the trigger
+        // renders as a boolean attribute — empty when open, absent when
+        // closed — and so cannot be told apart from a missing attribute.
+        const isOpen = (root: any) =>
+            root.shadowRoot
+                .querySelector('.limel-select-trigger')
+                .classList.contains('limel-select--focused');
+
+        // Note that there is no test for `disabled`. A disabled trigger never
+        // receives key events in a browser, but a dispatched event still
+        // reaches the listener, so such a test would only assert the test
+        // setup rather than the component.
+
+        it('opens the dropdown when a matching character is typed', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            await waitForChanges();
+
+            pressKey(root, 'm');
+            await waitForChanges();
+
+            expect(isOpen(root)).toBe(true);
+        });
+
+        it('suppresses the default action of a consumed character', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            await waitForChanges();
+
+            // Characters must not reach `MDCList`, which would treat them as
+            // its own typeahead and swallow the next `Enter`.
+            expect(pressKey(root, 'm').defaultPrevented).toBe(true);
+        });
+
+        it('leaves a key it does not consume alone', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            await waitForChanges();
+
+            expect(pressKey(root, 'ArrowDown').defaultPrevented).toBe(false);
+        });
+
+        it('does not change the value while typing', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            const changeSpy = spyOnEvent('change');
+            await waitForChanges();
+
+            pressKey(root, 'm');
+            await waitForChanges();
+            pressKey(root, 'a');
+            await waitForChanges();
+
+            expect(changeSpy).not.toHaveReceivedEvent();
+        });
+
+        it('leaves the dropdown closed when nothing matches', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            await waitForChanges();
+
+            pressKey(root, 'z');
+            await waitForChanges();
+
+            expect(isOpen(root)).toBe(false);
+        });
+
+        it('ignores characters typed with a modifier', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            await waitForChanges();
+
+            pressKey(root, 'm', { ctrlKey: true });
+            await waitForChanges();
+
+            expect(isOpen(root)).toBe(false);
+        });
+
+        it('leaves typeahead to the native dropdown on mobile', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select
+                    data-native
+                    label="Doctor"
+                    options={doctors}
+                ></limel-select>
+            );
+            await waitForChanges();
+
+            pressKey(root, 'm');
+            await waitForChanges();
+
+            expect(isOpen(root)).toBe(false);
+        });
+
+        it('highlights the matching option', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-select label="Doctor" options={doctors}></limel-select>
+            );
+            await waitForChanges();
+
+            pressKey(root, 'm');
+            await waitForChanges();
+
+            await vi.waitFor(() => {
+                const list = document.querySelector(
+                    'limel-menu-surface limel-list'
+                );
+                const focused = list?.shadowRoot?.activeElement as HTMLElement;
+
+                expect(focused?.dataset.index).toBe('2');
+            });
+        });
+
+        describe('still opens the dropdown', () => {
+            it('with Enter', async () => {
+                const { root, waitForChanges } = await render(
+                    <limel-select
+                        label="Doctor"
+                        options={doctors}
+                    ></limel-select>
+                );
+                await waitForChanges();
+
+                pressKey(root, 'Enter');
+                await waitForChanges();
+
+                expect(isOpen(root)).toBe(true);
+            });
+
+            it('with the space bar', async () => {
+                const { root, waitForChanges } = await render(
+                    <limel-select
+                        label="Doctor"
+                        options={doctors}
+                    ></limel-select>
+                );
+                await waitForChanges();
+
+                pressKey(root, ' ');
+                await waitForChanges();
+
+                expect(isOpen(root)).toBe(true);
+            });
+        });
+    });
 });

--- a/src/components/select/select.template.tsx
+++ b/src/components/select/select.template.tsx
@@ -20,7 +20,12 @@ interface SelectTemplateProps {
 
     id: string;
     onMenuChange: (event: CustomEvent<ListItem | ListItem[]>) => void;
-    onTriggerPress: (event: KeyboardEvent) => void;
+    onTriggerKeyDown: (event: KeyboardEvent) => void;
+    /**
+     * Stencil calls this with `null` when the `limel-list` goes away — on
+     * unmount, and when the native dropdown replaces the menu on mobile.
+     */
+    listRef: (element: HTMLLimelListElement | null) => void;
     isOpen: boolean;
     open: () => void;
     close: () => void;
@@ -117,7 +122,7 @@ const SelectValue: FunctionalComponent<
             slot="content"
             class={anchorClassList}
             onClick={props.open}
-            onKeyPress={props.onTriggerPress}
+            onKeyDown={props.onTriggerKeyDown}
             aria-haspopup="listbox"
             aria-expanded={props.isOpen}
             aria-controls={props.id}
@@ -213,6 +218,7 @@ const MenuDropdown: FunctionalComponent<SelectTemplateProps> = (props) => {
                 }}
             >
                 <limel-list
+                    ref={props.listRef}
                     items={items}
                     type={props.multiple ? 'checkbox' : 'selectable'}
                     onChange={props.onMenuChange}
@@ -273,7 +279,21 @@ function isSelected(option: Option, value: Option | Option[]): boolean {
     return option.value === value.value;
 }
 
-function createMenuItems(
+/**
+ * Create the items for the dropdown.
+ *
+ * The returned array is index-aligned with the `data-index` attribute that
+ * `limel-list` renders on each row. Separators are included, and occupy an
+ * index. Anything that needs to address a row by index — such as the
+ * typeahead in `select.tsx` — must derive its indices from this same array.
+ *
+ * @param options - the options of the select
+ * @param value - the currently selected option or options
+ * @param selectIsRequired - whether the select requires a value, in which
+ * case the "empty" option is left out
+ * @returns the items to render in the dropdown
+ */
+export function createMenuItems(
     options: Array<Option | ListSeparator>,
     value: Option | Option[],
     selectIsRequired = false

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -330,11 +330,21 @@ export class Select {
                 this.pendingTypeaheadIndex = undefined;
 
                 if (
-                    typeaheadIndex === undefined ||
-                    !this.focusMenuItemAtIndex(list, typeaheadIndex)
+                    typeaheadIndex !== undefined &&
+                    this.focusMenuItemAtIndex(list, typeaheadIndex)
                 ) {
-                    this.focusFirstMenuItem(list);
+                    return;
                 }
+
+                // Picking an option while `multiple` re-renders the dropdown
+                // without closing it, which brings us back here with a row
+                // already focused. Moving to the first option then would lose
+                // the user's place in the list after every pick.
+                if (this.getFocusedMenuItemIndex() !== NO_TYPEAHEAD_MATCH) {
+                    return;
+                }
+
+                this.focusFirstMenuItem(list);
             });
             this.focusObserver.observe(list);
         }, 0);
@@ -646,14 +656,25 @@ export class Select {
     }
 
     private focusTypeaheadMatch(index: number): void {
-        // Recorded even when the row can be focused right away. Opening the
-        // dropdown queues a `setMenuFocus` that waits for it to become
-        // visible, and someone typing quickly gets the next character in
-        // before that resolves. Leaving the earlier index in place would let
-        // the queued focus apply it on top of this newer match.
+        // Overwrites any index still pending from an earlier character, even
+        // when this one can be focused right away. Opening the dropdown queues
+        // a `setMenuFocus` that waits for it to become visible, and someone
+        // typing quickly gets the next character in before that resolves;
+        // leaving the earlier index in place would let the queued focus apply
+        // it on top of this newer match.
         this.pendingTypeaheadIndex = index;
 
         if (this.menuOpen && this.focusMenuItemAtIndex(this.list, index)) {
+            // Focus landed synchronously, so this index has already done its
+            // job. Clearing it — rather than leaving it for `setMenuFocus` to
+            // consume later — stops it from being replayed by some unrelated
+            // future re-render, such as picking an option in a `multiple`
+            // select, after the user has since moved focus elsewhere with the
+            // arrow keys. A `setMenuFocus` still queued from opening the
+            // dropdown a moment ago is unaffected: it finds this row already
+            // focused and leaves it alone, below.
+            this.pendingTypeaheadIndex = undefined;
+
             return;
         }
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -13,12 +13,34 @@ import {
     Watch,
 } from '@stencil/core';
 import { isMobileDevice } from '../../util/device';
-import { ENTER, SPACE } from '../../util/keycodes';
+import { ENTER, SPACEBAR } from '../../util/keycodes';
 import { isMultiple } from '../../util/multiple';
 import { createRandomString } from '../../util/random-string';
-import { SelectTemplate, triggerIconColorWarning } from './select.template';
+import {
+    findTypeaheadMatch,
+    isTypeaheadKey,
+    NO_TYPEAHEAD_MATCH,
+    TypeaheadBuffer,
+    TypeaheadCandidate,
+} from '../../util/typeahead';
+import {
+    createMenuItems,
+    SelectTemplate,
+    triggerIconColorWarning,
+} from './select.template';
 
 /**
+ * ## Keyboard
+ *
+ * Typing characters jumps to the option whose text starts with them, the way
+ * a native `<select>` does. Characters accumulate for a short while, so typing
+ * `n`, `e` finds "Netherlands" rather than the next option starting with `n`.
+ * Pressing the same character repeatedly cycles through all options starting
+ * with it. This works both while the dropdown is open, and while the closed
+ * component has focus — in which case the dropdown opens with the match
+ * highlighted. Typing only moves the highlight; the value is not changed until
+ * the option is picked with `Enter` or a click.
+ *
  * @exampleComponent limel-example-select-basic
  * @exampleComponent limel-example-select-with-icons
  * @exampleComponent limel-example-select-with-separators
@@ -127,6 +149,18 @@ export class Select {
         this.hasPrimaryComponentMemo = this.computeHasPrimaryComponent();
     }
 
+    /**
+     * `options` and `required` are the inputs that decide which rows the
+     * dropdown renders, and therefore which row an index refers to. When
+     * either changes, a buffered typeahead match no longer points at what the
+     * user was aiming for.
+     */
+    @Watch('options')
+    @Watch('required')
+    protected resetTypeaheadOnItemsChange() {
+        this.resetTypeahead();
+    }
+
     private checkValid: boolean = false;
     private mdcSelectHelperText: MDCSelectHelperText;
     private mdcFloatingLabel: MDCFloatingLabel;
@@ -135,11 +169,20 @@ export class Select {
     private focusObserver: IntersectionObserver;
     private focusTimeoutId: ReturnType<typeof setTimeout>;
 
+    private readonly typeaheadBuffer = new TypeaheadBuffer();
+
+    /**
+     * The row a typeahead match wants to focus, when it could not be focused
+     * right away — because the dropdown had not opened or rendered yet. It is
+     * consumed by `setMenuFocus`, once focus is about to land in the menu.
+     */
+    private pendingTypeaheadIndex: number | undefined;
+
+    private list: HTMLLimelListElement;
+
     constructor() {
         this.handleMenuChange = this.handleMenuChange.bind(this);
         this.handleNativeChange = this.handleNativeChange.bind(this);
-        this.handleMenuTriggerKeyPress =
-            this.handleMenuTriggerKeyPress.bind(this);
         this.openMenu = this.openMenu.bind(this);
         this.closeMenu = this.closeMenu.bind(this);
 
@@ -185,6 +228,7 @@ export class Select {
 
     public disconnectedCallback() {
         this.cancelPendingFocus();
+        this.resetTypeahead();
 
         if (this.mdcFloatingLabel) {
             this.mdcFloatingLabel.destroy();
@@ -219,7 +263,8 @@ export class Select {
                 options={this.options}
                 onMenuChange={this.handleMenuChange}
                 onNativeChange={this.handleNativeChange}
-                onTriggerPress={this.handleMenuTriggerKeyPress}
+                onTriggerKeyDown={this.handleMenuTriggerKeyDown}
+                listRef={this.setListElement}
                 multiple={this.multiple}
                 isOpen={this.menuOpen}
                 open={this.openMenu}
@@ -279,7 +324,17 @@ export class Select {
                     return;
                 }
 
-                this.focusFirstMenuItem(list);
+                // Consumed on read, so that a later, unrelated re-render
+                // cannot resurrect a stale index and yank focus.
+                const typeaheadIndex = this.pendingTypeaheadIndex;
+                this.pendingTypeaheadIndex = undefined;
+
+                if (
+                    typeaheadIndex === undefined ||
+                    !this.focusMenuItemAtIndex(list, typeaheadIndex)
+                ) {
+                    this.focusFirstMenuItem(list);
+                }
             });
             this.focusObserver.observe(list);
         }, 0);
@@ -304,6 +359,35 @@ export class Select {
         if (firstItem) {
             firstItem.focus({ preventScroll: true });
         }
+    }
+
+    /**
+     * Focus the row at a given index in the dropdown.
+     *
+     * The rows only become focusable once `limel-list` has set up `MDCList`,
+     * which is what gives them a `tabindex`. Callers use the return value to
+     * fall back to `pendingTypeaheadIndex` when that has not happened yet.
+     *
+     * @param list - the `limel-list` of the dropdown
+     * @param index - the index of the row, as rendered in its `data-index`
+     * @returns whether the row could be focused
+     */
+    private focusMenuItemAtIndex(list: HTMLElement, index: number): boolean {
+        const item: HTMLElement = list?.shadowRoot?.querySelector(
+            `[data-index="${index}"]`
+        );
+
+        if (!item) {
+            return false;
+        }
+
+        // Scrolled explicitly, and only within the dropdown: letting `focus()`
+        // scroll would scroll the page, since the dropdown is rendered into a
+        // portal that is absolutely positioned on the `body`.
+        item.focus({ preventScroll: true });
+        item.scrollIntoView({ block: 'nearest' });
+
+        return list.shadowRoot.activeElement === item;
     }
 
     private setTriggerFocus() {
@@ -374,6 +458,7 @@ export class Select {
         this.change.emit(option);
         this.menuOpen = false;
         this.cancelPendingFocus();
+        this.resetTypeahead();
         this.setTriggerFocus();
     }
 
@@ -417,18 +502,188 @@ export class Select {
     private closeMenu() {
         this.menuOpen = false;
         this.cancelPendingFocus();
+        this.resetTypeahead();
         this.setTriggerFocus();
     }
 
-    private handleMenuTriggerKeyPress(event: KeyboardEvent) {
+    private readonly handleMenuTriggerKeyDown = (
+        event: KeyboardEvent
+    ): void => {
+        // Typeahead runs first, so that a space extends an ongoing typeahead
+        // instead of just opening the dropdown. A *bare* space is declined by
+        // `handleTypeaheadKey`, and keeps its usual meaning below.
+        if (this.handleTypeaheadKey(event, NO_TYPEAHEAD_MATCH)) {
+            return;
+        }
+
         const isEnter = event.key === ENTER;
-        const isSpace = event.key === SPACE;
+        const isSpace = event.key === SPACEBAR;
 
         if (!this.menuOpen && (isSpace || isEnter)) {
             event.stopPropagation();
             event.preventDefault();
-            this.menuOpen = true;
+
+            // `preventDefault` cancels the activation click that the trigger
+            // `button` would otherwise synthesize, so the menu has to be
+            // opened here rather than through the click handler.
+            this.openMenu();
         }
+    };
+
+    private readonly setListElement = (
+        element: HTMLLimelListElement | null
+    ): void => {
+        if (this.list === element) {
+            return;
+        }
+
+        this.list?.removeEventListener(
+            'keydown',
+            this.handleListKeyDownCapture,
+            true
+        );
+
+        this.list = element;
+
+        this.list?.addEventListener(
+            'keydown',
+            this.handleListKeyDownCapture,
+            true
+        );
+    };
+
+    /**
+     * Key handler for the dropdown, in the capture phase.
+     *
+     * `MDCList` listens for `keydown` on the `ul` inside `limel-list`'s shadow
+     * root, so capturing on the `limel-list` element itself is the only place
+     * a typed character can be stopped before MDC sees it. It has to be
+     * stopped: MDC would add it to its own typeahead buffer, which suppresses
+     * selection with `Enter` for as long as that buffer lives, and it treats
+     * the space bar as a selection.
+     *
+     * @param event - the key that was pressed
+     */
+    private readonly handleListKeyDownCapture = (
+        event: KeyboardEvent
+    ): void => {
+        this.handleTypeaheadKey(event, this.getFocusedMenuItemIndex());
+    };
+
+    /**
+     * Move the highlight to the option matching the characters typed so far,
+     * the way a native `<select>` does. Never changes the value — the option
+     * still has to be picked with `Enter` or a click.
+     *
+     * @param event - the key that was pressed
+     * @param focusedIndex - the row that currently has focus, if any
+     * @returns whether the key was handled as typeahead
+     */
+    private handleTypeaheadKey(
+        event: KeyboardEvent,
+        focusedIndex: number
+    ): boolean {
+        // The native dropdown on mobile devices does its own typeahead. Note
+        // that `setMenuFocus` bails out on mobile too, so a pending index
+        // would never be consumed there.
+        if (this.isMobileDevice || !isTypeaheadKey(event)) {
+            return false;
+        }
+
+        // A space only continues an ongoing typeahead. On its own it keeps its
+        // usual meaning of opening the dropdown, or selecting the focused
+        // option.
+        if (event.key === SPACEBAR && this.typeaheadBuffer.isEmpty) {
+            return false;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        // Derived per key press rather than cached, so that the indices always
+        // refer to the rows the dropdown renders right now.
+        const items = createMenuItems(this.options, this.value, this.required);
+        const candidates: Array<TypeaheadCandidate | null> = items.map(
+            (item) => ('separator' in item ? null : item)
+        );
+
+        const buffer = this.typeaheadBuffer.append(event.key);
+        const currentIndex = this.resolveTypeaheadIndex(items, focusedIndex);
+        const index = findTypeaheadMatch(candidates, buffer, currentIndex);
+
+        if (index !== NO_TYPEAHEAD_MATCH) {
+            this.focusTypeaheadMatch(index);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param items - the items of the dropdown
+     * @param focusedIndex - the row that currently has focus, if any
+     * @returns the index a typeahead search should start from
+     */
+    private resolveTypeaheadIndex(
+        items: Array<ListItem<Option> | ListSeparator>,
+        focusedIndex: number
+    ): number {
+        if (focusedIndex !== NO_TYPEAHEAD_MATCH) {
+            return focusedIndex;
+        }
+
+        // Typed again before focus had time to land in the dropdown.
+        if (this.pendingTypeaheadIndex !== undefined) {
+            return this.pendingTypeaheadIndex;
+        }
+
+        // Falls back to the selected option, so that typing continues from
+        // wherever the highlight already is. `findIndex` returning `-1` for a
+        // select without a value is exactly the "no current row" that
+        // `findTypeaheadMatch` expects.
+        return items.findIndex(
+            (item) => !('separator' in item) && item.selected
+        );
+    }
+
+    private focusTypeaheadMatch(index: number): void {
+        // Recorded even when the row can be focused right away. Opening the
+        // dropdown queues a `setMenuFocus` that waits for it to become
+        // visible, and someone typing quickly gets the next character in
+        // before that resolves. Leaving the earlier index in place would let
+        // the queued focus apply it on top of this newer match.
+        this.pendingTypeaheadIndex = index;
+
+        if (this.menuOpen && this.focusMenuItemAtIndex(this.list, index)) {
+            return;
+        }
+
+        if (this.menuOpen) {
+            // Already open, so no re-render is coming that would trigger
+            // `componentDidUpdate`. Schedule the focus explicitly.
+            this.setMenuFocus();
+        } else {
+            this.openMenu();
+        }
+    }
+
+    /**
+     * @returns the index of the focused row of the dropdown, or
+     * `NO_TYPEAHEAD_MATCH` when no row has focus
+     */
+    private getFocusedMenuItemIndex(): number {
+        // Deliberately not `event.target`: a listener on the `limel-list`
+        // element sees events from inside its shadow root retargeted to the
+        // element itself, never to the row that was actually focused.
+        const focused = this.list?.shadowRoot?.activeElement;
+        const row = focused?.closest<HTMLElement>('[data-index]');
+        const index = Number.parseInt(row?.dataset.index ?? '', 10);
+
+        return Number.isNaN(index) ? NO_TYPEAHEAD_MATCH : index;
+    }
+
+    private resetTypeahead(): void {
+        this.typeaheadBuffer.clear();
+        this.pendingTypeaheadIndex = undefined;
     }
 
     private handleNativeChange(event: Event) {

--- a/src/util/keycodes.ts
+++ b/src/util/keycodes.ts
@@ -3,7 +3,10 @@
 export const TAB = 'Tab';
 export const ENTER = 'Enter';
 export const ESCAPE = 'Escape';
+/** `KeyboardEvent.code` for the space bar. NOT a `KeyboardEvent.key`. */
 export const SPACE = 'Space';
+/** `KeyboardEvent.key` for the space bar. */
+export const SPACEBAR = ' ';
 export const BACKSPACE = 'Backspace';
 export const DELETE = 'Delete';
 export const ARROW_UP = 'ArrowUp';

--- a/src/util/typeahead.spec.ts
+++ b/src/util/typeahead.spec.ts
@@ -1,0 +1,263 @@
+import {
+    findTypeaheadMatch,
+    isTypeaheadKey,
+    NO_TYPEAHEAD_MATCH,
+    TypeaheadBuffer,
+    TypeaheadCandidate,
+    TYPEAHEAD_BUFFER_TIMEOUT,
+} from './typeahead';
+
+const FRUITS: Array<TypeaheadCandidate | null> = [
+    { text: 'Apple' },
+    { text: 'Banana' },
+    { text: 'Blueberry' },
+];
+
+describe('findTypeaheadMatch', () => {
+    it('finds nothing without a buffer', () => {
+        expect(findTypeaheadMatch(FRUITS, '', 0)).toBe(NO_TYPEAHEAD_MATCH);
+    });
+
+    it('finds nothing without candidates', () => {
+        expect(findTypeaheadMatch([], 'a', 0)).toBe(NO_TYPEAHEAD_MATCH);
+    });
+
+    it('finds nothing when nothing starts with the buffer', () => {
+        expect(findTypeaheadMatch(FRUITS, 'z', 0)).toBe(NO_TYPEAHEAD_MATCH);
+    });
+
+    describe('with a single character', () => {
+        it('finds the first match when nothing is current', () => {
+            expect(findTypeaheadMatch(FRUITS, 'b', NO_TYPEAHEAD_MATCH)).toBe(1);
+        });
+
+        it('advances past the current candidate', () => {
+            expect(findTypeaheadMatch(FRUITS, 'b', 1)).toBe(2);
+        });
+
+        it('wraps around the end of the candidates', () => {
+            expect(findTypeaheadMatch(FRUITS, 'b', 2)).toBe(1);
+        });
+
+        it('advances even when the current candidate matches', () => {
+            // Without this, pressing the same key twice would keep
+            // re-matching the candidate that is already current.
+            expect(findTypeaheadMatch(FRUITS, 'a', 0)).toBe(0);
+            expect(findTypeaheadMatch(FRUITS, 'b', 1)).not.toBe(1);
+        });
+    });
+
+    describe('with a repeated character', () => {
+        it('cycles, rather than matching the repetition literally', () => {
+            expect(findTypeaheadMatch(FRUITS, 'bb', 1)).toBe(2);
+        });
+
+        it('wraps around the end of the candidates', () => {
+            expect(findTypeaheadMatch(FRUITS, 'bbb', 2)).toBe(1);
+        });
+
+        it('stays put when only one candidate matches', () => {
+            expect(findTypeaheadMatch(FRUITS, 'aa', 0)).toBe(0);
+        });
+
+        it('cycles on a non-ascii character', () => {
+            const names = [{ text: 'Åkesson' }, { text: 'Ångström' }];
+
+            expect(findTypeaheadMatch(names, 'åå', 0)).toBe(1);
+        });
+    });
+
+    describe('with several characters', () => {
+        it('matches the whole buffer', () => {
+            expect(findTypeaheadMatch(FRUITS, 'bl', 0)).toBe(2);
+        });
+
+        it('keeps a candidate that already matches', () => {
+            expect(findTypeaheadMatch(FRUITS, 'bl', 2)).toBe(2);
+        });
+
+        it('finds nothing when only part of the buffer matches', () => {
+            expect(findTypeaheadMatch(FRUITS, 'blake', 0)).toBe(
+                NO_TYPEAHEAD_MATCH
+            );
+        });
+
+        it('matches text containing spaces', () => {
+            const cities = [{ text: 'New Delhi' }, { text: 'New York' }];
+
+            expect(findTypeaheadMatch(cities, 'new y', 0)).toBe(1);
+        });
+    });
+
+    describe('matching', () => {
+        it('ignores case in the buffer', () => {
+            expect(findTypeaheadMatch(FRUITS, 'APP', 0)).toBe(0);
+        });
+
+        it('ignores case in the candidates', () => {
+            expect(findTypeaheadMatch([{ text: 'ÅKESSON' }], 'åk', 0)).toBe(0);
+        });
+
+        it('ignores surrounding whitespace in the candidates', () => {
+            expect(findTypeaheadMatch([{ text: '  Cherry ' }], 'c', 0)).toBe(0);
+        });
+
+        it('skips disabled candidates', () => {
+            const characters = [
+                { text: 'Luke Skywalker' },
+                { text: 'Han Solo', disabled: true },
+                { text: 'Leia Organa' },
+            ];
+
+            expect(findTypeaheadMatch(characters, 'h', 0)).toBe(
+                NO_TYPEAHEAD_MATCH
+            );
+            expect(findTypeaheadMatch(characters, 'l', 0)).toBe(2);
+        });
+
+        it('never matches candidates without text', () => {
+            expect(findTypeaheadMatch([{ text: '' }, {}], 'a', 0)).toBe(
+                NO_TYPEAHEAD_MATCH
+            );
+        });
+
+        it('finds nothing when every candidate is unmatchable', () => {
+            expect(
+                findTypeaheadMatch(
+                    [null, { text: 'Apple', disabled: true }],
+                    'a',
+                    0
+                )
+            ).toBe(NO_TYPEAHEAD_MATCH);
+        });
+    });
+
+    describe('with rows that can never match', () => {
+        it('lets them occupy their index', () => {
+            // A separator at index 0 means "Apple" is at index 1, and that is
+            // the index the caller has to be given back.
+            expect(findTypeaheadMatch([null, ...FRUITS], 'a', 0)).toBe(1);
+        });
+    });
+
+    describe('with a current index outside the candidates', () => {
+        it('searches from the beginning when it is too high', () => {
+            expect(findTypeaheadMatch(FRUITS, 'b', 99)).toBe(1);
+        });
+
+        it('searches from the beginning when it is negative', () => {
+            expect(findTypeaheadMatch(FRUITS, 'b', -5)).toBe(1);
+        });
+    });
+});
+
+describe('isTypeaheadKey', () => {
+    const keyboardEvent = (init: KeyboardEventInit): KeyboardEvent =>
+        new KeyboardEvent('keydown', init);
+
+    it.each([['a'], ['A'], ['1'], ['-'], ['å'], [' ']])(
+        'accepts "%s"',
+        (key: string) => {
+            expect(isTypeaheadKey(keyboardEvent({ key: key }))).toBe(true);
+        }
+    );
+
+    it.each([['Enter'], ['ArrowDown'], ['Escape'], ['Tab'], ['Shift'], ['F1']])(
+        'rejects "%s"',
+        (key: string) => {
+            expect(isTypeaheadKey(keyboardEvent({ key: key }))).toBe(false);
+        }
+    );
+
+    it('accepts a character typed with shift', () => {
+        expect(
+            isTypeaheadKey(keyboardEvent({ key: 'A', shiftKey: true }))
+        ).toBe(true);
+    });
+
+    it.each([['altKey'], ['ctrlKey'], ['metaKey']])(
+        'rejects a character typed with %s',
+        (modifier: string) => {
+            const event = keyboardEvent({ key: 'a', [modifier]: true });
+
+            expect(isTypeaheadKey(event)).toBe(false);
+        }
+    );
+
+    it('rejects a character that is being composed', () => {
+        const event = keyboardEvent({ key: 'a', isComposing: true });
+
+        expect(isTypeaheadKey(event)).toBe(false);
+    });
+});
+
+describe('TypeaheadBuffer', () => {
+    let buffer: TypeaheadBuffer;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        buffer = new TypeaheadBuffer();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('starts out empty', () => {
+        expect(buffer.value).toBe('');
+        expect(buffer.isEmpty).toBe(true);
+    });
+
+    it('accumulates the appended characters', () => {
+        expect(buffer.append('a')).toBe('a');
+        expect(buffer.append('b')).toBe('ab');
+        expect(buffer.value).toBe('ab');
+        expect(buffer.isEmpty).toBe(false);
+    });
+
+    it('discards the characters once typing stops', () => {
+        buffer.append('a');
+
+        vi.advanceTimersByTime(TYPEAHEAD_BUFFER_TIMEOUT - 1);
+        expect(buffer.value).toBe('a');
+
+        vi.advanceTimersByTime(1);
+        expect(buffer.value).toBe('');
+        expect(buffer.isEmpty).toBe(true);
+    });
+
+    it('keeps the characters as long as typing continues', () => {
+        buffer.append('a');
+        vi.advanceTimersByTime(TYPEAHEAD_BUFFER_TIMEOUT - 1);
+
+        buffer.append('b');
+        vi.advanceTimersByTime(TYPEAHEAD_BUFFER_TIMEOUT - 1);
+
+        expect(buffer.value).toBe('ab');
+    });
+
+    it('discards the characters when cleared', () => {
+        buffer.append('a');
+        buffer.clear();
+
+        expect(buffer.value).toBe('');
+    });
+
+    it('does not discard characters typed after being cleared', () => {
+        buffer.append('a');
+        buffer.clear();
+
+        buffer.append('b');
+        vi.advanceTimersByTime(TYPEAHEAD_BUFFER_TIMEOUT - 1);
+
+        expect(buffer.value).toBe('b');
+    });
+
+    it('honors a custom timeout', () => {
+        buffer = new TypeaheadBuffer(50);
+        buffer.append('a');
+
+        vi.advanceTimersByTime(50);
+        expect(buffer.value).toBe('');
+    });
+});

--- a/src/util/typeahead.ts
+++ b/src/util/typeahead.ts
@@ -1,0 +1,205 @@
+/**
+ * These helpers implement "type to jump", the behavior a native `<select>` has:
+ * typing characters moves to the option whose text starts with those
+ * characters. Characters accumulate into a short-lived buffer, so typing
+ * `n`, `e` finds "Netherlands" instead of re-matching on `n` every time.
+ *
+ * The matching itself is pure and stateless — all the state lives in a
+ * `TypeaheadBuffer`, which owns the timer that discards the buffer once the
+ * user stops typing.
+ */
+
+/**
+ * How long a buffer of typed characters is kept before it is discarded, in
+ * milliseconds. Roughly matches a native `<select>`.
+ */
+export const TYPEAHEAD_BUFFER_TIMEOUT = 1000;
+
+/**
+ * Returned by `findTypeaheadMatch` when nothing matched.
+ */
+export const NO_TYPEAHEAD_MATCH = -1;
+
+/**
+ * An entry that typeahead can match the typed characters against.
+ */
+export interface TypeaheadCandidate {
+    /**
+     * The text to match against. Candidates without text never match.
+     */
+    readonly text?: string;
+
+    /**
+     * Disabled candidates are never matched.
+     */
+    readonly disabled?: boolean;
+}
+
+/**
+ * Whether a keyboard event should be treated as a typed character.
+ *
+ * The space bar counts as a character here. Whether a *bare* space should
+ * start a buffer, or keep whatever meaning it has in the consuming component,
+ * is the consumer's decision.
+ *
+ * `shiftKey` is allowed, since capital letters are typed with it, and
+ * `event.repeat` is allowed, since holding a key down cycles through matches
+ * in a native `<select>` too.
+ *
+ * @param event - the keyboard event to inspect
+ * @returns `true` when the event represents a typed character
+ */
+export function isTypeaheadKey(event: KeyboardEvent): boolean {
+    return (
+        event.key.length === 1 &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.isComposing
+    );
+}
+
+/**
+ * Find the candidate to move to for a given buffer of typed characters.
+ *
+ * Two different searches are used, mirroring a native `<select>`:
+ * - When the buffer is a single character, possibly repeated (`b`, `bb`,
+ *   `bbb`), only that character is matched and the search starts *after*
+ *   `currentIndex`. Pressing the same key repeatedly therefore cycles through
+ *   all candidates starting with it.
+ * - Otherwise the whole buffer is matched and the search starts *at*
+ *   `currentIndex`, so continuing to type on an already-matching candidate
+ *   keeps it rather than jumping to the next one.
+ *
+ * Both searches wrap around the end of the list.
+ *
+ * @param candidates - the candidates to search, index-aligned with the rows
+ * they are rendered as. Use `null` for rows that can never match, such as
+ * separators, so that they still occupy their index.
+ * @param buffer - the characters typed so far
+ * @param currentIndex - the index to search from. Anything outside
+ * `candidates` is treated as "no current candidate", and the search starts
+ * from the beginning.
+ * @returns the index of the matching candidate, or `NO_TYPEAHEAD_MATCH`
+ */
+export function findTypeaheadMatch(
+    candidates: ReadonlyArray<TypeaheadCandidate | null>,
+    buffer: string,
+    currentIndex: number
+): number {
+    const count = candidates.length;
+    const query = buffer.toLowerCase();
+    if (!query || count === 0) {
+        return NO_TYPEAHEAD_MATCH;
+    }
+
+    const characters = [...query];
+    const cycles = isSingleDistinctCharacter(characters);
+    const needle = cycles ? characters[0] : query;
+
+    // Cycling starts one past the current candidate, so that pressing the same
+    // key again advances. Matching several characters starts at it, so that
+    // continuing to type keeps a candidate that already matches.
+    const offset = cycles ? 1 : 0;
+    const hasCurrent = currentIndex >= 0 && currentIndex < count;
+    const start = hasCurrent ? (currentIndex + offset) % count : 0;
+
+    for (let step = 0; step < count; step += 1) {
+        const index = (start + step) % count;
+        if (candidateMatches(candidates[index], needle)) {
+            return index;
+        }
+    }
+
+    return NO_TYPEAHEAD_MATCH;
+}
+
+/**
+ * Whether a string consists of a single character, possibly repeated. Also
+ * `true` for one character on its own, which is what makes a single key press
+ * advance past the current candidate rather than re-matching it.
+ *
+ * Takes the characters already split apart, so that the caller and this
+ * function agree on what "a character" is for anything outside the basic
+ * multilingual plane.
+ *
+ * @param characters - the characters of the string
+ * @returns `true` when every character is the same
+ */
+function isSingleDistinctCharacter(characters: readonly string[]): boolean {
+    return characters.every((character) => character === characters[0]);
+}
+
+/**
+ * @param candidate - the candidate to test, or `null` for a row that can
+ * never match
+ * @param needle - the lower cased characters to match
+ * @returns `true` when the candidate starts with the given characters
+ */
+function candidateMatches(
+    candidate: TypeaheadCandidate | null,
+    needle: string
+): boolean {
+    if (!candidate || candidate.disabled) {
+        return false;
+    }
+
+    const text = candidate.text?.trim().toLowerCase();
+
+    return !!text && text.startsWith(needle);
+}
+
+/**
+ * Accumulates typed characters, and discards them again once the user stops
+ * typing for `TYPEAHEAD_BUFFER_TIMEOUT`.
+ */
+export class TypeaheadBuffer {
+    private buffer: string = '';
+    private resetTimeoutId: ReturnType<typeof setTimeout>;
+    private readonly timeout: number;
+
+    constructor(timeout: number = TYPEAHEAD_BUFFER_TIMEOUT) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * The characters typed so far.
+     */
+    public get value(): string {
+        return this.buffer;
+    }
+
+    /**
+     * Whether nothing has been typed, or the buffer has been discarded.
+     */
+    public get isEmpty(): boolean {
+        return this.buffer === '';
+    }
+
+    /**
+     * Append a character, and restart the timer that discards the buffer.
+     *
+     * @param character - the character to append
+     * @returns the buffer, including the appended character
+     */
+    public append(character: string): string {
+        this.buffer += character;
+
+        clearTimeout(this.resetTimeoutId);
+        this.resetTimeoutId = setTimeout(() => {
+            this.clear();
+        }, this.timeout);
+
+        return this.buffer;
+    }
+
+    /**
+     * Discard the buffer, and cancel the timer that would have discarded it.
+     */
+    public clear(): void {
+        this.buffer = '';
+
+        clearTimeout(this.resetTimeoutId);
+        this.resetTimeoutId = undefined;
+    }
+}


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop keyboard typeahead support to select controls.
  * Find options with multi-character searches, repeated-character cycling, and space-containing text.
  * Matching skips disabled options and wraps through available choices.
  * Press Enter or Space to open and select options while retaining existing behavior.
  * Improved focus handling and scrolling for matched options, including multi-select controls.

* **Tests**
  * Added comprehensive coverage for keyboard navigation, selection, accessibility states, mobile behavior, and dropdown visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

Closes #4192

## Why

Reaching an option in `limel-select` from the keyboard meant pressing <kbd>↓</kbd>
once per row — around 30 presses to get to "Wisconsin" in the states example,
where a native `<select>` takes two. This adds the type-to-jump behavior a
native `<select>` has, without adding any public API.

## What changed for consumers

Typing characters moves the highlight to the option whose text starts with them:

- Characters accumulate for 1s, so `n`, `e` reaches "Netherlands" rather than the
  next option starting with `n`.
- Repeating a character cycles through every option starting with it, wrapping at
  the end.
- Works both on the closed component (opens the dropdown with the match
  highlighted) and in the open dropdown.
- **Typing never emits `change`.** It moves the highlight only; the value is
  still set by <kbd>Enter</kbd> or a click, so `multiple` behaves the same as
  single select.
- Disabled options and separators are skipped, matching ignores case, and text
  containing spaces is reachable ("New York").

No new props, events, or exported types — `src/util/typeahead.ts` is internal,
so this is a `fix` rather than a `feat`.

## Worth a reviewer's attention

**The capture-phase listener is load-bearing, not stylistic.** `MDCList` listens
for `keydown` on the `ul` inside `limel-list`'s shadow root. Any character that
reaches it lands in MDC's own typeahead buffer, which guards `notifyAction`
behind `isTypeaheadInProgress()` — so typing and then immediately pressing
<kbd>Enter</kbd> would select nothing — and MDC treats a space as a selection.
So `select.tsx` intercepts on the capture phase of the `limel-list` element and
stops propagation for *every* character it consumes, including non-matching ones.
Same pattern as `handleListKeyDownCapture` in `menu.tsx`.

**Why not just fix MDC's built-in typeahead.** `limel-list` already sets
`hasTypeahead = true`, but it is inert: MDC looks for
`.mdc-deprecated-list-item__primary-text` while `limel-list-item` renders
`<span class="label">`. Reviving it would have been a one-line change, and was
rejected because three of its behaviors are not configurable — a hard-coded
300ms buffer (which defeats multi-character matching), <kbd>Enter</kbd> ignored
while that buffer lives, and the space bar excluded from matches — and because it
would also enable typeahead in `limel-menu-list`, where `limel-menu` treats
single characters as item hotkeys. The second commit documents this on the
`hasTypeahead` line so it does not get "fixed" later.

**Index alignment.** `data-index` counts separators, MDC's internal indices do
not. The typeahead derives its candidates from `createMenuItems` — the same array
the template renders — with separators mapped to `null` so they still occupy an
index. `example-tests/components/select.spec.ts` covers this end to end via the
states example.

**Two drive-by fixes that the typeahead required**, both in the first commit
because they are not separately revertable: the trigger moves off the deprecated
`keypress` event to `keydown`, and the space bar is compared against `event.key`
instead of the `SPACE` constant, which holds a `KeyboardEvent.code` and so never
matched. Opening on the space bar previously only worked through the button's
synthesized click. Note the same latent `SPACE` comparison still exists in
`input-field.tsx` — left alone as out of scope.

**Pre-existing a11y bug found but not fixed:** the trigger renders
`aria-expanded` as a boolean attribute — `""` when open, absent when closed —
instead of the literal `"true"`/`"false"`, so assistive tech never hears
"collapsed". Out of scope here since fixing it touches the axe baseline and
visual snapshots; happy to open a separate issue.

## Verification

- `npm run lint`, `npm run build` — clean
- `npm test` — 1938 passed, 8 skipped
- `npm run test:examples:components` — 10 passed, stable across repeated
  parallel runs
- New coverage: 48 unit tests for the matcher and buffer
  (`src/util/typeahead.spec.ts`), 6 in `select.e2e.tsx`, and 9 Playwright example
  tests driving real key events and real focus

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such (none here)

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Verification was automated only — Chromium via Vitest browser mode and
Playwright, on macOS. Manual checks in Firefox and Safari would be welcome,
particularly the focus and `scrollIntoView` behavior inside the portal.

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

Mobile renders the native `<select>`, which has its own typeahead, so the new
code path is a deliberate no-op there.
