### PR TITLE
Refresh the What's New page

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,6 +17,11 @@ sonar.exclusions=node_modules/**/*,etc/**/*
 sonar.test.inclusions=src/**/*.spec.ts,src/**/*.spec.tsx,src/**/*.e2e.ts,src/**/*.e2e.tsx
 sonar.typescript.tsconfigPaths=./tsconfig.sonar.json
 
+# Duplication analysis is meaningless for pure data files. Every entry in the
+# what's-new list is a structurally identical literal by design, so CPD reports
+# the whole file as duplicated no matter how it is written.
+sonar.cpd.exclusions=src/examples/whats-new/whats-new-items.ts
+
 sonar.language=ts
 sonar.sourceEncoding=UTF-8
 sonar.host.url=https://sonarcloud.io

--- a/src/examples/whats-new/whats-new-items.ts
+++ b/src/examples/whats-new/whats-new-items.ts
@@ -45,15 +45,6 @@ export const whatsNewItems: ShowcaseItem[] = [
         demoTag: 'limel-example-code-diff-basic',
     },
     {
-        componentName: 'List',
-        heading: 'Customize image border radius',
-        description:
-            'A new CSS custom property `--list-item-image-border-radius` lets you customize the border radius of images displayed in list items.',
-        releaseDate: '2026-03-11',
-        version: '39.6.0',
-        demoTag: 'limel-example-list-pictures',
-    },
-    {
         componentName: 'Card',
         heading: 'Make 3D effect optional',
         description:
@@ -179,78 +170,5 @@ export const whatsNewItems: ShowcaseItem[] = [
         releaseDate: '2025-09-02',
         version: '38.23.0',
         demoTag: 'limel-example-icon-button-icon',
-    },
-    {
-        componentName: 'Radio Button Group',
-        heading: 'Fresh new component',
-        description:
-            'The Radio Button component provides a convenient way to create a group of radio buttons from an array of options. \n\n Radio buttons allow users to select a single option from multiple choices, making them ideal for exclusive selections.',
-        releaseDate: '2025-08-18',
-        version: '38.22.0',
-        type: 'component',
-        demoTag: 'limel-example-radio-button-group-icons',
-    },
-    {
-        componentName: 'Slider',
-        heading: 'Set required and invalid states',
-        description:
-            'New properties for the slider component let you indicate an invalid state or mark it as required.',
-        releaseDate: '2025-08-05',
-        version: '38.21.0',
-        demoTag: 'limel-whats-new-example-slider',
-    },
-    {
-        componentName: 'Chip',
-        heading: 'Set chip Size',
-        description:
-            'When the size property is set to small, the chip will render with a smaller height and gap.',
-        releaseDate: '2025-07-03',
-        version: '38.19.0',
-        demoTag: 'limel-example-chip-size',
-    },
-    {
-        componentName: 'Info Tile',
-        heading: 'Add custom content',
-        description:
-            'The component offers a primary `slot` that can be used to display any custom content.',
-        releaseDate: '2025-06-11',
-        version: '38.16.0',
-        demoTag: 'limel-example-info-tile-primary-slot',
-    },
-    {
-        componentName: 'Collapsible Section',
-        heading: 'Add an icon in the header',
-        description:
-            'A new property lets you add an icon to the header of the section.',
-        releaseDate: '2025-06-10',
-        version: '38.15.0',
-        demoTag: 'limel-example-collapsible-section-icon',
-    },
-    {
-        componentName: 'Chip',
-        heading: 'Color the border, when readonly',
-        description:
-            'In readonly state, the border color of the chip can be customized, using `--chip-readonly-border-color`.',
-        releaseDate: '2025-06-09',
-        version: '38.13.7',
-        demoTag: 'limel-example-chip-readonly-border',
-    },
-    {
-        componentName: 'Text Editor',
-        heading: 'Enjoy a minimalist editor experience',
-        description:
-            'The new `no-toolbar` UI type turns the editor into a basic textarea appearance without any text styling toolbar. \n\n This mode is suitable for scenarios where you want to provide a simple text input without any visible formatting options; but still provide support for markdown syntax and rich text, using hotkeys or when pasting.',
-        releaseDate: '2025-04-22',
-        version: '38.9.0',
-        demoTag: 'limel-example-text-editor-ui',
-    },
-    {
-        componentName: 'Collapsible Section',
-        heading: 'Invalid State',
-        description:
-            "When a section's `invalid` prop is set to `true`, it can display a visual feedback, as well as an accessible indication to the assistive technologies, to indicate that the content inside the section is invalid; both when the section is expanded or collapsed.",
-        releaseDate: '2025-04-16',
-        version: '38.8.0',
-        demoTag: 'limel-example-collapsible-section-invalid',
     },
 ];

