### PR TITLE
Line up list labels when only some items have pictures

### DIFF
--- a/src/components/list-item/examples/list-item-pictures.tsx
+++ b/src/components/list-item/examples/list-item-pictures.tsx
@@ -4,8 +4,13 @@ import { Component, h, Host, State } from '@stencil/core';
  * List item with pictures
  *
  * This example demonstrates how to use images in list items.
- * The first item shows a picture only, while the second item
- * shows both a picture and an icon together.
+ * The first item shows a picture only, the second one shows both a picture
+ * and an icon together, and the third one shows an icon but no picture.
+ *
+ * Notice how the icon of the third item is given the same footprint as the
+ * pictures above it, so that all three labels start in the same column.
+ * This happens whenever an item without a picture sits among items that
+ * have one, and applies to badge icons and plain icons alike.
  */
 @Component({
     tag: 'limel-example-list-item-pictures',
@@ -41,6 +46,16 @@ export class ListItemPicturesExample {
                         image={{
                             src: 'https://lundalogik.github.io/lime-elements/2e86c284-d190-4c41-8da2-4de50103a0cd.png',
                             alt: 'A picture of Kiarokh Moattar, Product Designer at Lime Technologies',
+                        }}
+                    />
+                    <limel-list-item
+                        text="Befkadu Degefa"
+                        secondaryText="Engineer"
+                        badgeIcon={this.badgeIcon}
+                        icon={{
+                            name: 'bowler_hat',
+                            title: 'Bowler hat icon',
+                            color: 'rgb(var(--color-sky-default))',
                         }}
                     />
                 </ul>

--- a/src/components/list-item/list-item.scss
+++ b/src/components/list-item/list-item.scss
@@ -4,10 +4,13 @@
  * @prop --limel-list-item-menu-order: Defines the order of the menu, within the list item's flexbox. Defaults to `3`.
  * @prop --list-item-image-border-radius: Defines the border radius of the list item image. Defaults to `50%`.
  * @prop --list-item-image-object-fit: Defines the object-fit property of the list item image. Defaults to `cover`.
+ * @prop --limel-list-item-image-size: Defines the size of the list item image. Defaults to `2rem`.
  */
 
 @use '../../style/mixins';
 @forward '../checkbox/checkbox';
+
+$image-box-shadow: 0 0 0 1px rgb(var(--contrast-800), 0.5);
 
 *,
 *:before,
@@ -16,6 +19,7 @@
 }
 
 limel-list-item {
+    --limel-list-item-image-size: 2rem;
     min-height: 2.5rem;
     @include mixins.visualize-keyboard-focus();
 
@@ -144,9 +148,9 @@ limel-list-item {
         flex-shrink: 0;
         object-fit: var(--list-item-image-object-fit, cover);
         border-radius: var(--list-item-image-border-radius, 50%);
-        width: 2rem;
-        height: 2rem;
-        box-shadow: 0 0 0 1px rgb(var(--contrast-800), 0.5);
+        width: var(--limel-list-item-image-size);
+        height: var(--limel-list-item-image-size);
+        box-shadow: $image-box-shadow;
     }
 
     limel-menu {
@@ -157,6 +161,29 @@ limel-list-item {
         // by giving it a bigger order number. Also, by making this into a variable
         // we can handle other edge-cases in consuming components.
         order: var(--limel-list-item-menu-order, 3);
+    }
+}
+
+// A list can mix items that carry an image with items that only carry an
+// icon. Icons are sized differently than images and are pulled to the left,
+// so those items would otherwise start their text somewhere else than their
+// neighbours, leaving the labels in two different columns.
+//
+// Give the lone icons the image's square instead, so that every label lines
+// up regardless of `iconSize` and regardless of whether the icons are badges.
+// `limel-icon` sizes itself with `!important` from inside its own shadow
+// root, where an outer `width` cannot reach it whether it is important or
+// not, so clamp the used size between a matching minimum and maximum.
+:has(> limel-list-item > img) > limel-list-item:not(:has(> img)) > limel-icon {
+    margin-left: 0;
+    min-width: var(--limel-list-item-image-size);
+    max-width: var(--limel-list-item-image-size);
+    min-height: var(--limel-list-item-image-size);
+    max-height: var(--limel-list-item-image-size);
+    box-shadow: $image-box-shadow;
+
+    &:not([badge]) {
+        padding: 0.25rem;
     }
 }
 

--- a/src/components/list/list.e2e.tsx
+++ b/src/components/list/list.e2e.tsx
@@ -1,4 +1,5 @@
 import { render, h } from '@stencil/vitest';
+import { IconSize } from '../icon/icon.types';
 
 describe('limel-list', () => {
     describe('without items', () => {
@@ -36,6 +37,71 @@ describe('limel-list', () => {
             expect(itemEl.getAttribute('aria-disabled')).toEqual('false');
             expect(itemEl.getAttribute('text')).toEqual('item 1');
         });
+    });
+
+    describe('with a mix of items with images and icon-only items', () => {
+        const items = [
+            {
+                text: 'with image',
+                icon: 'coffee',
+                image: {
+                    src: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCI+PHJlY3Qgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiBmaWxsPSJyZWQiLz48L3N2Zz4=',
+                    alt: 'a red square',
+                },
+            },
+            { text: 'icon only', icon: 'coffee' },
+        ];
+
+        const iconSizes: IconSize[] = ['x-small', 'small', 'medium', 'large'];
+        const variants = iconSizes.flatMap((iconSize) => [
+            { iconSize, badgeIcons: false },
+            { iconSize, badgeIcons: true },
+        ]);
+
+        const renderList = async (variant: (typeof variants)[number]) => {
+            const { root, waitForChanges } = await render(
+                <limel-list
+                    items={items}
+                    iconSize={variant.iconSize}
+                    badgeIcons={variant.badgeIcons}
+                />
+            );
+            await waitForChanges();
+
+            const [withImage, iconOnly] = [
+                ...root.shadowRoot.querySelectorAll('limel-list-item'),
+            ];
+
+            return { withImage, iconOnly };
+        };
+
+        it.each(variants)(
+            'lines up the labels when iconSize is $iconSize and badgeIcons is $badgeIcons',
+            async (variant) => {
+                const { withImage, iconOnly } = await renderList(variant);
+                const labelLeft = (item: Element) =>
+                    item.querySelector('.label').getBoundingClientRect().left;
+
+                expect(labelLeft(iconOnly)).toEqual(labelLeft(withImage));
+            }
+        );
+
+        it.each(variants)(
+            'gives the lone icon the image footprint when iconSize is $iconSize and badgeIcons is $badgeIcons',
+            async (variant) => {
+                const { withImage, iconOnly } = await renderList(variant);
+                const imageBox = withImage
+                    .querySelector('img')
+                    .getBoundingClientRect();
+                const iconBox = iconOnly
+                    .querySelector('limel-icon')
+                    .getBoundingClientRect();
+
+                expect(iconBox.width).toEqual(imageBox.width);
+                expect(iconBox.height).toEqual(imageBox.height);
+                expect(iconBox.left).toEqual(imageBox.left);
+            }
+        );
     });
 
     describe('with a disabled item', () => {


### PR DESCRIPTION
Closes #4256.

In a list where some items have a picture and others only have an icon, the icon-only items started their label further to the left, so the labels sat in two different columns. Measured in the browser: a row with a picture starts its label 3.5rem from the item's edge (1rem padding + 2rem picture + 0.5rem gap), while an icon-only row started at 2.25rem with plain icons and 2.75rem with `badgeIcons`. Because the two variants were off by different amounts they read as two separate bugs, which is why the issue calls out that they should behave alike.

The fix gives a lone icon the picture's square whenever the list holds pictures, so the icon stands in for the missing picture and every label starts in the same column.

## Where it lives, and why

`limel-list` renders its rows through the private `limel-list-item`, and all of the icon/picture layout lives in that component's `list-item.scss` — so the rule goes there rather than in `list.scss`. That also covers `limel-menu-list` and any direct use of `limel-list-item`, which had the same defect. Since `limel-list-item` is declared `shadow: false`, its stylesheet can reach the surrounding element and recognise the mixed case on its own, with no markup change and no change to the public API.

I first wrote the detection in `list-renderer.tsx` instead, handing the size down through internal `--limel-` custom properties. It needed two properties rather than one (reserving the space is not enough — the icon also has to stop reaching outside the item's padding, or the labels still land half a rem apart), it left every other consumer of `limel-list-item` to opt in by itself, and it was the larger diff. We settled on the CSS-only version.

## Two things worth a reviewer's eye

**The `:has()` selector.** It reads "a lone icon, in a list that holds at least one picture":

```scss
:has(> limel-list-item > img) > limel-list-item:not(:has(> img)) > limel-icon
```

The first `:has()` is on the parent `<ul>`, not on a sibling item, so it is not sensitive to where in the list the pictures are. The `>` combinators keep it from reaching into a nested list.

**The clamp instead of `width`.** `limel-icon` sets its own width and height with `!important` from inside its shadow root. For important declarations the inner tree wins the cascade, so an outer `width` can never reach it — important or not. `min-*`/`max-*` are different properties and clamp the used value, which is why the rule is written that way.

An earlier draft used only `min-width`/`min-height`. That left `badgeIcons` with `iconSize="medium"` or `"large"` misaligned, since those badges are 2.5rem and 2.75rem — wider than the picture. Clamping from both sides covers every size; the trade-off is that an oversized badge is pulled down to the picture's 2rem in a mixed list, which seems right given it is standing in for one.

## Testing

16 e2e tests in `list.e2e.tsx` assert equal label offsets and an identical icon/picture box across all four `iconSize` values times both `badgeIcons` states. 15 of them fail without the SCSS change. Full e2e and spec suites are otherwise unchanged — the `form` and `text-editor/prosemirror-*` failures are pre-existing and reproduce on a clean `main`.

## Out of scope

An item with neither a picture nor an icon, sitting among items with pictures, is still misaligned. Noted in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List items now maintain consistent label alignment when combining images with icon-only items.
  * Icon-only items match the configured image footprint across different icon sizes and badge configurations.
  * Image sizing can be customized using the `--limel-list-item-image-size` property.
  * Updated examples demonstrate mixed image and icon list items.

* **Tests**
  * Added coverage for mixed-content lists across icon sizes and badge settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->