### PR TITLE
fix(markdown): keep embedded images when sanitizing content

### DIFF
--- a/src/components/email-viewer/sanitize-email-html.ts
+++ b/src/components/email-viewer/sanitize-email-html.ts
@@ -3,17 +3,7 @@ import rehypeParse from 'rehype-parse';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 import { visit } from 'unist-util-visit';
-
-const allowedMimeTypes = new Set([
-    'image/png',
-    'image/jpeg',
-    'image/jpg',
-    'image/gif',
-    'image/webp',
-    'image/bmp',
-    'image/x-icon',
-    'image/vnd.microsoft.icon',
-]);
+import { isSafeImageDataUrl } from '../markdown/safe-image-data-urls';
 
 /**
  * Sanitizes email HTML to prevent XSS and other security issues while
@@ -161,27 +151,13 @@ function sanitizeDangerousUrls(node: any) {
  * @returns A safe `src` to keep, or `undefined` to strip it.
  */
 function getSafeEmailImageSrc(src: string): string | undefined {
-    const trimmedSrc = src.trim();
-    if (!trimmedSrc) {
-        return;
-    }
-
     // Only allow embedded images. Loading remote images has privacy implications
     // (tracking pixels) and may leak network details.
-    if (!trimmedSrc.toLowerCase().startsWith('data:')) {
+    if (!isSafeImageDataUrl(src)) {
         return;
     }
 
-    const mimeType = getDataUrlMimeType(trimmedSrc);
-    if (!mimeType) {
-        return;
-    }
-
-    if (!allowedMimeTypes.has(mimeType)) {
-        return;
-    }
-
-    return trimmedSrc;
+    return src.trim();
 }
 
 /**
@@ -196,21 +172,6 @@ function getRemoteEmailImageSrc(src: string): string | undefined {
     if (lower.startsWith('http://') || lower.startsWith('https://')) {
         return trimmedSrc;
     }
-}
-
-/**
- * Extracts the MIME type from a `data:` URL.
- *
- * @param dataUrl - A `data:` URL string.
- * @returns The MIME type if present.
- */
-function getDataUrlMimeType(dataUrl: string): string | undefined {
-    // data:[<mime type>][;charset=<charset>][;base64],<data>
-    const match = /^data:([^;,]+)(?:;charset=[^;,]+)?(?:;base64)?,/i.exec(
-        dataUrl
-    );
-    const mimeType = match?.[1]?.toLowerCase();
-    return mimeType || undefined;
 }
 
 /**

--- a/src/components/markdown/markdown-parser.spec.ts
+++ b/src/components/markdown/markdown-parser.spec.ts
@@ -727,14 +727,48 @@ describe('sanitizeHTML', () => {
         });
     });
 
-    describe('data URLs', () => {
-        it('should strip data URLs for security', async () => {
-            // Data URLs are stripped by the sanitizer to prevent
-            // potential XSS via data: protocol
+    describe('data URL images', () => {
+        const BASE64_PNG =
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
+
+        it('keeps an embedded image on an html img', async () => {
             const result = await sanitizeHTML(
-                '<img src="data:image/png;base64,abc123">'
+                `<p><img alt="picture.png" src="${BASE64_PNG}"></p>`
             );
-            expect(result).toEqualHtml('<img>');
+
+            expect(result).toContain(BASE64_PNG);
+        });
+
+        it('keeps an embedded image written as markdown', async () => {
+            const result = await markdownToHTML(
+                `![picture.png](${BASE64_PNG})`
+            );
+
+            expect(result).toContain(BASE64_PNG);
+        });
+
+        it('strips a data URL whose MIME type is not an image', async () => {
+            const result = await sanitizeHTML(
+                '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">'
+            );
+
+            expect(result).not.toContain('data:');
+        });
+
+        it('strips an svg data URL, which can carry script', async () => {
+            const result = await sanitizeHTML(
+                '<img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==">'
+            );
+
+            expect(result).not.toContain('data:');
+        });
+
+        it('strips a data URL from a link', async () => {
+            const result = await sanitizeHTML(
+                '<a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">Click</a>'
+            );
+
+            expect(result).not.toContain('data:');
         });
     });
 

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -14,6 +14,7 @@ import { createLazyLoadImagesPlugin } from './image-markdown-plugin';
 import { CustomElementDefinition } from '../../global/shared-types/custom-element.types';
 import { createLinksPlugin } from './link-markdown-plugin';
 import { createRemoveEmptyParagraphsPlugin } from './remove-empty-paragraphs-plugin';
+import { isSafeImageDataUrl } from './safe-image-data-urls';
 
 /**
  * Takes a string as input and returns a new string
@@ -44,13 +45,7 @@ export async function markdownToHTML(
         .use(rehypeRaw)
         .use(createLinksPlugin())
         .use(rehypeSanitize, getWhiteList(options?.whitelist ?? []))
-        .use(() => {
-            return (tree: Node) => {
-                // Run the sanitizeStyle function on all elements, to sanitize
-                // the value of the `style` attribute, if there is one.
-                visit(tree, 'element', sanitizeStyle);
-            };
-        })
+        .use(createElementSanitizationPlugin())
         .use(createRemoveEmptyParagraphsPlugin(options?.removeEmptyParagraphs))
         .use(createLazyLoadImagesPlugin(options?.lazyLoadImages))
         .use(rehypeStringify)
@@ -73,17 +68,51 @@ export async function sanitizeHTML(
     const file = await unified()
         .use(rehypeParse)
         .use(rehypeSanitize, getWhiteList(whitelist ?? []))
-        .use(() => {
-            return (tree: Node) => {
-                // Run the sanitizeStyle function on all elements, to sanitize
-                // the value of the `style` attribute, if there is one.
-                visit(tree, 'element', sanitizeStyle);
-            };
-        })
+        .use(createElementSanitizationPlugin())
         .use(rehypeStringify)
         .process(html);
 
     return file.toString();
+}
+
+/**
+ * Per-element sanitization that runs after `rehype-sanitize`, shared by
+ * `markdownToHTML` and `sanitizeHTML` so the same content is never sanitized
+ * one way on one path and another way on the other.
+ */
+function createElementSanitizationPlugin() {
+    return () => {
+        return (tree: Node) => {
+            // Sanitize the value of the `style` attribute, if there is one.
+            visit(tree, 'element', sanitizeStyle);
+            visit(tree, 'element', stripUnsafeDataUrlSources);
+        };
+    };
+}
+
+/**
+ * Removes a `src` holding a `data:` URL that is not an allowed image format.
+ *
+ * The schema lets `data:` through for `src` so that embedded images survive
+ * sanitization, which is wider than the format actually needs to be — this
+ * narrows it back down to image data, the only kind we intend to keep.
+ *
+ * @param node - The element to sanitize.
+ */
+function stripUnsafeDataUrlSources(node: any) {
+    const src = node?.properties?.src;
+
+    if (typeof src !== 'string') {
+        return;
+    }
+
+    // Only `data:` sources are in scope: every other protocol is already gated
+    // by the schema's protocol list, and `isSafeImageDataUrl` rejects them all.
+    const isDataUrl = src.trim().toLowerCase().startsWith('data:');
+
+    if (isDataUrl && !isSafeImageDataUrl(src)) {
+        delete node.properties.src;
+    }
 }
 
 function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
@@ -121,6 +150,15 @@ function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
         // — reinstate the prefix or scope its removal to whitelisted custom
         // elements only.
         clobberPrefix: '',
+        protocols: {
+            ...defaultSchema.protocols,
+            // Keep embedded images: the editor stores pasted images as
+            // `<img src="data:image/…;base64,…">` when no upload backend is
+            // configured, and stripping the protocol here would drop the image
+            // data on the way back in. `stripUnsafeDataUrlSources` narrows this
+            // to allowed image MIME types once the schema has run.
+            src: [...(defaultSchema.protocols?.src ?? []), 'data'],
+        },
         strip: [...(defaultSchema.strip ?? []), 'style'],
         tagNames: [
             ...(defaultSchema.tagNames || []),

--- a/src/components/markdown/safe-image-data-urls.spec.ts
+++ b/src/components/markdown/safe-image-data-urls.spec.ts
@@ -1,0 +1,72 @@
+import { isSafeImageDataUrl } from './safe-image-data-urls';
+
+describe('isSafeImageDataUrl', () => {
+    describe('accepts', () => {
+        it.each([
+            'data:image/png;base64,iVBORw0KGgo=',
+            'data:image/jpeg;base64,/9j/4AAQ==',
+            'data:image/gif;base64,R0lGODlh',
+            'data:image/webp;base64,UklGRg==',
+            'data:image/bmp;base64,Qk0=',
+            'data:image/x-icon;base64,AAABAA==',
+        ])('an allowed image format: %s', (url) => {
+            expect(isSafeImageDataUrl(url)).toBe(true);
+        });
+
+        it('an uppercase protocol and MIME type', () => {
+            expect(
+                isSafeImageDataUrl('DATA:IMAGE/PNG;base64,iVBORw0KGgo=')
+            ).toBe(true);
+        });
+
+        it('surrounding whitespace', () => {
+            expect(
+                isSafeImageDataUrl('  data:image/png;base64,iVBORw0KGgo=  ')
+            ).toBe(true);
+        });
+
+        it('a charset parameter before the encoding', () => {
+            expect(
+                isSafeImageDataUrl('data:image/png;charset=utf-8;base64,iVBOR')
+            ).toBe(true);
+        });
+
+        it('image data that is not base64 encoded', () => {
+            expect(isSafeImageDataUrl('data:image/gif,GIF87a')).toBe(true);
+        });
+    });
+
+    describe('rejects', () => {
+        it('an svg, which can carry script', () => {
+            expect(
+                isSafeImageDataUrl('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')
+            ).toBe(false);
+        });
+
+        it.each([
+            'data:text/html;base64,PHNjcmlwdD48L3NjcmlwdD4=',
+            'data:application/javascript;base64,YWxlcnQoMSk=',
+            'data:text/plain,hello',
+        ])('a MIME type that is not an image: %s', (url) => {
+            expect(isSafeImageDataUrl(url)).toBe(false);
+        });
+
+        it('a data URL without a MIME type', () => {
+            expect(isSafeImageDataUrl('data:;base64,iVBORw0KGgo=')).toBe(false);
+        });
+
+        it('a data URL with no comma to end the header', () => {
+            expect(isSafeImageDataUrl('data:image/png;base64')).toBe(false);
+        });
+
+        it.each([
+            'https://example.com/cat.png',
+            'http://example.com/cat.png',
+            'javascript:alert(1)',
+            '/relative/cat.png',
+            '',
+        ])('a URL that is not a data URL: %s', (url) => {
+            expect(isSafeImageDataUrl(url)).toBe(false);
+        });
+    });
+});

--- a/src/components/markdown/safe-image-data-urls.ts
+++ b/src/components/markdown/safe-image-data-urls.ts
@@ -1,0 +1,61 @@
+/**
+ * MIME types accepted in an image `data:` URL.
+ *
+ * Raster formats only. `image/svg+xml` is deliberately absent: an SVG document
+ * can carry script and its own external references, so it is not safe to embed
+ * from untrusted content even though browsers do not execute script for an SVG
+ * loaded through `<img>`.
+ *
+ * @internal
+ */
+const ALLOWED_IMAGE_MIME_TYPES = new Set([
+    'image/png',
+    'image/jpeg',
+    'image/jpg',
+    'image/gif',
+    'image/webp',
+    'image/bmp',
+    'image/x-icon',
+    'image/vnd.microsoft.icon',
+]);
+
+/**
+ * Extracts the MIME type from a `data:` URL.
+ *
+ * @param dataUrl - A `data:` URL string.
+ * @returns The MIME type if present.
+ * @internal
+ */
+export function getDataUrlMimeType(dataUrl: string): string | undefined {
+    // data:[<mime type>][;charset=<charset>][;base64],<data>
+    const match = /^data:([^;,]+)(?:;charset=[^;,]+)?(?:;base64)?,/i.exec(
+        dataUrl
+    );
+    const mimeType = match?.[1]?.toLowerCase();
+
+    return mimeType || undefined;
+}
+
+/**
+ * Whether a URL is a `data:` URL holding an image of an allowed MIME type, and
+ * is therefore safe to keep as the source of an image.
+ *
+ * Any other value — a non-`data:` URL, a `data:` URL without a MIME type, or
+ * one whose MIME type is not an allowed image format — is not safe here and
+ * must be handled by the caller.
+ *
+ * @param url - The URL to check.
+ * @returns `true` when the URL is an allowed image `data:` URL.
+ * @internal
+ */
+export function isSafeImageDataUrl(url: string): boolean {
+    const trimmedUrl = url.trim();
+
+    if (!trimmedUrl.toLowerCase().startsWith('data:')) {
+        return false;
+    }
+
+    const mimeType = getDataUrlMimeType(trimmedUrl);
+
+    return Boolean(mimeType) && ALLOWED_IMAGE_MIME_TYPES.has(mimeType);
+}

--- a/src/components/text-editor/text-editor.e2e.tsx
+++ b/src/components/text-editor/text-editor.e2e.tsx
@@ -504,4 +504,62 @@ describe('limel-text-editor', () => {
             expect(changes).toHaveLength(0);
         });
     });
+
+    describe('embedded base64 images', () => {
+        const BASE64_PNG =
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGP4DwABAQEAWk1v8QAAAABJRU5ErkJggg==';
+
+        const STORED_VALUE = `<p><img src="${BASE64_PNG}" alt="picture.png" /></p>`;
+
+        async function createEditor(value: string) {
+            const { root, waitForChanges } = await render(
+                <limel-text-editor contentType="html" value={value} />
+            );
+            await waitForChanges();
+
+            const editor = await vi.waitFor(() => {
+                const contentEditable = getAdapter(
+                    root
+                )?.shadowRoot?.querySelector('.ProseMirror') as HTMLElement;
+                expect(contentEditable).toBeTruthy();
+
+                return contentEditable;
+            });
+
+            const changes: string[] = [];
+            root.addEventListener('change', (event: CustomEvent<string>) => {
+                changes.push(event.detail);
+            });
+
+            return {
+                root: root as HTMLLimelTextEditorElement,
+                editor,
+                changes,
+            };
+        }
+
+        test('renders a stored image from its embedded data', async () => {
+            const { editor } = await createEditor(STORED_VALUE);
+
+            const image = await vi.waitFor(() => {
+                const img = editor.querySelector('img');
+                expect(img).toBeTruthy();
+
+                return img;
+            });
+
+            expect(image.getAttribute('src')).toBe(BASE64_PNG);
+        });
+
+        test('keeps the embedded data when the user edits stored content', async () => {
+            const { root, editor, changes } = await createEditor(STORED_VALUE);
+
+            editor.focus();
+            document.execCommand('insertText', false, 'caption');
+            await root.flushPendingChanges();
+
+            expect(changes).not.toHaveLength(0);
+            expect(changes.at(-1)).toContain(BASE64_PNG);
+        });
+    });
 });


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
@coderabbitai summary
<!-- End of CodeRabbit summary -->

Closes #3662

## 🔍 Needs a decision before merging

**This PR deliberately reverses a documented security choice, and that call should be reviewed rather than merged as-is.** Input wanted from whoever implemented the base64 inline-image support on whether this is the shape we want.

`markdown-parser.spec.ts` contained this, on purpose:

```ts
describe('data URLs', () => {
    it('should strip data URLs for security', async () => {
        // Data URLs are stripped by the sanitizer to prevent
        // potential XSS via data: protocol
        expect(await sanitizeHTML('<img src="data:image/png;base64,abc123">'))
            .toEqualHtml('<img>');
    });
});
```

That blanket ban is what breaks #3662, so this PR replaces it with a narrower rule: **image `data:` URLs are kept and MIME-validated; every other `data:` URL is still stripped.** If we would rather keep the blanket ban, the fix has to move elsewhere (see alternatives below) — that is the question to settle.

## Root cause

Not a backend parsing problem, as suspected in the issue — the value is stored correctly. The loss happens on the way back **into** the editor.

Both content converters parse incoming values through `rehype-sanitize` with a schema built on its `defaultSchema` (`markdown-parser.ts`), whose protocol list allows only `http`/`https` for `src`:

```
protocols: { src: ['http', 'https'], … }
```

So every base64 image src is deleted while loading saved content:

