### PR TITLE
Keep the picked option focused in a multiple limel-select

### DIFF
--- a/example-tests/components/select.spec.ts
+++ b/example-tests/components/select.spec.ts
@@ -5,10 +5,9 @@ import { test, expect, type Page } from '@playwright/test';
 // tests must know the component, so they live in their own file under
 // example-tests/components/.
 //
-// This file covers the typeahead: typing characters moves the highlight to the
-// option starting with them, without changing the value. That behavior needs
-// real key events and real focus, which is why it is tested here rather than in
-// select.e2e.tsx.
+// This file covers keyboard navigation of the dropdown — the typeahead, and
+// where focus lands after picking an option. Both need real key events and real
+// focus, which is why they are tested here rather than in select.e2e.tsx.
 //
 // Coupling (intentional, fails loudly if broken — never silently):
 //   1. drives the docs examples `limel-example-select-basic` (heroes Luke
@@ -63,7 +62,7 @@ const focusedOption = (page: Page) =>
         return row?.querySelector('.label')?.textContent ?? null;
     });
 
-test.describe('limel-select typeahead', () => {
+test.describe('limel-select keyboard navigation', () => {
     test.describe('with a plain list of options', () => {
         test.beforeEach(async ({ page }) => {
             await page.goto('/#/debug/limel-example-select-basic');
@@ -182,6 +181,38 @@ test.describe('limel-select typeahead', () => {
 
             await expect(page.locator('limel-example-value')).toContainText(
                 'luke'
+            );
+        });
+
+        test('keeps the picked option focused, so the next one is a key away', async ({
+            page,
+        }) => {
+            await openByClick(page);
+            await expect.poll(() => focusedOption(page)).toBe('Luke Skywalker');
+
+            await page.keyboard.press('ArrowDown');
+            await page.keyboard.press('ArrowDown');
+            await expect.poll(() => focusedOption(page)).toBe('Obi-Wan Kenobi');
+
+            await page.keyboard.press(' ');
+            await expect(page.locator('limel-example-value')).toContainText(
+                'Obi-Wan'
+            );
+
+            // Asserted after the value has landed, so the re-render that
+            // picking triggers has already happened. Focus must survive it:
+            // picking several options in a row is the point of a multiple
+            // select, and starting over from the top after each one makes that
+            // unusable.
+            await expect.poll(() => focusedOption(page)).toBe('Obi-Wan Kenobi');
+
+            // Navigation continues from where it left off.
+            await page.keyboard.press('ArrowDown');
+            await expect.poll(() => focusedOption(page)).toBe('Yoda');
+
+            await page.keyboard.press(' ');
+            await expect(page.locator('limel-example-value')).toContainText(
+                'Yoda'
             );
         });
     });

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -330,11 +330,21 @@ export class Select {
                 this.pendingTypeaheadIndex = undefined;
 
                 if (
-                    typeaheadIndex === undefined ||
-                    !this.focusMenuItemAtIndex(list, typeaheadIndex)
+                    typeaheadIndex !== undefined &&
+                    this.focusMenuItemAtIndex(list, typeaheadIndex)
                 ) {
-                    this.focusFirstMenuItem(list);
+                    return;
                 }
+
+                // Picking an option while `multiple` re-renders the dropdown
+                // without closing it, which brings us back here with a row
+                // already focused. Moving to the first option then would lose
+                // the user's place in the list after every pick.
+                if (this.getFocusedMenuItemIndex() !== NO_TYPEAHEAD_MATCH) {
+                    return;
+                }
+
+                this.focusFirstMenuItem(list);
             });
             this.focusObserver.observe(list);
         }, 0);


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

Closes #4194

> [!IMPORTANT]
> **Stacked on #4193.** The base is `fix/4192-select-typeahead`, not `main`, so
> this diff shows only the one new commit. It touches `setMenuFocus`, which
> #4193 rewrites, so basing it on `main` would just conflict. GitHub retargets
> this to `main` automatically once #4193 merges — please merge that first.

## Why

Picking an option in a `multiple` `limel-select` moved keyboard focus back to
the **first** option. Picking several options in a row is the entire point of a
multiple select, so this meant arrowing down from the top of the list again after
every single pick — the 10th and 11th option cost ten arrow presses each.

It predates the typeahead in #4193 and reproduces with arrow keys alone, but it
became obvious once there was a fast way to move the highlight in the first
place.

## The cause

`handleMenuChange` deliberately leaves the dropdown open in `multiple` mode and
emits `change`. The consumer updates `value`, which re-renders `limel-select` and
lands in `componentDidUpdate` → `setMenuFocus` → `focusFirstMenuItem`.

That fallback is correct when the dropdown has just opened — focus is on the
trigger and has to be moved into the list. It is wrong on a re-render while the
dropdown is already open and a row already has focus. The fix is to leave focus
alone in exactly that case.

Single select was never affected: picking there closes the dropdown and returns
focus to the trigger.

## Worth a reviewer's attention

**Why the guard sits inside `setMenuFocus` and not in `componentDidUpdate`.**
Guarding the call site looks tidier, but `focusTypeaheadMatch` also calls
`setMenuFocus`, and there we *do* want focus moved even though a row already has
it. The distinction is not "is a row focused" but "is there a specific row we
want" — so the guard belongs on the `focusFirstMenuItem` fallback, after the
pending typeahead index has had its chance.

**It relies on focus surviving the re-render.** It does: rows are keyed
`item-${index}` in `list-renderer.tsx`, so Stencil patches the existing
`limel-list-item` elements rather than replacing them, and nothing in
`limel-list`'s `itemsChanged` path blurs. If focus ever did get lost, the guard
reads `shadowRoot.activeElement` as `null` and falls through to the old
behavior — so the failure mode is today's behavior, not focus stranded on
`<body>`.

**Not fixed here, deliberately:** opening a select that already has a value
focuses the first row rather than the selected one, because
`focusFirstMenuItem` queries `[tabindex]` and MDC's `layout()` gives *every* row
a `tabindex`. That is a separate pre-existing bug with a separate cause; happy to
file it.

## Verification

- `npm run lint`, `npm run build` — clean
- `npm test` — 1940 passed, 8 skipped
- `npm run test:examples:components` — 11 passed, stable across 3 consecutive
  parallel runs
- New example test `keeps the picked option focused, so the next one is a key
  away`, which fails on the base branch and passes here. It arrows to the third
  option, picks it, asserts focus stayed after the value has landed (so the
  re-render has definitely happened), then arrows on and picks the next one — so
  it covers both halves of the complaint.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such (none here)

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Verification was automated only — Chromium via Playwright, on macOS. Since this
is purely about where focus lands after a re-render, a manual pass in Firefox and
Safari would be worthwhile.

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

Mobile with `multiple` renders the menu dropdown rather than the native
`<select>`, but `setMenuFocus` returns early on mobile, so this path is not
reached there.
