### PR TITLE
Fix chart tooltip percentages and allow hiding them

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -247,6 +247,7 @@ export namespace Components {
         "accessibleValuesLabel"?: string;
         "axisIncrement"?: number;
         "displayAxisLabels": boolean;
+        "displayItemPercentage": boolean;
         "displayItemText": boolean;
         "displayItemValue": boolean;
         "items": ChartItem[];
@@ -1806,6 +1807,7 @@ export namespace JSX {
         "accessibleValuesLabel"?: string;
         "axisIncrement"?: number;
         "displayAxisLabels"?: boolean;
+        "displayItemPercentage"?: boolean;
         "displayItemText"?: boolean;
         "displayItemValue"?: boolean;
         "items": ChartItem[];
@@ -1838,6 +1840,8 @@ export namespace JSX {
         "axisIncrement": number;
         // (undocumented)
         "displayAxisLabels": boolean;
+        // (undocumented)
+        "displayItemPercentage": boolean;
         // (undocumented)
         "displayItemText": boolean;
         // (undocumented)

--- a/src/components/chart/chart.spec.tsx
+++ b/src/components/chart/chart.spec.tsx
@@ -7,7 +7,10 @@ const items: ChartItem[] = [
 ];
 
 type Props = Partial<
-    Pick<HTMLLimelChartElement, 'type' | 'items' | 'maxValue'>
+    Pick<
+        HTMLLimelChartElement,
+        'type' | 'items' | 'maxValue' | 'displayItemPercentage'
+    >
 >;
 
 async function setup(props: Props = {}) {
@@ -31,6 +34,7 @@ async function setup(props: Props = {}) {
 
     return {
         labels: tooltips.map((tooltip) => tooltip.label),
+        values: tooltips.map((tooltip) => tooltip.helperLabel),
         sizes,
         offsets: rows.map((row) =>
             Number(
@@ -135,6 +139,20 @@ describe('limel-chart', () => {
             const { sizes } = await setup({ items: negativeItems });
 
             expect(sizes.every((size) => size < 0)).toBe(true);
+        });
+    });
+
+    describe('displayItemPercentage', () => {
+        test('set to false, the tooltip shows the text alone', async () => {
+            const { labels } = await setup({ displayItemPercentage: false });
+
+            expect(labels).toEqual(['Applications', 'Photos']);
+        });
+
+        test('set to false, the tooltip still shows the value', async () => {
+            const { values } = await setup({ displayItemPercentage: false });
+
+            expect(values).toEqual(['25', '75']);
         });
     });
 

--- a/src/components/chart/chart.spec.tsx
+++ b/src/components/chart/chart.spec.tsx
@@ -1,0 +1,151 @@
+import { render, h } from '@stencil/vitest';
+import { ChartItem } from './chart.types';
+
+const items: ChartItem[] = [
+    { text: 'Applications', value: 25 },
+    { text: 'Photos', value: 75 },
+];
+
+type Props = Partial<
+    Pick<HTMLLimelChartElement, 'type' | 'items' | 'maxValue'>
+>;
+
+async function setup(props: Props = {}) {
+    const { root, waitForChanges } = await render(
+        <limel-chart items={items} {...props} />
+    );
+    await waitForChanges();
+
+    const shadow = root.shadowRoot;
+    const tooltips = [
+        ...shadow.querySelectorAll('limel-tooltip'),
+    ] as HTMLLimelTooltipElement[];
+    const rows = [...shadow.querySelectorAll('tr.item')];
+    const sizes = rows.map((row) =>
+        Number(
+            (row as HTMLElement).style.getPropertyValue(
+                '--limel-chart-item-size'
+            )
+        )
+    );
+
+    return {
+        labels: tooltips.map((tooltip) => tooltip.label),
+        sizes,
+        offsets: rows.map((row) =>
+            Number(
+                (row as HTMLElement).style.getPropertyValue(
+                    '--limel-chart-item-offset'
+                )
+            )
+        ),
+    };
+}
+
+describe('limel-chart', () => {
+    describe('items that are parts of a whole', () => {
+        test('a stacked bar sizes its items as shares of their sum', async () => {
+            const { labels, sizes } = await setup();
+
+            expect(sizes).toEqual([25, 75]);
+            expect(labels).toEqual([
+                'Applications (25.00%)',
+                'Photos (75.00%)',
+            ]);
+        });
+
+        test('maxValue is the whole, and is not rounded to an axis step', async () => {
+            const { labels, sizes } = await setup({ maxValue: 210 });
+
+            expect(sizes[0]).toBeCloseTo(11.9, 1);
+            expect(labels[0]).toBe('Applications (11.90%)');
+        });
+
+        test('a pie fills the whole circle', async () => {
+            const { sizes } = await setup({ type: 'pie' });
+
+            expect(sizes[0] + sizes[1]).toBe(100);
+        });
+
+        test('a ring shows each item as its share of maxValue', async () => {
+            const { labels, sizes } = await setup({
+                type: 'ring',
+                maxValue: 250,
+            });
+
+            expect(sizes).toEqual([10, 30]);
+            expect(labels[0]).toBe('Applications (10.00%)');
+        });
+
+        test('changing the type recalculates the range', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-chart items={items} type="bar" />
+            );
+            await waitForChanges();
+
+            root.type = 'ring';
+            await waitForChanges();
+
+            const sizes = [...root.shadowRoot.querySelectorAll('tr.item')].map(
+                (row) =>
+                    Number(
+                        (row as HTMLElement).style.getPropertyValue(
+                            '--limel-chart-item-size'
+                        )
+                    )
+            );
+
+            expect(sizes).toEqual([25, 75]);
+        });
+
+        test('range items use their extents as shares', async () => {
+            const rangeItems: ChartItem[] = [
+                { text: 'Planning', value: [10, 40] },
+                { text: 'Delivery', value: [40, 100] },
+            ];
+            const { labels, sizes } = await setup({ items: rangeItems });
+
+            expect(sizes[0]).toBeCloseTo(100 / 3);
+            expect(sizes[1]).toBeCloseTo((100 * 2) / 3);
+            expect(labels).toEqual(['Planning (33.33%)', 'Delivery (66.67%)']);
+        });
+
+        test('ring range items start at zero', async () => {
+            const rangeItems: ChartItem[] = [
+                { text: 'Planning', value: [10, 40] },
+                { text: 'Delivery', value: [40, 100] },
+            ];
+            const { offsets, sizes } = await setup({
+                type: 'ring',
+                items: rangeItems,
+                maxValue: 90,
+            });
+
+            expect(offsets).toEqual([0, 0]);
+            expect(sizes[0]).toBeCloseTo(100 / 3);
+            expect(sizes[1]).toBeCloseTo((100 * 2) / 3);
+        });
+
+        test('negative items are not inverted into positive shares', async () => {
+            const negativeItems: ChartItem[] = [
+                { text: 'First', value: -5 },
+                { text: 'Second', value: -10 },
+                { text: 'Third', value: -15 },
+            ];
+            const { sizes } = await setup({ items: negativeItems });
+
+            expect(sizes.every((size) => size < 0)).toBe(true);
+        });
+    });
+
+    describe('items on an axis', () => {
+        test.each(['bar', 'dot', 'line', 'area'] as const)(
+            'a %s chart shows no percentage',
+            async (type) => {
+                const { labels } = await setup({ type });
+
+                expect(labels).toEqual(['Applications', 'Photos']);
+            }
+        );
+    });
+});

--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -7,6 +7,17 @@ import { ChartItem } from './chart.types';
 const PERCENT = 100;
 const DEFAULT_INCREMENT_SIZE = 10;
 
+/**
+ * Types whose items are parts of one whole. They draw no axis, and an
+ * item's size is its share of `maxValue`, or of the sum of the items.
+ */
+const WHOLE_TYPES: ReadonlySet<string> = new Set([
+    'stacked-bar',
+    'pie',
+    'doughnut',
+    'ring',
+]);
+
 interface AxisRange {
     minValue: number;
     maxValue: number;
@@ -139,15 +150,17 @@ export class Chart {
     public orientation?: 'landscape' | 'portrait' = 'landscape';
 
     /**
-     * Specifies the range that items' values could be in.
-     * This is used in calculation of the size of the items in the chart.
-     * When not provided, the sum of all values in the items will be considered as the range.
+     * The upper end of the range that items are drawn against.
+     * For `stacked-bar`, `pie`, `doughnut`, and `ring` charts it is the whole
+     * that each item is a share of, and defaults to the sum of the items.
+     * For the other types it defaults to the largest value among the items.
      */
     @Prop({ reflect: true })
     public maxValue?: number;
 
     /**
      * Specifies the increment for the axis lines.
+     * Has no effect on chart types without axis lines.
      */
     @Prop({ reflect: true })
     public axisIncrement?: number;
@@ -403,6 +416,13 @@ export class Chart {
             };
         }
 
+        if (this.isPartOfWhole()) {
+            return {
+                size: (this.getValueSpan(item) / totalRange) * PERCENT,
+                offset: 0,
+            };
+        }
+
         let startValue = 0;
         if (this.isRangeItem(item)) {
             startValue = this.getMinimumValue(item);
@@ -452,12 +472,7 @@ export class Chart {
             elementId: itemId,
         };
 
-        if (
-            this.type !== 'bar' &&
-            this.type !== 'dot' &&
-            this.type !== 'nps' &&
-            this.type !== 'scatter'
-        ) {
+        if (this.isPartOfWhole()) {
             tooltipProps.label = `${text} (${size.toFixed(PERCENT_DECIMAL)}%)`;
         }
 
@@ -471,25 +486,18 @@ export class Chart {
         );
     }
 
-    private calculateRange() {
+    private calculateRange(): AxisRange {
         if (this.range) {
             return this.range;
         }
 
+        if (this.isPartOfWhole()) {
+            return this.calculateWholeRange();
+        }
+
         const minRange = Math.min(0, ...this.items.map(this.getMinimumValue));
         const maxRange = Math.max(...this.items.map(this.getMaximumValue));
-        const totalSum = this.items.reduce(
-            (sum, item) => sum + this.getMaximumValue(item),
-            0
-        );
-
-        let finalMaxRange = this.maxValue ?? maxRange;
-        if (
-            (this.type === 'pie' || this.type === 'doughnut') &&
-            !this.maxValue
-        ) {
-            finalMaxRange = totalSum;
-        }
+        const finalMaxRange = this.maxValue ?? maxRange;
 
         if (!this.axisIncrement) {
             this.axisIncrement = this.calculateAxisIncrement(
@@ -509,6 +517,33 @@ export class Chart {
             totalRange: totalRange,
             increment: this.axisIncrement,
         };
+    }
+
+    /**
+     * The range of a chart whose items are parts of one whole: `maxValue`
+     * when set, otherwise the sum of the items. The whole is not rounded to
+     * an axis step, since these types draw no axis and an item's size has
+     * to be its exact share.
+     */
+    private calculateWholeRange(): AxisRange {
+        const sum = this.items.reduce(
+            (total, item) => total + this.getValueSpan(item),
+            0
+        );
+        const inferredWhole = sum > 0 ? sum : 1;
+        // An explicit zero also falls back to 1, so normalization stays finite.
+        const whole = (this.maxValue ?? inferredWhole) || 1;
+
+        return {
+            minValue: 0,
+            maxValue: whole,
+            totalRange: whole,
+            increment: whole,
+        };
+    }
+
+    private isPartOfWhole(): boolean {
+        return WHOLE_TYPES.has(this.type);
     }
 
     private calculateAxisIncrement(
@@ -587,6 +622,14 @@ export class Chart {
         return Array.isArray(value) ? Math.max(...value) : value;
     }
 
+    private getValueSpan(item: ChartItem): number {
+        const startValue = this.isRangeItem(item)
+            ? this.getMinimumValue(item)
+            : 0;
+
+        return this.getMaximumValue(item) - startValue;
+    }
+
     private isRangeItem(item: ChartItem): item is ChartItem<[number, number]> {
         return Array.isArray(item.value);
     }
@@ -594,6 +637,7 @@ export class Chart {
     @Watch('items')
     @Watch('axisIncrement')
     @Watch('maxValue')
+    @Watch('type')
     handleChange() {
         this.range = null;
         this.secondaryAxisRange = null;

--- a/src/components/chart/chart.tsx
+++ b/src/components/chart/chart.tsx
@@ -8,8 +8,8 @@ const PERCENT = 100;
 const DEFAULT_INCREMENT_SIZE = 10;
 
 /**
- * Types whose items are parts of one whole. They draw no axis, and an
- * item's size is its share of `maxValue`, or of the sum of the items.
+ * Types whose items are parts of one whole. They draw no axis, and an item's
+ * value or range extent is its share of `maxValue`, or of the combined items.
  */
 const WHOLE_TYPES: ReadonlySet<string> = new Set([
     'stacked-bar',
@@ -34,6 +34,7 @@ interface AxisRange {
  * @exampleComponent limel-example-chart-stacked-bar
  * @exampleComponent limel-example-chart-orientation
  * @exampleComponent limel-example-chart-max-value
+ * @exampleComponent limel-example-chart-display-item-percentage
  * @exampleComponent limel-example-chart-type-bar
  * @exampleComponent limel-example-chart-type-dot
  * @exampleComponent limel-example-chart-type-area
@@ -120,6 +121,15 @@ export class Chart {
     public displayItemValue = false;
 
     /**
+     * Set to `false` to hide the percentage in item tooltips.
+     * The percentage is an item's value or range extent as a share of the
+     * whole. The whole is `maxValue` when set and the combined items otherwise.
+     * Applies to `stacked-bar`, `pie`, `doughnut`, and `ring` charts.
+     */
+    @Prop({ reflect: true })
+    public displayItemPercentage = true;
+
+    /**
      * List of items in the chart,
      * each representing a data point.
      */
@@ -150,17 +160,21 @@ export class Chart {
     public orientation?: 'landscape' | 'portrait' = 'landscape';
 
     /**
-     * The upper end of the range that items are drawn against.
-     * For `stacked-bar`, `pie`, `doughnut`, and `ring` charts it is the whole
-     * that each item is a share of, and defaults to the sum of the items.
-     * For the other types it defaults to the largest value among the items.
+     * Sets the value used to scale item values.
+     * For `stacked-bar`, `pie`, `doughnut`, and `ring`, it is the denominator
+     * used as the whole. It defaults to the combined item values or range
+     * extents. The combined size can exceed `maxValue` and produce a total
+     * above 100%.
+     * For `bar`, `dot`, `area`, and `line`, it is the requested upper bound.
+     * The chart can round that bound up to the next `axisIncrement`.
+     * Has no effect on `nps` or `scatter`.
      */
     @Prop({ reflect: true })
     public maxValue?: number;
 
     /**
-     * Specifies the increment for the axis lines.
-     * Has no effect on chart types without axis lines.
+     * Sets the axis increment for `bar`, `dot`, `area`, and `line` charts.
+     * Has no effect on other chart types.
      */
     @Prop({ reflect: true })
     public axisIncrement?: number;
@@ -472,7 +486,7 @@ export class Chart {
             elementId: itemId,
         };
 
-        if (this.isPartOfWhole()) {
+        if (this.displayItemPercentage && this.isPartOfWhole()) {
             tooltipProps.label = `${text} (${size.toFixed(PERCENT_DECIMAL)}%)`;
         }
 
@@ -521,9 +535,10 @@ export class Chart {
 
     /**
      * The range of a chart whose items are parts of one whole: `maxValue`
-     * when set, otherwise the sum of the items. The whole is not rounded to
-     * an axis step, since these types draw no axis and an item's size has
-     * to be its exact share.
+     * when set, otherwise the combined item values or range extents. The value
+     * is a scale, not a cap, so the combined size can exceed it. The whole is
+     * not rounded to an axis step, since these types draw no axis and an item's
+     * size has to be its exact share.
      */
     private calculateWholeRange(): AxisRange {
         const sum = this.items.reduce(

--- a/src/components/chart/examples/chart-display-item-percentage.tsx
+++ b/src/components/chart/examples/chart-display-item-percentage.tsx
@@ -1,0 +1,43 @@
+import { Component, h, Host, State } from '@stencil/core';
+import { chartItems } from './chart-items-stack';
+
+/**
+ * Hiding the percentage in tooltips
+ *
+ * The tooltip of an item in a `stacked-bar`, `pie`, `doughnut`, or `ring`
+ * chart shows the item's share of the whole next to its `text`.
+ * Set `displayItemPercentage` to `false` to show the `text` and the value alone.
+ *
+ * @sourceFile chart-items-stack.ts
+ */
+@Component({
+    tag: 'limel-example-chart-display-item-percentage',
+    shadow: true,
+    styleUrl: 'chart-examples.scss',
+})
+export class ChartDisplayItemPercentageExample {
+    @State()
+    private displayItemPercentage = false;
+
+    public render() {
+        return (
+            <Host>
+                <limel-chart
+                    items={chartItems}
+                    displayItemPercentage={this.displayItemPercentage}
+                />
+                <limel-example-controls>
+                    <limel-switch
+                        label="displayItemPercentage"
+                        value={this.displayItemPercentage}
+                        onChange={this.handleChange}
+                    />
+                </limel-example-controls>
+            </Host>
+        );
+    }
+
+    private readonly handleChange = (event: CustomEvent<boolean>) => {
+        this.displayItemPercentage = event.detail;
+    };
+}

--- a/src/components/chart/examples/chart-max-value.tsx
+++ b/src/components/chart/examples/chart-max-value.tsx
@@ -4,23 +4,18 @@ import { chartItems } from './chart-items-stack';
 /**
  * Using the `maxValue` prop
  *
- * The `maxValue` prop defines the upper limit of the visual range for the chart.
- * It determines the maximum value represented on the axis and is used to
- * calculate the size of each item in the chart relative to this value.
+ * For `stacked-bar`, `pie`, `doughnut`, and `ring`, `maxValue` is the
+ * denominator used as the whole. An item with value `10` occupies 10% when
+ * `maxValue` is `100`. The combined item size can exceed `maxValue`, producing
+ * a total above 100%. Without `maxValue`, the chart uses the combined item
+ * values or range extents.
  *
- * For example, if `maxValue` is set to `100`, an item with a value of `10`
- * will occupy 10% of the chart, while an item with a value of `50` will occupy 50%.
- * If `maxValue` is set to `200`, an item with a value of `50` will occupy 25% of the chart.
+ * For `bar`, `dot`, `area`, and `line`, `maxValue` sets the requested upper
+ * bound. The chart can round that bound up to the next `axisIncrement`. The
+ * lower bound includes zero and negative item values, rounded down to the
+ * previous `axisIncrement`.
  *
- * If `maxValue` is not provided, the chart will calculate the maximum value based on
- * the actual data points, and the size of each item will be calculated relative to
- * the total range of the data.
- *
- * :::note
- * The `maxValue` only affects the upper limit of the chart's range.
- * The chart will always start from the smallest value present in the dataset,
- * which could be a negative number.
- * :::
+ * `maxValue` has no effect on `nps` or `scatter`.
  *
  * @sourceFile chart-items-stack.ts
  */


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable tooltip percentage visibility for pie, doughnut, ring, and stacked-bar charts.
  - Added an interactive example for toggling tooltip percentages.
  - Improved whole-chart sizing and maximum-value handling.
  - Chart ranges now recalculate when the chart type changes.

- **Documentation**
  - Clarified how maximum values apply across chart types.

- **Tests**
  - Added coverage for sizing, rendering, tooltip values, percentage suppression, range handling, and chart type changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

Two changes to the tooltip percentage of `limel-chart`.

**Fix.** For `stacked-bar`, `pie`, `doughnut`, and `ring`, an item's size and tooltip percentage are its share of `maxValue` when set. Otherwise, the whole is the combined scalar values and range extents. The chart does not round this whole to an axis step. `maxValue` is a scale, not a cap, so combined items can exceed 100%. A stacked bar used to divide by its largest item, so its percentages did not add up to 100, and a pie rounded its whole and left a gap. Charts with an axis show no percentage. `line` and `area` used to print one.

**Opt-out.** `displayItemPercentage`, default `true`. Set it to `false` to show the `text` and the value alone.

Part of Lundalogik/crm-insights-and-intelligence#354. Drawing a stacked bar chart with several bars in one element is Lundalogik/lime-elements#4263.

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
