### PR TITLE
Add an example for the info tile's link property

### DIFF
--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -127,17 +127,19 @@ export class Card {
 
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
+    private cleanup3dHoverEffect: () => void;
     private markdownResizeObserver?: ResizeObserver;
 
     public componentWillLoad() {
-        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
-            this.host
-        );
+        const { handleMouseEnter, handleMouseLeave, cleanup } =
+            getMouseEventHandlers(this.host);
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.cleanup3dHoverEffect = cleanup;
     }
 
     public disconnectedCallback() {
+        this.cleanup3dHoverEffect();
         this.markdownResizeObserver?.disconnect();
         this.markdownElement?.removeEventListener(
             'scroll',

--- a/src/components/info-tile/examples/info-tile-link.scss
+++ b/src/components/info-tile/examples/info-tile-link.scss
@@ -1,0 +1,30 @@
+:host(limel-example-info-tile-link) {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 1rem;
+}
+
+limel-info-tile {
+    height: 8rem;
+
+    // Each tile also sets its text and icon color, not just its background.
+    // The default text color resolves to `--contrast-1100`, which turns
+    // light in dark mode and would sit at roughly 1.1:1 over a pastel.
+    &.forecast {
+        --info-tile-background-color: rgb(var(--color-glaucous-lighter));
+        --info-tile-text-color: rgb(var(--color-glaucous-darker));
+        --info-tile-icon-color: rgb(var(--color-glaucous-darker));
+    }
+
+    &.deals {
+        --info-tile-background-color: rgb(var(--color-green-lighter));
+        --info-tile-text-color: rgb(var(--color-green-darker));
+        --info-tile-icon-color: rgb(var(--color-green-darker));
+    }
+
+    &.office {
+        --info-tile-background-color: rgb(var(--color-violet-lighter));
+        --info-tile-text-color: rgb(var(--color-violet-darker));
+        --info-tile-icon-color: rgb(var(--color-violet-darker));
+    }
+}

--- a/src/components/info-tile/examples/info-tile-link.tsx
+++ b/src/components/info-tile/examples/info-tile-link.tsx
@@ -1,0 +1,101 @@
+import { Component, h, Host } from '@stencil/core';
+import { Link } from '@limetech/lime-elements';
+
+/**
+ * Turning the tile into a link
+ *
+ * An info tile usually summarizes something the user will want to look
+ * into. Supply a `link` and the tile's anchor gets an `href`: it can then
+ * be opened in a new tab from the context menu, and assistive technologies
+ * announce it as a link rather than as a piece of text.
+ *
+ * Supplying a `link` is also what gives the tile its interactive styling:
+ * a resting shadow, `cursor: pointer`, and — on hover — the elevation,
+ * the tilt that follows the cursor, and the glow. Hover the first two
+ * tiles below, then the third, which has no `link` and so stays flat and
+ * completely still.
+ *
+ * The three tiles cover the cases you are likely to run into.
+ *
+ * **Navigating to another page.** The forecast tile points at an external
+ * page and sets `target="_blank"`, so it opens in a new tab. Its `title`
+ * becomes the tooltip, and `rel="noopener noreferrer"` is added
+ * automatically.
+ *
+ * **Navigating inside your own app.** The deals tile is a link too, but its
+ * click is intercepted so that a single page application can route without
+ * reloading itself. Point the `link` at the real destination anyway, so that
+ * modifier-clicking it still opens that destination in a new tab. Try
+ * clicking it, and then shift-clicking it.
+ *
+ * **Not navigating at all.** The office tile has no `link`. It reports a
+ * number and nothing more, so it gets none of the interactive styling, it
+ * is not reachable with the keyboard, and it does not track the cursor. A
+ * tile that cannot be activated should not look or behave as if it can.
+ *
+ * :::tip
+ * If the tile must act on a click but has no URL to point at — a dialog
+ * opens, for instance — supply `{ href: '#' }`. Without it the tile gets
+ * no interactive styling and cannot be reached with the keyboard, so a
+ * click handler on its own leaves the interaction invisible. Prefer a real
+ * URL whenever one exists.
+ * :::
+ */
+@Component({
+    tag: 'limel-example-info-tile-link',
+    shadow: true,
+    styleUrl: 'info-tile-link.scss',
+})
+export class InfoTileLinkExample {
+    private readonly forecastLink: Link = {
+        href: 'https://duckduckgo.com/?q=weather+Stockholm',
+        title: 'See the full forecast for Stockholm',
+        target: '_blank',
+    };
+
+    private readonly dealsLink: Link = {
+        href: '#/component/limel-table',
+        title: 'Open the list of won deals',
+    };
+
+    public render() {
+        return (
+            <Host>
+                <limel-info-tile
+                    class="forecast"
+                    icon="partly_cloudy_day"
+                    label="Partly cloudy"
+                    prefix="Stockholm"
+                    value="7"
+                    suffix="°C"
+                    link={this.forecastLink}
+                />
+                <limel-info-tile
+                    class="deals"
+                    icon="money"
+                    label="Won deals this month"
+                    value="24"
+                    link={this.dealsLink}
+                    onClick={this.handleDealsClick}
+                />
+                <limel-info-tile
+                    class="office"
+                    icon="meeting"
+                    label="Colleagues in the office today"
+                    value="14"
+                />
+            </Host>
+        );
+    }
+
+    private readonly handleDealsClick = (event: PointerEvent) => {
+        if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+            return;
+        }
+
+        event.preventDefault();
+        alert(
+            'No modifier key was pressed, so the application would normally hand this over to its own router instead of reloading the whole page.\n\nTry holding down a modifier key, such as Shift, while clicking.'
+        );
+    };
+}

--- a/src/components/info-tile/examples/info-tile-reduced-presence.tsx
+++ b/src/components/info-tile/examples/info-tile-reduced-presence.tsx
@@ -21,11 +21,11 @@ import { Component, h, Host, State } from '@stencil/core';
  *
  * Set `reducedPresence` to `true` on the tiles whose values are not
  * currently noteworthy. This is better than hiding the individual tiles.
- * This way, the tile keeps its position in a grid layout, and also remains
- * interactive. But is rendered with reduced saturation and opacity,
- * so the eye is drawn to the tiles that actually warrant attention.
- * The dimming clears on hover and keyboard focus, so the tile is
- * still fully readable when the user looks at it.
+ * This way, the tile keeps its position in a grid layout, but is rendered
+ * with reduced saturation and opacity, so the eye is drawn to the tiles
+ * that actually warrant attention. The dimming clears while the pointer is
+ * over the tile, so it is still fully readable when the user looks at it —
+ * and on a tile that has a `link`, keyboard focus clears it too.
  *
  * The example below shows a typical operations dashboard. Four of the
  * six tiles report something unimportant; the other two report something the

--- a/src/components/info-tile/info-tile.e2e.tsx
+++ b/src/components/info-tile/info-tile.e2e.tsx
@@ -14,6 +14,62 @@ describe('limel-info-tile', () => {
         });
     });
 
