### PR TITLE
fix(dock): allow consumers to correctly use padding-related css variables

### DIFF
--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -35,6 +35,7 @@
 
     isolation: isolate;
     position: relative;
+    box-sizing: border-box;
 
     display: inline-flex;
     flex-direction: column;


### PR DESCRIPTION
…

The component offers public CSS variables for controlling the Dock's paddings, such as --dock-padding-top. However, due to lack of `box-sizing: border-box;` style on the component, added paddings by consumers would increase the visual size of the dock, pushing its edges out of the screen.

<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dock component sizing and layout consistency by ensuring padding and borders are included in its overall dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
