### PR TITLE
feat(button-group): support disabling individual buttons

### DIFF
--- a/etc/lime-elements.api.md
+++ b/etc/lime-elements.api.md
@@ -58,6 +58,7 @@ export interface BreadcrumbsItem {
 // @public (undocumented)
 export interface Button {
     badge?: number | string;
+    disabled?: boolean;
     icon?: string;
     id: string;
     selected?: boolean;

--- a/src/components/button-group/button-group.e2e.tsx
+++ b/src/components/button-group/button-group.e2e.tsx
@@ -1,4 +1,5 @@
 import { render, h } from '@stencil/vitest';
+import { Button } from '../button/button.types';
 
 describe('limel-button-group', () => {
     describe('basic button group', () => {
@@ -37,6 +38,178 @@ describe('limel-button-group', () => {
                 id: '1',
                 title: 'Lime',
             });
+        });
+    });
+
+    describe('button group with a disabled item', () => {
+        const items: Button[] = [
+            { id: '1', title: 'Lime' },
+            { id: '2', title: 'Apple', disabled: true },
+            { id: '3', title: 'Tasks' },
+        ];
+
+        it('disables only the input of the disabled item', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-button-group value={items}></limel-button-group>
+            );
+            await waitForChanges();
+
+            const inputs = root.shadowRoot.querySelectorAll<HTMLInputElement>(
+                'input[type="radio"]'
+            );
+            expect(inputs[0].disabled).toEqual(false);
+            expect(inputs[1].disabled).toEqual(true);
+        });
+
+        it('does not emit a change event when the disabled item is clicked', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-button-group value={items}></limel-button-group>
+            );
+            const changeSpy = spyOnEvent('change');
+            await waitForChanges();
+
+            const labels =
+                root.shadowRoot.querySelectorAll<HTMLElement>('.button label');
+            labels[1].click();
+            await waitForChanges();
+
+            expect(changeSpy).toHaveReceivedEventTimes(0);
+
+            // Positive control, so the assertion above cannot pass just
+            // because the click never reached anything.
+            labels[0].click();
+            await waitForChanges();
+
+            expect(changeSpy).toHaveReceivedEventTimes(1);
+        });
+
+        it('marks the disabled item with aria-disabled', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-button-group value={items}></limel-button-group>
+            );
+            await waitForChanges();
+
+            const inputs = root.shadowRoot.querySelectorAll<HTMLInputElement>(
+                'input[type="radio"]'
+            );
+            expect(inputs[0].getAttribute('aria-disabled')).toEqual('false');
+            expect(inputs[1].getAttribute('aria-disabled')).toEqual('true');
+        });
+
+        it('dims the disabled item without dimming its divider', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-button-group value={items}></limel-button-group>
+            );
+            await waitForChanges();
+
+            const buttons =
+                root.shadowRoot.querySelectorAll<HTMLElement>('.button');
+            const label = buttons[1].querySelector('label');
+
+            expect(getComputedStyle(label).opacity).toEqual('0.4');
+            expect(getComputedStyle(label).cursor).toEqual('not-allowed');
+
+            // The divider is a pseudo-element of the button, so dimming the
+            // button itself would compound with its own opacity.
+            expect(getComputedStyle(buttons[1], '::after').opacity).toEqual(
+                '0.1'
+            );
+            expect(getComputedStyle(buttons[0]).opacity).toEqual('1');
+        });
+
+        it('ignores a change event dispatched on the disabled input', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-button-group value={items}></limel-button-group>
+            );
+            const changeSpy = spyOnEvent('change');
+            await waitForChanges();
+
+            const inputs = root.shadowRoot.querySelectorAll<HTMLInputElement>(
+                'input[type="radio"]'
+            );
+            inputs[1].dispatchEvent(new Event('change', { bubbles: true }));
+            await waitForChanges();
+
+            expect(changeSpy).toHaveReceivedEventTimes(0);
+        });
+
+        it('ignores a click after the disabled attribute is removed', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-button-group value={items}></limel-button-group>
+            );
+            const changeSpy = spyOnEvent('change');
+            await waitForChanges();
+
+            const inputs = root.shadowRoot.querySelectorAll<HTMLInputElement>(
+                'input[type="radio"]'
+            );
+            inputs[1].removeAttribute('disabled');
+            inputs[1].click();
+            await waitForChanges();
+
+            expect(changeSpy).toHaveReceivedEventTimes(0);
+        });
+    });
+
+    describe('disabled button group', () => {
+        const items: Button[] = [
+            { id: '1', title: 'Lime' },
+            { id: '2', title: 'Apple', disabled: true },
+            { id: '3', title: 'Tasks' },
+        ];
+
+        it('disables every input', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-button-group value={items} disabled></limel-button-group>
+            );
+            await waitForChanges();
+
+            const inputs = root.shadowRoot.querySelectorAll<HTMLInputElement>(
+                'input[type="radio"]'
+            );
+            expect([...inputs].map((input) => input.disabled)).toEqual([
+                true,
+                true,
+                true,
+            ]);
+        });
+
+        it('dims every button without dimming the dividers', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-button-group value={items} disabled></limel-button-group>
+            );
+            await waitForChanges();
+
+            const buttons =
+                root.shadowRoot.querySelectorAll<HTMLElement>('.button');
+
+            expect(
+                [...buttons].map(
+                    (button) =>
+                        getComputedStyle(button.querySelector('label')).cursor
+                )
+            ).toEqual(['not-allowed', 'not-allowed', 'not-allowed']);
+            expect(
+                getComputedStyle(buttons[0].querySelector('label')).opacity
+            ).toEqual('0.4');
+            expect(getComputedStyle(buttons[0], '::after').opacity).toEqual(
+                '0.1'
+            );
+        });
+
+        it('does not emit a change event when a button is clicked', async () => {
+            const { root, waitForChanges, spyOnEvent } = await render(
+                <limel-button-group value={items} disabled></limel-button-group>
+            );
+            const changeSpy = spyOnEvent('change');
+            await waitForChanges();
+
+            const labels =
+                root.shadowRoot.querySelectorAll<HTMLElement>('.button label');
+            labels[0].click();
+            await waitForChanges();
+
+            expect(changeSpy).toHaveReceivedEventTimes(0);
         });
     });
 });

