### PR TITLE
Improve list handling in the text editor

### DIFF
--- a/src/components/text-editor/prosemirror-adapter/editor-commands.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-commands.spec.ts
@@ -6,6 +6,7 @@ import {
     textSelection,
 } from './test/editor-test-harness';
 import './test/editor-doc-matcher';
+import { AllSelection } from 'prosemirror-state';
 import { EditorMenuTypes, editorMenuTypesArray } from './menu/types';
 import { CommandWithActive } from './menu/menu-commands';
 
@@ -213,6 +214,21 @@ describe('menu commands against the real schema', () => {
             expect(next.doc).toEqualDoc(
                 doc(heading({ level: level }, 'title'))
             );
+        });
+
+        it('is a no-op for a select-all spanning multiple blocks', () => {
+            const start = doc(p('one'), p('two'));
+            const state = createEditorTestState(
+                harness,
+                start,
+                new AllSelection(start)
+            );
+            const { state: next, handled } = runCommand(
+                state,
+                harness.factory.getCommand(EditorMenuTypes.HeaderLevel1)
+            );
+            expect(handled).toBe(false);
+            expect(next.doc).toEqualDoc(start);
         });
 
         it('turns a heading back into a paragraph at the same level', () => {

--- a/src/components/text-editor/prosemirror-adapter/editor-commands.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-commands.spec.ts
@@ -175,12 +175,21 @@ describe('menu commands against the real schema', () => {
     });
 
     describe('allowed()', () => {
-        it('is undefined on every command', () => {
+        const listTypes = new Set<EditorMenuTypes>([
+            EditorMenuTypes.BulletList,
+            EditorMenuTypes.OrderedList,
+        ]);
+
+        it('is a function on the list commands and undefined on the rest', () => {
             for (const type of editorMenuTypesArray) {
                 const command = harness.factory.getCommand(
                     type
                 ) as CommandWithActive;
-                expect(command.allowed).toBeUndefined();
+                if (listTypes.has(type)) {
+                    expect(command.allowed).toBeTypeOf('function');
+                } else {
+                    expect(command.allowed).toBeUndefined();
+                }
             }
         });
     });
@@ -369,7 +378,7 @@ describe('menu commands against the real schema', () => {
             expect(next.doc).toEqualDoc(doc(p('item')));
         });
 
-        it('lifts out of a bullet list instead of converting when OrderedList is applied', () => {
+        it('converts the innermost bullet list when OrderedList is applied', () => {
             const start = doc(bulletList(listItem(p('item'))));
             const state = createEditorTestState(
                 harness,
@@ -380,10 +389,10 @@ describe('menu commands against the real schema', () => {
                 state,
                 harness.factory.getCommand(EditorMenuTypes.OrderedList)
             );
-            expect(next.doc).toEqualDoc(doc(p('item')));
+            expect(next.doc).toEqualDoc(doc(orderedList(listItem(p('item')))));
         });
 
-        it('wraps a two-paragraph selection into a single list item', () => {
+        it('wraps a two-paragraph selection as one item per paragraph', () => {
             const start = doc(p('aa'), p('bb'));
             const state = createEditorTestState(
                 harness,
@@ -395,8 +404,126 @@ describe('menu commands against the real schema', () => {
                 harness.factory.getCommand(EditorMenuTypes.BulletList)
             );
             expect(next.doc).toEqualDoc(
-                doc(bulletList(listItem(p('aa'), p('bb'))))
+                doc(bulletList(listItem(p('aa')), listItem(p('bb'))))
             );
+        });
+
+        it('toggle-off on a middle item splits the list around it', () => {
+            const start = doc(
+                bulletList(
+                    listItem(p('one')),
+                    listItem(p('two')),
+                    listItem(p('three'))
+                )
+            );
+            const state = createEditorTestState(
+                harness,
+                start,
+                textSelection(start, 11)
+            );
+            const { state: next } = runCommand(
+                state,
+                harness.factory.getCommand(EditorMenuTypes.BulletList)
+            );
+            expect(next.doc).toEqualDoc(
+                doc(
+                    bulletList(listItem(p('one'))),
+                    p('two'),
+                    bulletList(listItem(p('three')))
+                )
+            );
+        });
+
+        it('toggle-off lifts every item in a range selection', () => {
+            const start = doc(
+                bulletList(
+                    listItem(p('one')),
+                    listItem(p('two')),
+                    listItem(p('three'))
+                )
+            );
+            const state = createEditorTestState(
+                harness,
+                start,
+                textSelection(start, 4, 11)
+            );
+            const { state: next } = runCommand(
+                state,
+                harness.factory.getCommand(EditorMenuTypes.BulletList)
+            );
+            expect(next.doc).toEqualDoc(
+                doc(p('one'), p('two'), bulletList(listItem(p('three'))))
+            );
+        });
+
+        it('converts only the innermost list with a caret in a nested sub-list', () => {
+            const start = doc(
+                bulletList(listItem(p('a'), bulletList(listItem(p('inner')))))
+            );
+            const state = createEditorTestState(
+                harness,
+                start,
+                textSelection(start, 9)
+            );
+            const { state: next } = runCommand(
+                state,
+                harness.factory.getCommand(EditorMenuTypes.OrderedList)
+            );
+            expect(next.doc).toEqualDoc(
+                doc(
+                    bulletList(
+                        listItem(p('a'), orderedList(listItem(p('inner'))))
+                    )
+                )
+            );
+        });
+
+        it('unifies a mixed selection into one list of the target type', () => {
+            const start = doc(p('x'), bulletList(listItem(p('y'))), p('z'));
+            const state = createEditorTestState(
+                harness,
+                start,
+                textSelection(start, 1, 12)
+            );
+            const { state: next } = runCommand(
+                state,
+                harness.factory.getCommand(EditorMenuTypes.OrderedList)
+            );
+            expect(next.doc).toEqualDoc(
+                doc(
+                    orderedList(
+                        listItem(p('x')),
+                        listItem(p('y')),
+                        listItem(p('z'))
+                    )
+                )
+            );
+        });
+
+        it('allowed() is false when the selection contains a non-listable block', () => {
+            const start = doc(heading({ level: 1 }, 'h'), p('t'));
+            const state = createEditorTestState(
+                harness,
+                start,
+                textSelection(start, 1, 5)
+            );
+            const command = harness.factory.getCommand(
+                EditorMenuTypes.BulletList
+            ) as CommandWithActive;
+            expect(command.allowed(state)).toBe(false);
+        });
+
+        it('allowed() is true for a plain paragraph selection', () => {
+            const start = doc(p('aa'), p('bb'));
+            const state = createEditorTestState(
+                harness,
+                start,
+                textSelection(start, 2, 6)
+            );
+            const command = harness.factory.getCommand(
+                EditorMenuTypes.BulletList
+            ) as CommandWithActive;
+            expect(command.allowed(state)).toBe(true);
         });
 
         it('active() reports both list types inside a nested list', () => {

--- a/src/components/text-editor/prosemirror-adapter/editor-config.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-config.ts
@@ -115,7 +115,16 @@ export function buildEditorPlugins(options: EditorPluginsOptions): Plugin[] {
     } = options;
 
     return [
-        ...exampleSetup({ schema: schema, menuBar: false }),
+        // exampleSetup binds Shift-Ctrl-8/9 to a plain wrapInList. On
+        // Windows/Linux those are the same physical keys as our
+        // Mod-Shift-8/7 list commands, and exampleSetup's keymap runs
+        // first, so its bindings are suppressed to let the context-aware
+        // list commands own the shortcuts on every platform.
+        ...exampleSetup({
+            schema: schema,
+            menuBar: false,
+            mapKeys: { 'Shift-Ctrl-8': false, 'Shift-Ctrl-9': false },
+        }),
         keymap(menuCommandFactory.buildKeymap()),
         createTriggerPlugin(triggerCharacters, contentConverter),
         createLinkPlugin(onNewLinkSelection),

--- a/src/components/text-editor/prosemirror-adapter/editor-config.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-config.ts
@@ -13,6 +13,7 @@ import { createImageInserterPlugin } from './plugins/image/inserter';
 import { createImageViewPlugin } from './plugins/image/view';
 import { createMenuStateTrackingPlugin } from './plugins/menu-state-tracking-plugin';
 import { createActionBarInteractionPlugin } from './plugins/menu-action-interaction-plugin';
+import { createListKeyHandlerPlugin } from './plugins/list-key-handler';
 import { createTriggerPlugin } from './plugins/trigger/factory';
 import { getTableNodes, getTableEditingPlugins } from './plugins/table-plugin';
 import { getImageNode } from './plugins/image/node';
@@ -136,6 +137,7 @@ export function buildEditorPlugins(options: EditorPluginsOptions): Plugin[] {
             onActiveItemsChange
         ),
         createActionBarInteractionPlugin(menuCommandFactory),
+        createListKeyHandlerPlugin(schema),
         ...getTableEditingPlugins(contentType === 'html'),
     ];
 }

--- a/src/components/text-editor/prosemirror-adapter/editor-keymap.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-keymap.spec.ts
@@ -13,7 +13,7 @@ const doc = b.doc;
 const p = b.p;
 
 describe('editor keymap', () => {
-    it('the factory keymap has exactly the eight documented bindings', () => {
+    it('the factory keymap has exactly the ten documented bindings', () => {
         const keymap = harness.factory.buildKeymap();
         expect(Object.keys(keymap).sort()).toEqual(
             [
@@ -22,6 +22,8 @@ describe('editor keymap', () => {
                 'Mod-Shift-1',
                 'Mod-Shift-2',
                 'Mod-Shift-3',
+                'Mod-Shift-7',
+                'Mod-Shift-8',
                 'Mod-Shift-C',
                 'Mod-Shift-X',
                 'Mod-`',
@@ -39,6 +41,8 @@ describe('editor keymap', () => {
             ['Mod-Shift-X', EditorMenuTypes.Strikethrough],
             ['Mod-`', EditorMenuTypes.Code],
             ['Mod-Shift-C', EditorMenuTypes.CodeBlock],
+            ['Mod-Shift-7', EditorMenuTypes.OrderedList],
+            ['Mod-Shift-8', EditorMenuTypes.BulletList],
         ];
 
         it.each(bindings)(

--- a/src/components/text-editor/prosemirror-adapter/editor-lists.e2e.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-lists.e2e.ts
@@ -1,0 +1,166 @@
+import { EditorView } from 'prosemirror-view';
+import {
+    createEditorTestHarness,
+    createEditorTestState,
+    mountView,
+    pressKey,
+    textSelection,
+} from './test/editor-test-harness';
+import './test/editor-doc-matcher';
+
+const harness = createEditorTestHarness();
+const b = harness.builders as Record<string, any>;
+const doc = b.doc;
+const p = b.p;
+const bulletList = b.bullet_list;
+const listItem = b.list_item;
+
+describe('list key handling through the real stack', () => {
+    let view: EditorView;
+    let cleanup: (() => void) | undefined;
+
+    afterEach(() => {
+        cleanup?.();
+        cleanup = undefined;
+    });
+
+    const mountDoc = (startDoc: any, caretPos: number) => {
+        ({ view, cleanup } = mountView(
+            createEditorTestState(
+                harness,
+                startDoc,
+                textSelection(startDoc, caretPos)
+            )
+        ));
+    };
+
+    describe('Tab', () => {
+        it('indents an item under its preceding sibling', () => {
+            const start = doc(
+                bulletList(listItem(p('one')), listItem(p('two')))
+            );
+            mountDoc(start, 11);
+
+            pressKey(view, { key: 'Tab', keyCode: 9 });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(
+                    bulletList(
+                        listItem(p('one'), bulletList(listItem(p('two'))))
+                    )
+                )
+            );
+        });
+
+        it('leaves the document unchanged on a first item', () => {
+            const start = doc(
+                bulletList(listItem(p('one')), listItem(p('two')))
+            );
+            mountDoc(start, 4);
+
+            pressKey(view, { key: 'Tab', keyCode: 9 });
+
+            expect(view.state.doc).toEqualDoc(start);
+        });
+    });
+
+    describe('Shift-Tab', () => {
+        it('outdents a nested item one level', () => {
+            const start = doc(
+                bulletList(listItem(p('one'), bulletList(listItem(p('two')))))
+            );
+            mountDoc(start, 11);
+
+            pressKey(view, { key: 'Tab', keyCode: 9, shiftKey: true });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(bulletList(listItem(p('one')), listItem(p('two'))))
+            );
+        });
+
+        it('lifts a top-level item out to a paragraph', () => {
+            const start = doc(
+                bulletList(listItem(p('one')), listItem(p('two')))
+            );
+            mountDoc(start, 11);
+
+            pressKey(view, { key: 'Tab', keyCode: 9, shiftKey: true });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(bulletList(listItem(p('one'))), p('two'))
+            );
+        });
+    });
+
+    describe('Enter', () => {
+        it('splits a non-empty item into a new item', () => {
+            const start = doc(bulletList(listItem(p('one'))));
+            mountDoc(start, 6);
+
+            pressKey(view, { key: 'Enter', keyCode: 13 });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(bulletList(listItem(p('one')), listItem(p())))
+            );
+        });
+
+        it('outdents an empty nested item one level', () => {
+            const start = doc(
+                bulletList(listItem(p('one'), bulletList(listItem(p()))))
+            );
+            mountDoc(start, 10);
+
+            pressKey(view, { key: 'Enter', keyCode: 13 });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(bulletList(listItem(p('one')), listItem(p())))
+            );
+        });
+
+        it('exits the list from an empty top-level item', () => {
+            const start = doc(bulletList(listItem(p('one')), listItem(p())));
+            mountDoc(start, 10);
+
+            pressKey(view, { key: 'Enter', keyCode: 13 });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(bulletList(listItem(p('one'))), p())
+            );
+        });
+    });
+
+    describe('Backspace', () => {
+        it('joins with the previous item at item start', () => {
+            const start = doc(
+                bulletList(listItem(p('one')), listItem(p('two')))
+            );
+            mountDoc(start, 10);
+
+            pressKey(view, { key: 'Backspace', keyCode: 8 });
+
+            const list = view.state.doc.firstChild;
+            expect(list.childCount).toBe(1);
+            expect(list.child(0).textContent).toBe('onetwo');
+        });
+    });
+
+    describe('Mod-Shift-8', () => {
+        it('toggles the item off instead of wrapping it deeper', () => {
+            const start = doc(
+                bulletList(listItem(p('one')), listItem(p('two')))
+            );
+            mountDoc(start, 11);
+
+            pressKey(view, {
+                key: '8',
+                keyCode: 56,
+                mod: true,
+                shiftKey: true,
+            });
+
+            expect(view.state.doc).toEqualDoc(
+                doc(bulletList(listItem(p('one'))), p('two'))
+            );
+        });
+    });
+});

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/active-state-utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/active-state-utils.ts
@@ -1,0 +1,58 @@
+import { MarkType, NodeType } from 'prosemirror-model';
+import { LevelMapping } from '../types';
+import { CommandWithActive } from '../menu-commands';
+
+export const setActiveMethodForMark = (
+    command: CommandWithActive,
+    markType: MarkType
+) => {
+    command.active = (state) => {
+        const { from, $from, to, empty } = state.selection;
+        if (empty) {
+            return !!markType.isInSet(state.storedMarks || $from.marks());
+        }
+
+        return state.doc.rangeHasMark(from, to, markType);
+    };
+};
+
+export const setActiveMethodForNode = (
+    command: CommandWithActive,
+    nodeType: NodeType,
+    level?: number
+) => {
+    command.active = (state) => {
+        const { $from } = state.selection;
+        const node = $from.node($from.depth);
+
+        if (node && node.type.name === nodeType.name) {
+            if (nodeType.name === LevelMapping.Heading && level) {
+                return node.attrs.level === level;
+            }
+
+            return true;
+        }
+
+        return false;
+    };
+};
+
+export const setActiveMethodForWrap = (
+    command: CommandWithActive,
+    nodeType: NodeType
+) => {
+    command.active = (state) => {
+        const { from, to } = state.selection;
+        for (let pos = from; pos <= to; pos++) {
+            const resolvedPos = state.doc.resolve(pos);
+            for (let i = resolvedPos.depth; i > 0; i--) {
+                const node = resolvedPos.node(i);
+                if (node && node.type.name === nodeType.name) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    };
+};

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/active-state-utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/active-state-utils.ts
@@ -43,16 +43,15 @@ export const setActiveMethodForWrap = (
 ) => {
     command.active = (state) => {
         const { from, to } = state.selection;
-        for (let pos = from; pos <= to; pos++) {
-            const resolvedPos = state.doc.resolve(pos);
-            for (let i = resolvedPos.depth; i > 0; i--) {
-                const node = resolvedPos.node(i);
-                if (node && node.type.name === nodeType.name) {
-                    return true;
-                }
+        let found = false;
+        state.doc.nodesBetween(from, to, (node) => {
+            if (node.type === nodeType) {
+                found = true;
             }
-        }
 
-        return false;
+            return !found;
+        });
+
+        return found;
     };
 };

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/list-utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/list-utils.ts
@@ -12,7 +12,8 @@ type Dispatch = (tr: Transaction) => void;
 
 export type ListContext =
     | { kind: 'same-type' | 'other-type'; listDepth: number }
-    | { kind: 'no-list' | 'mixed'; listDepth: null };
+    | { kind: 'no-list'; listDepth: null; singleBlock: boolean }
+    | { kind: 'mixed'; listDepth: null };
 
 const isListNode = (node: Node, schema: Schema): boolean =>
     node.type === schema.nodes.bullet_list ||
@@ -87,7 +88,7 @@ export const resolveListContext = (
     }
 
     if (fromDepth === null && sameTopLevelBlock) {
-        return { kind: 'no-list', listDepth: null };
+        return { kind: 'no-list', listDepth: null, singleBlock: true };
     }
 
     // The range spans multiple top-level blocks: uniform paragraphs mean a
@@ -116,7 +117,7 @@ export const resolveListContext = (
         return { kind: 'mixed', listDepth: null };
     }
 
-    return { kind: 'no-list', listDepth: null };
+    return { kind: 'no-list', listDepth: null, singleBlock: false };
 };
 
 const listContextAt = (

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/list-utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/list-utils.ts
@@ -1,0 +1,382 @@
+import { EditorState, Transaction } from 'prosemirror-state';
+import {
+    Node,
+    NodeRange,
+    NodeType,
+    ResolvedPos,
+    Schema,
+} from 'prosemirror-model';
+import { canSplit, findWrapping } from 'prosemirror-transform';
+
+type Dispatch = (tr: Transaction) => void;
+
+export type ListContext =
+    | { kind: 'same-type' | 'other-type'; listDepth: number }
+    | { kind: 'no-list' | 'mixed'; listDepth: null };
+
+const isListNode = (node: Node, schema: Schema): boolean =>
+    node.type === schema.nodes.bullet_list ||
+    node.type === schema.nodes.ordered_list;
+
+const innermostListDepth = (state: EditorState): number | null => {
+    const { $from } = state.selection;
+    for (let depth = $from.depth; depth > 0; depth--) {
+        if (isListNode($from.node(depth), state.schema)) {
+            return depth;
+        }
+    }
+
+    return null;
+};
+
+/**
+ * Whether the selection touches top-level blocks that cannot become list
+ * items (list_item requires a leading paragraph, so headings, blockquotes,
+ * code blocks and tables are not listable).
+ *
+ * @param state - the current editor state
+ * @returns true when a non-listable block intersects the selection
+ */
+export const selectionHasNonListableBlock = (state: EditorState): boolean => {
+    const { from, to } = state.selection;
+    const { schema } = state;
+    let found = false;
+    state.doc.nodesBetween(from, to, (node, _pos, parent) => {
+        if (found) {
+            return false;
+        }
+
+        const isTopLevelBlock = parent?.type === schema.topNodeType;
+        const listable =
+            node.type === schema.nodes.paragraph ||
+            node.type === schema.nodes.list_item ||
+            isListNode(node, schema);
+        if (isTopLevelBlock && !listable) {
+            found = true;
+
+            return false;
+        }
+
+        return !isTopLevelBlock || isListNode(node, schema);
+    });
+
+    return found;
+};
+
+/**
+ * Classifies the selection for the list command ladder.
+ *
+ * @param state - the current editor state
+ * @param listType - the list type the command targets
+ * @returns the ladder branch to take, plus the innermost list depth when
+ * the selection sits inside a list
+ */
+export const resolveListContext = (
+    state: EditorState,
+    listType: NodeType
+): ListContext => {
+    const { $from, $to } = state.selection;
+    const fromDepth = innermostListDepth(state);
+    const sameTopLevelBlock =
+        state.selection.empty ||
+        $from.sameParent($to) ||
+        $from.node(1) === $to.node(1);
+
+    if (fromDepth !== null && sameTopLevelBlock) {
+        return listContextAt($from, fromDepth, listType);
+    }
+
+    if (fromDepth === null && sameTopLevelBlock) {
+        return { kind: 'no-list', listDepth: null };
+    }
+
+    // The range spans multiple top-level blocks: uniform paragraphs mean a
+    // plain wrap; lists that are all of the target type mean a toggle;
+    // any other list in the mix means unification.
+    const listTypes = new Set<NodeType>();
+    let sawParagraph = false;
+    const startIndex = $from.index(0);
+    const endIndex = Math.min($to.index(0), state.doc.childCount - 1);
+    for (let i = startIndex; i <= endIndex; i++) {
+        const child = state.doc.child(i);
+        if (isListNode(child, state.schema)) {
+            listTypes.add(child.type);
+        } else if (child.type === state.schema.nodes.paragraph) {
+            sawParagraph = true;
+        }
+    }
+
+    const uniformTargetLists =
+        !sawParagraph && listTypes.size === 1 && listTypes.has(listType);
+    if (uniformTargetLists && fromDepth !== null) {
+        return listContextAt($from, fromDepth, listType);
+    }
+
+    if (listTypes.size > 0) {
+        return { kind: 'mixed', listDepth: null };
+    }
+
+    return { kind: 'no-list', listDepth: null };
+};
+
+const listContextAt = (
+    $from: ResolvedPos,
+    listDepth: number,
+    listType: NodeType
+): ListContext => ({
+    kind: $from.node(listDepth).type === listType ? 'same-type' : 'other-type',
+    listDepth: listDepth,
+});
+
+/**
+ * Converts the innermost list around the selection to the target list type.
+ * bullet_list and ordered_list share the list_item+ content model, so the
+ * node can change type in place.
+ *
+ * @param state - the current editor state
+ * @param listDepth - depth of the list node, from resolveListContext
+ * @param targetType - the list type to convert to
+ * @param dispatch - the dispatch function; omit for a dry-run capability check
+ * @returns true when the conversion applies
+ */
+export const convertInnermostList = (
+    state: EditorState,
+    listDepth: number,
+    targetType: NodeType,
+    dispatch?: Dispatch
+): boolean => {
+    const { $from } = state.selection;
+    const pos = $from.before(listDepth);
+    const node = state.doc.nodeAt(pos);
+    if (!node) {
+        return false;
+    }
+
+    if (dispatch) {
+        dispatch(
+            state.tr
+                .setNodeMarkup(
+                    pos,
+                    targetType,
+                    listAttrsFor(targetType, node.attrs, state.schema)
+                )
+                .scrollIntoView()
+        );
+    }
+
+    return true;
+};
+
+const listAttrsFor = (
+    targetType: NodeType,
+    attrs: Record<string, unknown>,
+    schema: Schema
+): Record<string, unknown> => {
+    if (targetType === schema.nodes.ordered_list) {
+        return { ...attrs, order: attrs.order ?? 1 };
+    }
+
+    return {};
+};
+
+const mapKeepBefore = (tr: Transaction, position: number): number =>
+    // ProseMirror's Mapping.map takes (pos, assoc); the unicorn rule
+    // misreads it as Array#map with a `this` argument.
+    // eslint-disable-next-line unicorn/no-array-method-this-argument
+    tr.mapping.map(position, -1);
+
+const wrapRunInList = (
+    tr: Transaction,
+    targetType: NodeType,
+    runStart: number,
+    runEnd: number
+): void => {
+    const $start = tr.doc.resolve(tr.mapping.map(runStart) + 1);
+    const $end = tr.doc.resolve(mapKeepBefore(tr, runEnd) - 1);
+    const range = new NodeRange($start, $end, 0);
+    const wrapping = findWrapping(range, targetType);
+    if (!wrapping) {
+        return;
+    }
+
+    tr.wrap(range, wrapping);
+
+    // tr.wrap puts the whole run inside a single list_item; splitting at
+    // each block boundary gives one item per block, the same shape
+    // wrapInList produces.
+    const listIndex = wrapping.findIndex((entry) => entry.type === targetType);
+    const splitDepth = wrapping.length - (listIndex + 1);
+    let splitPos = range.start + wrapping.length;
+    for (let i = range.startIndex; i < range.endIndex; i++) {
+        if (i > range.startIndex && canSplit(tr.doc, splitPos, splitDepth)) {
+            tr.split(splitPos, splitDepth);
+            splitPos += 2 * splitDepth;
+        }
+
+        splitPos += range.parent.child(i).nodeSize;
+    }
+};
+
+const convertListsAndWrapRuns = (
+    tr: Transaction,
+    state: EditorState,
+    targetType: NodeType,
+    startIndex: number,
+    endIndex: number
+): void => {
+    // Positions computed against the pre-transform doc are mapped through
+    // tr.mapping when applied.
+    const doc = state.doc;
+    let runStart: number | null = null;
+    let runEnd: number | null = null;
+    let pos = 0;
+
+    for (let i = 0; i < doc.childCount; i++) {
+        const child = doc.child(i);
+        const inRange = i >= startIndex && i <= endIndex;
+        const isList = isListNode(child, state.schema);
+
+        if (inRange && child.type === state.schema.nodes.paragraph) {
+            runStart = runStart ?? pos;
+            runEnd = pos + child.nodeSize;
+        } else if (runStart !== null && runEnd !== null) {
+            wrapRunInList(tr, targetType, runStart, runEnd);
+            runStart = null;
+            runEnd = null;
+        }
+
+        if (inRange && isList && child.type !== targetType) {
+            tr.setNodeMarkup(
+                tr.mapping.map(pos),
+                targetType,
+                listAttrsFor(targetType, child.attrs, state.schema)
+            );
+        }
+
+        pos += child.nodeSize;
+    }
+
+    if (runStart !== null && runEnd !== null) {
+        wrapRunInList(tr, targetType, runStart, runEnd);
+    }
+};
+
+const joinAdjacentLists = (
+    tr: Transaction,
+    targetType: NodeType,
+    mappedFrom: number,
+    mappedTo: number
+): void => {
+    // Scan the transformed doc's top-level boundaries back to front, so
+    // earlier join positions stay valid as joins shrink the doc.
+    const boundaries: number[] = [];
+    let boundary = 0;
+    for (let i = 0; i < tr.doc.childCount; i++) {
+        boundary += tr.doc.child(i).nodeSize;
+        boundaries.push(boundary);
+    }
+
+    for (const joinPos of boundaries.reverse()) {
+        if (joinPos <= mappedFrom || joinPos > mappedTo + 1) {
+            continue;
+        }
+
+        joinSameTypeBoundary(tr, targetType, joinPos);
+    }
+};
+
+/**
+ * Turns a mixed top-level selection (paragraphs and lists) into a single
+ * list of the target type: paragraph runs are wrapped, lists are converted
+ * in place, and adjacent same-type lists are joined. Nesting inside
+ * converted lists is preserved.
+ *
+ * @param state - the current editor state
+ * @param targetType - the list type to unify into
+ * @param dispatch - the dispatch function; omit for a dry-run capability check
+ * @returns true when the unification applies
+ */
+export const unifyToList = (
+    state: EditorState,
+    targetType: NodeType,
+    dispatch?: Dispatch
+): boolean => {
+    const { $from, $to } = state.selection;
+    if ($from.depth === 0 || $to.depth === 0) {
+        return false;
+    }
+
+    if (dispatch === undefined) {
+        return true;
+    }
+
+    const tr = state.tr;
+    convertListsAndWrapRuns(
+        tr,
+        state,
+        targetType,
+        $from.index(0),
+        $to.index(0)
+    );
+    joinAdjacentLists(
+        tr,
+        targetType,
+        tr.mapping.map($from.before(1)),
+        mapKeepBefore(tr, $to.after(1))
+    );
+
+    dispatch(tr.scrollIntoView());
+
+    return true;
+};
+
+/**
+ * Wraps a dispatch so that after a list is wrapped around the selection,
+ * adjacent top-level lists of the same type are joined with it.
+ *
+ * @param state - the editor state the wrap command runs on
+ * @param targetType - the list type being wrapped
+ * @param dispatch - the dispatch function; omitted for a dry-run capability check
+ * @returns the wrapped dispatch, or undefined when no dispatch was given
+ */
+export const joinAdjacentListsOnDispatch = (
+    state: EditorState,
+    targetType: NodeType,
+    dispatch?: Dispatch
+): Dispatch | undefined => {
+    if (!dispatch) {
+        return undefined;
+    }
+
+    const { $from, $to } = state.selection;
+
+    return (tr) => {
+        // The new list's outer boundaries: the start maps before the
+        // inserted wrapping, the end maps after it.
+        const start = mapKeepBefore(tr, $from.before(1));
+        const end = tr.mapping.map($to.after(1));
+        // Back to front, so the earlier boundary stays valid after a join.
+        joinSameTypeBoundary(tr, targetType, end);
+        joinSameTypeBoundary(tr, targetType, start);
+
+        dispatch(tr);
+    };
+};
+
+const joinSameTypeBoundary = (
+    tr: Transaction,
+    targetType: NodeType,
+    boundary: number
+): void => {
+    if (boundary <= 0 || boundary >= tr.doc.content.size) {
+        return;
+    }
+
+    const $boundary = tr.doc.resolve(boundary);
+    if (
+        $boundary.nodeBefore?.type === targetType &&
+        $boundary.nodeAfter?.type === targetType
+    ) {
+        tr.join(boundary);
+    }
+};

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/list-utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/list-utils.ts
@@ -15,21 +15,6 @@ export type ListContext =
     | { kind: 'no-list'; listDepth: null; singleBlock: boolean }
     | { kind: 'mixed'; listDepth: null };
 
-const isListNode = (node: Node, schema: Schema): boolean =>
-    node.type === schema.nodes.bullet_list ||
-    node.type === schema.nodes.ordered_list;
-
-const innermostListDepth = (state: EditorState): number | null => {
-    const { $from } = state.selection;
-    for (let depth = $from.depth; depth > 0; depth--) {
-        if (isListNode($from.node(depth), state.schema)) {
-            return depth;
-        }
-    }
-
-    return null;
-};
-
 /**
  * Whether the selection touches top-level blocks that cannot become list
  * items (list_item requires a leading paragraph, so headings, blockquotes,
@@ -120,15 +105,6 @@ export const resolveListContext = (
     return { kind: 'no-list', listDepth: null, singleBlock: false };
 };
 
-const listContextAt = (
-    $from: ResolvedPos,
-    listDepth: number,
-    listType: NodeType
-): ListContext => ({
-    kind: $from.node(listDepth).type === listType ? 'same-type' : 'other-type',
-    listDepth: listDepth,
-});
-
 /**
  * Converts the innermost list around the selection to the target list type.
  * bullet_list and ordered_list share the list_item+ content model, so the
@@ -168,6 +144,126 @@ export const convertInnermostList = (
     return true;
 };
 
+/**
+ * Turns a mixed top-level selection (paragraphs and lists) into a single
+ * list of the target type: paragraph runs are wrapped, lists are converted
+ * in place, and adjacent same-type lists are joined. Nesting inside
+ * converted lists is preserved.
+ *
+ * @param state - the current editor state
+ * @param targetType - the list type to unify into
+ * @param dispatch - the dispatch function; omit for a dry-run capability check
+ * @returns true when the unification applies
+ */
+export const unifyToList = (
+    state: EditorState,
+    targetType: NodeType,
+    dispatch?: Dispatch
+): boolean => {
+    const { $from, $to } = state.selection;
+    if ($from.depth === 0 || $to.depth === 0) {
+        return false;
+    }
+
+    if (dispatch === undefined) {
+        return true;
+    }
+
+    const tr = state.tr;
+    convertListsAndWrapRuns(
+        tr,
+        state,
+        targetType,
+        $from.index(0),
+        $to.index(0)
+    );
+    joinAdjacentLists(
+        tr,
+        targetType,
+        tr.mapping.map($from.before(1)),
+        mapKeepBefore(tr, $to.after(1))
+    );
+
+    dispatch(tr.scrollIntoView());
+
+    return true;
+};
+
+/**
+ * Wraps a dispatch so that after a list is wrapped around the selection,
+ * adjacent top-level lists of the same type are joined with it.
+ *
+ * @param state - the editor state the wrap command runs on
+ * @param targetType - the list type being wrapped
+ * @param dispatch - the dispatch function; omitted for a dry-run capability check
+ * @returns the wrapped dispatch, or undefined when no dispatch was given
+ */
+export const joinAdjacentListsOnDispatch = (
+    state: EditorState,
+    targetType: NodeType,
+    dispatch?: Dispatch
+): Dispatch | undefined => {
+    if (!dispatch) {
+        return undefined;
+    }
+
+    const { $from, $to } = state.selection;
+
+    return (tr) => {
+        // The new list's outer boundaries: the start maps before the
+        // inserted wrapping, the end maps after it.
+        const start = mapKeepBefore(tr, $from.before(1));
+        const end = tr.mapping.map($to.after(1));
+        // Back to front, so the earlier boundary stays valid after a join.
+        joinSameTypeBoundary(tr, targetType, end);
+        joinSameTypeBoundary(tr, targetType, start);
+
+        dispatch(tr);
+    };
+};
+
+const joinSameTypeBoundary = (
+    tr: Transaction,
+    targetType: NodeType,
+    boundary: number
+): void => {
+    if (boundary <= 0 || boundary >= tr.doc.content.size) {
+        return;
+    }
+
+    const $boundary = tr.doc.resolve(boundary);
+    if (
+        $boundary.nodeBefore?.type === targetType &&
+        $boundary.nodeAfter?.type === targetType
+    ) {
+        tr.join(boundary);
+    }
+};
+
+const isListNode = (node: Node, schema: Schema): boolean =>
+    node.type === schema.nodes.bullet_list ||
+    node.type === schema.nodes.ordered_list;
+
+const innermostListDepth = (state: EditorState): number | null => {
+    const { $from } = state.selection;
+    for (let depth = $from.depth; depth > 0; depth--) {
+        if (isListNode($from.node(depth), state.schema)) {
+            return depth;
+        }
+    }
+
+    return null;
+};
+
+const listContextAt = (
+    $from: ResolvedPos,
+    listDepth: number,
+    listType: NodeType
+): ListContext => ({
+    kind: $from.node(listDepth).type === listType ? 'same-type' : 'other-type',
+    listDepth: listDepth,
+});
+
 const listAttrsFor = (
     targetType: NodeType,
     attrs: Record<string, unknown>,
@@ -177,7 +273,9 @@ const listAttrsFor = (
         return { ...attrs, order: attrs.order ?? 1 };
     }
 
-    return {};
+    const { order, ...withoutOrder } = attrs;
+
+    return withoutOrder;
 };
 
 const mapKeepBefore = (tr: Transaction, position: number): number =>
@@ -277,107 +375,12 @@ const joinAdjacentLists = (
         boundaries.push(boundary);
     }
 
-    for (const joinPos of boundaries.reverse()) {
+    for (let i = boundaries.length - 1; i >= 0; i--) {
+        const joinPos = boundaries[i];
         if (joinPos <= mappedFrom || joinPos > mappedTo + 1) {
             continue;
         }
 
         joinSameTypeBoundary(tr, targetType, joinPos);
-    }
-};
-
-/**
- * Turns a mixed top-level selection (paragraphs and lists) into a single
- * list of the target type: paragraph runs are wrapped, lists are converted
- * in place, and adjacent same-type lists are joined. Nesting inside
- * converted lists is preserved.
- *
- * @param state - the current editor state
- * @param targetType - the list type to unify into
- * @param dispatch - the dispatch function; omit for a dry-run capability check
- * @returns true when the unification applies
- */
-export const unifyToList = (
-    state: EditorState,
-    targetType: NodeType,
-    dispatch?: Dispatch
-): boolean => {
-    const { $from, $to } = state.selection;
-    if ($from.depth === 0 || $to.depth === 0) {
-        return false;
-    }
-
-    if (dispatch === undefined) {
-        return true;
-    }
-
-    const tr = state.tr;
-    convertListsAndWrapRuns(
-        tr,
-        state,
-        targetType,
-        $from.index(0),
-        $to.index(0)
-    );
-    joinAdjacentLists(
-        tr,
-        targetType,
-        tr.mapping.map($from.before(1)),
-        mapKeepBefore(tr, $to.after(1))
-    );
-
-    dispatch(tr.scrollIntoView());
-
-    return true;
-};
-
-/**
- * Wraps a dispatch so that after a list is wrapped around the selection,
- * adjacent top-level lists of the same type are joined with it.
- *
- * @param state - the editor state the wrap command runs on
- * @param targetType - the list type being wrapped
- * @param dispatch - the dispatch function; omitted for a dry-run capability check
- * @returns the wrapped dispatch, or undefined when no dispatch was given
- */
-export const joinAdjacentListsOnDispatch = (
-    state: EditorState,
-    targetType: NodeType,
-    dispatch?: Dispatch
-): Dispatch | undefined => {
-    if (!dispatch) {
-        return undefined;
-    }
-
-    const { $from, $to } = state.selection;
-
-    return (tr) => {
-        // The new list's outer boundaries: the start maps before the
-        // inserted wrapping, the end maps after it.
-        const start = mapKeepBefore(tr, $from.before(1));
-        const end = tr.mapping.map($to.after(1));
-        // Back to front, so the earlier boundary stays valid after a join.
-        joinSameTypeBoundary(tr, targetType, end);
-        joinSameTypeBoundary(tr, targetType, start);
-
-        dispatch(tr);
-    };
-};
-
-const joinSameTypeBoundary = (
-    tr: Transaction,
-    targetType: NodeType,
-    boundary: number
-): void => {
-    if (boundary <= 0 || boundary >= tr.doc.content.size) {
-        return;
-    }
-
-    const $boundary = tr.doc.resolve(boundary);
-    if (
-        $boundary.nodeBefore?.type === targetType &&
-        $boundary.nodeAfter?.type === targetType
-    ) {
-        tr.join(boundary);
     }
 };

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/node-utils.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-command-utils/node-utils.ts
@@ -1,0 +1,21 @@
+import { ResolvedPos, NodeType } from 'prosemirror-model';
+
+/**
+ * Finds the depth of the nearest ancestor of a given node type.
+ *
+ * @param $pos - The resolved position in the document.
+ * @param type - The node type to search for.
+ * @returns The depth at which the node is found, or null if not found.
+ */
+export const findAncestorDepthOfType = (
+    $pos: ResolvedPos,
+    type: NodeType
+): number | null => {
+    for (let depth = $pos.depth; depth > 0; depth--) {
+        if ($pos.node(depth).type === type) {
+            return depth;
+        }
+    }
+
+    return null;
+};

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -1,7 +1,12 @@
 import { toggleMark, setBlockType, wrapIn, lift } from 'prosemirror-commands';
 import { Schema, MarkType, NodeType, Attrs } from 'prosemirror-model';
 import { wrapInList, liftListItem } from 'prosemirror-schema-list';
-import { Command, EditorState, TextSelection } from 'prosemirror-state';
+import {
+    AllSelection,
+    Command,
+    EditorState,
+    TextSelection,
+} from 'prosemirror-state';
 import { EditorMenuTypes, EditorTextLink, LevelMapping } from './types';
 import { getLinkAttributes } from '../plugins/link/utils';
 import {
@@ -202,6 +207,30 @@ const createWrapInCommand = (
     return command;
 };
 
+// Select-all produces an AllSelection, whose endpoints resolve at the
+// document level where list commands cannot operate. Re-anchoring it as
+// a TextSelection over the same content lets the list ladder (and the
+// delegated prosemirror-schema-list commands) treat select-all like any
+// other full-content selection.
+const withTextSelection = (state: EditorState): EditorState => {
+    if (!(state.selection instanceof AllSelection)) {
+        return state;
+    }
+
+    const selection = TextSelection.between(
+        state.doc.resolve(0),
+        state.doc.resolve(state.doc.content.size)
+    );
+
+    // A plugin-free scratch state on the shared doc: only feed it
+    // commands driven by doc and selection.
+    return EditorState.create({
+        doc: state.doc,
+        selection: selection,
+        storedMarks: state.storedMarks,
+    });
+};
+
 /**
  * Creates a command for toggling list types.
  *
@@ -218,11 +247,24 @@ export const createListCommand = (
         throw new Error(`List type "${listTypeName}" not found in schema`);
     }
 
+    const itemType = schema.nodes.list_item;
+    if (!itemType) {
+        throw new Error('Node type "list_item" not found in schema');
+    }
+
+    // The keymap invokes the command directly, so the command body applies
+    // the same applicability rules as `allowed` to keep keyboard and
+    // toolbar behavior identical.
     const command: CommandWithActive = (state, dispatch) => {
+        state = withTextSelection(state);
+        if (!(state.selection instanceof TextSelection)) {
+            return false;
+        }
+
         const context = resolveListContext(state, type);
 
         if (context.kind === 'same-type') {
-            return liftListItem(schema.nodes.list_item)(state, dispatch);
+            return liftListItem(itemType)(state, dispatch);
         }
 
         if (context.kind === 'other-type') {
@@ -235,18 +277,42 @@ export const createListCommand = (
         }
 
         if (context.kind === 'no-list') {
+            // For a single block the schema decides, through the wrap
+            // command itself; multi-block selections keep the stricter
+            // gate so unify cannot half-apply.
+            if (!context.singleBlock && selectionHasNonListableBlock(state)) {
+                return false;
+            }
+
             return wrapInList(type)(
                 state,
                 joinAdjacentListsOnDispatch(state, type, dispatch)
             );
         }
 
+        if (selectionHasNonListableBlock(state)) {
+            return false;
+        }
+
         return unifyToList(state, type, dispatch);
     };
 
     command.allowed = (state) => {
+        state = withTextSelection(state);
         if (!(state.selection instanceof TextSelection)) {
             return false;
+        }
+
+        const context = resolveListContext(state, type);
+
+        // Inside a list, toggling or converting is always applicable, even
+        // when a non-listable ancestor wraps the list.
+        if (context.kind === 'same-type' || context.kind === 'other-type') {
+            return true;
+        }
+
+        if (context.kind === 'no-list' && context.singleBlock) {
+            return wrapInList(type)(state);
         }
 
         return !selectionHasNonListableBlock(state);

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -252,24 +252,7 @@ export const createListCommand = (
         return !selectionHasNonListableBlock(state);
     };
 
-    command.active = (state) => {
-        let isActive = false;
-        state.doc.nodesBetween(
-            state.selection.from,
-            state.selection.to,
-            (node) => {
-                if (node.type === type) {
-                    isActive = true;
-
-                    return false;
-                }
-
-                return true;
-            }
-        );
-
-        return isActive;
-    };
+    setActiveMethodForWrap(command, type);
 
     return command;
 };

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -127,14 +127,15 @@ const toggleNodeType = (
     return (state, dispatch) => {
         const { $from, $to } = state.selection;
 
-        const hasActiveWrap = $from.node($from.depth - 1).type === nodeType;
-
         if (
             state.selection instanceof TextSelection &&
             // Ensure selection is within the same parent block
             // We don't want toggling block types across multiple blocks
             $from.sameParent($from.doc.resolve($to.pos))
         ) {
+            // Resolved only under the TextSelection guard: an AllSelection
+            // resolves at depth 0, where there is no parent node to read.
+            const hasActiveWrap = $from.node($from.depth - 1).type === nodeType;
             if ($from.parent.type === nodeType) {
                 if (dispatch) {
                     dispatch(

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-commands.ts
@@ -1,9 +1,21 @@
 import { toggleMark, setBlockType, wrapIn, lift } from 'prosemirror-commands';
 import { Schema, MarkType, NodeType, Attrs } from 'prosemirror-model';
-import { findWrapping, liftTarget } from 'prosemirror-transform';
+import { wrapInList, liftListItem } from 'prosemirror-schema-list';
 import { Command, EditorState, TextSelection } from 'prosemirror-state';
 import { EditorMenuTypes, EditorTextLink, LevelMapping } from './types';
 import { getLinkAttributes } from '../plugins/link/utils';
+import {
+    setActiveMethodForMark,
+    setActiveMethodForNode,
+    setActiveMethodForWrap,
+} from './menu-command-utils/active-state-utils';
+import {
+    resolveListContext,
+    convertInnermostList,
+    joinAdjacentListsOnDispatch,
+    selectionHasNonListableBlock,
+    unifyToList,
+} from './menu-command-utils/list-utils';
 
 type CommandFunction = (
     schema: Schema,
@@ -19,62 +31,6 @@ export interface CommandWithActive extends Command {
     active?: (state: EditorState) => boolean;
     allowed?: (state: EditorState) => boolean;
 }
-
-const setActiveMethodForMark = (
-    command: CommandWithActive,
-    markType: MarkType
-) => {
-    command.active = (state) => {
-        const { from, $from, to, empty } = state.selection;
-        if (empty) {
-            return !!markType.isInSet(state.storedMarks || $from.marks());
-        } else {
-            return state.doc.rangeHasMark(from, to, markType);
-        }
-    };
-};
-
-const setActiveMethodForNode = (
-    command: CommandWithActive,
-    nodeType: NodeType,
-    level?: number
-) => {
-    command.active = (state) => {
-        const { $from } = state.selection;
-        const node = $from.node($from.depth);
-
-        if (node && node.type.name === nodeType.name) {
-            if (nodeType.name === LevelMapping.Heading && level) {
-                return node.attrs.level === level;
-            }
-
-            return true;
-        }
-
-        return false;
-    };
-};
-
-const setActiveMethodForWrap = (
-    command: CommandWithActive,
-    nodeType: NodeType
-) => {
-    command.active = (state) => {
-        const { from, to } = state.selection;
-
-        for (let pos = from; pos <= to; pos++) {
-            const resolvedPos = state.doc.resolve(pos);
-            for (let i = resolvedPos.depth; i > 0; i--) {
-                const node = resolvedPos.node(i);
-                if (node && node.type.name === nodeType.name) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    };
-};
 
 const createInsertLinkCommand: CommandFunction = (
     schema: Schema,
@@ -246,51 +202,74 @@ const createWrapInCommand = (
     return command;
 };
 
-const toggleList = (listType) => {
-    return (state, dispatch) => {
-        const { $from, $to } = state.selection;
-        const range = $from.blockRange($to);
+/**
+ * Creates a command for toggling list types.
+ *
+ * @param schema - The ProseMirror schema.
+ * @param listTypeName - The name of the list type to toggle.
+ * @returns A command for toggling list types.
+ */
+export const createListCommand = (
+    schema: Schema,
+    listTypeName: string
+): CommandWithActive => {
+    const type = schema.nodes[listTypeName];
+    if (!type) {
+        throw new Error(`List type "${listTypeName}" not found in schema`);
+    }
 
-        if (!range) {
+    const command: CommandWithActive = (state, dispatch) => {
+        const context = resolveListContext(state, type);
+
+        if (context.kind === 'same-type') {
+            return liftListItem(schema.nodes.list_item)(state, dispatch);
+        }
+
+        if (context.kind === 'other-type') {
+            return convertInnermostList(
+                state,
+                context.listDepth,
+                type,
+                dispatch
+            );
+        }
+
+        if (context.kind === 'no-list') {
+            return wrapInList(type)(
+                state,
+                joinAdjacentListsOnDispatch(state, type, dispatch)
+            );
+        }
+
+        return unifyToList(state, type, dispatch);
+    };
+
+    command.allowed = (state) => {
+        if (!(state.selection instanceof TextSelection)) {
             return false;
         }
 
-        const wrapping = range && findWrapping(range, listType);
+        return !selectionHasNonListableBlock(state);
+    };
 
-        if (wrapping) {
-            // Wrap the selection in a list
-            if (dispatch) {
-                dispatch(state.tr.wrap(range, wrapping).scrollIntoView());
-            }
+    command.active = (state) => {
+        let isActive = false;
+        state.doc.nodesBetween(
+            state.selection.from,
+            state.selection.to,
+            (node) => {
+                if (node.type === type) {
+                    isActive = true;
 
-            return true;
-        } else {
-            // Check if we are in a list item and lift out of the list
-            const liftRange = range && liftTarget(range);
-            if (liftRange !== null) {
-                if (dispatch) {
-                    dispatch(state.tr.lift(range, liftRange).scrollIntoView());
+                    return false;
                 }
 
                 return true;
             }
+        );
 
-            return false;
-        }
+        return isActive;
     };
-};
-
-const createListCommand = (
-    schema: Schema,
-    listType: string
-): CommandWithActive => {
-    const type: NodeType | undefined = schema.nodes[listType];
-    if (!type) {
-        throw new Error(`List type "${listType}" not found in schema`);
-    }
-
-    const command: CommandWithActive = toggleList(type);
-    setActiveMethodForWrap(command, type);
 
     return command;
 };
@@ -354,6 +333,8 @@ export class MenuCommandFactory {
             'Mod-Shift-1': this.getCommand(EditorMenuTypes.HeaderLevel1),
             'Mod-Shift-2': this.getCommand(EditorMenuTypes.HeaderLevel2),
             'Mod-Shift-3': this.getCommand(EditorMenuTypes.HeaderLevel3),
+            'Mod-Shift-7': this.getCommand(EditorMenuTypes.OrderedList),
+            'Mod-Shift-8': this.getCommand(EditorMenuTypes.BulletList),
             'Mod-Shift-X': this.getCommand(EditorMenuTypes.Strikethrough),
             'Mod-`': this.getCommand(EditorMenuTypes.Code),
             'Mod-Shift-C': this.getCommand(EditorMenuTypes.CodeBlock),

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-list-commands.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-list-commands.spec.ts
@@ -1,0 +1,741 @@
+import { vi, type Mock } from 'vitest';
+import { Node, Schema } from 'prosemirror-model';
+import { AllSelection, EditorState, TextSelection } from 'prosemirror-state';
+import { createListCommand } from './menu-commands';
+import { EditorMenuTypes } from './types';
+
+describe('List Commands', () => {
+    let schema: Schema;
+    let state: EditorState;
+    let dispatch: Mock;
+
+    // Helper functions
+    const createParagraph = (text: string) =>
+        schema.nodes.paragraph.create(null, schema.text(text));
+
+    const createParagraphs = (texts: string[]) => {
+        let tr = state.tr;
+        for (const [i, text] of texts.entries()) {
+            const paragraph = createParagraph(text);
+            if (i === 0) {
+                tr = tr.replaceWith(0, state.doc.content.size, paragraph);
+            } else {
+                tr = tr.insert(tr.doc.content.size, paragraph);
+            }
+        }
+
+        return tr;
+    };
+
+    const selectAll = () => {
+        const $from = state.doc.resolve(1); // Start after doc node
+        const $to = state.doc.resolve(state.doc.content.size - 1); // End before doc node
+
+        const selTr = state.tr.setSelection(
+            TextSelection.create(state.doc, $from.pos, $to.pos)
+        );
+
+        state = state.apply(selTr);
+    };
+
+    const verifyListStructure = (
+        listType: string,
+        expectedItems: string[],
+        expectedCount: number = expectedItems.length
+    ) => {
+        expect(state.doc.firstChild.type.name).toBe(listType);
+        expect(state.doc.firstChild.childCount).toBe(expectedCount);
+
+        for (let i = 0; i < state.doc.firstChild.childCount; i++) {
+            const item = state.doc.firstChild.child(i);
+            expect(item.type.name).toBe('list_item');
+            expect(item.firstChild.textContent).toBe(expectedItems[i]);
+        }
+    };
+
+    beforeEach(() => {
+        schema = new Schema({
+            nodes: {
+                doc: {
+                    content: 'block+',
+                    toDOM: () => ['div', 0],
+                },
+                paragraph: {
+                    group: 'block',
+                    content: 'inline*',
+                    toDOM: () => ['p', 0],
+                },
+                bullet_list: {
+                    group: 'block',
+                    content: 'list_item+',
+                    toDOM: () => ['ul', 0],
+                },
+                ordered_list: {
+                    group: 'block',
+                    content: 'list_item+',
+                    toDOM: () => ['ol', 0],
+                },
+                list_item: {
+                    content: 'paragraph block*',
+                    toDOM: () => ['li', 0],
+                },
+                text: {
+                    group: 'inline',
+                    toDOM: () => ['span', 0],
+                },
+                heading: {
+                    group: 'block',
+                    content: 'inline*',
+                    attrs: { level: { default: 1 } },
+                    toDOM: (node) => [`h${node.attrs.level}`, 0],
+                },
+                blockquote: {
+                    group: 'block',
+                    content: 'block+',
+                    toDOM: () => ['blockquote', 0],
+                },
+            },
+            marks: {},
+        });
+
+        state = EditorState.create({
+            schema: schema,
+            doc: schema.topNodeType.createAndFill(),
+        });
+        dispatch = vi.fn((tr) => {
+            state = state.apply(tr);
+        });
+    });
+
+    describe('basic list operations', () => {
+        it.each([
+            [EditorMenuTypes.BulletList, EditorMenuTypes.BulletList],
+            [EditorMenuTypes.OrderedList, EditorMenuTypes.OrderedList],
+        ])('converts paragraph to %s', (menuType, listType) => {
+            const command = createListCommand(schema, menuType);
+
+            state = state.apply(createParagraphs(['Test text']));
+            command(state, dispatch);
+
+            verifyListStructure(listType, ['Test text'], 1);
+        });
+
+        it('toggles between bullet and ordered list with single paragraph', () => {
+            const bulletCommand = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            const orderedCommand = createListCommand(
+                schema,
+                EditorMenuTypes.OrderedList
+            );
+
+            state = state.apply(createParagraphs(['Test text']));
+
+            // Convert to bullet list
+            bulletCommand(state, dispatch);
+            expect(state.doc.firstChild.type.name).toBe(
+                EditorMenuTypes.BulletList
+            );
+
+            // Convert to ordered list
+            orderedCommand(state, dispatch);
+            expect(state.doc.firstChild.type.name).toBe(
+                EditorMenuTypes.OrderedList
+            );
+        });
+
+        it('toggles between bullet and ordered list with multiple paragraphs', () => {
+            const bulletCommand = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            const orderedCommand = createListCommand(
+                schema,
+                EditorMenuTypes.OrderedList
+            );
+
+            const expectedItems = ['First item', 'Second item', 'Third item'];
+            state = state.apply(createParagraphs(expectedItems));
+            selectAll();
+
+            // Convert to bullet list
+            bulletCommand(state, dispatch);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, expectedItems);
+
+            // Convert to ordered list
+            orderedCommand(state, dispatch);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.OrderedList, expectedItems);
+        });
+
+        it('toggles list off back to paragraph', () => {
+            // Create bullet list
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            state = state.apply(createParagraphs(['Test text']));
+
+            // Convert to bullet list
+            command(state, dispatch);
+            expect(state.doc.firstChild.type.name).toBe(
+                EditorMenuTypes.BulletList
+            );
+
+            // Toggle it off
+            command(state, dispatch);
+            expect(state.doc.firstChild.type.name).toBe('paragraph');
+            expect(state.doc.firstChild.textContent).toBe('Test text');
+        });
+    });
+
+    describe('multiple line selection', () => {
+        const TEST_LINES = ['First line', 'Second line', 'Third line'];
+
+        beforeEach(() => {
+            // Setup multiple paragraphs
+            const tr = createParagraphs(TEST_LINES);
+            state = state.apply(tr);
+        });
+
+        it('converts multiple paragraphs to list items', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            // Select all content
+            selectAll();
+
+            command(state, dispatch);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, TEST_LINES);
+        });
+
+        it('preserves existing list items when converting mixed selection', () => {
+            const bulletCommand = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            const orderedCommand = createListCommand(
+                schema,
+                EditorMenuTypes.OrderedList
+            );
+
+            // Select all content
+            selectAll();
+
+            // Convert to bullet list first
+            bulletCommand(state, dispatch);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, TEST_LINES);
+
+            // Convert to ordered list
+            orderedCommand(state, dispatch);
+
+            verifyListStructure(EditorMenuTypes.OrderedList, TEST_LINES);
+        });
+    });
+
+    describe('selection spanning multiple lists', () => {
+        const listItem = (...children: Node[]) =>
+            schema.nodes.list_item.create(null, children);
+
+        const selectAcrossLists = (first: Node, second: Node) => {
+            const doc = schema.nodes.doc.create(null, [first, second]);
+            state = EditorState.create({
+                schema: schema,
+                doc: doc,
+                selection: TextSelection.create(doc, 4, doc.content.size - 4),
+            });
+        };
+
+        it('unifies two lists of different types into the target type', () => {
+            selectAcrossLists(
+                schema.nodes.bullet_list.create(null, [
+                    listItem(createParagraph('one')),
+                ]),
+                schema.nodes.ordered_list.create(null, [
+                    listItem(createParagraph('two')),
+                ])
+            );
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.OrderedList
+            );
+
+            expect(command(state, dispatch)).toBe(true);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.OrderedList, ['one', 'two']);
+        });
+
+        it('unifies into the type of the first list as well', () => {
+            selectAcrossLists(
+                schema.nodes.bullet_list.create(null, [
+                    listItem(createParagraph('one')),
+                ]),
+                schema.nodes.ordered_list.create(null, [
+                    listItem(createParagraph('two')),
+                ])
+            );
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            expect(command(state, dispatch)).toBe(true);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, ['one', 'two']);
+        });
+
+        it('wraps each paragraph in its own item when unifying with a list', () => {
+            const doc = schema.nodes.doc.create(null, [
+                createParagraph('one'),
+                createParagraph('two'),
+                schema.nodes.ordered_list.create(null, [
+                    listItem(createParagraph('alpha')),
+                ]),
+            ]);
+            state = EditorState.create({
+                schema: schema,
+                doc: doc,
+                selection: TextSelection.create(doc, 1, doc.content.size - 4),
+            });
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            expect(command(state, dispatch)).toBe(true);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, [
+                'one',
+                'two',
+                'alpha',
+            ]);
+        });
+
+        it('preserves nested sublists when unifying', () => {
+            selectAcrossLists(
+                schema.nodes.bullet_list.create(null, [
+                    listItem(
+                        createParagraph('one'),
+                        schema.nodes.bullet_list.create(null, [
+                            listItem(createParagraph('nested')),
+                        ])
+                    ),
+                ]),
+                schema.nodes.ordered_list.create(null, [
+                    listItem(createParagraph('two')),
+                ])
+            );
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.OrderedList
+            );
+
+            expect(command(state, dispatch)).toBe(true);
+
+            expect(state.doc.childCount).toBe(1);
+            const list = state.doc.firstChild;
+            expect(list.type.name).toBe(EditorMenuTypes.OrderedList);
+            expect(list.childCount).toBe(2);
+
+            const sublist = list.child(0).child(1);
+            expect(sublist.type.name).toBe(EditorMenuTypes.BulletList);
+        });
+    });
+
+    describe('select-all selections', () => {
+        const applyAllSelection = () => {
+            state = state.apply(
+                state.tr.setSelection(new AllSelection(state.doc))
+            );
+        };
+
+        it('wraps every paragraph in its own item', () => {
+            state = state.apply(createParagraphs(['one', 'two']));
+            applyAllSelection();
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            expect(command.allowed(state)).toBe(true);
+            expect(command(state, dispatch)).toBe(true);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, ['one', 'two']);
+        });
+
+        it('toggles a fully selected list off', () => {
+            const doc = schema.nodes.doc.create(
+                null,
+                schema.nodes.bullet_list.create(null, [
+                    schema.nodes.list_item.create(null, createParagraph('one')),
+                    schema.nodes.list_item.create(null, createParagraph('two')),
+                ])
+            );
+            state = EditorState.create({ schema: schema, doc: doc });
+            applyAllSelection();
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            expect(command.allowed(state)).toBe(true);
+            expect(command(state, dispatch)).toBe(true);
+
+            expect(state.doc.childCount).toBe(2);
+            expect(state.doc.child(0).type.name).toBe('paragraph');
+            expect(state.doc.child(1).type.name).toBe('paragraph');
+        });
+    });
+
+    describe('toggle inside an existing list', () => {
+        it('lifts the selected item out of the list', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+
+            // Create initial content as separate paragraphs.
+            state = state.apply(createParagraphs(['Parent', 'Child']));
+
+            // Convert both paragraphs to a list
+            selectAll();
+            command(state, dispatch);
+
+            // Find the text node containing "Child" and capture its text content.
+            let childPos: number | null = null;
+            state.doc.descendants((node, pos) => {
+                if (node.isText && node.text.includes('Child')) {
+                    // Compute absolute position of "Child" inside this text node.
+                    const index = node.text.indexOf('Child');
+                    childPos = pos + index;
+
+                    return false; // Stop traversal.
+                }
+
+                return true;
+            });
+            if (childPos === null) {
+                throw new Error('Did not find text "Child"');
+            }
+
+            // For a text "Child" (length = 5), select from offset 1 up to offset 4.
+            const selFrom = childPos + 1;
+            const selTo = childPos + 4;
+            const tr = state.tr.setSelection(
+                TextSelection.create(state.doc, selFrom, selTo)
+            );
+            state = state.apply(tr);
+
+            // Same-type toggle on the selected item lifts it out of the list.
+            command(state, dispatch);
+
+            expect(state.doc.childCount).toBe(2);
+
+            const remainingList = state.doc.child(0);
+            expect(remainingList.type.name).toBe(EditorMenuTypes.BulletList);
+            expect(remainingList.childCount).toBe(1);
+            expect(remainingList.child(0).textContent).toBe('Parent');
+
+            const liftedParagraph = state.doc.child(1);
+            expect(liftedParagraph.type.name).toBe('paragraph');
+            expect(liftedParagraph.textContent).toBe('Child');
+        });
+    });
+
+    describe('joining with adjacent lists', () => {
+        const createList = (type: string, texts: string[]) =>
+            schema.nodes[type].create(
+                {},
+                texts.map((text) =>
+                    schema.nodes.list_item.create({}, [createParagraph(text)])
+                )
+            );
+
+        const placeCaret = (pos: number) => {
+            state = state.apply(
+                state.tr.setSelection(TextSelection.create(state.doc, pos))
+            );
+        };
+
+        it('joins a wrapped paragraph with a preceding list of the same type', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            state = state.apply(
+                state.tr.replaceWith(0, state.doc.content.size, [
+                    createList('bullet_list', ['one']),
+                    createParagraph('two'),
+                ])
+            );
+            placeCaret(11);
+
+            command(state, dispatch);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, ['one', 'two']);
+        });
+
+        it('joins a wrapped paragraph with lists on both sides', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            state = state.apply(
+                state.tr.replaceWith(0, state.doc.content.size, [
+                    createList('bullet_list', ['one']),
+                    createParagraph('two'),
+                    createList('bullet_list', ['three']),
+                ])
+            );
+            placeCaret(11);
+
+            command(state, dispatch);
+
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, [
+                'one',
+                'two',
+                'three',
+            ]);
+        });
+
+        it('leaves a neighboring list of another type alone', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            state = state.apply(
+                state.tr.replaceWith(0, state.doc.content.size, [
+                    createList('ordered_list', ['one']),
+                    createParagraph('two'),
+                ])
+            );
+            placeCaret(11);
+
+            command(state, dispatch);
+
+            expect(state.doc.childCount).toBe(2);
+            expect(state.doc.firstChild.type.name).toBe(
+                EditorMenuTypes.OrderedList
+            );
+            expect(state.doc.lastChild.type.name).toBe(
+                EditorMenuTypes.BulletList
+            );
+        });
+
+        it('restores a single list when an item is toggled off and back on', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            state = state.apply(
+                state.tr.replaceWith(
+                    0,
+                    state.doc.content.size,
+                    createList('bullet_list', ['one', 'two'])
+                )
+            );
+            placeCaret(11);
+
+            command(state, dispatch);
+            expect(state.doc.childCount).toBe(2);
+
+            command(state, dispatch);
+            expect(state.doc.childCount).toBe(1);
+            verifyListStructure(EditorMenuTypes.BulletList, ['one', 'two']);
+        });
+    });
+
+    describe('active state', () => {
+        it('reports active state for bullet list', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            const tr = state.tr.insertText('Test text');
+            state = state.apply(tr);
+            command(state, dispatch);
+
+            expect(command.active(state)).toBe(true);
+        });
+
+        it('reports inactive state for different list type', () => {
+            const bulletCommand = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            const orderedCommand = createListCommand(
+                schema,
+                EditorMenuTypes.OrderedList
+            );
+
+            const tr = state.tr.insertText('Test text');
+            state = state.apply(tr);
+            bulletCommand(state, dispatch);
+
+            expect(orderedCommand.active(state)).toBe(false);
+            expect(bulletCommand.active(state)).toBe(true);
+        });
+
+        it('reports active state for partial selection in list', () => {
+            const command = createListCommand(
+                schema,
+                EditorMenuTypes.BulletList
+            );
+            let tr = state.tr.insertText('First\nSecond\nThird');
+            state = state.apply(tr);
+            command(state, dispatch);
+
+            // Select middle line
+            tr = state.tr.setSelection(
+                TextSelection.create(
+                    state.doc,
+                    state.doc.content.firstChild.nodeSize / 2,
+                    state.doc.content.firstChild.nodeSize / 2 + 6
+                )
+            );
+            state = state.apply(tr);
+
+            expect(command.active(state)).toBe(true);
+        });
+    });
+
+    describe('edge cases', () => {
+        describe('empty selections', () => {
+            it('creates empty list item when no text is selected', () => {
+                const command = createListCommand(
+                    schema,
+                    EditorMenuTypes.BulletList
+                );
+                const tr = state.tr.setSelection(
+                    TextSelection.create(state.doc, 1, 1)
+                );
+                state = state.apply(tr);
+
+                command(state, dispatch);
+
+                expect(state.doc.firstChild.type.name).toBe(
+                    EditorMenuTypes.BulletList
+                );
+                expect(state.doc.firstChild.textContent).toBe('');
+            });
+        });
+
+        describe('mixed content handling', () => {
+            it('handles selection with mixed content types', () => {
+                // Setup paragraph and header
+                const tr = state.tr
+                    .insertText('Regular text\n')
+                    .insert(
+                        state.tr.mapping.map(state.doc.content.size),
+                        schema.nodes.heading.create(
+                            { level: 1 },
+                            schema.text('Heading')
+                        )
+                    );
+                state = state.apply(tr);
+
+                // Select all and convert to list
+                const command = createListCommand(
+                    schema,
+                    EditorMenuTypes.BulletList
+                );
+                selectAll();
+
+                command(state, dispatch);
+
+                expect(state.doc.firstChild.type.name).toBe(
+                    EditorMenuTypes.BulletList
+                );
+                expect(state.doc.firstChild.childCount).toBe(2);
+            });
+
+            it('handles list items containing multiple block types', () => {
+                const command = createListCommand(
+                    schema,
+                    EditorMenuTypes.BulletList
+                );
+                const tr = state.tr
+                    .insertText('Paragraph text')
+                    .insert(
+                        state.tr.mapping.map(state.doc.content.size),
+                        schema.nodes.blockquote.create({}, schema.text('Quote'))
+                    );
+                state = state.apply(tr);
+
+                // Select all content so that both blocks are included in the conversion.
+                selectAll();
+                command(state, dispatch);
+
+                const listItem = state.doc.firstChild.firstChild;
+                expect(listItem.content.childCount).toBe(2);
+            });
+
+            it('wraps a blockquote paragraph holding the caret in a list', () => {
+                const command = createListCommand(
+                    schema,
+                    EditorMenuTypes.BulletList
+                );
+                const quote = schema.nodes.blockquote.create({}, [
+                    createParagraph('Quote'),
+                ]);
+                state = state.apply(
+                    state.tr.replaceWith(0, state.doc.content.size, quote)
+                );
+                state = state.apply(
+                    state.tr.setSelection(TextSelection.create(state.doc, 3))
+                );
+
+                expect(command.allowed(state)).toBe(true);
+                expect(command(state, dispatch)).toBe(true);
+
+                const quoteNode = state.doc.firstChild;
+                expect(quoteNode.type.name).toBe('blockquote');
+                expect(quoteNode.firstChild.type.name).toBe(
+                    EditorMenuTypes.BulletList
+                );
+                expect(quoteNode.firstChild.firstChild.type.name).toBe(
+                    'list_item'
+                );
+                expect(quoteNode.textContent).toBe('Quote');
+            });
+
+            it('does not apply with the caret in a heading', () => {
+                const command = createListCommand(
+                    schema,
+                    EditorMenuTypes.BulletList
+                );
+                const heading = schema.nodes.heading.create(
+                    { level: 1 },
+                    schema.text('Heading')
+                );
+                state = state.apply(
+                    state.tr.replaceWith(0, state.doc.content.size, heading)
+                );
+                state = state.apply(
+                    state.tr.setSelection(TextSelection.create(state.doc, 2))
+                );
+
+                expect(command.allowed(state)).toBe(false);
+                expect(command(state, dispatch)).toBe(false);
+                expect(dispatch).not.toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-list-commands.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-list-commands.spec.ts
@@ -9,7 +9,6 @@ describe('List Commands', () => {
     let state: EditorState;
     let dispatch: Mock;
 
-    // Helper functions
     const createParagraph = (text: string) =>
         schema.nodes.paragraph.create(null, schema.text(text));
 
@@ -132,13 +131,11 @@ describe('List Commands', () => {
 
             state = state.apply(createParagraphs(['Test text']));
 
-            // Convert to bullet list
             bulletCommand(state, dispatch);
             expect(state.doc.firstChild.type.name).toBe(
                 EditorMenuTypes.BulletList
             );
 
-            // Convert to ordered list
             orderedCommand(state, dispatch);
             expect(state.doc.firstChild.type.name).toBe(
                 EditorMenuTypes.OrderedList
@@ -159,13 +156,11 @@ describe('List Commands', () => {
             state = state.apply(createParagraphs(expectedItems));
             selectAll();
 
-            // Convert to bullet list
             bulletCommand(state, dispatch);
 
             expect(state.doc.childCount).toBe(1);
             verifyListStructure(EditorMenuTypes.BulletList, expectedItems);
 
-            // Convert to ordered list
             orderedCommand(state, dispatch);
 
             expect(state.doc.childCount).toBe(1);
@@ -173,7 +168,6 @@ describe('List Commands', () => {
         });
 
         it('toggles list off back to paragraph', () => {
-            // Create bullet list
             const command = createListCommand(
                 schema,
                 EditorMenuTypes.BulletList
@@ -181,13 +175,11 @@ describe('List Commands', () => {
 
             state = state.apply(createParagraphs(['Test text']));
 
-            // Convert to bullet list
             command(state, dispatch);
             expect(state.doc.firstChild.type.name).toBe(
                 EditorMenuTypes.BulletList
             );
 
-            // Toggle it off
             command(state, dispatch);
             expect(state.doc.firstChild.type.name).toBe('paragraph');
             expect(state.doc.firstChild.textContent).toBe('Test text');
@@ -198,7 +190,6 @@ describe('List Commands', () => {
         const TEST_LINES = ['First line', 'Second line', 'Third line'];
 
         beforeEach(() => {
-            // Setup multiple paragraphs
             const tr = createParagraphs(TEST_LINES);
             state = state.apply(tr);
         });
@@ -209,7 +200,6 @@ describe('List Commands', () => {
                 EditorMenuTypes.BulletList
             );
 
-            // Select all content
             selectAll();
 
             command(state, dispatch);
@@ -228,16 +218,13 @@ describe('List Commands', () => {
                 EditorMenuTypes.OrderedList
             );
 
-            // Select all content
             selectAll();
 
-            // Convert to bullet list first
             bulletCommand(state, dispatch);
 
             expect(state.doc.childCount).toBe(1);
             verifyListStructure(EditorMenuTypes.BulletList, TEST_LINES);
 
-            // Convert to ordered list
             orderedCommand(state, dispatch);
 
             verifyListStructure(EditorMenuTypes.OrderedList, TEST_LINES);
@@ -409,18 +396,14 @@ describe('List Commands', () => {
                 EditorMenuTypes.BulletList
             );
 
-            // Create initial content as separate paragraphs.
             state = state.apply(createParagraphs(['Parent', 'Child']));
 
-            // Convert both paragraphs to a list
             selectAll();
             command(state, dispatch);
 
-            // Find the text node containing "Child" and capture its text content.
             let childPos: number | null = null;
             state.doc.descendants((node, pos) => {
                 if (node.isText && node.text.includes('Child')) {
-                    // Compute absolute position of "Child" inside this text node.
                     const index = node.text.indexOf('Child');
                     childPos = pos + index;
 
@@ -441,7 +424,6 @@ describe('List Commands', () => {
             );
             state = state.apply(tr);
 
-            // Same-type toggle on the selected item lifts it out of the list.
             command(state, dispatch);
 
             expect(state.doc.childCount).toBe(2);
@@ -649,7 +631,6 @@ describe('List Commands', () => {
 
         describe('mixed content handling', () => {
             it('does not apply when the selection includes a heading', () => {
-                // Setup paragraph and header
                 const tr = state.tr
                     .insertText('Regular text\n')
                     .insert(
@@ -685,7 +666,6 @@ describe('List Commands', () => {
                     );
                 state = state.apply(tr);
 
-                // Select all content so that both blocks are included.
                 selectAll();
 
                 expect(command.allowed(state)).toBe(false);

--- a/src/components/text-editor/prosemirror-adapter/menu/menu-list-commands.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/menu/menu-list-commands.spec.ts
@@ -598,17 +598,27 @@ describe('List Commands', () => {
                 schema,
                 EditorMenuTypes.BulletList
             );
-            let tr = state.tr.insertText('First\nSecond\nThird');
-            state = state.apply(tr);
+            state = state.apply(createParagraphs(['First', 'Second', 'Third']));
+            selectAll();
             command(state, dispatch);
 
-            // Select middle line
-            tr = state.tr.setSelection(
-                TextSelection.create(
-                    state.doc,
-                    state.doc.content.firstChild.nodeSize / 2,
-                    state.doc.content.firstChild.nodeSize / 2 + 6
-                )
+            // Select part of the text inside the second list item.
+            let secondPos: number | null = null;
+            state.doc.descendants((node, pos) => {
+                if (node.isText && node.text === 'Second') {
+                    secondPos = pos;
+
+                    return false;
+                }
+
+                return true;
+            });
+            if (secondPos === null) {
+                throw new Error('Did not find text "Second"');
+            }
+
+            const tr = state.tr.setSelection(
+                TextSelection.create(state.doc, secondPos + 1, secondPos + 4)
             );
             state = state.apply(tr);
 
@@ -638,7 +648,7 @@ describe('List Commands', () => {
         });
 
         describe('mixed content handling', () => {
-            it('handles selection with mixed content types', () => {
+            it('does not apply when the selection includes a heading', () => {
                 // Setup paragraph and header
                 const tr = state.tr
                     .insertText('Regular text\n')
@@ -651,22 +661,18 @@ describe('List Commands', () => {
                     );
                 state = state.apply(tr);
 
-                // Select all and convert to list
                 const command = createListCommand(
                     schema,
                     EditorMenuTypes.BulletList
                 );
                 selectAll();
 
-                command(state, dispatch);
-
-                expect(state.doc.firstChild.type.name).toBe(
-                    EditorMenuTypes.BulletList
-                );
-                expect(state.doc.firstChild.childCount).toBe(2);
+                expect(command.allowed(state)).toBe(false);
+                expect(command(state, dispatch)).toBe(false);
+                expect(dispatch).not.toHaveBeenCalled();
             });
 
-            it('handles list items containing multiple block types', () => {
+            it('does not apply when the selection includes a blockquote', () => {
                 const command = createListCommand(
                     schema,
                     EditorMenuTypes.BulletList
@@ -679,12 +685,12 @@ describe('List Commands', () => {
                     );
                 state = state.apply(tr);
 
-                // Select all content so that both blocks are included in the conversion.
+                // Select all content so that both blocks are included.
                 selectAll();
-                command(state, dispatch);
 
-                const listItem = state.doc.firstChild.firstChild;
-                expect(listItem.content.childCount).toBe(2);
+                expect(command.allowed(state)).toBe(false);
+                expect(command(state, dispatch)).toBe(false);
+                expect(dispatch).not.toHaveBeenCalled();
             });
 
             it('wraps a blockquote paragraph holding the caret in a list', () => {
@@ -735,6 +741,38 @@ describe('List Commands', () => {
                 expect(command.allowed(state)).toBe(false);
                 expect(command(state, dispatch)).toBe(false);
                 expect(dispatch).not.toHaveBeenCalled();
+            });
+
+            it('allows toggling a list nested inside a blockquote', () => {
+                const command = createListCommand(
+                    schema,
+                    EditorMenuTypes.BulletList
+                );
+                const nested = schema.nodes.blockquote.create(
+                    {},
+                    schema.nodes.bullet_list.create({}, [
+                        schema.nodes.list_item.create({}, [
+                            schema.nodes.paragraph.create(
+                                null,
+                                schema.text('Item')
+                            ),
+                        ]),
+                    ])
+                );
+                const tr = state.tr.replaceWith(
+                    0,
+                    state.doc.content.size,
+                    nested
+                );
+                state = state.apply(tr);
+
+                // Place the caret inside the nested list item.
+                const sel = state.tr.setSelection(
+                    TextSelection.create(state.doc, 4)
+                );
+                state = state.apply(sel);
+
+                expect(command.allowed(state)).toBe(true);
             });
         });
     });

--- a/src/components/text-editor/prosemirror-adapter/plugins/list-key-handler.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/list-key-handler.ts
@@ -1,0 +1,110 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+import {
+    sinkListItem,
+    liftListItem,
+    splitListItem,
+} from 'prosemirror-schema-list';
+import { Node, Schema } from 'prosemirror-model';
+import { chainCommands, joinBackward } from 'prosemirror-commands';
+import { findAncestorDepthOfType } from '../menu/menu-command-utils/node-utils';
+
+export const listKeyHandlerPluginKey = new PluginKey('listKeyHandlerPlugin');
+
+const isEmptyListItem = (item: Node, schema: Schema): boolean =>
+    item.childCount === 1 &&
+    item.firstChild.type === schema.nodes.paragraph &&
+    item.firstChild.content.size === 0;
+
+const isPlainKey = (event: KeyboardEvent): boolean =>
+    !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
+
+/**
+ * Creates a plugin for handling keydown events specific to lists
+ * - Tab: indent list item (when in a list)
+ * - Shift+Tab: outdent list item (when in a list)
+ * - Enter: split list item or exit list if empty
+ * - Backspace: join with previous item or lift out of list
+ *
+ * @param schema - The document schema
+ * @returns A ProseMirror plugin for handling list-specific key events
+ */
+export function createListKeyHandlerPlugin(schema: Schema) {
+    return new Plugin({
+        key: listKeyHandlerPluginKey,
+        props: {
+            handleKeyDown: (view, event) => {
+                const { state } = view;
+                const { $from, empty } = state.selection;
+                const listItemDepth = findAncestorDepthOfType(
+                    $from,
+                    schema.nodes.list_item
+                );
+
+                // Only act when in a list item
+                if (listItemDepth === null) {
+                    return false;
+                }
+
+                // Inside a list item, Tab and Shift+Tab are always handled
+                // so focus never leaves the editor mid-list, even when the
+                // indent or outdent itself cannot apply.
+                if (event.key === 'Tab') {
+                    event.preventDefault();
+
+                    if (event.shiftKey) {
+                        liftListItem(schema.nodes.list_item)(
+                            state,
+                            view.dispatch
+                        );
+
+                        return true;
+                    }
+
+                    // Sinking fails on first items (no preceding sibling to
+                    // become the parent); Tab is still swallowed.
+                    sinkListItem(schema.nodes.list_item)(state, view.dispatch);
+
+                    return true;
+                }
+
+                // Handle Enter key
+                if (event.key === 'Enter' && isPlainKey(event)) {
+                    event.preventDefault();
+
+                    // If list item is empty, exit the list
+                    if (isEmptyListItem($from.node(listItemDepth), schema)) {
+                        return liftListItem(schema.nodes.list_item)(
+                            state,
+                            view.dispatch
+                        );
+                    }
+
+                    // Otherwise split the list item
+                    return splitListItem(schema.nodes.list_item)(
+                        state,
+                        view.dispatch
+                    );
+                }
+
+                // Handle Backspace key, only at the start of a list item
+                if (
+                    event.key === 'Backspace' &&
+                    isPlainKey(event) &&
+                    empty &&
+                    $from.pos === $from.start(listItemDepth)
+                ) {
+                    event.preventDefault();
+
+                    // Try joinBackward first (join with previous list item)
+                    // If that fails, try to lift the list item out
+                    return chainCommands(
+                        joinBackward,
+                        liftListItem(schema.nodes.list_item)
+                    )(state, view.dispatch);
+                }
+
+                return false;
+            },
+        },
+    });
+}

--- a/src/components/text-editor/prosemirror-adapter/plugins/list-key-handler.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/list-key-handler.ts
@@ -1,29 +1,15 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
-import {
-    sinkListItem,
-    liftListItem,
-    splitListItem,
-} from 'prosemirror-schema-list';
-import { Node, Schema } from 'prosemirror-model';
-import { chainCommands, joinBackward } from 'prosemirror-commands';
+import { sinkListItem, liftListItem } from 'prosemirror-schema-list';
+import { Schema } from 'prosemirror-model';
 import { findAncestorDepthOfType } from '../menu/menu-command-utils/node-utils';
 
 export const listKeyHandlerPluginKey = new PluginKey('listKeyHandlerPlugin');
 
-const isEmptyListItem = (item: Node, schema: Schema): boolean =>
-    item.childCount === 1 &&
-    item.firstChild.type === schema.nodes.paragraph &&
-    item.firstChild.content.size === 0;
-
-const isPlainKey = (event: KeyboardEvent): boolean =>
-    !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
-
 /**
- * Creates a plugin for handling keydown events specific to lists
- * - Tab: indent list item (when in a list)
- * - Shift+Tab: outdent list item (when in a list)
- * - Enter: split list item or exit list if empty
- * - Backspace: join with previous item or lift out of list
+ * Creates a plugin for handling Tab and Shift+Tab inside list items:
+ * Tab indents the item and Shift+Tab outdents it. Enter and Backspace
+ * are handled by the base keymap (splitListItem and joinBackward), which
+ * runs before this plugin.
  *
  * @param schema - The document schema
  * @returns A ProseMirror plugin for handling list-specific key events
@@ -33,77 +19,36 @@ export function createListKeyHandlerPlugin(schema: Schema) {
         key: listKeyHandlerPluginKey,
         props: {
             handleKeyDown: (view, event) => {
-                const { state } = view;
-                const { $from, empty } = state.selection;
-                const listItemDepth = findAncestorDepthOfType(
-                    $from,
-                    schema.nodes.list_item
-                );
+                if (event.key !== 'Tab') {
+                    return false;
+                }
 
-                // Only act when in a list item
-                if (listItemDepth === null) {
+                const { state } = view;
+                const { $from } = state.selection;
+                const inListItem =
+                    findAncestorDepthOfType($from, schema.nodes.list_item) !==
+                    null;
+
+                if (!inListItem) {
                     return false;
                 }
 
                 // Inside a list item, Tab and Shift+Tab are always handled
                 // so focus never leaves the editor mid-list, even when the
                 // indent or outdent itself cannot apply.
-                if (event.key === 'Tab') {
-                    event.preventDefault();
+                event.preventDefault();
 
-                    if (event.shiftKey) {
-                        liftListItem(schema.nodes.list_item)(
-                            state,
-                            view.dispatch
-                        );
-
-                        return true;
-                    }
-
-                    // Sinking fails on first items (no preceding sibling to
-                    // become the parent); Tab is still swallowed.
-                    sinkListItem(schema.nodes.list_item)(state, view.dispatch);
+                if (event.shiftKey) {
+                    liftListItem(schema.nodes.list_item)(state, view.dispatch);
 
                     return true;
                 }
 
-                // Handle Enter key
-                if (event.key === 'Enter' && isPlainKey(event)) {
-                    event.preventDefault();
+                // Sinking fails on first items (no preceding sibling to
+                // become the parent); Tab is still swallowed.
+                sinkListItem(schema.nodes.list_item)(state, view.dispatch);
 
-                    // If list item is empty, exit the list
-                    if (isEmptyListItem($from.node(listItemDepth), schema)) {
-                        return liftListItem(schema.nodes.list_item)(
-                            state,
-                            view.dispatch
-                        );
-                    }
-
-                    // Otherwise split the list item
-                    return splitListItem(schema.nodes.list_item)(
-                        state,
-                        view.dispatch
-                    );
-                }
-
-                // Handle Backspace key, only at the start of a list item
-                if (
-                    event.key === 'Backspace' &&
-                    isPlainKey(event) &&
-                    empty &&
-                    $from.pos === $from.start(listItemDepth)
-                ) {
-                    event.preventDefault();
-
-                    // Try joinBackward first (join with previous list item)
-                    // If that fails, try to lift the list item out
-                    return chainCommands(
-                        joinBackward,
-                        liftListItem(schema.nodes.list_item)
-                    )(state, view.dispatch);
-                }
-
-                return false;
+                return true;
             },
         },
     });

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -531,21 +531,19 @@ export class ProsemirrorAdapter {
         activeTypes: Record<EditorMenuTypes, boolean>,
         allowedTypes: Record<EditorMenuTypes, boolean>
     ) => {
-        const newItems = getTextEditorMenuItems().map((item) => {
-            if (isItem(item)) {
-                return {
-                    ...item,
-                    selected: activeTypes[item.value],
-                    allowed: allowedTypes[item.value],
-                };
-            }
+        this.actionBarItems = getTextEditorMenuItems()
+            .map(this.getTranslatedItem)
+            .map((item) => {
+                if (isItem(item)) {
+                    return {
+                        ...item,
+                        selected: activeTypes[item.value],
+                        disabled: !allowedTypes[item.value],
+                    };
+                }
 
-            return item;
-        });
-
-        this.actionBarItems = newItems.filter((item) =>
-            isItem(item) ? item.allowed : true
-        );
+                return item;
+            });
     };
 
     private async updateView(content: string) {

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -157,6 +157,44 @@ describe('limel-text-editor', () => {
         expect(adapter.getAttribute('id')).toBe(labelId);
     });
 
+    describe('toolbar translations', () => {
+        test('a menu-state update keeps the labels in the configured language', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-text-editor language="sv" value="hej" />
+            );
+            await waitForChanges();
+
+            const adapter = getAdapter(root);
+            const actionBar = await vi.waitFor(() => {
+                const bar = adapter.shadowRoot.querySelector(
+                    'limel-action-bar'
+                ) as any;
+                expect(bar).toBeTruthy();
+
+                return bar;
+            });
+
+            const bulletItem = () =>
+                actionBar.actions.find(
+                    (item: any) => item.value === 'bullet_list'
+                );
+
+            expect(bulletItem().text).toBe('Punktlista');
+
+            actionBar.dispatchEvent(
+                new CustomEvent('itemSelected', {
+                    detail: { value: 'bullet_list' },
+                })
+            );
+            await waitForChanges();
+
+            await vi.waitFor(() => {
+                expect(bulletItem().selected).toBe(true);
+            });
+            expect(bulletItem().text).toBe('Punktlista');
+        });
+    });
+
     describe('caret position on focus', () => {
         // The adapter restores a clicked position one tick after the focus
         // event; wait comfortably longer before asserting caret behavior.


### PR DESCRIPTION
This PR replaces the text editor's ad-hoc list handling with a small set of utilities built on `prosemirror-schema-list`, giving the bullet/ordered list buttons a predictable ladder of behaviors:

- **Toggle off** — pressing the button for the list type you are already in lifts the selection out of the list.
- **Convert** — pressing the button for the other list type converts the innermost list in place.
- **Wrap** — a selection outside any list is wrapped, one list item per block, and joined with any adjacent list of the same type.
- **Unify** — a mixed selection (paragraphs plus lists of both types) becomes a single list of the requested type.

List buttons are greyed out when a multi-block selection contains a block that cannot live in a list. With the caret in a single block, the schema decides: a paragraph inside a blockquote can become a list, while a heading or code block cannot.

Key bindings: `Mod-Shift-7` (ordered) and `Mod-Shift-8` (bullet) run the same ladder. Tab/Shift-Tab indent and outdent inside lists; Tab is always swallowed inside a list item so keyboard focus never escapes the editor, and Tab on a first item is a no-op, since indenting it cannot be done without leaving an empty parent item behind.

The behavior matrix is covered by unit tests in `editor-commands.spec.ts`, `menu-list-commands.spec.ts`, and `editor-keymap.spec.ts`.

Replaces #3431.

Fixes #3313
Fixes #3178

Follow-up: #4214 (hardening of `active-state-utils`/`node-utils`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Improved ordered and bulleted list controls, including conversion, toggling, nesting, splitting, lifting, and mixed-content handling.
- Added keyboard shortcuts for ordered and bulleted lists.
- Added intuitive list editing with Tab, Shift+Tab, Enter, and Backspace.
- Improved menu indicators for active formatting, headings, and lists.

## Bug Fixes

- Improved handling of mixed selections, nested lists, multi-paragraph selections, and list transitions.
- Menu actions now remain visible and appear disabled when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## To Test this PR:

**Toolbar**: the four list behaviors

1. Wrap — Place the caret in a paragraph, click the bullet-list button. The paragraph becomes a one-item bullet list. Then type three paragraphs, select all three, click bullet list. One list, one item per paragraph — not one item containing everything. Finally, with a bullet list followed by a loose paragraph, put the caret in the paragraph and click bullet list: the paragraph joins the existing list as its last item — one list, not two.
2. Toggle off — With the caret in a bullet-list item, click the bullet-list button again. That item lifts out of the list and becomes a paragraph; other items stay listed.
3. Convert — With the caret in a bullet list, click the ordered-list button. The list converts in place; no content is lost. Repeat inside a nested sub-list: only the innermost list converts.
4. Unify — Create a bullet list, a loose paragraph below it, and an ordered list below that. Select across all three, click bullet list. Everything merges into a single bullet list, in order, with nesting preserved.

**Grey-out rule**

5. Select a range that includes a heading, blockquote, or code block together with a paragraph. Both list buttons grey out. Press Mod-Shift-8 on the same selection. Nothing happens — keyboard and toolbar must agree.
6. Place the caret in a paragraph inside a blockquote. The list buttons stay enabled, and clicking bullet list wraps the paragraph in a list inside the quote. With the caret in a heading or code block instead, both list buttons grey out. Inside a blockquote-nested list, toggling and converting keep working.

**Keyboard**

7. Mod-Shift-8 / Mod-Shift-7 — repeat scenarios 1–3 using the shortcuts instead of the buttons. Identical results.
8. Tab — In a two-item list with the caret in the second item, press Tab. The item indents uaret in the first item, press Tab. Nothing changes — but focus stays in the editor (Tab mustnever jump to the next form control while inside a list).
9. Shift-Tab — On a nested item: outdents one level. On a top-level item: becomes a paragrap
10. Enter — Mid-item: splits into a new item. On an empty nested item: outdents. On an empty last top-level item: exits the list into a paragraph.
11. Backspace — With the caret at the very start of the second item's text: joins with the p

**Active state**

12. Caret inside a list: the matching list button shows as active. Caret in a nested ordered: both buttons show active.
