### PR TITLE
fix(text-editor): focus the link field when the link menu opens

### DIFF
--- a/src/components/text-editor/link-menu/editor-link-menu.e2e.tsx
+++ b/src/components/text-editor/link-menu/editor-link-menu.e2e.tsx
@@ -1,0 +1,44 @@
+import { render, h } from '@stencil/vitest';
+
+describe('limel-text-editor-link-menu', () => {
+    const link = {
+        text: 'Lime Technologies',
+        href: 'https://www.lime-technologies.com',
+    };
+
+    async function createMenu() {
+        const { root, waitForChanges } = await render(
+            <limel-text-editor-link-menu link={link} isOpen={true} />
+        );
+        await waitForChanges();
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+
+        return { root: root as HTMLElement, waitForChanges };
+    }
+
+    function getInputFields(root: HTMLElement) {
+        const fields =
+            root.shadowRoot.querySelectorAll<HTMLLimelInputFieldElement>(
+                'limel-input-field'
+            );
+
+        return { textField: fields[0], linkField: fields[1] };
+    }
+
+    describe('when opened', () => {
+        test('focuses the link field, not the text field', async () => {
+            const { root } = await createMenu();
+            const { textField, linkField } = getInputFields(root);
+
+            expect(root.shadowRoot.activeElement).toBe(linkField);
+            expect(root.shadowRoot.activeElement).not.toBe(textField);
+        });
+
+        test('places the caret in the input element of the link field', async () => {
+            const { root } = await createMenu();
+            const { linkField } = getInputFields(root);
+
+            expect(linkField.shadowRoot.activeElement?.tagName).toBe('INPUT');
+        });
+    });
+});

--- a/src/components/text-editor/link-menu/editor-link-menu.tsx
+++ b/src/components/text-editor/link-menu/editor-link-menu.tsx
@@ -54,7 +54,7 @@ export class TextEditorLinkMenu {
     @Event()
     private linkChange: EventEmitter<EditorTextLink>;
 
-    private textInput: HTMLLimelInputFieldElement;
+    private linkInput: HTMLLimelInputFieldElement;
     private saveButton: HTMLLimelButtonElement;
 
     public connectedCallback() {
@@ -76,12 +76,12 @@ export class TextEditorLinkMenu {
     }
 
     public componentDidLoad() {
-        this.focusOnTextInput();
+        this.focusOnLinkInput();
     }
 
-    private focusOnTextInput() {
-        if (this.textInput) {
-            const inputField = this.textInput.shadowRoot.querySelector('input');
+    private focusOnLinkInput() {
+        if (this.linkInput) {
+            const inputField = this.linkInput.shadowRoot.querySelector('input');
             if (inputField) {
                 requestAnimationFrame(() => {
                     inputField.focus();
@@ -100,9 +100,6 @@ export class TextEditorLinkMenu {
                 leadingIcon="text_cursor"
                 onChange={this.handleLinkTitleChange}
                 onKeyDown={this.handleKeyDown}
-                ref={(el) =>
-                    (this.textInput = el as HTMLLimelInputFieldElement)
-                }
             />,
             <limel-input-field
                 label={this.getTranslation('editor-link-menu.link')}
@@ -114,6 +111,9 @@ export class TextEditorLinkMenu {
                 onChange={this.handleLinkValueChange}
                 onAction={this.handleLinkInputAction}
                 onKeyDown={this.handleKeyDown}
+                ref={(el) =>
+                    (this.linkInput = el as HTMLLimelInputFieldElement)
+                }
             />,
             <div class="actions">
                 <limel-button


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the link menu so the link field receives focus when opened.
  * Ensured the text cursor is correctly positioned in the link input for immediate editing.

* **Tests**
  * Added end-to-end coverage validating link-field focus and cursor placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

Closes #3181

The link menu already moved focus to an input when it opened — it just picked
the *Text* field. Since the point of opening the menu is to enter a URL, the
`ref` now points at the *Link* field instead.

The menu element is torn down and rebuilt on every open (`renderLinkMenu()`
returns nothing while closed), so `componentDidLoad` — and the focus call —
runs each time the menu opens, not only the first.

The link field is focused, but its existing value is **not** selected. When
editing an existing link the URL still has to be cleared by hand. Worth
deciding after trying it out whether select-on-open is wanted too.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
