### PR TITLE
build: remove invalid packageManager field to unblock Dependabot

### DIFF
--- a/.github/actions/set-up-node/action.yml
+++ b/.github/actions/set-up-node/action.yml
@@ -26,9 +26,10 @@ runs:
         # npm caching is handled by the install-dependencies action instead,
         # which saves the cache as soon as npm ci succeeds; setup-node's
         # built-in cache only saves when the whole job succeeds (post-if:
-        # success()) and restores on exact lock-file match only. Explicitly
-        # disabled here because package.json has a `packageManager` field,
-        # which would otherwise auto-enable the built-in cache.
+        # success()) and restores on exact lock-file match only.
+        # This input defaults to true, so keep it false as a guard: setup-node
+        # re-enables its cache if package.json regains a `packageManager` or
+        # `devEngines.packageManager` field.
         package-manager-cache: false
     - name: Verify Node.js setup
       shell: bash

--- a/package.json
+++ b/package.json
@@ -139,6 +139,5 @@
   "bugs": {
     "url": "https://github.com/Lundalogik/lime-elements/issues"
   },
-  "homepage": "https://github.com/Lundalogik/lime-elements#readme",
-  "packageManager": "npm@>=10.9"
+  "homepage": "https://github.com/Lundalogik/lime-elements#readme"
 }


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated setup guidance for package-manager caching.
  * Removed package-manager metadata from the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Why

The npm Dependabot updater has opened nothing since 2025-08-25. Thirteen security
alerts sit open, all with a published patch. The `github-actions` updater kept
running the whole time, which points at something npm-specific rather than a
disabled setting. Dependabot security updates are in fact enabled and unpaused.

Commit 78483eb added `"packageManager": "npm@>=10.9"` three days before the npm
PRs stopped. That field takes an exact version, not a range, so the updater
cannot resolve it. Nothing in this repo uses Corepack, and CI reads the Node
version from `.nvmrc`, so the field is removed rather than pinned.

`package-manager-cache: false` in `set-up-node` stays. Its old comment named the
`packageManager` field as the reason it was set. The input defaults to `true`,
so the line is now a guard for the case where `packageManager` or
`devEngines.packageManager` returns to `package.json`. The comment says that
instead.

## Check after merging

Open the [Dependabot updates page](https://github.com/Lundalogik/lime-elements/network/updates)
and confirm the npm updater runs green. Expect several PRs at once: security
updates have their own limit of 10, separate from `open-pull-requests-limit: 4`.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
Not applicable. This changes packaging metadata and a CI comment. The published
components are untouched.

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS