### PR TITLE
feat(date-picker): enter date directly into the input field

### DIFF
--- a/src/components/date-picker/date-formatter.spec.ts
+++ b/src/components/date-picker/date-formatter.spec.ts
@@ -1,0 +1,202 @@
+import { DateFormatter } from './date-formatter';
+
+const asLocalDateString = (date: Date): string =>
+    `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+
+describe('parseDate', () => {
+    it('parses a fully zero-padded date', () => {
+        const formatter = new DateFormatter('en');
+
+        const date = formatter.parseDate('01/24/2020', 'MM/DD/YYYY');
+
+        expect(asLocalDateString(date)).toBe('2020-1-24');
+    });
+
+    it('accepts a single-digit month and day', () => {
+        const formatter = new DateFormatter('en');
+
+        const date = formatter.parseDate('1/24/2020', 'MM/DD/YYYY');
+
+        expect(asLocalDateString(date)).toBe('2020-1-24');
+    });
+
+    it('accepts a 2-digit year', () => {
+        const formatter = new DateFormatter('en');
+
+        const date = formatter.parseDate('1/24/20', 'MM/DD/YYYY');
+
+        expect(asLocalDateString(date)).toBe('2020-1-24');
+    });
+
+    it('accepts a 2-digit year typed in a locale using dots', () => {
+        // Regression test: German expects "DD.MM.YYYY", and a 2-digit
+        // year like this used to be rejected by strict-mode parsing even
+        // though it unambiguously names a complete date.
+        const formatter = new DateFormatter('de');
+
+        const date = formatter.parseDate('31.01.20', 'L');
+
+        expect(asLocalDateString(date)).toBe('2020-1-31');
+    });
+
+    it('parses British English as day-first, unlike plain English', () => {
+        const formatter = new DateFormatter('en-gb');
+
+        const date = formatter.parseDate('24/01/2020', 'L');
+
+        expect(asLocalDateString(date)).toBe('2020-1-24');
+    });
+
+    it('rejects text with a piece of the format still missing', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('01', 'MM/DD/YYYY')).toBeNull();
+    });
+
+    it('rejects a date with an out-of-range day for its month', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('02/30/2020', 'MM/DD/YYYY')).toBeNull();
+    });
+
+    it('rejects text that does not match the format at all', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('not a date', 'MM/DD/YYYY')).toBeNull();
+    });
+
+    it('returns null for an empty string', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('', 'MM/DD/YYYY')).toBeNull();
+    });
+
+    it('rejects a single leftover digit typed into the year', () => {
+        // Regression test: moment's lenient parsing (needed to accept a
+        // 2-digit year as shorthand) also happily accepts *any* digit
+        // count for "YYYY", applying its 2-digit-year pivot even to a
+        // single stray digit — so "1/24/2" mid-keystroke was silently
+        // parsed as a "complete" date in the year 2 AD.
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('1/24/2', 'MM/DD/YYYY')).toBeNull();
+    });
+
+    it('rejects a single leftover digit typed into the year, against the raw "L" token', () => {
+        // Regression test: `internalFormat` is normally the unexpanded
+        // shorthand token itself (e.g. "L"), not the literal pattern it
+        // expands to — and the ambiguous-year check above used to
+        // tokenize that raw "L" as one opaque letter-run instead of
+        // "DD"/"MM"/"YYYY", silently never matching and never rejecting
+        // anything. Reproduces deleting a digit from a real "17.01.20"
+        // down to "17.01.2".
+        const formatter = new DateFormatter('de');
+
+        expect(formatter.parseDate('17.01.2', 'L')).toBeNull();
+    });
+
+    it('rejects a 3-digit year', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('1/24/202', 'MM/DD/YYYY')).toBeNull();
+    });
+
+    it('accepts a 2-digit year on its own, with no other tokens', () => {
+        const formatter = new DateFormatter('en');
+
+        const date = formatter.parseDate('20', 'YYYY');
+
+        expect(asLocalDateString(date)).toBe('2020-1-1');
+    });
+
+    it('rejects a single leftover digit typed into a year-only field', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.parseDate('2', 'YYYY')).toBeNull();
+    });
+});
+
+describe('formatDate', () => {
+    it('formats a date according to the given format', () => {
+        const formatter = new DateFormatter('en');
+
+        const text = formatter.formatDate(new Date(2020, 0, 24), 'MM/DD/YYYY');
+
+        expect(text).toBe('01/24/2020');
+    });
+
+    it('returns an empty string when there is no date', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.formatDate(undefined, 'MM/DD/YYYY')).toBe('');
+    });
+});
+
+describe('expandFormat', () => {
+    it('expands the localized "L" token for English', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.expandFormat('L')).toBe('MM/DD/YYYY');
+    });
+
+    it('expands the localized "L" token for German', () => {
+        const formatter = new DateFormatter('de');
+
+        expect(formatter.expandFormat('L')).toBe('DD.MM.YYYY');
+    });
+
+    it('treats "no" as Norwegian Bokmål', () => {
+        const formatter = new DateFormatter('no');
+
+        expect(formatter.expandFormat('L')).toBe('DD.MM.YYYY');
+    });
+
+    it('expands British English day-first, unlike plain English', () => {
+        // Regression test: "en" and "en-gb" used to collapse to the same
+        // value, always validating against the US month-first pattern
+        // even for a user who picked British English formatting.
+        const formatter = new DateFormatter('en-gb');
+
+        expect(formatter.expandFormat('L')).toBe('DD/MM/YYYY');
+    });
+});
+
+describe('getDateFormat', () => {
+    it('derives the month format from the day-inclusive one, for a locale using slashes', () => {
+        const formatter = new DateFormatter('en');
+
+        expect(formatter.getDateFormat('month')).toBe('MM/YYYY');
+    });
+
+    it('derives the month format from the day-inclusive one, for a locale using dots', () => {
+        // Regression test: this used to be hardcoded to the English
+        // "MM/YYYY" regardless of language, so a Danish user's typed
+        // "01.2020" was rejected for not matching a slash-separated
+        // pattern they were never shown.
+        const formatter = new DateFormatter('da');
+
+        expect(formatter.getDateFormat('month')).toBe('MM.YYYY');
+    });
+
+    it('derives the month format from the day-inclusive one, for a locale with the year first', () => {
+        const formatter = new DateFormatter('sv');
+
+        expect(formatter.getDateFormat('month')).toBe('YYYY-MM');
+    });
+
+    it('keeps the fixed format for a type with no locale-specific order', () => {
+        const formatter = new DateFormatter('sv');
+
+        expect(formatter.getDateFormat('year')).toBe('YYYY');
+    });
+
+    it('derives the month format for British English', () => {
+        // Coincidentally the same as plain English's "MM/YYYY": dropping
+        // the day from "DD/MM/YYYY" and from "MM/DD/YYYY" both leave
+        // month before year, since day was the only thing distinguishing
+        // their order.
+        const formatter = new DateFormatter('en-gb');
+
+        expect(formatter.getDateFormat('month')).toBe('MM/YYYY');
+    });
+});

--- a/src/components/date-picker/date-formatter.ts
+++ b/src/components/date-picker/date-formatter.ts
@@ -8,6 +8,11 @@ import 'moment/locale/sv';
 import moment from 'moment/moment';
 import { DateType } from './date.types';
 
+// Longest-first, so e.g. `LTS` and `LT` aren't cut short by `L` matching
+// first — regex alternation takes the first alternative that matches at a
+// position, not the longest one.
+const LONG_DATE_FORMAT_TOKENS = /LTS|LLLL|LLL|LL|LT|L|lts|llll|lll|ll|lt|l/g;
+
 export class DateFormatter {
     private language: string;
 
@@ -25,7 +30,23 @@ export class DateFormatter {
 
     public parseDate(date: string, dateFormat: string) {
         if (date) {
-            return moment(date, dateFormat).toDate();
+            // The locale must be passed to the parse call itself, not
+            // chained on afterwards: `dateFormat` can be a localized token
+            // like `L`, and which literal pattern that expands to (e.g.
+            // `MM/DD/YYYY` for `en` vs `DD/MM/YYYY` for many others) is
+            // decided at parse time. Importing every `moment/locale/*` file
+            // (for the calendar UI) has the side effect of switching
+            // moment's global default locale to whichever was imported
+            // last, so parsing without pinning a locale here silently used
+            // the wrong one instead of `this.language`.
+            //
+            // Strict mode matters too: moment's default lenient parsing
+            // treats almost any partial prefix of a format as already
+            // "valid", silently defaulting the missing pieces (e.g. "01"
+            // against "MM/DD/YYYY" parses as today's date with the month
+            // forced to January) — which made every debounced keystroke
+            // while typing look like a complete, committable date.
+            return moment(date, dateFormat, this.getLanguage(), true).toDate();
         }
 
         return null;
@@ -37,6 +58,28 @@ export class DateFormatter {
         }
 
         return this.language;
+    }
+
+    /**
+     * Turns a moment format into the literal pattern it expands to for
+     * this instance's language — e.g. `L` becomes `MM/DD/YYYY` for `en`,
+     * `DD/MM/YYYY` for many others. Shown to the user (in a placeholder or
+     * an error message), the shorthand token itself means nothing; only
+     * the expanded pattern tells them what to type.
+     * @param format - the moment format to expand, e.g. `L` or `L - LT`
+     */
+    public expandFormat(format: string): string {
+        if (!format) {
+            return format;
+        }
+
+        const localeData = moment.localeData(this.getLanguage());
+
+        return format.replaceAll(
+            LONG_DATE_FORMAT_TOKENS,
+            (token: moment.LongDateFormatKey) =>
+                localeData.longDateFormat(token) || token
+        );
     }
 
     public getDateFormat(type: DateType) {

--- a/src/components/date-picker/date-formatter.ts
+++ b/src/components/date-picker/date-formatter.ts
@@ -1,5 +1,6 @@
 import 'moment/locale/da';
 import 'moment/locale/de';
+import 'moment/locale/en-gb';
 import 'moment/locale/fi';
 import 'moment/locale/fr';
 import 'moment/locale/nb';
@@ -12,6 +13,177 @@ import { DateType } from './date.types';
 // first — regex alternation takes the first alternative that matches at a
 // position, not the longest one.
 const LONG_DATE_FORMAT_TOKENS = /LTS|LLLL|LLL|LL|LT|L|lts|llll|lll|ll|lt|l/g;
+
+/**
+ * Turns a moment format into the literal pattern it expands to for a given
+ * locale — e.g. `L` becomes `MM/DD/YYYY` for `en`, `DD/MM/YYYY` for many
+ * others. `internalFormat` is normally left as this kind of shorthand
+ * token (it's what moment itself parses/formats against directly), but
+ * anything that needs to reason about the *literal* token structure — a
+ * placeholder shown to the user, or `hasAmbiguousYear` checking digit
+ * counts per token below — needs it expanded first.
+ * @param format - the moment format to expand, e.g. `L` or `L - LT`
+ * @param locale - the moment locale to expand it for
+ */
+function expandLongDateFormatTokens(format: string, locale: string): string {
+    if (!format) {
+        return format;
+    }
+
+    const localeData = moment.localeData(locale);
+
+    return format.replaceAll(
+        LONG_DATE_FORMAT_TOKENS,
+        (token: moment.LongDateFormatKey) =>
+            localeData.longDateFormat(token) || token
+    );
+}
+
+/**
+ * Parses `date` against `format`, accepting shorthand digit counts (e.g.
+ * `1/24/20` for `MM/DD/YYYY`) while still rejecting a genuinely incomplete
+ * or invalid date.
+ *
+ * Moment's *strict* mode was tried first, but it demands an exact digit
+ * count per token — `YYYY` refuses a 2-digit year, `MM`/`DD` refuse a
+ * single digit — rejecting plenty of dates a person would naturally type
+ * and consider complete. Moment's *lenient* mode goes too far the other
+ * way: it treats almost any partial prefix of a format as already valid,
+ * silently defaulting the missing pieces (e.g. "01" against "MM/DD/YYYY"
+ * parses as today's date with the month forced to January) — which made
+ * every debounced keystroke while typing look like a complete,
+ * committable date.
+ *
+ * The middle ground: parse leniently, then use moment's own parsing flags
+ * to demand that every token in `format` actually matched something and
+ * that no trailing text was left over — i.e. lenient about *how many
+ * digits*, strict about *nothing being missing*.
+ * @param date - the raw text to parse
+ * @param format - the moment format to parse it against
+ * @param locale - the moment locale to parse it in
+ */
+export function parseComplete(
+    date: string,
+    format: string,
+    locale: string
+): Date | null {
+    const parsed = moment(date, format, locale, false);
+
+    if (!parsed.isValid()) {
+        return null;
+    }
+
+    const flags = parsed.parsingFlags();
+    if (flags.charsLeftOver > 0 || flags.unusedTokens.length > 0) {
+        return null;
+    }
+
+    if (hasAmbiguousYear(date, format, locale)) {
+        return null;
+    }
+
+    return parsed.toDate();
+}
+
+/**
+ * `YYYY`/`GGGG` are the only tokens where lenient parsing's tolerance for
+ * "however many digits were typed" creates real ambiguity: moment accepts
+ * any* digit count there, applying its 2-digit-year pivot (e.g. "20" →
+ * 2020) — which also means a single leftover digit mid-keystroke (e.g.
+ * "1/24/2") silently parses as a "complete" date in year 2 AD, exactly the
+ * kind of not-yet-finished input `parseComplete` exists to reject. `MM`/
+ * `DD` don't have this problem: 1 or 2 digits are both unambiguous there
+ * (no pivoting), so they're intentionally left alone.
+ *
+ * A 2-digit year is kept as valid shorthand (moment's pivot handles it);
+ * `GGGG` gets no such allowance, since moment's pivot doesn't apply to it
+ * at all — a 2-digit input there parses as literally the year 20, not
+ * 2020.
+ *
+ * `format` has to be expanded first: `internalFormat` is normally a
+ * shorthand token like `L`, which this function's own tokenizer would
+ * otherwise see as one opaque letter-run rather than the `DD`/`MM`/`YYYY`
+ * it actually stands for — silently never matching, and never rejecting
+ * anything.
+ * @param date - the raw text that was parsed
+ * @param format - the moment format it was parsed against
+ * @param locale - the moment locale `format` expands against
+ */
+function hasAmbiguousYear(
+    date: string,
+    format: string,
+    locale: string
+): boolean {
+    const expandedFormat = expandLongDateFormatTokens(format, locale);
+    const formatParts = expandedFormat.match(/[a-zA-Z]+|[^a-zA-Z]+/g) || [];
+    const inputPattern = formatParts
+        .map((part) =>
+            /^[a-zA-Z]+$/.test(part)
+                ? String.raw`(\d{1,4})`
+                : part.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+        )
+        .join('');
+    const match = date.match(new RegExp(`^${inputPattern}$`));
+
+    if (!match) {
+        // Doesn't even line up with the format's token/separator
+        // structure — `parseComplete`'s other checks handle rejecting it.
+        return false;
+    }
+
+    const tokens = formatParts.filter((part) => /^[a-zA-Z]+$/.test(part));
+
+    return tokens.some((token, index) => {
+        const digitCount = match[index + 1].length;
+
+        if (token === 'YYYY') {
+            return digitCount !== 2 && digitCount !== 4;
+        }
+
+        if (token === 'GGGG') {
+            return digitCount !== 4;
+        }
+
+        return false;
+    });
+}
+
+/**
+ * Derives a month-and-year-only format from a full day-inclusive one (e.g.
+ * `DD.MM.YYYY` → `MM.YYYY`, `YYYY-MM-DD` → `YYYY-MM`) by dropping the day
+ * token and one of its adjacent separators.
+ *
+ * There's no moment long-date-format token for "month and year, in this
+ * locale's own order and separator" the way `L` covers a full date — so
+ * without this, a month-type field has no locale-aware format to fall
+ * back on. Deriving it from the locale's own `L` keeps the month/year
+ * order and separator consistent with how this locale writes a full date,
+ * rather than hardcoding one locale's convention (e.g. `MM/YYYY`) for
+ * everyone.
+ * @param format - a day-inclusive format, e.g. this locale's own `L`
+ */
+function stripDay(format: string): string {
+    const parts = format.match(/[a-zA-Z]+|[^a-zA-Z]+/g) || [];
+    const dayIndex = parts.findIndex((part) => /^D+$/.test(part));
+
+    if (dayIndex === -1) {
+        return format;
+    }
+
+    const withoutDay = [...parts];
+    withoutDay.splice(dayIndex, 1);
+
+    const isSeparator = (part: string | undefined) =>
+        part !== undefined && /^[^a-zA-Z]+$/.test(part);
+
+    if (isSeparator(withoutDay[dayIndex])) {
+        withoutDay.splice(dayIndex, 1);
+    } else if (isSeparator(withoutDay[dayIndex - 1])) {
+        withoutDay.splice(dayIndex - 1, 1);
+    }
+
+    return withoutDay.join('');
+}
 
 export class DateFormatter {
     private language: string;
@@ -39,14 +211,7 @@ export class DateFormatter {
             // moment's global default locale to whichever was imported
             // last, so parsing without pinning a locale here silently used
             // the wrong one instead of `this.language`.
-            //
-            // Strict mode matters too: moment's default lenient parsing
-            // treats almost any partial prefix of a format as already
-            // "valid", silently defaulting the missing pieces (e.g. "01"
-            // against "MM/DD/YYYY" parses as today's date with the month
-            // forced to January) — which made every debounced keystroke
-            // while typing look like a complete, committable date.
-            return moment(date, dateFormat, this.getLanguage(), true).toDate();
+            return parseComplete(date, dateFormat, this.getLanguage());
         }
 
         return null;
@@ -69,26 +234,21 @@ export class DateFormatter {
      * @param format - the moment format to expand, e.g. `L` or `L - LT`
      */
     public expandFormat(format: string): string {
-        if (!format) {
-            return format;
-        }
-
-        const localeData = moment.localeData(this.getLanguage());
-
-        return format.replaceAll(
-            LONG_DATE_FORMAT_TOKENS,
-            (token: moment.LongDateFormatKey) =>
-                localeData.longDateFormat(token) || token
-        );
+        return expandLongDateFormatTokens(format, this.getLanguage());
     }
 
     public getDateFormat(type: DateType) {
+        if (type === 'month') {
+            return stripDay(
+                moment.localeData(this.getLanguage()).longDateFormat('L')
+            );
+        }
+
         return (
             {
                 date: 'L',
                 time: 'LT',
                 week: '[w] W GGGG',
-                month: 'MM/YYYY',
                 quarter: '[Q]Q YYYY',
                 year: 'YYYY',
                 datetime: 'L - LT',

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -6,6 +6,7 @@ import {
     Element,
     EventEmitter,
     Event,
+    Watch,
 } from '@stencil/core';
 import { createRandomString } from '../../util/random-string';
 import { isAndroidDevice, isIOSDevice } from '../../util/device';
@@ -49,6 +50,7 @@ const nativeFormatForType = {
  * @exampleComponent limel-example-date-picker-programmatic-change
  * @exampleComponent limel-example-date-picker-composite
  * @exampleComponent limel-example-date-picker-custom-formatter
+ * @exampleComponent limel-example-date-picker-typed-input
  */
 @Component({
     tag: 'limel-date-picker',
@@ -76,6 +78,11 @@ export class DatePicker {
     /**
      * Set to `true` to indicate that the current value of the date picker is
      * invalid.
+     *
+     * Note: this is separate from — and unaffected by — the component's own
+     * detection of unparseable typed text. Use this prop for your own
+     * business rules (e.g. `required`); the component flags format errors
+     * on its own regardless of this value.
      */
     @Prop({ reflect: true })
     public invalid = false;
@@ -87,16 +94,30 @@ export class DatePicker {
     public label: string;
 
     /**
-     * The placeholder text shown inside the input field, when the field is focused and empty
+     * The placeholder text shown inside the input field, when the field is focused and empty.
+     *
+     * Defaults to the expected date format (e.g. `MM/DD/YYYY`), so a
+     * consumer that sets `format` gets a hint for what to type for free.
      */
     @Prop({ reflect: true })
     public placeholder: string;
 
     /**
-     * Optional helper text to display below the input field when it has focus
+     * Optional helper text to display below the input field when it has focus.
+     *
+     * Overridden by `invalidFormatMessage` while the typed text doesn't
+     * parse as a valid date.
      */
     @Prop({ reflect: true })
     public helperText: string;
+
+    /**
+     * Message shown instead of `helperText` when the text currently typed
+     * into the field cannot be parsed as a date. If omitted, a generic
+     * message naming the expected format is shown.
+     */
+    @Prop({ reflect: true })
+    public invalidFormatMessage: string;
 
     /**
      * Set to `true` to indicate that the field is required.
@@ -140,7 +161,11 @@ export class DatePicker {
     public formatter?: (date: Date) => string;
 
     /**
-     * Emitted when the date picker value is changed.
+     * Emitted when the date picker value is changed, whether by typing a
+     * valid date and committing it, picking a day in the calendar, choosing
+     * "Today", or clearing the field. This is the single source of truth
+     * for value changes — it always fires, regardless of which interaction
+     * caused it.
      */
     @Event()
     private change: EventEmitter<Date>;
@@ -152,6 +177,24 @@ export class DatePicker {
     private internalFormat: string;
     @State()
     private showPortal = false;
+
+    /**
+     * `true` while the text currently in the input field cannot be parsed
+     * as a valid date in `internalFormat`. This is distinct from the
+     * `invalid` prop: it's the component's own assessment of the typed
+     * text, not a business rule set by the consumer.
+     */
+    @State()
+    private parseError = false;
+
+    /**
+     * Holds the user's raw, uncommitted, unparseable text so it stays
+     * visible (instead of being overwritten by the last valid `value` on
+     * re-render) until it's corrected, cleared, or overridden by picking a
+     * date from the calendar.
+     */
+    @State()
+    private rawInputValue: string | undefined;
 
     private useNative: boolean;
     private nativeType: InputType;
@@ -189,6 +232,18 @@ export class DatePicker {
         this.removeDocumentListeners();
     }
 
+    /**
+     * If the value changes from outside (e.g. the consumer resets a form,
+     * or another control updates this field programmatically), drop any
+     * stale parse-error state so the field reflects the new value instead
+     * of leftover invalid text.
+     */
+    @Watch('value')
+    protected watchValue() {
+        this.parseError = false;
+        this.rawInputValue = undefined;
+    }
+
     public render() {
         const inputProps: any = {
             onAction: this.clearValue,
@@ -198,8 +253,7 @@ export class DatePicker {
             inputProps.trailingIcon = 'clear_symbol';
         }
 
-        const helperText =
-            this.disabled || this.readonly ? undefined : this.helperText;
+        const helperText = this.getHelperText();
 
         if (this.useNative) {
             return (
@@ -227,12 +281,12 @@ export class DatePicker {
             <limel-input-field
                 disabled={this.disabled}
                 readonly={this.readonly}
-                invalid={this.invalid}
+                invalid={this.invalid || this.parseError}
                 label={this.label}
-                placeholder={this.placeholder}
+                placeholder={this.getPlaceholder()}
                 helperText={helperText}
                 required={this.required}
-                value={this.value ? formatter(this.value) : ''}
+                value={this.getDisplayValue(formatter)}
                 onFocus={this.showCalendar}
                 onBlur={this.hideCalendar}
                 onClick={this.onInputClick}
@@ -259,15 +313,56 @@ export class DatePicker {
         ];
     }
 
+    /**
+     * What the text field should currently show: the raw text the user is
+     * mid-typing if it doesn't yet parse, otherwise the formatted
+     * committed value.
+     * @param formatter - formats `value` for display when there's no
+     * pending invalid text to show instead
+     */
+    private getDisplayValue(formatter: (date: Date) => string): string {
+        if (this.parseError && this.rawInputValue !== undefined) {
+            return this.rawInputValue;
+        }
+
+        return this.value ? formatter(this.value) : '';
+    }
+
+    private getPlaceholder(): string {
+        return (
+            this.placeholder ??
+            this.dateFormatter.expandFormat(this.internalFormat)
+        );
+    }
+
+    private getHelperText(): string {
+        if (this.parseError) {
+            return (
+                this.invalidFormatMessage ??
+                `Enter a valid date (${this.dateFormatter.expandFormat(this.internalFormat)})`
+            );
+        }
+
+        return this.disabled || this.readonly ? undefined : this.helperText;
+    }
+
     private updateInternalFormatAndType() {
         this.nativeType = nativeTypeForConsumerType[this.type || 'default'];
         this.nativeFormat = nativeFormatForType[this.nativeType];
 
         if (this.useNative) {
             this.internalFormat = this.nativeFormat;
-        } else if (this.formatter || this.format) {
+        } else if (this.format) {
             this.internalFormat = this.format;
         } else {
+            // Deliberately ignores `formatter`: it's an arbitrary function
+            // for *displaying* an already-committed value (e.g. via
+            // `Intl.DateTimeFormat`), with no format string to invert, so
+            // it can't tell us what pattern typed text should be validated
+            // against. Falling back to the locale default here — rather
+            // than leaving `internalFormat` undefined — is what typed
+            // input is parsed against, and what the placeholder and
+            // invalid-format message show.
             this.internalFormat = this.dateFormatter.getDateFormat(this.type);
         }
     }
@@ -278,7 +373,10 @@ export class DatePicker {
             event.detail,
             this.internalFormat
         );
-        this.change.emit(date);
+
+        if (date && !Number.isNaN(date.getTime())) {
+            this.change.emit(date);
+        }
     }
 
     private showCalendar(event) {
@@ -289,7 +387,17 @@ export class DatePicker {
         }
         this.showPortal = true;
         const inputElement = this.textField.shadowRoot.querySelector('input');
-        setTimeout(() => {
+        // A microtask, not a `setTimeout`: on the very first focus, this is
+        // what creates the Flatpickr instance (see
+        // `DatePickerCalendar.componentDidUpdate`), and Flatpickr's own
+        // constructor synchronously writes its computed value into the
+        // input's DOM value as part of setup. A macrotask delay left a
+        // window where that write could land after the user had already
+        // started typing, silently overwriting their first keystrokes.
+        // Microtasks always drain before the next keystroke is processed,
+        // so this closes that window while still deferring off the current
+        // call stack.
+        queueMicrotask(() => {
             this.datePickerCalendar.inputElement = inputElement;
         });
         event.stopPropagation();
@@ -349,7 +457,7 @@ export class DatePicker {
         }
         const mdcTextField = new MDCTextField(root);
         mdcTextField.getDefaultFoundation().deactivateFocus();
-        mdcTextField.valid = !this.invalid;
+        mdcTextField.valid = !(this.invalid || this.parseError);
     }
 
     private documentClickListener = (event: MouseEvent) => {
@@ -366,10 +474,23 @@ export class DatePicker {
     private handleCalendarChange(event) {
         const date = event.detail;
         event.stopPropagation();
+
+        if (date === null && this.parseError) {
+            // Flatpickr independently tries to parse whatever is in the
+            // input on blur too, and clears it when that fails — racing
+            // the typed-input handling above, which (for the same blur)
+            // already correctly flagged this text as invalid and is
+            // preserving it for the user to fix. Let that stand rather
+            // than have Flatpickr's own clear silently wipe it out.
+            return;
+        }
+
         if (this.pickerIsAutoClosing()) {
             this.hideCalendar();
         }
 
+        this.parseError = false;
+        this.rawInputValue = undefined;
         this.change.emit(date);
     }
 
@@ -385,16 +506,45 @@ export class DatePicker {
         this.showCalendar(event);
     }
 
-    private handleInputElementChange(event) {
+    /**
+     * Handles every text-field commit: typing a date and blurring/pressing
+     * enter, or emptying the field. This is the path that previously only
+     * reacted to an emptied field — it now also parses whatever text was
+     * typed and, if it's a valid date, emits it exactly the same way a
+     * calendar pick does.
+     * @param event - the input field's `change` event; `event.detail` is
+     * the current raw text
+     */
+    private handleInputElementChange(event: CustomEvent<string>) {
         if (this.disabled || this.readonly) {
             event.stopPropagation();
             return;
         }
-        if (event.detail === '') {
-            this.clearValue();
-        }
 
         event.stopPropagation();
+
+        const text = event.detail;
+
+        if (text === '') {
+            this.parseError = false;
+            this.rawInputValue = undefined;
+            this.clearValue();
+            return;
+        }
+
+        const date = this.dateFormatter.parseDate(text, this.internalFormat);
+
+        if (date && !Number.isNaN(date.getTime())) {
+            this.parseError = false;
+            this.rawInputValue = undefined;
+            this.change.emit(date);
+        } else {
+            // Don't emit a change and don't let the next render overwrite
+            // what the user typed with the old committed value — keep it
+            // visible, flagged as invalid, until it's fixed or replaced.
+            this.parseError = true;
+            this.rawInputValue = text;
+        }
     }
 
     private pickerIsAutoClosing() {

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -156,6 +156,11 @@ export class DatePicker {
      * :::note
      * overrides `format` and `language`
      * :::
+     *
+     * Only while the field is at rest: `formatter` can't be inverted into
+     * a pattern to validate typed text against, so while the field has
+     * focus it's shown and validated using `format`/`language` instead,
+     * then redisplayed via `formatter` once it's blurred.
      */
     @Prop()
     public formatter?: (date: Date) => string;
@@ -195,6 +200,14 @@ export class DatePicker {
      */
     @State()
     private rawInputValue: string | undefined;
+
+    /**
+     * `true` while the input field has focus. Drives which formatter
+     * `getDisplayValue` shows the value with — see `formatter`'s doc
+     * comment for why.
+     */
+    @State()
+    private isEditing = false;
 
     private useNative: boolean;
     private nativeType: InputType;
@@ -306,7 +319,6 @@ export class DatePicker {
                     value={this.value}
                     ref={(el) => (this.datePickerCalendar = el)}
                     isOpen={this.showPortal}
-                    formatter={formatter}
                     onChange={this.handleCalendarChange}
                 />
             </limel-portal>,
@@ -315,14 +327,27 @@ export class DatePicker {
 
     /**
      * What the text field should currently show: the raw text the user is
-     * mid-typing if it doesn't yet parse, otherwise the formatted
-     * committed value.
+     * mid-typing (whether or not it currently parses) if there is any,
+     * otherwise the formatted committed value.
      * @param formatter - formats `value` for display when there's no
-     * pending invalid text to show instead
+     * typed text to show instead
      */
     private getDisplayValue(formatter: (date: Date) => string): string {
         if (this.parseError && this.rawInputValue !== undefined) {
             return this.rawInputValue;
+        }
+
+        if (this.isEditing) {
+            if (this.rawInputValue !== undefined) {
+                return this.rawInputValue;
+            }
+
+            // Focused, but nothing typed yet: show the internalFormat-based
+            // text (matches the placeholder and what typed input gets
+            // parsed against), not `formatter`'s pretty text, which might
+            // use a totally different pattern — see `formatter`'s doc
+            // comment.
+            return this.value ? this.formatValue(this.value) : '';
         }
 
         return this.value ? formatter(this.value) : '';
@@ -385,6 +410,7 @@ export class DatePicker {
 
             return;
         }
+        this.isEditing = true;
         this.showPortal = true;
         const inputElement = this.textField.shadowRoot.querySelector('input');
         // A microtask, not a `setTimeout`: on the very first focus, this is
@@ -427,6 +453,17 @@ export class DatePicker {
     }
 
     private hideCalendar() {
+        this.isEditing = false;
+
+        if (!this.parseError) {
+            // Done editing a valid value: drop the preserved raw typed
+            // text so the next focus starts from the current committed
+            // value instead of a stale partial edit. Left alone while
+            // `parseError` is true, so the invalid text stays visible to
+            // fix even after losing focus.
+            this.rawInputValue = undefined;
+        }
+
         setTimeout(() => {
             this.showPortal = false;
         });
@@ -536,7 +573,15 @@ export class DatePicker {
 
         if (date && !Number.isNaN(date.getTime())) {
             this.parseError = false;
-            this.rawInputValue = undefined;
+            // Keep showing exactly what was typed rather than the freshly
+            // committed value's canonical (e.g. zero-padded) formatting:
+            // this fires on a debounce, not just on blur, so a 2-digit
+            // year someone is still typing toward 4 digits (e.g. "20" on
+            // its way to "2026") already parses as valid shorthand and
+            // would otherwise get rewritten to "2020" out from under
+            // their next keystrokes. `hideCalendar` clears this once
+            // they're actually done editing.
+            this.rawInputValue = text;
             this.change.emit(date);
         } else {
             // Don't emit a change and don't let the next render overwrite

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -597,6 +597,15 @@ export class DatePicker {
     }
 
     private clearValue() {
+        // Mirrors the `text === ''` branch of `handleInputElementChange`:
+        // without resetting these first, any `rawInputValue` left over
+        // from earlier typing (valid or not) would keep winning in
+        // `getDisplayValue` forever afterward — `value` turning falsy
+        // doesn't matter once that check is reached — making the field
+        // look permanently stuck on stale text no matter what's typed
+        // next.
+        this.parseError = false;
+        this.rawInputValue = undefined;
         this.change.emit(null);
     }
 

--- a/src/components/date-picker/date.types.ts
+++ b/src/components/date-picker/date.types.ts
@@ -17,6 +17,7 @@ export type Languages =
     | 'da'
     | 'de'
     | 'en'
+    | 'en-gb'
     | 'fi'
     | 'fr'
     | 'nb'

--- a/src/components/date-picker/examples/date-picker-typed-input.scss
+++ b/src/components/date-picker/examples/date-picker-typed-input.scss
@@ -1,0 +1,4 @@
+limel-select,
+limel-date-picker {
+    margin-bottom: 1rem;
+}

--- a/src/components/date-picker/examples/date-picker-typed-input.tsx
+++ b/src/components/date-picker/examples/date-picker-typed-input.tsx
@@ -1,0 +1,66 @@
+import { Component, h, State } from '@stencil/core';
+import { LimelSelectCustomEvent, Option } from '@limetech/lime-elements';
+
+const DATE_FORMATS: Array<Option<string>> = [
+    { text: 'US — MM/DD/YYYY', value: 'MM/DD/YYYY' },
+    { text: 'European — DD/MM/YYYY', value: 'DD/MM/YYYY' },
+    { text: 'Swedish (ISO) — YYYY-MM-DD', value: 'YYYY-MM-DD' },
+];
+
+/**
+ * Typing a date directly
+ *
+ * Try typing a date directly into the field and pressing <kbd>Tab</kbd> or
+ * clicking away. A valid date is committed just like picking one from the
+ * calendar. An unparseable value is flagged with a helper message, and your
+ * typed text stays visible until it's corrected.
+ *
+ * Use the format picker below to test typing against different date
+ * formats.
+ */
+@Component({
+    tag: 'limel-example-date-picker-typed-input',
+    shadow: true,
+    styleUrl: 'date-picker-typed-input.scss',
+})
+export class DatePickerTypedInputExample {
+    @State()
+    private format = DATE_FORMATS[0].value;
+
+    @State()
+    private formatTestValue: Date;
+
+    public render() {
+        return [
+            <limel-select
+                label="Date format"
+                helperText="Choose how dates appear across the app."
+                options={DATE_FORMATS}
+                value={this.getSelectedFormat()}
+                onChange={this.handleFormatChange}
+            />,
+            <limel-date-picker
+                type="date"
+                label="Date"
+                format={this.format}
+                value={this.formatTestValue}
+                onChange={this.handleFormatTestValueChange}
+            />,
+            <limel-example-value value={this.formatTestValue} />,
+        ];
+    }
+
+    private getSelectedFormat() {
+        return DATE_FORMATS.find((option) => option.value === this.format);
+    }
+
+    private handleFormatChange = (
+        event: LimelSelectCustomEvent<Option<string>>
+    ) => {
+        this.format = event.detail.value;
+    };
+
+    private handleFormatTestValueChange = (event) => {
+        this.formatTestValue = event.detail;
+    };
+}

--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
@@ -61,9 +61,6 @@ export class DatePickerCalendar {
     @Prop()
     public language: Languages = 'en';
 
-    @Prop()
-    public formatter!: (date: Date) => string;
-
     /**
      * Emitted when the date picker value is changed.
      */
@@ -142,10 +139,6 @@ export class DatePickerCalendar {
                 );
                 break;
             }
-        }
-
-        if (this.formatter) {
-            this.picker.formatter = this.formatter;
         }
     }
 

--- a/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
+++ b/src/components/date-picker/flatpickr-adapter/flatpickr-adapter.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop, Watch } from '@stencil/core';
 import { DateType, Languages } from '../../date-picker/date.types';
 import translate from '../../../global/translations';
 import { DatePicker as DateOnlyPicker } from '../pickers/date-picker';
@@ -147,6 +147,17 @@ export class DatePickerCalendar {
         if (this.formatter) {
             this.picker.formatter = this.formatter;
         }
+    }
+
+    /**
+     * `componentWillLoad` only runs once, when the calendar is first
+     * created, so the `Picker` instance's own date format would otherwise
+     * stay pinned to whatever `format` was at that point — silently
+     * ignoring any later change to this prop.
+     */
+    @Watch('format')
+    protected watchFormat() {
+        this.picker?.setDateFormat(this.format);
     }
 
     public componentDidUpdate() {

--- a/src/components/date-picker/pickers/picker.ts
+++ b/src/components/date-picker/pickers/picker.ts
@@ -3,6 +3,7 @@ import FlatpickrLanguages from 'flatpickr/dist/l10n';
 import { EventEmitter } from '@stencil/core';
 import 'moment/locale/da';
 import 'moment/locale/de';
+import 'moment/locale/en-gb';
 import 'moment/locale/fi';
 import 'moment/locale/fr';
 import 'moment/locale/nb';
@@ -10,11 +11,24 @@ import 'moment/locale/nl';
 import 'moment/locale/sv';
 import moment from 'moment/moment';
 import { isAndroidDevice, isIOSDevice } from '../../../util/device';
+import { parseComplete } from '../date-formatter';
 
 const ARIA_DATE_FORMAT = 'F j, Y';
 
 export abstract class Picker {
-    public formatter = (date: Date) =>
+    /**
+     * Deliberately not settable from outside — a consumer-supplied
+     * `formatter` (an arbitrary, non-invertible function) is what
+     * `limel-date-picker`'s own render logic uses for its "pretty"
+     * at-rest display, but it's not safe to also let Flatpickr use it
+     * here: this is what keeps Flatpickr's own internal sync of the
+     * bound input (e.g. right after a calendar pick) consistent with
+     * `dateFormat` — the exact pattern typed text gets validated
+     * against. A custom formatter producing different text (e.g. a
+     * different separator) would fail that re-validation immediately.
+     * @param date - the date to format
+     */
+    private formatter = (date: Date) =>
         moment(date).locale(this.getMomentLang()).format(this.dateFormat);
 
     protected dateFormat: string;
@@ -163,6 +177,14 @@ export abstract class Picker {
             return 'no';
         }
 
+        // Flatpickr ships a single English locale, with no separate
+        // British variant — its `|| FlatpickrLanguages.en` fallback would
+        // already land here anyway, but doing it explicitly keeps this in
+        // step with `getMomentLang`, which does need to distinguish them.
+        if (this.language === 'en-gb') {
+            return 'en';
+        }
+
         return this.language;
     }
 
@@ -213,20 +235,16 @@ export abstract class Picker {
      * afterwards) for the same reason `DateFormatter.parseDate` does: this
      * module's `import 'moment/locale/*'` side effects switch moment's
      * global default locale, so a localized token like `L` would otherwise
-     * get parsed against the wrong locale's pattern. Strict mode avoids
-     * moment's lenient partial-match parsing treating a not-yet-finished
-     * typed string as already a complete, committable date.
+     * get parsed against the wrong locale's pattern. Uses the same
+     * lenient-but-complete parsing as `DateFormatter.parseDate` — see its
+     * doc comment for why plain strict-mode parsing rejects too much.
      * @param dateStr - the raw text Flatpickr wants parsed as a date
      */
     private parseDate = (dateStr: string): Date | undefined => {
-        const parsed = moment(
-            dateStr,
-            this.dateFormat,
-            this.getMomentLang(),
-            true
+        return (
+            parseComplete(dateStr, this.dateFormat, this.getMomentLang()) ??
+            undefined
         );
-
-        return parsed.isValid() ? parsed.toDate() : undefined;
     };
 
     private handleOnClose() {

--- a/src/components/date-picker/pickers/picker.ts
+++ b/src/components/date-picker/pickers/picker.ts
@@ -41,11 +41,34 @@ export abstract class Picker {
         this.getFlatpickrLang = this.getFlatpickrLang.bind(this);
     }
 
+    /**
+     * `dateFormat` is otherwise only set once, from the constructor. Without
+     * this, changing the `format` prop on `limel-date-picker` after the
+     * calendar has already been created updates what's displayed and what
+     * `DateFormatter.parseDate` validates typed text against, but not what
+     * this Flatpickr instance itself parses typed text against on blur or
+     * `Enter` — so it would keep accepting (and silently reformatting) text
+     * in the old format.
+     * @param dateFormat - the new moment format string to parse and
+     * display against
+     */
+    public setDateFormat(dateFormat: string) {
+        if (dateFormat) {
+            this.dateFormat = dateFormat;
+        }
+    }
+
     public init(element: HTMLElement, container: HTMLElement, value?: Date) {
         const config: flatpickr.Options.Options = {
+            // Flatpickr defaults to `false`, which forces the bound input
+            // to `readonly` — silently blocking all keyboard character
+            // entry, so a value can only ever come from picking a date in
+            // the calendar. Typing a date directly requires this to be on.
+            allowInput: true,
             clickOpens: this.nativePicker,
             disableMobile: !this.nativePicker,
             formatDate: this.nativePicker ? undefined : this.formatDate,
+            parseDate: this.nativePicker ? undefined : this.parseDate,
             appendTo: container,
             onClose: this.handleOnClose,
             defaultDate: value,
@@ -64,9 +87,47 @@ export abstract class Picker {
         (config.locale as flatpickr.CustomLocale).firstDayOfWeek = 1;
 
         this.flatpickr = flatpickr(element, config) as flatpickr.Instance;
+
+        // Whenever typed text fails to parse, Flatpickr's own onBlur/Enter
+        // handling calls `setDate(rawText, ...)` on its own — which, once
+        // it finds nothing parseable, still unconditionally overwrites the
+        // input's DOM value directly (to an empty string) and fires
+        // `onValueUpdate`, bypassing Stencil and racing the typed-input
+        // handling above, which has already decided to keep the raw
+        // invalid text visible with an error message instead. Flatpickr
+        // exposes no option to opt out of just that reaction, so only let
+        // its own `setDate` through for input it can actually parse;
+        // programmatic calls (e.g. `Picker.setValue`, an actual calendar
+        // pick) always pass a real `Date`, never a raw string, so they are
+        // untouched by this guard.
+        const setDate = this.flatpickr.setDate.bind(this.flatpickr);
+        this.flatpickr.setDate = (date, triggerChange, format) => {
+            if (typeof date === 'string' && !this.parseDate(date)) {
+                return;
+            }
+
+            setDate(date, triggerChange, format);
+        };
     }
 
     public setValue(value: Date) {
+        const currentlySelected = this.flatpickr?.selectedDates[0];
+        const isUnchanged = currentlySelected
+            ? value?.getTime() === currentlySelected.getTime()
+            : !value;
+
+        if (isUnchanged) {
+            // Nothing to sync: Flatpickr's own selected date already
+            // matches (or both are empty). This runs on every re-render
+            // while the calendar is closed, including ones that have
+            // nothing to do with `value` at all — e.g. the typed-input
+            // handling flagging invalid text as an error. Calling
+            // `setDate` anyway would still force-sync the input's raw DOM
+            // value unconditionally, wiping out that preserved invalid
+            // text even though nothing about the *value* actually changed.
+            return;
+        }
+
         this.flatpickr?.setDate(value, false);
     }
 
@@ -138,6 +199,35 @@ export abstract class Picker {
     private getWeek(date) {
         return moment(date).isoWeek();
     }
+
+    /**
+     * Without this, Flatpickr falls back to its own default date-format
+     * tokens (`Y-m-d`) to parse whatever the user types on blur or `Enter` —
+     * a different, mismatched format from `dateFormat` (the one actually
+     * displayed, and the one `DateFormatter.parseDate` uses elsewhere for
+     * the exact same text). That mismatch let Flatpickr silently commit a
+     * misparsed date out from under the typed-input handling. Routing it
+     * through the same moment format keeps both in agreement.
+     *
+     * The locale must be passed into the parse call itself (not chained on
+     * afterwards) for the same reason `DateFormatter.parseDate` does: this
+     * module's `import 'moment/locale/*'` side effects switch moment's
+     * global default locale, so a localized token like `L` would otherwise
+     * get parsed against the wrong locale's pattern. Strict mode avoids
+     * moment's lenient partial-match parsing treating a not-yet-finished
+     * typed string as already a complete, committable date.
+     * @param dateStr - the raw text Flatpickr wants parsed as a date
+     */
+    private parseDate = (dateStr: string): Date | undefined => {
+        const parsed = moment(
+            dateStr,
+            this.dateFormat,
+            this.getMomentLang(),
+            true
+        );
+
+        return parsed.isValid() ? parsed.toDate() : undefined;
+    };
 
     private handleOnClose() {
         this.flatpickr?.element.focus();

--- a/src/global/translations.ts
+++ b/src/global/translations.ts
@@ -11,6 +11,10 @@ const allTranslations = {
     da: da,
     de: de,
     en: en,
+    // English UI text doesn't differ between regions — only the date
+    // format itself does — so this shares the "en" bundle rather than
+    // needing its own translated copy.
+    'en-gb': en,
     fi: fi,
     fr: fr,
     no: no,
@@ -22,7 +26,19 @@ const REGEX = /\{\s*(\w+)\s*\}/g;
 
 export class Translations {
     public get(key: string, language = 'en', params?: object): string {
-        const translation: string = allTranslations[language][key];
+        // Falls back to the key itself for an unrecognized `language` too
+        // (matching the existing "no translation found" fallback right
+        // below), rather than letting a typo'd or newly-added-elsewhere
+        // language code throw here. A supported `Languages` value with no
+        // corresponding entry above previously threw synchronously inside
+        // Flatpickr's `onReady` callback — which, left uncaught, aborted
+        // `MonthPicker`/`QuarterPicker`/`YearPicker`'s calendar bootstrap
+        // partway through, and (since the failure was inside `init()`,
+        // before `flatPickrCreated` got set) caused every subsequent
+        // re-render to retry the whole init from scratch, stacking a
+        // fresh, still-partially-broken calendar header on top of the
+        // last one instead of ever finishing or cleaning up.
+        const translation: string = allTranslations[language]?.[key];
         if (!translation) {
             return key;
         }


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/solution-packers-dev/issues/443 

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct date entry with strict, locale-aware parsing.
  * Added British English (`en-gb`) date and translation support.
  * Added localized format expansion, placeholders, helper text, and month formats.
  * Added configurable invalid-format messaging while preserving invalid input.
  * Date formats now update dynamically when changed.
  * Added an interactive typed-input and validation example.

* **Bug Fixes**
  * Prevented invalid input from overwriting valid selections.
  * Improved synchronization when dates or formats change.
  * Changes now emit only for valid dates or cleared values.
  * Improved handling of missing or unsupported language settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