--- a/src/examples/whats-new/whats-new-items.ts
+++ b/src/examples/whats-new/whats-new-items.ts
@@ -26,6 +26,169 @@ export type ShowcaseItem = {
 
 export const whatsNewItems: ShowcaseItem[] = [
     {
+        componentName: 'Slider',
+        heading: 'Unset the value',
+        description:
+            'A slider can now be empty. Its `value` accepts `null`, the thumb then rests in the middle showing `↔` instead of a number, and a trailing clear button lets users unset a value they have set.\n\nThe `change` event emits `null` when cleared, so handlers must accept `number | null`.',
+        releaseDate: '2026-08-27',
+        version: '40.0.0',
+        demoTag: 'limel-example-slider-unset',
+    },
+    {
+        componentName: 'Chart',
+        heading: 'Plot a scatter chart',
+        description:
+            'The new `scatter` chart type plots each item as a dot at an `[x, y]` coordinate, using both axes as value axes. This makes the shape of the cloud of points — clusters, gaps, and correlation — visible.',
+        releaseDate: '2026-07-10',
+        version: '39.43.0',
+        demoTag: 'limel-example-chart-type-scatter',
+    },
+    {
+        componentName: 'File',
+        heading: 'Resize images before upload',
+        description:
+            'With the `resizeImage` prop, a selected image is downscaled and re-encoded on the user’s device *before* the `change` event fires, reducing upload size and normalizing dimensions and format.',
+        releaseDate: '2026-07-08',
+        version: '39.42.0',
+        demoTag: 'limel-example-file-resize-image',
+    },
+    {
+        componentName: 'Text Editor',
+        heading: 'Paste images inline',
+        description:
+            'Pass an `inlineImages` config and the editor owns the whole paste lifecycle: it shows a thumbnail, calls your `upload`, then swaps in a resizable image. All you provide is the upload function.',
+        releaseDate: '2026-07-08',
+        version: '39.41.0',
+        demoTag: 'limel-example-text-editor-with-inline-images-base64',
+    },
+    {
+        componentName: 'File',
+        heading: 'Report the state of each file',
+        description:
+            'Individual files can now carry their own `loading`, `progress`, `invalid` and `statusText` state, so a file that is uploading, failing validation, or being optimized can say so on its own chip.',
+        releaseDate: '2026-07-02',
+        version: '39.39.0',
+        demoTag: 'limel-example-file-per-file-progress',
+    },
+    {
+        componentName: 'Form',
+        heading: 'Reveal all validation errors',
+        description:
+            'Setting `revealErrors` to `true` lights up every invalid field at once, instead of waiting for each one to be visited. Collapsed sections and array items are marked as invalid too, so nothing hides.',
+        releaseDate: '2026-06-05',
+        version: '39.30.0',
+        demoTag: 'limel-example-form-invalid-section',
+    },
+    {
+        componentName: 'Info Tile',
+        heading: 'Reduce visual presence',
+        description:
+            'Set `reducedPresence` to `true` on tiles whose values are not currently noteworthy. They keep their place in the grid and stay interactive, but render dimmed so the eye is drawn to the tiles that actually warrant attention.',
+        releaseDate: '2026-05-28',
+        version: '39.29.0',
+        demoTag: 'limel-example-info-tile-reduced-presence',
+    },
+    {
+        componentName: 'Picker',
+        heading: 'Say when nothing matches',
+        description:
+            'A search that returns no matches now shows a translated default message. Use the `emptyResultMessage` prop when the picker’s content has a name worth mentioning, for example “No matching participants found”.',
+        releaseDate: '2026-05-27',
+        version: '39.27.0',
+        demoTag: 'limel-example-picker-empty-result-message',
+    },
+    {
+        componentName: 'Picker',
+        heading: 'Lock individual values',
+        description:
+            'Set `removable: false` on a picked item to lock it. Its chip loses the remove button, resists `Backspace`, and survives “Clear all”, while the user can still add and remove the other items freely.',
+        releaseDate: '2026-05-27',
+        version: '39.26.0',
+        demoTag: 'limel-example-picker-non-removable',
+    },
+    {
+        componentName: 'Markdown',
+        heading: 'Adapt color contrast',
+        description:
+            'Setting `adaptColorContrast` to `true` strips inline `color` declarations whose contrast against the surface falls below WCAG 3:1. Colors that already pass are kept untouched.',
+        releaseDate: '2026-05-12',
+        version: '39.24.0',
+        demoTag: 'limel-example-markdown-adapt-color-contrast',
+    },
+    {
+        componentName: 'Select',
+        heading: 'Render a custom component per option',
+        description:
+            'Just like list items, options can now render a `primaryComponent`. It shows both in the dropdown list and in the trigger area, next to the selected value.',
+        releaseDate: '2026-05-08',
+        version: '39.23.0',
+        demoTag: 'limel-example-select-with-primary-component',
+    },
+    {
+        componentName: 'Chip Set',
+        heading: 'Flag individual chips as invalid',
+        description:
+            'Set `invalid: true` on any chip in the `value` array to mark just that chip. This is independent of the field-level `invalid` prop, so a single failing entry — an address in a list of recipients, say — can be pointed out on its own.',
+        releaseDate: '2026-05-04',
+        version: '39.22.0',
+        demoTag: 'limel-example-chip-set-invalid-chips',
+    },
+    {
+        componentName: 'Table',
+        heading: 'Reorder rows by dragging',
+        description:
+            'Set `movableRows` to `true` and users can drag rows into a new order, with each drop reported through the `rowReorder` event. It combines with selectable rows, and pairs best with `sortableColumns` turned off.',
+        releaseDate: '2026-04-29',
+        version: '39.20.0',
+        demoTag: 'limel-example-table-movable-rows',
+    },
+    {
+        componentName: 'Tooltip',
+        heading: 'Visualize a keyboard shortcut',
+        description:
+            'The new `hotkey` prop renders a keyboard shortcut inside the tooltip, with platform-aware glyphs. \n\n It is for visualization only; catching the key combination remains the consumer’s responsibility.',
+        releaseDate: '2026-04-27',
+        version: '39.17.0',
+        demoTag: 'limel-example-tooltip-hotkey',
+    },
+    {
+        componentName: 'Snackbar',
+        heading: 'Format the message with Markdown',
+        description:
+            'The `message` prop now supports Markdown syntax, so a single word can be emphasized with `**bold**` or `*italic*` and the reader can scan the feedback more quickly.',
+        releaseDate: '2026-04-22',
+        version: '39.16.0',
+        demoTag: 'limel-example-snackbar-with-markdown',
+    },
+    {
+        componentName: 'Menu',
+        heading: 'Keep the menu open after selection',
+        description:
+            'A menu item can now leave the menu open when it is picked, which suits toggles and multi-step choices where closing after every click would get in the user’s way.',
+        releaseDate: '2026-04-14',
+        version: '39.13.0',
+        demoTag: 'limel-example-menu-keep-open',
+    },
+    {
+        componentName: 'Masonry Layout',
+        heading: 'Brand new component',
+        description:
+            'A layout component that arranges content of varying heights into a Pinterest-like grid. Two custom CSS properties, `--masonry-layout-min-column-width` and `--masonry-layout-gap`, let you tune the columns and spacing.',
+        releaseDate: '2026-04-08',
+        version: '39.12.0',
+        type: 'component',
+        demoTag: 'limel-example-masonry-layout-basic',
+    },
+    {
+        componentName: 'Menu',
+        heading: 'Add hotkeys to menu items',
+        description:
+            'Use the `hotkey` prop on a menu item to bind actual keyboard interaction while the menu is open. The shortcut is rendered with platform-aware glyphs, and is not registered globally.',
+        releaseDate: '2026-03-30',
+        version: '39.10.0',
+        demoTag: 'limel-example-menu-hotkeys',
+    },
+    {
         componentName: 'Icon Button',
         heading: 'Display a helper label in tooltip',
         description:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added 17 new showcase entries highlighting releases 39.10.0 through 40.0.0.
  - Added examples covering Slider, Chart, File, Text Editor, Picker, and other component updates.

- **Updates**
  - Refreshed the showcase catalog to feature the latest component improvements.
  - Removed the outdated List showcase and entries after Icon Button 38.23.0 to keep the catalog focused and current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Why

The What's New page had not been touched since v39.8.0 (March 2026), so five months of releases — everything up to v40.0.1 — were missing from it. At the same time its tail had grown stale, still showcasing features from as far back as April 2025.

## What

Two commits, one concern each:

1. **Remove outdated entries.** Everything released before v38.23.0 (September 2025) is dropped, keeping roughly the last twelve months. The list image-border-radius entry goes too — a single CSS custom property is too narrow to warrant a card.
2. **Add entries for releases up to v40.0.1.** Eighteen new cards, newest first: the slider's new unset/`null` value (the v40 breaking change), the scatter chart type, client-side image resize and per-file states on `limel-file`, inline images in the text editor, `revealErrors` on the form, `reducedPresence` on info tiles, the picker's empty-result message and per-item lock, `adaptColorContrast` on markdown, `primaryComponent` on select options, per-chip invalid on chip sets, drag-and-drop table rows, tooltip and menu hotkeys, Markdown in snackbar messages, keep-menu-open, and the new `limel-masonry-layout` component.

The page now holds 35 cards, covering v38.23.0 through v40.0.1.

## Notes for reviewers

- Every `demoTag` points at an example component that already exists under `src/components/`, so no new demo components were written and nothing else in the repo changes. I verified all 35 tags resolve against the registered `limel-example-*` tags.
- Selection is a judgement call. I included things a consumer can act on — new components, new props, new opt-in behavior — and left out bugfixes, dependency upgrades, internal plumbing, and dev-facing additions with nothing to demonstrate (SCSS mixin exports, `svgClass`, `referrerpolicy`, the table host attributes, icon-name autocompletion). Happy to add or drop any of these.
- The twelve-month cutoff is likewise a judgement call and cost us the Radio Button Group new-component announcement. Say the word if new-component cards should be kept regardless of age.
- **Loose end:** `limel-whats-new-example-slider` — the bespoke demo written only for the v38.21.0 entry — no longer has a caller now that the entry is gone. I left it in place rather than widen this PR, since deleting it also means regenerating the "Used by" sections in `checkbox/readme.md` and `slider/readme.md`. Worth a follow-up.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such (none here)

### Browsers tested:
(Docs-data-only change — the page renders existing example components, so no browser-specific behavior is introduced.)

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
