### PR TITLE
fix(markdown): keep nested ordered lists from inheriting bullet dots

### DIFF
--- a/src/components/markdown/examples/markdown-nested-lists.tsx
+++ b/src/components/markdown/examples/markdown-nested-lists.tsx
@@ -1,0 +1,38 @@
+import { Component, h } from '@stencil/core';
+
+const markdown = `
+1. Ordered top level
+2. With a nested unordered list
+    * unordered item
+    * with a nested ordered list
+        1. numbered sub-sub-item
+        2. another numbered sub-sub-item
+    * back to unordered
+3. Ordered again
+    1. ordered sub-item
+        * unordered sub-sub-item
+        * another unordered sub-sub-item
+
+> Lists work inside blockquotes too
+>
+> * unordered item
+>     1. numbered sub-item
+>     2. another numbered sub-item
+> * back to unordered
+`;
+
+/**
+ * Nested lists
+ *
+ * Ordered and unordered lists can be nested inside each other, also
+ * inside blockquotes.
+ */
+@Component({
+    tag: 'limel-example-markdown-nested-lists',
+    shadow: true,
+})
+export class MarkdownNestedListsExample {
+    public render() {
+        return <limel-markdown value={markdown} />;
+    }
+}

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -25,6 +25,7 @@ import { adaptColorContrast } from '../../util/adapt-color-contrast';
  * @exampleComponent limel-example-markdown-headings
  * @exampleComponent limel-example-markdown-emphasis
  * @exampleComponent limel-example-markdown-lists
+ * @exampleComponent limel-example-markdown-nested-lists
  * @exampleComponent limel-example-markdown-links
  * @exampleComponent limel-example-markdown-images
  * @exampleComponent limel-example-markdown-code

--- a/src/components/markdown/partial-styles/_lists.scss
+++ b/src/components/markdown/partial-styles/_lists.scss
@@ -1,7 +1,10 @@
 ul {
     list-style: none;
-    li {
-        position: relative;
+
+    // Child combinator: a descendant selector would also give the
+    // custom bullet to items of an `ol` nested inside a `ul`, showing
+    // both a number and a dot on the same item.
+    > li {
         margin-left: 0.75rem;
 
         &:before {
@@ -38,5 +41,9 @@ ol ul {
 }
 
 li {
+    // Positioned regardless of list type: the text editor anchors its
+    // node-selection outline (`li.ProseMirror-selectednode:after`) to
+    // the item's box.
+    position: relative;
     margin-bottom: 0.25rem;
 }

--- a/src/components/text-editor/examples/text-editor-lists.tsx
+++ b/src/components/text-editor/examples/text-editor-lists.tsx
@@ -1,0 +1,49 @@
+import { Component, h, Host, State } from '@stencil/core';
+
+const initialValue = `1. Ordered top level
+2. With a nested unordered list
+    * unordered item
+    * with a nested ordered list
+        1. numbered sub-sub-item
+        2. another numbered sub-sub-item
+    * back to unordered
+3. Ordered again
+
+> Lists work inside blockquotes too
+>
+> * unordered item
+>     1. numbered sub-item
+`;
+
+/**
+ * Lists
+ *
+ * Ordered and unordered lists can be toggled from the toolbar or with
+ * `Mod-Shift-7` and `Mod-Shift-8`. Toggling an existing list converts
+ * it in place, and `Tab` / `Shift+Tab` indent and outdent list items.
+ * Lists can be nested, also inside blockquotes.
+ */
+@Component({
+    tag: 'limel-example-text-editor-lists',
+    shadow: true,
+})
+export class TextEditorListsExample {
+    @State()
+    private value: string = initialValue;
+
+    public render() {
+        return (
+            <Host>
+                <limel-text-editor
+                    value={this.value}
+                    onChange={this.handleChange}
+                />
+                <limel-example-value value={this.value} />
+            </Host>
+        );
+    }
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -35,6 +35,7 @@ import { EditorUiType } from './types';
  * @exampleComponent limel-example-text-editor-with-markdown
  * @exampleComponent limel-example-text-editor-with-html
  * @exampleComponent limel-example-text-editor-with-tables
+ * @exampleComponent limel-example-text-editor-lists
  * @exampleComponent limel-example-text-editor-with-inline-images-base64
  * @exampleComponent limel-example-text-editor-with-inline-images-custom-tag
  * @exampleComponent limel-example-text-editor-allow-resize


### PR DESCRIPTION
## The bug

The hand-drawn bullet in the markdown list styles used a descendant selector (`ul li:before`), so any list item with a `ul` ancestor got the dot — including items of an `ol` nested inside a `ul`. A structure like `ol → ul → ol` rendered its innermost items with **both** the number and a bullet dot ("1• item").

The partial is shared by `limel-markdown` and the text editor (`limel-prosemirror-adapter`), so both the feed's rendered view and the editor showed the artifact. It surfaced now that list conversion from the toolbar makes mixed nesting easy to produce (#4222).

## The fix

Use the child combinator (`ul > li`) so the custom bullet (and the item margin that came with it) only applies to items whose own list is unordered.

## Example

Adds `limel-example-markdown-nested-lists` and `limel-example-text-editor-lists`, covering mixed `ol`/`ul` nesting in both directions, including inside a blockquote — rendered and editable respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive examples demonstrating nested ordered and unordered lists in Markdown and the text editor.
  * Added examples showing lists nested within blockquotes.
  * Documented list toggling, keyboard shortcuts, nesting, and indentation behavior in the text editor.
  * Added a live preview of edited content in the text editor example.

* **Bug Fixes**
  * Improved list styling so nested list items retain the appropriate formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->