### PR TITLE
fix(dock): include the padding custom properties in the width formulas

### DIFF
--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -51,7 +51,10 @@
 
 :host(limel-dock:not(.has-mobile-layout)) {
     height: 100%;
-    width: calc((var(--limel-dock-padding) * 2) + var(--dock-item-height));
+    width: calc(
+        (var(--limel-dock-padding) * 2) + var(--dock-item-height) +
+            var(--dock-padding-left, 0px) + var(--dock-padding-right, 0px)
+    );
     nav {
         padding-bottom: calc((var(--limel-dock-padding) + 0.25rem));
     }

--- a/src/components/dock/dock.scss
+++ b/src/components/dock/dock.scss
@@ -3,7 +3,7 @@
 @use '../../style/functions';
 
 /**
-* @prop --dock-expanded-max-width: The maximum width of the Dock when it is expanded. Defaults to `max-content` which means the Dock will adjust its width to the widest dock item.
+* @prop --dock-expanded-max-width: The width of the Dock when it is expanded. Defaults to `10rem`. Horizontal `--dock-padding-*` values are added on top of it, so this is the width available to dock items.
 * @prop --dock-background-color: Background color of the whole component, defaults to `--contrast-100`.
 * @prop --dock-item-background-color--selected: Background color of selected dock item, defaults to `--contrast-200`.
 * @prop --dock-item-text-color: Text of dock items, defaults to `--contrast-1100`.
@@ -61,7 +61,10 @@
 }
 
 :host(limel-dock.expanded) {
-    width: var(--dock-expanded-max-width, max-content);
+    width: calc(
+        var(--dock-expanded-max-width, 10rem) + var(--dock-padding-left, 0px) +
+            var(--dock-padding-right, 0px)
+    );
 }
 
 .footer-separator {


### PR DESCRIPTION
<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dock sizing so collapsed and expanded states account for horizontal padding.
  - Updated the default expanded dock width for more consistent layout behavior.

- **Documentation**
  - Clarified that the expanded width setting controls available space for dock items, with padding added separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

Follow-up to #4260, which gave the Dock host `box-sizing: border-box` so that `height: 100%` stays true once a consumer sets `--dock-padding-top` or `--dock-padding-bottom`. That part is correct and stays — without it the host grows past its parent by the padding, measured as 482px inside a 402px parent.

What it missed is that both width formulas were written for `content-box` and were left untouched, so they now have to absorb the horizontal padding rather than sitting alongside it.

**Collapsed.** `calc((var(--limel-dock-padding) * 2) + var(--dock-item-height))` describes what the dock items need — the nav's own padding on both sides plus one item's width — and says nothing about `--dock-padding-*`. That is 52px. `env(safe-area-inset-left)` is roughly 59px on an iPhone in landscape, so under `border-box` the content box clamped to zero and the dock buttons rendered invisible and cut off. This is a real, visible regression in the Lime CRM webclient today.

**Expanded.** Same shape: a length passed in `--dock-expanded-max-width` has to absorb the padding. At the 10rem the webclient sets, with a 59px inset, the Dock stayed 160px wide and left its labels only 101px.

Measured against the compiled stylesheet in a consumer's real element chain, with a 59px inset:

| | total | width for items |
|---|---|---|
| collapsed, before | 59px | **0px** |
| collapsed, after | 111px | 52px |
| expanded `10rem`, before | 160px | 101px |
| expanded `10rem`, after | 219px | 160px |
| expanded, default, after | 219px | 160px |
| collapsed, no inset | 52px | 52px (unchanged) |

Consumers that never set `--dock-padding-*` see no change at all.

### Please look closely at one thing: the changed default

`calc()` cannot take `max-content` (verified: `CSS.supports('width', 'calc(max-content + 59px)')` is `false`), so wrapping the expanded expression forced the documented default to become a length. It is now `10rem`, matching what the webclient already passes.

I want to be explicit that **the `max-content` default was not itself broken.** I measured it before changing it: `width: max-content` under `border-box` already sizes to content plus padding correctly — 179px total with 120px of content against a 59px inset. Only consumers passing a length were ever affected.

So this half of the change is the price of being able to wrap the expression, not a fix in itself, and it costs something: an expanded Dock is now a fixed width by default instead of adapting to the widest item. **Two things follow, both reviewer calls:**

1. **Should this be marked as a breaking change?** It alters the rendered default of a documented public custom property, and a consumer relying on content-adaptive sizing cannot opt back in without setting the prop. As committed these are `fix:` commits, so semantic-release will cut a patch. If you would rather that be a major, say so and I will add a proper `BREAKING CHANGE:` footer to the second commit.
2. **Or keep the adaptive default entirely.** `width: max-content` with `max-width: calc(var(--dock-expanded-max-width, …) + padding)` preserves it, and arguably matches the prop's name better — `--dock-expanded-max-width` is currently applied as a `width`, not a `max-width`. I did not do this because it is a larger behavioural change than the bug required, but it is the cleaner design if you want it.

The first commit stands on its own either way, and is the one fixing the live regression.

`src/components/dock/readme.md` is gitignored and regenerated at build, so the `@prop` comment in the SCSS is the only place the default is documented.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

Left unchecked deliberately — see question 1 above. Nothing is marked breaking at present; whether the changed default warrants it is the open question, not an oversight.

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

All boxes are left unchecked on purpose rather than out of laziness. Verification so far is headless Chromium, measuring the compiled stylesheet in a reconstruction of the real `limec-application → limec-dock → limel-dock` chain — enough to establish the geometry, and it is the geometry that is wrong. But the motivating case is an iPhone in landscape where `env(safe-area-inset-left)` is non-zero, and no desktop browser reproduces a safe-area inset at all, so a desktop pass would show nothing either way. The iOS check wants doing against a build of this branch before merge.