| input | output before this PR |
|---|---|
| `![pic.png](data:image/png;base64,…)` | `<p><img alt="pic.png"></p>` |
| `<img alt="pic.png" src="data:image/png;base64,…">` | `<p><img alt="pic.png"></p>` |

Then the loss becomes permanent:

1. Paste → the node holds the full data URI → serialized to `<img src="data:…" />` → **saved correctly** (which is why it still renders in Lime Portal)
2. Reopen → **sanitizer deletes `src`**
3. `img` parseDOM (`plugins/image/node.ts`) takes `src: dom.getAttribute('src') || ''`, so a src-less `<img>` becomes an image node with `src: ''` and `state: 'success'` — the editor shows only the alt text
4. Next edit → `getImageHTML` writes `src="${attrs.src}"` → the consumer is handed `<img src="" …>` → **the base64 payload is overwritten in the database**

Step 4, reproduced in Chromium before the fix:

```
Received: '<p><img src="" alt="picture.png" style="max-width: 100%;">caption</p>'
```

Within a single session it looks fine, because the value echoed back into the editor is suppressed — the loss only surfaces after a reload or remount.

This also affects our own documented example, `limel-example-text-editor-with-inline-images-base64`, and any consumer letting users paste images without an upload backend.

## The change

- `safe-image-data-urls.ts` — the MIME allowlist and `data:` URL parsing, lifted out of `email-viewer/sanitize-email-html.ts`, which had already solved exactly this problem (raster formats only; `image/svg+xml` excluded, since an SVG can carry script). That module had no callers other than its own tests, so this puts the logic to work instead of duplicating it.
- `markdown-parser.ts` — allow `data` for `src` in the schema, then narrow it back to allow-listed image MIME types in a post-sanitize pass. The pass is shared by `markdownToHTML` and `sanitizeHTML` so the two paths cannot drift apart.