--- a/src/components/button-group/button-group.scss
+++ b/src/components/button-group/button-group.scss
@@ -28,18 +28,14 @@
     flex-wrap: nowrap; // Not sure about this. It'll put items on one row, but also can look bad on action bars. Kia
 }
 
-:host([disabled]:not([disabled='false'])) {
-    @include shared_input-select-picker.looks-disabled;
-}
-
 .button {
-    @include mixins.is-flat-inset-clickable($background-color: transparent);
-    &:has(input[disabled]) {
-        &:hover {
-            box-shadow: none;
-            transform: none;
-        }
+    color: var(--limel-theme-on-surface-color);
+
+    // Not `input[disabled]`, which would outweigh `.button--selected` below.
+    &:not(:has(:disabled)) {
+        @include mixins.is-flat-inset-clickable($background-color: transparent);
     }
+
     position: relative;
     display: inline-grid;
     grid-auto-flow: column;
@@ -92,6 +88,13 @@
         }
     }
 
+    // Dims a single disabled button and a fully disabled group alike. On the
+    // `label`, not on `.button`, because `opacity` there would compound with
+    // the `:after` divider's own and dim it to an effective 0.04.
+    &:has(:disabled) label {
+        @include shared_input-select-picker.looks-disabled;
+    }
+
     input[type='radio'] {
         position: absolute;
         width: 0;
@@ -139,7 +142,7 @@
         box-shadow: var(--button-shadow-inset);
         color: var(--lime-primary-color, var(--limel-theme-primary-color));
 
-        &:active {
+        &:not(:has(:disabled)):active {
             box-shadow: var(--button-shadow-inset-pressed);
         }
     }

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -45,6 +45,7 @@ import { createRandomString } from '../../util/random-string';
  * @exampleComponent limel-example-button-group-basic
  * @exampleComponent limel-example-button-group-mix
  * @exampleComponent limel-example-button-group-badges
+ * @exampleComponent limel-example-button-group-disabled-item
  * @exampleComponent limel-example-button-group-composite
  */
 @Component({
@@ -60,7 +61,10 @@ export class ButtonGroup {
     public value: Button[] = [];
 
     /**
-     * True if the button-group should be disabled
+     * True if the button-group should be disabled.
+     *
+     * Disables every button in the group, regardless of the `disabled` value
+     * of each individual button.
      */
     @Prop({ reflect: true })
     public disabled: boolean = false;
@@ -96,6 +100,7 @@ export class ButtonGroup {
         // Prefix with 'b' because html IDs cannot start with a digit,
         // and we need to differentiate from the ID on the limel-icon. /Ads
         const buttonId = `b${button.id}`;
+        const isDisabled = this.disabled || button.disabled;
 
         const classes = {
             button: true,
@@ -108,7 +113,8 @@ export class ButtonGroup {
                     type="radio"
                     name={this.radioGroupName}
                     checked={this.isButtonChecked(button)}
-                    disabled={this.disabled}
+                    disabled={isDisabled}
+                    aria-disabled={isDisabled ? 'true' : 'false'}
                     id={buttonId}
                     onChange={this.onChange}
                 />
@@ -166,10 +172,19 @@ export class ButtonGroup {
         event.stopPropagation();
         const target = event.target as HTMLInputElement;
         // The ID is prefixed with `b` in the HTML, remember? /Ads
-        this.selectedButtonId = target.id.slice(1);
+        const buttonId = target.id.slice(1);
         const button = this.value.find((item) => {
-            return item.id === this.selectedButtonId;
+            return item.id === buttonId;
         });
+
+        // The `disabled` attribute on the input already stops the browser
+        // from getting here. This makes it hold even if the attribute is
+        // removed from the DOM, or a `change` event is dispatched by hand.
+        if (!button || this.disabled || button.disabled) {
+            return;
+        }
+
+        this.selectedButtonId = buttonId;
         this.change.emit(button);
     }
 

--- a/src/components/button-group/examples/button-group-disabled-item.tsx
+++ b/src/components/button-group/examples/button-group-disabled-item.tsx
@@ -1,0 +1,80 @@
+import { Component, h, Host, State } from '@stencil/core';
+import { Button, LimelButtonGroupCustomEvent } from '@limetech/lime-elements';
+
+/**
+ * Disabled item
+ *
+ * Individual buttons can be disabled by setting `disabled: true` on the
+ * button, without disabling the rest of the group.
+ *
+ * :::note
+ * Do not combine `disabled` with `selected` on the same button. Once the user
+ * picks another button, the disabled one can never be selected again.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-button-group-disabled-item',
+    shadow: true,
+})
+export class ButtonGroupDisabledItemExample {
+    @State()
+    private buttons: Button[] = [
+        {
+            id: '1',
+            title: 'First',
+            selected: true,
+        },
+        {
+            id: '2',
+            title: 'Second',
+            disabled: true,
+        },
+        {
+            id: '3',
+            title: 'Third',
+        },
+    ];
+
+    @State()
+    private disabled: boolean = false;
+
+    private eventPrinter: HTMLLimelExampleEventPrinterElement;
+
+    public render() {
+        return (
+            <Host>
+                <limel-button-group
+                    onChange={this.handleChange}
+                    value={this.buttons}
+                    disabled={this.disabled}
+                />
+                <limel-example-controls>
+                    <limel-switch
+                        label="Disabled"
+                        onChange={this.toggleEnabled}
+                        value={this.disabled}
+                    />
+                </limel-example-controls>
+                <limel-example-event-printer
+                    ref={(el) => (this.eventPrinter = el)}
+                />
+            </Host>
+        );
+    }
+
+    private handleChange = (event: LimelButtonGroupCustomEvent<Button>) => {
+        this.eventPrinter.writeEvent(event);
+        const changedButton = event.detail;
+
+        this.buttons = this.buttons.map((button) => {
+            return {
+                ...button,
+                selected: button.id === changedButton.id,
+            };
+        });
+    };
+
+    private toggleEnabled = () => {
+        this.disabled = !this.disabled;
+    };
+}

--- a/src/components/button/button.types.ts
+++ b/src/components/button/button.types.ts
@@ -26,4 +26,15 @@ export interface Button {
      * The label displayed in the badge
      */
     badge?: number | string;
+
+    /**
+     * True if the button should be disabled.
+     *
+     * Disabling every button in the group is not the same as disabling the
+     * group itself; set `disabled` on `limel-button-group` for that.
+     *
+     * Combining this with `selected` is not supported. Once the user picks
+     * another button, the disabled one can never be selected again.
+     */
+    disabled?: boolean;
 }


### PR DESCRIPTION
<!-- If the PR title includes `@coderabbitai`, CodeRabbit will generate an automatic PR title -->
fix: https://github.com/Lundalogik/lime-elements/issues/4274

<!-- Automated summary by CodeRabbit will be added here -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Button groups now support disabling individual buttons while keeping other options active.
  * Disabled buttons are visibly styled, expose their disabled state for accessibility, and cannot be selected.
  * Individual disabled states work alongside the group-level disabled setting.
  * Disabled buttons remain inactive even when change events are triggered programmatically.

* **Documentation**
  * Added an example demonstrating a button group with an individually disabled option.

* **Tests**
  * Added end-to-end coverage for disabled button behavior and state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- End of CodeRabbit summary -->

## Review:
- [ ] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [ ] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
