### PR TITLE
build(package.json): make prosemirror-model override track direct dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "yargs": "^17.7.2"
   },
   "overrides": {
-    "prosemirror-model": ">=1.22.1"
+    "prosemirror-model": "$prosemirror-model"
   },
   "keywords": [
     "lime elements",


### PR DESCRIPTION
Fixes the red Dependabot run: [run 31372098192](https://github.com/Lundalogik/lime-elements/actions/runs/31372098192) / [job log](https://github.com/Lundalogik/lime-elements/network/updates/1516970288).

## The failure

The Dependabot job created its 17 PRs but still went red, because one dependency failed to resolve:

```
Handled error whilst updating prosemirror-model: dependency_file_not_resolvable
{message: "Override for prosemirror-model@1.25.11 conflicts with direct dependency."}
```

Dependabot reports an unresolvable dependency as a job-level error, so this one dependency failed the whole run.

## Root cause

`prosemirror-model` is listed in **both** `devDependencies` and `overrides`, with the spec written out twice:

```json
"devDependencies": { "prosemirror-model": ">=1.22.1" },
"overrides":        { "prosemirror-model": ">=1.22.1" }
```

npm requires a root `overrides` entry for a package that is *also* a direct dependency to match that dependency's spec **exactly**, otherwise it aborts with `EOVERRIDE`. The two specs above matched only because they were hand-written identically when the override was introduced in 55a916c9e9bb9b1e2041ff76a08807dbbc48bba6 (the prosemirror XSS fix, Nov 2024).

When Dependabot ran its update command, npm rewrote the direct dependency spec but left `overrides` untouched. The two diverged, and npm bailed out:

```console
$ npm install prosemirror-model@1.25.11 --package-lock-only --dry-run=true --ignore-scripts
npm error code EOVERRIDE
npm error Override for prosemirror-model@1.25.11 conflicts with direct dependency
```

This was not a one-off — it would have broken *every* future `prosemirror-model` bump.

## The fix

Use npm's [`$<name>` override syntax](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides), which is intended for exactly this case:

```json
"overrides": { "prosemirror-model": "$prosemirror-model" }
```

The override now *references* the direct dependency's spec instead of restating it, so the two can no longer drift apart — whatever version Dependabot bumps it to.

## Verification

- The command that failed in CI now succeeds:

  ```console
  $ npm install prosemirror-model@1.25.11 --package-lock-only --dry-run=true --ignore-scripts
  up to date in 397ms
  ```

- **The override is still enforced** — checked rather than assumed. With the direct dependency pinned to `1.22.1` and `prosemirror-markdown` asking for `^1.25.0`:

  | `overrides` | resulting tree |
  | --- | --- |
  | *(none)* | `prosemirror-model` 1.22.1 **+ a nested** `prosemirror-markdown/node_modules/prosemirror-model` 1.25.11 |
  | `$prosemirror-model` | a single `prosemirror-model` 1.22.1 |

  It still collapses the nested copies that transitive dependants would otherwise pull in, which is what the original XSS fix needed it for.

- `package-lock.json` is byte-identical after `npm install --package-lock-only`, and `npm ci --dry-run` passes — the resolved tree is unchanged, so no lockfile update is needed.

## Why `build` and not `fix`

`overrides` is inert for consumers of the published package — npm only honours it in the root project — so this has no consumer-facing effect and does not warrant a release. `build` is a no-release type under the `conventionalcommits` preset.

## Follow-up

Once this lands, Dependabot's next run should open the `prosemirror-model` PR it has been unable to create, and the run should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