`limel-markdown` shares this sanitizer, so it can now also render the base64 images the editor produces. That is intentional — the editor writing content its own renderer cannot display is a bug in its own right — but it does mean the change reaches every markdown consumer in the library, which is the main reason to review the scope.

### Alternatives, if the shared change is too wide

1. Thread an opt-in flag through the text-editor's converters only, leaving `limel-markdown` unable to display base64 images.
2. Keep the blanket ban and have the editor refuse to persist images it cannot round-trip, so users get an explicit failure instead of silent loss.

## Guardrails

Kept as tests, so a future widening of the protocol list cannot quietly re-open them:

- `data:text/html`, `data:application/javascript`, `data:text/plain` — stripped
- `data:image/svg+xml` — stripped
- `data:` on `<a href>` — stripped
- `data:` without a MIME type, and a malformed header with no comma — rejected
- `javascript:` on `src` and `href` — unchanged, still stripped

The genuinely dangerous sinks (`iframe`, `embed`, `object`, `a href`) are not affected: they remain protocol-gated, and `<img src="data:text/html">` does not execute.

## Not addressed here

- A `data:` image we legitimately reject (an SVG, say) still becomes `src=""` and can overwrite stored data on the next save. Narrower than #3662 but the same failure mode — worth its own issue.
- The email composer (`limepkg-email`) feeds `prefilledBody + emailSignature + forwardData.html` straight into the editor with `contentType="html"`. Its own pasted images are uploaded and use `http(s)` srcs, so they were never affected, but a `data:` image in a **forwarded body or an admin-configured signature** would have been stripped before sending. This PR fixes that path too. Traced through the code, not reproduced in a running composer — worth confirming.
- `hydrate-custom-elements.ts` validates URLs inside custom-element JSON attributes against the same default protocol list, so `data:` images there are still stripped. Out of scope.

## Verification

- `npm run test:spec` — 74 files, 1138 tests, green
- `npx stencil-test --project e2e` — 50 files, 1022 passed / 8 skipped, green
- `npm run lint` — clean
- The two round-trip e2e tests fail on `main` (`src=""`) and pass here

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