+    describe('when a link is supplied', () => {
+        it('is a link, and carries the 3d hover effect', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-info-tile
+                    value="1"
+                    link={{ href: 'https://example.com' }}
+                ></limel-info-tile>
+            );
+            await waitForChanges();
+
+            const anchor = root.shadowRoot!.querySelector('a');
+            expect(anchor.classList.contains('is-clickable')).toBe(true);
+            expect(anchor.getAttribute('tabindex')).toEqual('0');
+            expect(
+                anchor.querySelector('limel-3d-hover-effect-glow')
+            ).not.toBeNull();
+        });
+    });
+
+    describe('when no link is supplied', () => {
+        // Nothing to activate, so the tile must not signal that it can be.
+        it('is neither focusable nor given the 3d hover effect', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-info-tile value="1"></limel-info-tile>
+            );
+            await waitForChanges();
+
+            const anchor = root.shadowRoot!.querySelector('a');
+            expect(anchor.classList.contains('is-clickable')).toBe(false);
+            expect(anchor.getAttribute('tabindex')).toBeNull();
+            expect(
+                anchor.querySelector('limel-3d-hover-effect-glow')
+            ).toBeNull();
+        });
+    });
+
+    describe('when a link is supplied but the tile is disabled', () => {
+        it('is neither focusable nor given the 3d hover effect', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-info-tile
+                    value="1"
+                    disabled={true}
+                    link={{ href: 'https://example.com' }}
+                ></limel-info-tile>
+            );
+            await waitForChanges();
+
+            const anchor = root.shadowRoot!.querySelector('a');
+            expect(anchor.classList.contains('is-clickable')).toBe(false);
+            expect(anchor.getAttribute('tabindex')).toBeNull();
+            expect(
+                anchor.querySelector('limel-3d-hover-effect-glow')
+            ).toBeNull();
+        });
+    });
+
     describe('when value is empty', () => {
         it('does not crash and renders the label', async () => {
             const { root, waitForChanges } = await render(

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -411,10 +411,11 @@ limel-3d-hover-effect-glow {
     @include mixins.parent-of-the-3d-element;
 }
 
-a {
+// Only a tile that is actually a link gets the hover elevation, the tilt and
+// the glow. Without a `link` there is nothing to activate, so signalling
+// interactivity would be a lie — the same reasoning as `limel-card`, which
+// gates these on its `clickable` and `show3dEffect` properties.
+a.is-clickable {
     @include mixins.the-3d-element;
-
-    &.is-clickable {
-        @include mixins.the-3d-element--clickable;
-    }
+    @include mixins.the-3d-element--clickable;
 }

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -153,11 +153,12 @@ export class InfoTile {
 
         const link = this.disabled ? '#' : this.link?.href;
         const rel = getRel(this.link?.target, this.link?.rel);
+        const isClickable = !!this.link?.href && !this.disabled;
 
         return (
             <Host
-                onMouseEnter={this.handleMouseEnter}
-                onMouseLeave={this.handleMouseLeave}
+                onMouseEnter={isClickable ? this.handleMouseEnter : undefined}
+                onMouseLeave={isClickable ? this.handleMouseLeave : undefined}
                 class={{ 'has-primary-slot-content': this.hasPrimarySlot }}
             >
                 <a
@@ -165,13 +166,13 @@ export class InfoTile {
                     href={link}
                     target={this.link?.target}
                     rel={rel}
-                    tabindex="0"
+                    tabindex={isClickable ? 0 : undefined}
                     aria-label={extendedAriaLabel}
                     aria-disabled={this.disabled}
                     aria-busy={this.loading ? 'true' : 'false'}
                     aria-live="polite"
                     class={{
-                        'is-clickable': !!this.link?.href && !this.disabled,
+                        'is-clickable': isClickable,
                     }}
                 >
                     {this.renderIcon()}
@@ -189,7 +190,7 @@ export class InfoTile {
                         {this.renderSpinner()}
                     </div>
                     {this.renderLabel()}
-                    <limel-3d-hover-effect-glow />
+                    {isClickable && <limel-3d-hover-effect-glow />}
                 </a>
                 {this.renderNotification()}
             </Host>

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -123,14 +123,19 @@ export class InfoTile {
 
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
+    private cleanup3dHoverEffect: () => void;
 
     public componentWillLoad() {
-        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
-            this.host
-        );
+        const { handleMouseEnter, handleMouseLeave, cleanup } =
+            getMouseEventHandlers(this.host);
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.cleanup3dHoverEffect = cleanup;
         this.updateHasPrimarySlotContent();
+    }
+
+    public disconnectedCallback() {
+        this.cleanup3dHoverEffect();
     }
 
     public render() {

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -14,6 +14,7 @@ import { getRel } from '../../util/link-helper';
  * using the `link` property.
  *
  * @exampleComponent limel-example-info-tile-basic
+ * @exampleComponent limel-example-info-tile-link
  * @exampleComponent limel-example-info-tile-badge
  * @exampleComponent limel-example-info-tile-progress
  * @exampleComponent limel-example-info-tile-loading

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -61,13 +61,18 @@ export class Shortcut {
 
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
+    private cleanup3dHoverEffect: () => void;
 
     public componentWillLoad() {
-        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
-            this.host
-        );
+        const { handleMouseEnter, handleMouseLeave, cleanup } =
+            getMouseEventHandlers(this.host);
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.cleanup3dHoverEffect = cleanup;
+    }
+
+    public disconnectedCallback() {
+        this.cleanup3dHoverEffect();
     }
 
     public render() {

--- a/src/util/3d-tilt-hover-effect.spec.ts
+++ b/src/util/3d-tilt-hover-effect.spec.ts
@@ -1,0 +1,80 @@
+import { getMouseEventHandlers } from './3d-tilt-hover-effect';
+
+const TILT = '--limel-3d-hover-effect-rotate3d';
+const GLOW = '--limel-3d-hover-effect-glow-position';
+
+const moveMouse = () => {
+    document.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 20, clientY: 30 })
+    );
+};
+
+describe('getMouseEventHandlers', () => {
+    let element: HTMLElement;
+
+    beforeEach(() => {
+        element = document.createElement('div');
+        document.body.append(element);
+    });
+
+    afterEach(() => {
+        element.remove();
+    });
+
+    it('tilts the element while it is hovered', () => {
+        const { handleMouseEnter } = getMouseEventHandlers(element);
+
+        handleMouseEnter();
+        moveMouse();
+
+        expect(element.style.getPropertyValue(TILT)).not.toBe('');
+        expect(element.style.getPropertyValue(GLOW)).not.toBe('');
+    });
+
+    it('stops tilting once the pointer leaves', () => {
+        const { handleMouseEnter, handleMouseLeave } =
+            getMouseEventHandlers(element);
+
+        handleMouseEnter();
+        handleMouseLeave();
+        moveMouse();
+
+        expect(element.style.getPropertyValue(TILT)).toBe('');
+    });
+
+    describe('when the element is removed while still hovered', () => {
+        // `mouseleave` never fires in this case, so without `cleanup` the
+        // listener stays on `document` for the rest of the page's life.
+        it('stops tilting once cleaned up', () => {
+            const { handleMouseEnter, cleanup } =
+                getMouseEventHandlers(element);
+
+            handleMouseEnter();
+            element.remove();
+            cleanup();
+            moveMouse();
+
+            expect(element.style.getPropertyValue(TILT)).toBe('');
+        });
+    });
+
+    describe('when `mouseenter` fires twice without a `mouseleave`', () => {
+        it('leaves no callback behind that `cleanup` cannot reach', () => {
+            const { handleMouseEnter, cleanup } =
+                getMouseEventHandlers(element);
+
+            handleMouseEnter();
+            handleMouseEnter();
+            cleanup();
+            moveMouse();
+
+            expect(element.style.getPropertyValue(TILT)).toBe('');
+        });
+    });
+
+    it('does not throw when cleaned up before ever being hovered', () => {
+        const { cleanup } = getMouseEventHandlers(element);
+
+        expect(() => cleanup()).not.toThrow();
+    });
+});

--- a/src/util/3d-tilt-hover-effect.ts
+++ b/src/util/3d-tilt-hover-effect.ts
@@ -50,7 +50,8 @@
  * 3. **Initialize in your component**:
  *
  * Use `getMouseEventHandlers()` to attach the required mouse event listeners
- * to the "interactive element" (`the-3d-element`). For example:
+ * to the "interactive element" (`the-3d-element`), and call the `cleanup()` it
+ * returns when the component is disconnected. For example:
  *
  * ```tsx
  * @Element()
@@ -58,15 +59,25 @@
  *
  * private handleMouseEnter: () => void;
  * private handleMouseLeave: () => void;
+ * private cleanup3dHoverEffect: () => void;
  *
  * public componentWillLoad() {
- *     const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
- *         this.host.querySelector('.the-3d-element'),
- *     );
+ *     const { handleMouseEnter, handleMouseLeave, cleanup } =
+ *         getMouseEventHandlers(
+ *             this.host.querySelector('.the-3d-element'),
+ *         );
  *     this.handleMouseEnter = handleMouseEnter;
  *     this.handleMouseLeave = handleMouseLeave;
+ *     this.cleanup3dHoverEffect = cleanup;
+ * }
+ *
+ * public disconnectedCallback() {
+ *     this.cleanup3dHoverEffect();
  * }
  * ```
+ *
+ * Skipping the `disconnectedCallback` leaks a `document` level `mousemove`
+ * listener every time the element is removed while it is being hovered.
  *
  * 4. **Attach event handlers in your render method**:
  *
@@ -148,14 +159,23 @@ export const tiltFollowingTheCursor =
 export const getMouseEventHandlers = (element: HTMLElement) => {
     let tiltCallback: (e: MouseEvent) => void;
 
+    const stopTracking = () => {
+        document.removeEventListener('mousemove', tiltCallback);
+    };
+
     const handleMouseEnter = () => {
+        // A second `mouseenter` without an intervening `mouseleave` would
+        // otherwise strand the previous callback on `document` with nothing
+        // left holding a reference to remove it with.
+        stopTracking();
+
         const bounds = element.getBoundingClientRect();
         tiltCallback = tiltFollowingTheCursor(bounds, element);
         document.addEventListener('mousemove', tiltCallback);
     };
 
     const handleMouseLeave = () => {
-        document.removeEventListener('mousemove', tiltCallback);
+        stopTracking();
         element.style.removeProperty('--limel-3d-hover-effect-rotate3d');
         element.style.removeProperty('--limel-3d-hover-effect-glow-position');
     };
@@ -163,5 +183,16 @@ export const getMouseEventHandlers = (element: HTMLElement) => {
     return {
         handleMouseEnter: handleMouseEnter,
         handleMouseLeave: handleMouseLeave,
+
+        /**
+         * Removes the `mousemove` listener without touching the element.
+         *
+         * `mouseleave` never fires for an element that is removed from the
+         * DOM while the pointer is still over it, which in a single page
+         * application is the ordinary case: a click routes away from the
+         * view holding the element. Call this from `disconnectedCallback`
+         * so the listener does not outlive the element it tilts.
+         */
+        cleanup: stopTracking,
     };
 };


### PR DESCRIPTION
@coderabbitai summary

## Why

The `link` property of `limel-info-tile` had no example of its own. Nothing in the docs showed what supplying a link does, what leaving it out does, or how to handle the common case where a single page application wants to route a click itself instead of letting the browser navigate.

The new example has three tiles:

1. **An external link.** `target="_blank"`, a `title` that becomes the tooltip, and `rel="noopener noreferrer"` filled in automatically by `getRel`.
2. **An in-app link with an intercepted click.** The `link` points at the real destination so modifier-clicking still opens it in a new tab, while a plain click is `preventDefault`ed for the application's own router — the same pattern as `limel-example-shortcut-with-click-handler`.
3. **No link at all.** Hovering this one next to the first two is the whole point of the example: it stays flat and still, while they elevate and tilt.

## Note on the split

This PR originally carried three separate concerns. Two have been split out so they can be reviewed and merged on their own:

- **#4285** — four `perf` commits fixing the `mousemove` listener leak (#4282). No behavioural change. Can merge whenever.
- **#4286** — `fix(info-tile): drop the 3d hover effect when the tile is not a link`. The look-and-feel and clickability change.

Their commits are deliberately **still on this branch**, unchanged and at the same SHAs, so this PR stands up on its own in the meantime. As they merge, this branch gets rebased and those commits drop out by patch-id, leaving only `docs(info-tile): add an example for the link property`.

**#4286 needs to merge before this one.** The example's prose describes the post-fix behaviour — it tells the reader the third tile stays "flat and completely still" and "is not reachable with the keyboard". Landing the docs first would mean shipping text that describes behaviour `main` does not have yet.

## Things worth a reviewer's attention on the example itself

**The tiles set text and icon colours, not just backgrounds.** They use soft `-lighter` backgrounds from the palette, and each also sets `--info-tile-text-color` and `--info-tile-icon-color` to the matching `-darker` swatch. Setting the background alone is not enough: the default `--info-tile-text-color` resolves to `--contrast-1100`, which flips to a *light* grey in dark mode and lands at roughly **1.1:1** over a pastel. Same pairing as `limel-example-callout-styles`. Verified by reading the computed backgrounds off the rendered anchors in both light and dark mode.

**An earlier revision of this example fetched live weather from Open-Meteo**, so the tile's `loading` state was real rather than simulated. That was dropped in favour of a static reading, to keep the docs site free of a third-party runtime dependency. Mentioning it only so the idea is on record rather than lost.

## Verified

- `npm run docs:rebuild` clean; `npm run lint` clean.
- Example accessibility suite: all `info-tile` examples pass, no new axe violations, no baseline entries added.
- Example runtime suite green.
- Screenshots checked in light and dark mode.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made — every change to an `examples/*.tsx` file is `docs`, including a new one
- [x] Commits with *breaking changes* are marked as such (none in the documentation commit)

### Browsers tested:
Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
