### PR TITLE
feat(text-editor): add named regions to the editor

### DIFF
--- a/src/components/markdown/markdown-parser.spec.ts
+++ b/src/components/markdown/markdown-parser.spec.ts
@@ -413,6 +413,15 @@ describe('markdownToHTML', () => {
             );
         });
 
+        it("should not strip a built-in tag's own attributes when the whitelist names it", async () => {
+            const result = await sanitizeHTML(
+                '<img src="https://example.com/a.png" alt="a">',
+                [{ tagName: 'img', attributes: ['data-tracked'] }]
+            );
+
+            expect(result).toContain('src="https://example.com/a.png"');
+        });
+
         it('should strip non-whitelisted custom elements', async () => {
             const result = await markdownToHTML(
                 '<unknown-element>Content</unknown-element>'

--- a/src/components/markdown/markdown-parser.ts
+++ b/src/components/markdown/markdown-parser.ts
@@ -133,6 +133,10 @@ function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
         ],
         attributes: {
             ...defaultSchema.attributes,
+            // Marker for the text editor's regions. Written here as a hast
+            // property name, which is what the schema matches on:
+            // `data-lime-region`.
+            div: [...(defaultSchema.attributes.div ?? []), 'dataLimeRegion'],
             p: [
                 ...(defaultSchema.attributes.p ?? []),
                 ['className', 'MsoNormal'],
@@ -143,7 +147,13 @@ function getWhiteList(allowedComponents: CustomElementDefinition[]): Schema {
     };
 
     for (const component of allowedComponents) {
-        whitelist.attributes[component.tagName] = component.attributes;
+        // Merge rather than assign: a definition naming a built-in tag would
+        // otherwise replace that tag's own rules wholesale, e.g. stripping
+        // `src` from every image.
+        whitelist.attributes[component.tagName] = [
+            ...(whitelist.attributes[component.tagName] ?? []),
+            ...component.attributes,
+        ];
     }
 
     return whitelist;

--- a/src/components/text-editor/examples/text-editor-regions.tsx
+++ b/src/components/text-editor/examples/text-editor-regions.tsx
@@ -1,0 +1,65 @@
+import { Component, Element, h, State } from '@stencil/core';
+import { EditorRegion } from '../text-editor.types';
+
+const REGIONS: EditorRegion[] = [{ name: 'signature', label: 'Signature' }];
+
+/**
+ * Regions
+ *
+ * A region is a named block of the document that keeps its identity through
+ * the editor. Declare the names you use on the `regions` property, and mark
+ * them in the value as `<div data-lime-region="name">`.
+ *
+ * The editor frames a region with its label so a writer can tell it apart
+ * from the body, while its content stays fully editable. The label is drawn
+ * by the editor and never becomes part of the value, which stays ordinary
+ * HTML for anything that renders it later.
+ *
+ * `replaceRegion` swaps one region's content, leaving everything the user
+ * has typed untouched.
+ */
+@Component({
+    tag: 'limel-example-text-editor-regions',
+    shadow: true,
+})
+export class TextEditorRegionsExample {
+    @Element()
+    private host: HTMLLimelExampleTextEditorRegionsElement;
+
+    @State()
+    private value: string =
+        '<p>Thanks for getting back to me!</p>' +
+        '<div data-lime-region="signature">' +
+        '<p>Kind regards,<br />Robin</p>' +
+        '</div>';
+
+    public render() {
+        return [
+            <limel-text-editor
+                value={this.value}
+                onChange={this.handleChange}
+                contentType="html"
+                regions={REGIONS}
+            />,
+            <limel-example-controls>
+                <limel-button
+                    label="Replace signature"
+                    onClick={this.replaceSignature}
+                />
+            </limel-example-controls>,
+            <limel-example-value value={this.value} />,
+        ];
+    }
+
+    private replaceSignature = async () => {
+        const editor = this.host.shadowRoot.querySelector('limel-text-editor');
+        await editor.replaceRegion(
+            'signature',
+            '<p>Best,<br />Robin — sent from a different account</p>'
+        );
+    };
+
+    private handleChange = (event: CustomEvent<string>) => {
+        this.value = event.detail;
+    };
+}

--- a/src/components/text-editor/prosemirror-adapter/editor-config.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-config.ts
@@ -17,11 +17,17 @@ import { createListKeyHandlerPlugin } from './plugins/list-key-handler';
 import { createTriggerPlugin } from './plugins/trigger/factory';
 import { getTableNodes, getTableEditingPlugins } from './plugins/table-plugin';
 import { getImageNode } from './plugins/image/node';
+import { getRegionNodes } from './plugins/regions/node';
+import { createRegionViewPlugin } from './plugins/regions/view';
 import { createNodeSpec } from '../utils/plugin-factory';
 import { ContentTypeConverter } from '../utils/content-type-converter';
 import { CustomElementDefinition } from '../../../global/shared-types/custom-element.types';
 import { Languages } from '../../date-picker/date.types';
-import { TriggerCharacter, InlineImages } from '../text-editor.types';
+import {
+    TriggerCharacter,
+    InlineImages,
+    EditorRegion,
+} from '../text-editor.types';
 
 /**
  * Content format the text editor reads and emits.
@@ -35,6 +41,7 @@ export interface EditorSchemaOptions {
     contentType: ContentType;
     language: Languages;
     inlineImages?: InlineImages;
+    regions?: EditorRegion[];
 }
 
 /**
@@ -48,7 +55,8 @@ export interface EditorSchemaOptions {
  * @returns the configured ProseMirror schema
  */
 export function buildEditorSchema(options: EditorSchemaOptions): Schema {
-    const { customElements, contentType, language, inlineImages } = options;
+    const { customElements, contentType, language, inlineImages, regions } =
+        options;
 
     let nodes = basicSchema.spec.nodes;
 
@@ -62,6 +70,10 @@ export function buildEditorSchema(options: EditorSchemaOptions): Schema {
 
     if (contentType === 'html') {
         nodes = nodes.append(getTableNodes());
+
+        if (regions?.length) {
+            nodes = nodes.append(getRegionNodes(regions));
+        }
     }
 
     nodes = nodes.append(getImageNode(language, inlineImages));
@@ -83,6 +95,7 @@ export interface EditorPluginsOptions {
     contentType: ContentType;
     triggerCharacters: TriggerCharacter[];
     inlineImages?: InlineImages;
+    regions?: EditorRegion[];
     onNewLinkSelection: Parameters<typeof createLinkPlugin>[0];
     onImagePasted: Parameters<typeof createImageInserterPlugin>[0];
     onActiveItemsChange: Parameters<typeof createMenuStateTrackingPlugin>[2];
@@ -110,6 +123,7 @@ export function buildEditorPlugins(options: EditorPluginsOptions): Plugin[] {
         contentType,
         triggerCharacters,
         inlineImages,
+        regions,
         onNewLinkSelection,
         onImagePasted,
         onActiveItemsChange,
@@ -138,6 +152,9 @@ export function buildEditorPlugins(options: EditorPluginsOptions): Plugin[] {
         ),
         createActionBarInteractionPlugin(menuCommandFactory),
         createListKeyHandlerPlugin(schema),
+        ...(contentType === 'html' && regions?.length
+            ? [createRegionViewPlugin(regions)]
+            : []),
         ...getTableEditingPlugins(contentType === 'html'),
     ];
 }

--- a/src/components/text-editor/prosemirror-adapter/editor-regions.spec.ts
+++ b/src/components/text-editor/prosemirror-adapter/editor-regions.spec.ts
@@ -1,0 +1,157 @@
+import { DOMSerializer } from 'prosemirror-model';
+import { HTMLConverter } from '../utils/html-converter';
+import { createReplaceRegionTransaction } from './plugins/regions/commands';
+import {
+    createEditorTestHarness,
+    createEditorTestState,
+    mountView,
+    parseHTML,
+} from './test/editor-test-harness';
+
+describe('editor regions (real stack)', () => {
+    const regions = [
+        { name: 'signature', label: 'Signature' },
+        { name: 'quote' },
+    ];
+    const html = createEditorTestHarness({
+        contentType: 'html',
+        regions: regions,
+    });
+    const markdown = createEditorTestHarness({
+        contentType: 'markdown',
+        regions: regions,
+    });
+
+    const signature = '<div data-lime-region="signature"><p>Regards</p></div>';
+
+    it('parses a declared region into a region node carrying its name', () => {
+        const doc = parseHTML(html.schema, signature);
+
+        expect(doc.firstChild.type.name).toBe('region');
+        expect(doc.firstChild.attrs.name).toBe('signature');
+    });
+
+    it('ignores a region whose name was not declared', () => {
+        const doc = parseHTML(
+            html.schema,
+            '<div data-lime-region="disclaimer"><p>Regards</p></div>'
+        );
+
+        expect(doc.firstChild.type.name).toBe('paragraph');
+    });
+
+    it('serializes a region node back to a marked div', () => {
+        const doc = parseHTML(html.schema, signature);
+        const dom = DOMSerializer.fromSchema(html.schema).serializeNode(
+            doc.firstChild
+        ) as HTMLElement;
+
+        expect(dom.outerHTML).toBe(signature);
+    });
+
+    it('does not recognise regions in markdown mode', () => {
+        const doc = parseHTML(markdown.schema, signature);
+
+        expect(markdown.schema.nodes.region).toBeUndefined();
+        expect(doc.firstChild.type.name).toBe('paragraph');
+    });
+
+    it('keeps the region marker through sanitization', async () => {
+        const converter = new HTMLConverter([]);
+
+        const sanitized = await converter.parseAsHTML(signature);
+        const doc = parseHTML(html.schema, sanitized);
+
+        expect(doc.firstChild.type.name).toBe('region');
+        expect(doc.firstChild.attrs.name).toBe('signature');
+    });
+
+    it('serializes the marker back out while the node view is mounted', () => {
+        const source = `<p>Hi</p>${signature}`;
+        const doc = parseHTML(html.schema, source);
+        const { view, cleanup } = mountView(createEditorTestState(html, doc));
+
+        const serialized = new HTMLConverter([]).serialize(view);
+
+        expect(serialized).toBe(source);
+
+        cleanup();
+    });
+
+    it('draws the declared label without putting it in the content', () => {
+        const doc = parseHTML(html.schema, `<p>Hi</p>${signature}`);
+        const { view, cleanup } = mountView(createEditorTestState(html, doc));
+
+        const label = view.dom.querySelector('.region__label');
+
+        expect(label?.textContent).toBe('Signature');
+        expect(view.state.doc.child(1).textContent).toBe('Regards');
+
+        cleanup();
+    });
+
+    it('draws no label for a region declared without one', () => {
+        const doc = parseHTML(
+            html.schema,
+            '<div data-lime-region="quote"><p>On Monday</p></div>'
+        );
+        const { view, cleanup } = mountView(createEditorTestState(html, doc));
+
+        expect(view.dom.querySelector('.region__label')).toBeNull();
+
+        cleanup();
+    });
+
+    it('keeps region content editable', () => {
+        const doc = parseHTML(html.schema, `<p>Hi</p>${signature}`);
+        const state = createEditorTestState(html, doc);
+
+        // Just inside the region's paragraph, after "Reg"
+        const next = state.apply(state.tr.insertText('ards and reg', 9));
+
+        expect(next.doc.child(1).textContent).toBe('Regards and regards');
+    });
+
+    it('replaces a named region and leaves the rest alone', () => {
+        const doc = parseHTML(html.schema, `<p>Hi</p>${signature}`);
+        const state = createEditorTestState(html, doc);
+
+        const next = state.apply(
+            createReplaceRegionTransaction(state, 'signature', '<p>New</p>')
+        );
+
+        expect(next.doc.childCount).toBe(2);
+        expect(next.doc.child(0).textContent).toBe('Hi');
+        expect(next.doc.child(1).attrs.name).toBe('signature');
+        expect(next.doc.child(1).textContent).toBe('New');
+    });
+
+    it('leaves other regions untouched when replacing one', () => {
+        const doc = parseHTML(
+            html.schema,
+            `${signature}<div data-lime-region="quote"><p>On Monday</p></div>`
+        );
+        const state = createEditorTestState(html, doc);
+
+        const next = state.apply(
+            createReplaceRegionTransaction(state, 'signature', '<p>New</p>')
+        );
+
+        expect(next.doc.child(0).textContent).toBe('New');
+        expect(next.doc.child(1).attrs.name).toBe('quote');
+        expect(next.doc.child(1).textContent).toBe('On Monday');
+    });
+
+    it('appends the region when the document has none', () => {
+        const doc = parseHTML(html.schema, '<p>Hi</p>');
+        const state = createEditorTestState(html, doc);
+
+        const next = state.apply(
+            createReplaceRegionTransaction(state, 'signature', '<p>New</p>')
+        );
+
+        expect(next.doc.childCount).toBe(2);
+        expect(next.doc.child(1).attrs.name).toBe('signature');
+        expect(next.doc.child(1).textContent).toBe('New');
+    });
+});

--- a/src/components/text-editor/prosemirror-adapter/plugins/regions/commands.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/regions/commands.ts
@@ -1,0 +1,62 @@
+import { DOMParser, Node } from 'prosemirror-model';
+import { EditorState, Transaction } from 'prosemirror-state';
+
+/**
+ * Builds a transaction that sets the named region's content, leaving every
+ * other part of the document untouched. When the document has no such
+ * region yet, one is appended.
+ *
+ * The content is parsed into the region, so the caller keeps ownership of
+ * sanitizing it first.
+ *
+ * @param state - the state the transaction is built against
+ * @param name - the region to replace
+ * @param html - the region's new content
+ * @returns a transaction replacing the region
+ */
+export function createReplaceRegionTransaction(
+    state: EditorState,
+    name: string,
+    html: string
+): Transaction {
+    const region = parseRegion(state, name, html);
+    const existing = findRegion(state, name);
+
+    if (existing) {
+        return state.tr.replaceWith(
+            existing.pos,
+            existing.pos + existing.node.nodeSize,
+            region
+        );
+    }
+
+    return state.tr.insert(state.doc.content.size, region);
+}
+
+function parseRegion(state: EditorState, name: string, html: string): Node {
+    const container = document.createElement('div');
+    container.innerHTML = html;
+
+    return DOMParser.fromSchema(state.schema).parse(container, {
+        topNode: state.schema.nodes.region.createAndFill({ name: name }),
+    });
+}
+
+function findRegion(
+    state: EditorState,
+    name: string
+): { pos: number; node: Node } | undefined {
+    const type = state.schema.nodes.region;
+    let pos = 0;
+
+    for (let index = 0; index < state.doc.childCount; index++) {
+        const node = state.doc.child(index);
+        if (node.type === type && node.attrs.name === name) {
+            return { pos: pos, node: node };
+        }
+
+        pos += node.nodeSize;
+    }
+
+    return undefined;
+}

--- a/src/components/text-editor/prosemirror-adapter/plugins/regions/node.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/regions/node.ts
@@ -1,0 +1,52 @@
+import { DOMOutputSpec, NodeSpec } from 'prosemirror-model';
+import { EditorRegion } from '../../../text-editor.types';
+
+/**
+ * Attribute a region is marked with in the editor's HTML.
+ */
+export const REGION_ATTRIBUTE = 'data-lime-region';
+
+/**
+ * Builds the node spec for regions: named block-level areas of the document
+ * that keep their identity through a parse and serialize round trip, so a
+ * consumer can address one after the content has been through the editor.
+ *
+ * A region is a plain div carrying a marker attribute rather than a custom
+ * element, so the serialized value stays ordinary HTML wherever it is sent
+ * on to.
+ *
+ * @param regions - the regions the consumer has declared
+ */
+export function getRegionNodes(
+    regions: EditorRegion[]
+): Record<string, NodeSpec> {
+    return { region: createRegionNodeSpec(regions) };
+}
+
+function createRegionNodeSpec(regions: EditorRegion[]): NodeSpec {
+    const declared = new Set(regions.map((region) => region.name));
+
+    return {
+        group: 'block',
+        content: 'block+',
+        defining: true,
+        attrs: { name: {} },
+        toDOM: (node): DOMOutputSpec => [
+            'div',
+            { [REGION_ATTRIBUTE]: node.attrs.name },
+            0,
+        ],
+        parseDOM: [
+            {
+                tag: `div[${REGION_ATTRIBUTE}]`,
+                getAttrs: (dom: HTMLElement) => {
+                    const name = dom.getAttribute(REGION_ATTRIBUTE);
+
+                    // An undeclared name is ordinary content: a consumer only
+                    // owns the regions it asked for.
+                    return declared.has(name) ? { name: name } : false;
+                },
+            },
+        ],
+    };
+}

--- a/src/components/text-editor/prosemirror-adapter/plugins/regions/view.scss
+++ b/src/components/text-editor/prosemirror-adapter/plugins/regions/view.scss
@@ -1,0 +1,17 @@
+.region {
+    margin-block-start: 1rem;
+    padding-block-start: 0.5rem;
+    border-block-start: 1px solid var(--contrast-300);
+}
+
+.region__label {
+    display: block;
+    margin-block-end: 0.25rem;
+
+    color: var(--contrast-700);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+
+    user-select: none;
+}

--- a/src/components/text-editor/prosemirror-adapter/plugins/regions/view.ts
+++ b/src/components/text-editor/prosemirror-adapter/plugins/regions/view.ts
@@ -1,0 +1,63 @@
+import { Node } from 'prosemirror-model';
+import { Plugin } from 'prosemirror-state';
+import { NodeView } from 'prosemirror-view';
+import { EditorRegion } from '../../../text-editor.types';
+
+/**
+ * Frames each declared region so a writer can tell it apart from the body
+ * they are typing. The label is chrome drawn by this view, never part of
+ * the document, so it is not serialized and never leaves the editor.
+ *
+ * @param regions - the regions the consumer has declared
+ */
+export const createRegionViewPlugin = (regions: EditorRegion[]) => {
+    const labels = new Map(
+        regions
+            .filter((region) => region.label)
+            .map((region) => [region.name, region.label])
+    );
+
+    return new Plugin({
+        props: {
+            nodeViews: {
+                region: (node) => new RegionView(node, labels),
+            },
+        },
+    });
+};
+
+class RegionView implements NodeView {
+    public dom: HTMLElement;
+    public contentDOM: HTMLElement;
+
+    public constructor(node: Node, labels: Map<string, string>) {
+        this.dom = document.createElement('div');
+        this.dom.className = 'region';
+        // A styling hook, so a consumer can tell one region from another
+        // without the serialized marker leaking into the view layer.
+        this.dom.dataset.region = node.attrs.name;
+
+        const label = labels.get(node.attrs.name);
+        if (label) {
+            const element = document.createElement('span');
+            element.className = 'region__label';
+            element.contentEditable = 'false';
+            element.textContent = label;
+            this.dom.append(element);
+        }
+
+        this.contentDOM = document.createElement('div');
+        this.contentDOM.className = 'region__content';
+        this.dom.append(this.contentDOM);
+    }
+
+    /**
+     * Mutations outside the content element are this view's own chrome,
+     * not document changes, so they must not trigger a re-parse.
+     *
+     * @param mutation
+     */
+    public ignoreMutation(mutation: MutationRecord): boolean {
+        return !this.contentDOM.contains(mutation.target);
+    }
+}

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.scss
@@ -9,6 +9,7 @@
 @forward '../../markdown/partial-styles/kbd';
 @forward '../../markdown/partial-styles/img';
 @forward 'plugins/image/view';
+@forward 'plugins/regions/view';
 
 :host(limel-prosemirror-adapter) {
     display: flex;

--- a/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
+++ b/src/components/text-editor/prosemirror-adapter/prosemirror-adapter.tsx
@@ -35,6 +35,7 @@ import {
     EditorLink,
     InlineImages,
     isInlineImageTag,
+    EditorRegion,
 } from '../text-editor.types';
 import { imageCache } from './plugins/image/node';
 import {
@@ -42,6 +43,7 @@ import {
     buildEditorPlugins,
     ContentType,
 } from './editor-config';
+import { createReplaceRegionTransaction } from './plugins/regions/commands';
 import { EditorUiType } from '../types';
 import {
     getMetadataFromDoc,
@@ -114,6 +116,15 @@ export class ProsemirrorAdapter {
      */
     @Prop()
     public inlineImages?: InlineImages;
+
+    /**
+     * Named block-level regions the editor should recognise in its value.
+     *
+     * @private
+     * @alpha
+     */
+    @Prop()
+    public regions?: EditorRegion[];
 
     /**
      * set to private to avoid usage while under development
@@ -262,6 +273,34 @@ export class ProsemirrorAdapter {
         }
 
         await this.updateView('');
+    }
+
+    /**
+     * Replace the content of a named region, leaving the rest of the
+     * document untouched. When the document has no such region yet, one is
+     * appended.
+     *
+     * Emits a `change` event, so a consumer mirroring the content stays in
+     * sync. A region that was not declared on `regions` is a silent no-op.
+     *
+     * @param name - the region to replace
+     * @param html - the region's new content
+     */
+    @Method()
+    public async replaceRegion(name: string, html: string): Promise<void> {
+        const declared = this.regions?.some((region) => region.name === name);
+        if (!this.view || !this.schema.nodes.region || !declared) {
+            return;
+        }
+
+        const sanitized = await this.contentConverter.parseAsHTML(
+            html,
+            this.schema
+        );
+
+        this.view.dispatch(
+            createReplaceRegionTransaction(this.view.state, name, sanitized)
+        );
     }
 
     @Watch('value')
@@ -490,6 +529,7 @@ export class ProsemirrorAdapter {
             contentType: this.contentType,
             language: this.language,
             inlineImages: this.validatedInlineImages,
+            regions: this.regions,
         });
     }
 
@@ -520,6 +560,7 @@ export class ProsemirrorAdapter {
                 contentType: this.contentType,
                 triggerCharacters: this.triggerCharacters,
                 inlineImages: this.validatedInlineImages,
+                regions: this.regions,
                 onNewLinkSelection: this.handleNewLinkSelection,
                 onImagePasted: this.imagePasted.emit,
                 onActiveItemsChange: this.updateActiveActionBarItems,

--- a/src/components/text-editor/prosemirror-adapter/test/editor-test-harness.ts
+++ b/src/components/text-editor/prosemirror-adapter/test/editor-test-harness.ts
@@ -22,7 +22,11 @@ import { ContentTypeConverter } from '../../utils/content-type-converter';
 type EditorTestHarnessOverrides = Partial<
     Pick<
         EditorSchemaOptions,
-        'customElements' | 'contentType' | 'language' | 'inlineImages'
+        | 'customElements'
+        | 'contentType'
+        | 'language'
+        | 'inlineImages'
+        | 'regions'
     > &
         Pick<
             EditorPluginsOptions,
@@ -67,6 +71,7 @@ export function createEditorTestHarness(
         contentType: overrides.contentType ?? 'html',
         language: overrides.language ?? 'en',
         inlineImages: overrides.inlineImages,
+        regions: overrides.regions,
     });
     const factory = new MenuCommandFactory(schema);
     const plugins = buildEditorPlugins({
@@ -76,6 +81,7 @@ export function createEditorTestHarness(
         language: overrides.language ?? 'en',
         contentType: overrides.contentType ?? 'html',
         inlineImages: overrides.inlineImages,
+        regions: overrides.regions,
         triggerCharacters: overrides.triggerCharacters ?? [],
         onNewLinkSelection: overrides.onNewLinkSelection ?? (() => undefined),
         onImagePasted:

--- a/src/components/text-editor/text-editor.spec.tsx
+++ b/src/components/text-editor/text-editor.spec.tsx
@@ -141,6 +141,24 @@ describe('limel-text-editor', () => {
         });
     });
 
+    describe('replaceRegion', () => {
+        test('it resolves', async () => {
+            const { root } = await createComponent({ contentType: 'html' });
+
+            await expect(
+                root.replaceRegion('signature', '<p>Kind regards</p>')
+            ).resolves.toBeUndefined();
+        });
+
+        test('it resolves in readonly mode, where no adapter is rendered', async () => {
+            const { root } = await createComponent({ readonly: true });
+
+            await expect(
+                root.replaceRegion('signature', '<p>Kind regards</p>')
+            ).resolves.toBeUndefined();
+        });
+    });
+
     describe('label', () => {
         test('it renders the label', async () => {
             const { root } = await createComponent({ label: 'my label' });

--- a/src/components/text-editor/text-editor.tsx
+++ b/src/components/text-editor/text-editor.tsx
@@ -18,6 +18,7 @@ import {
     EditorImage,
     EditorMetadata,
     InlineImages,
+    EditorRegion,
 } from './text-editor.types';
 import { EditorUiType } from './types';
 
@@ -43,6 +44,7 @@ import { EditorUiType } from './types';
  * @exampleComponent limel-example-text-editor-ui
  * @exampleComponent limel-example-text-editor-custom-element
  * @exampleComponent limel-example-text-editor-triggers
+ * @exampleComponent limel-example-text-editor-regions
  * @exampleComponent limel-example-text-editor-composite
  * @beta
  */
@@ -140,6 +142,20 @@ export class TextEditor implements FormComponent<string> {
      */
     @Prop()
     public inlineImages?: InlineImages;
+
+    /**
+     * Named block-level regions the editor should recognise in its value,
+     * each written as `<div data-lime-region="name">`. A region keeps its
+     * identity through the editor, so it can be replaced on its own with
+     * `replaceRegion` without disturbing the rest of the document.
+     *
+     * Only available in `html` mode.
+     *
+     * @private
+     * @alpha
+     */
+    @Prop()
+    public regions?: EditorRegion[];
 
     /**
      * A set of trigger characters
@@ -301,6 +317,25 @@ export class TextEditor implements FormComponent<string> {
         await this.adapterElement?.clear();
     }
 
+    /**
+     * Replace the content of a named region, leaving the rest of the
+     * document untouched.
+     *
+     * A region is a `<div data-lime-region="name">` in the editor's value.
+     * When the document has no such region yet, one is appended.
+     *
+     * Emits a `change` event, so a consumer mirroring the content stays in
+     * sync. A region that was not declared on `regions` is a silent no-op,
+     * as is readonly mode, where no editor is rendered.
+     *
+     * @param name - the region to replace
+     * @param html - the region's new content
+     */
+    @Method()
+    public async replaceRegion(name: string, html: string): Promise<void> {
+        await this.adapterElement?.replaceRegion(name, html);
+    }
+
     public render() {
         return (
             <Host>
@@ -348,6 +383,7 @@ export class TextEditor implements FormComponent<string> {
                 onMetadataChange={this.handleMetadataChange}
                 customElements={this.customElements}
                 inlineImages={this.inlineImages}
+                regions={this.regions}
                 value={this.value}
                 aria-controls={this.helperText ? this.helperTextId : undefined}
                 id={this.editorId}

--- a/src/components/text-editor/text-editor.types.ts
+++ b/src/components/text-editor/text-editor.types.ts
@@ -253,3 +253,28 @@ export interface EditorMetadata {
      */
     links: EditorLink[];
 }
+
+/**
+ * A named block-level area of the editor's document that keeps its identity
+ * through a parse and serialize round trip. Declared by the consumer, so the
+ * editor never has to know what a region means.
+ *
+ * A region is written in the value as `<div data-lime-region="name">`, which
+ * keeps the value ordinary HTML for anything that renders it later.
+ *
+ * @alpha
+ */
+export interface EditorRegion {
+    /**
+     * The region's name, as it appears in the marker attribute. Content
+     * marked with a name that was not declared is treated as ordinary
+     * content.
+     */
+    name: string;
+
+    /**
+     * Optional label drawn above the region inside the editor, so a writer
+     * can tell it apart from the body. Never part of the value.
+     */
+    label?: string;
+}


### PR DESCRIPTION
## Description

Draft, parked. Opening it to make the approach visible and easy to comment on — not asking for review yet.

Adds a **named region** to the text editor: a block-level area of the document that keeps its identity through a parse and serialize round trip, so a consumer can replace one on its own without disturbing the rest of the document.

```html
<div data-lime-region="signature">…</div>
```

```tsx
<limel-text-editor
    contentType="html"
    regions={[{ name: 'signature', label: 'Signature' }]}
/>
```

- One `region` node with a required `name`. Parsing rejects any name the consumer has not declared, so unrelated markup stays ordinary content.
- `replaceRegion(name, html)` sets one region's content and leaves everything else alone.
- A declared `label` is drawn by a node view and never enters the value.
- Only available in `html` mode, and only when `regions` is non-empty — nothing changes for existing consumers.

Also fixes a bug in the markdown sanitizer whitelist, with its own test: `getWhiteList` assigned rather than merged, so a whitelist entry naming a built-in tag replaced that tag's rules wholesale — whitelisting `img` stripped `src` from every image.

**Why a marked `div` and not a custom element.** The first consumer is the email composer, and its serialized value is sent on to Gmail, Outlook and Apple Mail. An unknown tag gets no block layout there, so a custom element would need a server-side unwrap to be safe. A `div` with a data attribute is inert everywhere.

There is a separate design doc proposing `content: 'block'` on `CustomElementDefinition` plus a `limel-signature` component. Its analysis is sound and was used here — in particular that `createNodeSpec` produces inline atoms and so cannot express an editable block. This differs on representation only, for the wire-format reason above. `content: 'block'` is still worth doing on its own merits; it is simply not required by this.

Connected to Lundalogik/crm-client#1290

**Known gaps:** no e2e coverage, readme not regenerated, and no way to remove a region once added.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
Not browser tested — 1212 spec tests pass, but this has not been exercised in a running app.
