### PR TITLE
fix(text-editor): keep caret position when focus is regained without a click

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -171,6 +171,7 @@ export class ProsemirrorAdapter {
     private changeWaiting = false;
     private transactionFired = false;
     private lastClickedPos: number | null = null;
+    private focusRestoreTimeout: ReturnType<typeof setTimeout> | null = null;
     private metadata: EditorMetadata = { images: [], links: [] };
 
     /**
@@ -324,6 +325,14 @@ export class ProsemirrorAdapter {
     }
 
     public disconnectedCallback() {
+        // The pending caret restoration must not run against a destroyed
+        // editor view. Chromium clears the click position via `blur` when a
+        // focused editor is removed, but that is not guaranteed in every
+        // browser.
+        clearTimeout(this.focusRestoreTimeout);
+        this.focusRestoreTimeout = null;
+        this.lastClickedPos = null;
+
         imageCache.clear();
 
         this.host.removeEventListener(
@@ -688,7 +697,7 @@ export class ProsemirrorAdapter {
             // Focus regained without a click (e.g. switching back to the window)
             // must leave the selection untouched.
             this.transactionFired = false;
-            setTimeout(() => {
+            this.focusRestoreTimeout = setTimeout(() => {
                 const clickedPos = this.lastClickedPos;
                 this.lastClickedPos = null;
                 if (

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -682,11 +682,22 @@ export class ProsemirrorAdapter {
             //
             // To detect this, we wait one tick after focus. If no transaction has fired by then,
             // we assume the selection is unresolved and manually move the cursor to the last clicked position.
+            //
+            // The clicked position is only meaningful for the focus event that the
+            // click itself triggered, so it is consumed here and cleared on blur.
+            // Focus regained without a click (e.g. switching back to the window)
+            // must leave the selection untouched.
             this.transactionFired = false;
             setTimeout(() => {
-                if (!this.transactionFired && this.lastClickedPos) {
+                const clickedPos = this.lastClickedPos;
+                this.lastClickedPos = null;
+                if (
+                    !this.transactionFired &&
+                    clickedPos !== null &&
+                    clickedPos <= this.view.state.doc.content.size
+                ) {
                     const { doc, tr } = this.view.state;
-                    const resolvedPos = doc.resolve(this.lastClickedPos);
+                    const resolvedPos = doc.resolve(clickedPos);
                     const selection = Selection.near(resolvedPos);
                     tr.setMeta('pointer', true);
                     this.view.dispatch(tr.setSelection(selection));
@@ -722,6 +733,7 @@ export class ProsemirrorAdapter {
     }, DEBOUNCE_TIMEOUT);
 
     private handleBlur = () => {
+        this.lastClickedPos = null;
         this.changeEmitter.flush();
     };
 }

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -207,6 +207,7 @@ describe('limel-text-editor', () => {
             };
 
             return {
+                root: root as HTMLLimelTextEditorElement,
                 setProps,
                 editable,
                 mouseDownAtTextOffset,
@@ -248,6 +249,32 @@ describe('limel-text-editor', () => {
 
             typeText('!');
             expect(editable.textContent).toBe('hello!');
+        });
+
+        test('unmounting the editor right after a click-to-focus does not touch the destroyed view', async () => {
+            const { root, editable, mouseDownAtTextOffset } =
+                await createEditor('hello');
+
+            const errors: string[] = [];
+            const onError = (event: ErrorEvent) => {
+                errors.push(event.message);
+            };
+            window.addEventListener('error', onError);
+
+            try {
+                // Click to focus, then remove the editor in the same tick —
+                // like a popover closing on the click that focused it. The
+                // pending focus restoration must not run against the
+                // destroyed editor view.
+                mouseDownAtTextOffset(0);
+                editable.focus();
+                root.remove();
+                await sleep(FOCUS_SETTLE_WAIT);
+
+                expect(errors).toEqual([]);
+            } finally {
+                window.removeEventListener('error', onError);
+            }
         });
 
         test('a click position beyond a shrunken document is ignored on focus', async () => {

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -243,6 +243,11 @@ describe('limel-text-editor', () => {
             const { editable, mouseDownAtTextOffset, typeText } =
                 await createEditor('hello');
 
+            editable.focus();
+            await sleep(FOCUS_SETTLE_WAIT);
+            editable.blur();
+            await sleep(FOCUS_SETTLE_WAIT);
+
             mouseDownAtTextOffset('hello'.length - 1, 'after');
             editable.focus();
             await sleep(FOCUS_SETTLE_WAIT);

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -157,6 +157,131 @@ describe('limel-text-editor', () => {
         expect(adapter.getAttribute('id')).toBe(labelId);
     });
 
+    describe('caret position on focus', () => {
+        // The adapter restores a clicked position one tick after the focus
+        // event; wait comfortably longer before asserting caret behavior.
+        const FOCUS_SETTLE_WAIT = 50;
+
+        const sleep = (ms: number) =>
+            new Promise((resolve) => setTimeout(resolve, ms));
+
+        async function createEditor(value: string) {
+            const { root, waitForChanges, setProps } = await render(
+                <limel-text-editor value={value} />
+            );
+            await waitForChanges();
+
+            const editable = await vi.waitFor(() => {
+                const contentEditable = getAdapter(
+                    root
+                )?.shadowRoot?.querySelector('.ProseMirror') as HTMLElement;
+                expect(contentEditable).toBeTruthy();
+
+                return contentEditable;
+            });
+
+            const mouseDownAtTextOffset = (
+                offset: number,
+                side: 'before' | 'after' = 'before'
+            ) => {
+                const textNode = editable.querySelector('p').firstChild as Text;
+                const range = document.createRange();
+                range.setStart(textNode, offset);
+                range.setEnd(textNode, offset + 1);
+                const rect = range.getBoundingClientRect();
+                const clientX =
+                    side === 'before' ? rect.left + 1 : rect.right - 1;
+                editable.dispatchEvent(
+                    new MouseEvent('mousedown', {
+                        bubbles: true,
+                        composed: true,
+                        button: 0,
+                        clientX,
+                        clientY: rect.top + rect.height / 2,
+                    })
+                );
+            };
+
+            const typeText = (text: string) => {
+                document.execCommand('insertText', false, text);
+            };
+
+            return {
+                setProps,
+                editable,
+                mouseDownAtTextOffset,
+                typeText,
+            };
+        }
+
+        test('regaining focus without a click keeps the caret where typing left it', async () => {
+            const { editable, mouseDownAtTextOffset, typeText } =
+                await createEditor('hello');
+
+            // Click on the first character to focus the editor; the adapter
+            // records the clicked position.
+            mouseDownAtTextOffset(0);
+            editable.focus();
+            await sleep(FOCUS_SETTLE_WAIT);
+
+            typeText('ABC');
+            expect(editable.textContent).toBe('ABChello');
+
+            // Losing and regaining focus without a click (e.g. switching
+            // windows) must not move the caret back to the clicked position.
+            editable.blur();
+            await sleep(FOCUS_SETTLE_WAIT);
+            editable.focus();
+            await sleep(FOCUS_SETTLE_WAIT);
+
+            typeText('!');
+            expect(editable.textContent).toBe('ABC!hello');
+        });
+
+        test('clicking a blurred editor places the caret at the clicked position', async () => {
+            const { editable, mouseDownAtTextOffset, typeText } =
+                await createEditor('hello');
+
+            mouseDownAtTextOffset('hello'.length - 1, 'after');
+            editable.focus();
+            await sleep(FOCUS_SETTLE_WAIT);
+
+            typeText('!');
+            expect(editable.textContent).toBe('hello!');
+        });
+
+        test('a click position beyond a shrunken document is ignored on focus', async () => {
+            const value = 'hello world, hello world';
+            const { setProps, editable, mouseDownAtTextOffset, typeText } =
+                await createEditor(value);
+
+            const errors: string[] = [];
+            const onError = (event: ErrorEvent) => {
+                errors.push(event.message);
+            };
+            window.addEventListener('error', onError);
+
+            try {
+                // Record a click position at the end of the text, then shrink
+                // the document below that position before focus is granted.
+                mouseDownAtTextOffset(value.length - 1, 'after');
+                await setProps({ value: '' });
+                await vi.waitFor(() => {
+                    expect(editable.textContent).toBe('');
+                });
+
+                editable.focus();
+                await sleep(FOCUS_SETTLE_WAIT);
+
+                typeText('!');
+                expect(editable.textContent).toBe('!');
+                expect(errors).toEqual([]);
+            } finally {
+                window.removeEventListener('error', onError);
+            }
+        });
+    });
+
     describe('change event handling', () => {
         // Comfortably longer than the editor's 300 ms change debounce.
         const DEBOUNCE_WAIT = 500;


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text editor focus and blur behavior.
  * Preserved the typing caret when refocusing without a new click.
  * Prevented invalid cursor positions from being restored after document changes.
  * Safely canceled pending caret restoration when the editor is removed.
  * Ensured temporary click-position data is cleared reliably.

* **Tests**
  * Added end-to-end coverage for caret restoration, click placement, editor removal, and document changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Description

Fixes the caret jumping to the position of the last mouse click when the editor regains focus without a click — most visibly when alt-tabbing away from the window and back, where the caret ended up at the beginning of the document instead of where typing left off.

FIxes: Lundalogik/crm-client#927.

### Root cause

`handleFocus` contains a workaround for ProseMirror sometimes not dispatching a selection transaction when a click on the first/last line grants focus: one tick after focus, if no transaction has fired, it forces the selection to `lastClickedPos`. That stored click position persisted indefinitely, so a focus event with no associated click (window refocus, keyboard focus) moved the caret to a stale position.

### Fix

`lastClickedPos` is now only valid for the click→focus handshake it belongs to:

- consumed (read once, then cleared) when the focus workaround runs
- cleared on blur, so it can never survive a focus round-trip
- guarded against positions beyond `doc.content.size`, preventing a `RangeError` when the document shrinks after the click

The workaround still applies for its intended case, since the clicked position is then always fresh from the mousedown that triggered the focus event.

Manually verified: alt-tab away/back keeps the caret where typing left it; click-then-alt-tab no longer re-aims the caret; clicking the first/last line of a blurred editor still places the caret where clicked.

## Manual testing steps

1. **Reported bug:** Type in the editor, alt-tab away to another window and back — the caret should stay where typing left it (not jump to the beginning of the document).
2. **Stale click position:** Click somewhere mid-text, type to add more text, then alt-tab away and back — the caret should stay where you left it (not jump back to the clicked spot).
3. **Original workaround still works:** With a multi-line document and the editor blurred, click directly on the first line and then on the last line — the caret should land where clicked (not fall to the end of the document).
4. **No crash on shrunken document:** Click at the end of a long text, select all + delete, then alt-tab away and back — no console errors (previously a potential `RangeError`).

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
