### PR TITLE
Stop the 3D tilt hover effect leaking a mousemove listener

### DIFF
--- a/src/components/card/card.e2e.tsx
+++ b/src/components/card/card.e2e.tsx
@@ -1,0 +1,33 @@
+import { render, h } from '@stencil/vitest';
+
+const TILT = '--limel-3d-hover-effect-rotate3d';
+
+const moveMouse = () => {
+    document.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 20, clientY: 30 })
+    );
+};
+
+describe('limel-card', () => {
+    describe('when the card is removed while it is still hovered', () => {
+        // `mouseleave` never fires in this case, so the 3d tilt effect's
+        // `document` level `mousemove` listener has to be removed by the
+        // card's `disconnectedCallback` instead.
+        it('stops tilting', async () => {
+            const { root, waitForChanges, unmount } = await render(
+                <limel-card></limel-card>
+            );
+            await waitForChanges();
+
+            root.dispatchEvent(new MouseEvent('mouseenter'));
+            moveMouse();
+
+            expect(root.style.getPropertyValue(TILT)).not.toBe('');
+
+            unmount();
+            moveMouse();
+
+            expect(root.style.getPropertyValue(TILT)).toBe('');
+        });
+    });
+});

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -127,14 +127,15 @@ export class Card {
 
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
+    private cleanup3dHoverEffect?: () => void;
     private markdownResizeObserver?: ResizeObserver;
 
     public componentWillLoad() {
-        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
-            this.host
-        );
+        const { handleMouseEnter, handleMouseLeave, cleanup } =
+            getMouseEventHandlers(this.host);
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.cleanup3dHoverEffect = cleanup;
     }
 
     public disconnectedCallback() {
@@ -143,6 +144,7 @@ export class Card {
             'scroll',
             this.checkIfScrollable
         );
+        this.cleanup3dHoverEffect?.();
     }
 
     public componentDidLoad() {

--- a/src/components/info-tile/info-tile.e2e.tsx
+++ b/src/components/info-tile/info-tile.e2e.tsx
@@ -1,5 +1,13 @@
 import { render, h } from '@stencil/vitest';
 
+const TILT = '--limel-3d-hover-effect-rotate3d';
+
+const moveMouse = () => {
+    document.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 20, clientY: 30 })
+    );
+};
+
 describe('limel-info-tile', () => {
     describe('smoke test', () => {
         it('displays the correct value', async () => {
@@ -24,6 +32,28 @@ describe('limel-info-tile', () => {
             const label = root.shadowRoot!.querySelector('.label');
             expect(label).not.toBeNull();
             expect(label.textContent).toEqual('Test label');
+        });
+    });
+
+    describe('when the tile is removed while it is still hovered', () => {
+        // `mouseleave` never fires in this case, so the 3d tilt effect's
+        // `document` level `mousemove` listener has to be removed by the
+        // tile's `disconnectedCallback` instead.
+        it('stops tilting', async () => {
+            const { root, waitForChanges, unmount } = await render(
+                <limel-info-tile value="Test value"></limel-info-tile>
+            );
+            await waitForChanges();
+
+            root.dispatchEvent(new MouseEvent('mouseenter'));
+            moveMouse();
+
+            expect(root.style.getPropertyValue(TILT)).not.toBe('');
+
+            unmount();
+            moveMouse();
+
+            expect(root.style.getPropertyValue(TILT)).toBe('');
         });
     });
 });

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -123,14 +123,19 @@ export class InfoTile {
 
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
+    private cleanup3dHoverEffect?: () => void;
 
     public componentWillLoad() {
-        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
-            this.host
-        );
+        const { handleMouseEnter, handleMouseLeave, cleanup } =
+            getMouseEventHandlers(this.host);
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.cleanup3dHoverEffect = cleanup;
         this.updateHasPrimarySlotContent();
+    }
+
+    public disconnectedCallback() {
+        this.cleanup3dHoverEffect?.();
     }
 
     public render() {

--- a/src/components/shortcut/shortcut.e2e.tsx
+++ b/src/components/shortcut/shortcut.e2e.tsx
@@ -1,5 +1,13 @@
 import { render, h } from '@stencil/vitest';
 
+const TILT = '--limel-3d-hover-effect-rotate3d';
+
+const moveMouse = () => {
+    document.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 20, clientY: 30 })
+    );
+};
+
 describe('limel-shortcut', () => {
     describe('with a label', () => {
         let root: HTMLElement;
@@ -186,6 +194,28 @@ describe('limel-shortcut', () => {
                 const badge = root.shadowRoot!.querySelector('limel-badge');
                 expect(badge.getAttribute('label')).toEqual('3');
             });
+        });
+    });
+
+    describe('when the shortcut is removed while it is still hovered', () => {
+        // `mouseleave` never fires in this case, so the 3d tilt effect's
+        // `document` level `mousemove` listener has to be removed by the
+        // shortcut's `disconnectedCallback` instead.
+        it('stops tilting', async () => {
+            const { root, waitForChanges, unmount } = await render(
+                <limel-shortcut label="iSpiffy"></limel-shortcut>
+            );
+            await waitForChanges();
+
+            root.dispatchEvent(new MouseEvent('mouseenter'));
+            moveMouse();
+
+            expect(root.style.getPropertyValue(TILT)).not.toBe('');
+
+            unmount();
+            moveMouse();
+
+            expect(root.style.getPropertyValue(TILT)).toBe('');
         });
     });
 });

--- a/src/components/shortcut/shortcut.tsx
+++ b/src/components/shortcut/shortcut.tsx
@@ -61,13 +61,18 @@ export class Shortcut {
 
     private handleMouseEnter: () => void;
     private handleMouseLeave: () => void;
+    private cleanup3dHoverEffect?: () => void;
 
     public componentWillLoad() {
-        const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
-            this.host
-        );
+        const { handleMouseEnter, handleMouseLeave, cleanup } =
+            getMouseEventHandlers(this.host);
         this.handleMouseEnter = handleMouseEnter;
         this.handleMouseLeave = handleMouseLeave;
+        this.cleanup3dHoverEffect = cleanup;
+    }
+
+    public disconnectedCallback() {
+        this.cleanup3dHoverEffect?.();
     }
 
     public render() {

--- a/src/util/3d-tilt-hover-effect.spec.ts
+++ b/src/util/3d-tilt-hover-effect.spec.ts
@@ -1,0 +1,94 @@
+import { getMouseEventHandlers } from './3d-tilt-hover-effect';
+
+const TILT = '--limel-3d-hover-effect-rotate3d';
+const GLOW = '--limel-3d-hover-effect-glow-position';
+
+const moveMouse = () => {
+    document.dispatchEvent(
+        new MouseEvent('mousemove', { clientX: 20, clientY: 30 })
+    );
+};
+
+describe('getMouseEventHandlers', () => {
+    let element: HTMLElement;
+
+    beforeEach(() => {
+        element = document.createElement('div');
+        document.body.append(element);
+    });
+
+    afterEach(() => {
+        element.remove();
+    });
+
+    it('tilts the element while it is hovered', () => {
+        const { handleMouseEnter, cleanup } = getMouseEventHandlers(element);
+
+        handleMouseEnter();
+        moveMouse();
+
+        expect(element.style.getPropertyValue(TILT)).not.toBe('');
+        expect(element.style.getPropertyValue(GLOW)).not.toBe('');
+
+        cleanup();
+    });
+
+    it('stops tilting once the pointer leaves', () => {
+        const { handleMouseEnter, handleMouseLeave } =
+            getMouseEventHandlers(element);
+
+        handleMouseEnter();
+        handleMouseLeave();
+        moveMouse();
+
+        expect(element.style.getPropertyValue(TILT)).toBe('');
+        expect(element.style.getPropertyValue(GLOW)).toBe('');
+    });
+
+    it('returns the element to rest when cleaned up', () => {
+        const { handleMouseEnter, cleanup } = getMouseEventHandlers(element);
+
+        handleMouseEnter();
+        moveMouse();
+        cleanup();
+
+        expect(element.style.getPropertyValue(TILT)).toBe('');
+        expect(element.style.getPropertyValue(GLOW)).toBe('');
+    });
+
+    describe('when the element is removed while still hovered', () => {
+        // `mouseleave` never fires in this case, so without `cleanup` the
+        // listener stays on `document` for the rest of the page's life.
+        it('stops tilting once cleaned up', () => {
+            const { handleMouseEnter, cleanup } =
+                getMouseEventHandlers(element);
+
+            handleMouseEnter();
+            element.remove();
+            cleanup();
+            moveMouse();
+
+            expect(element.style.getPropertyValue(TILT)).toBe('');
+        });
+    });
+
+    describe('when `mouseenter` fires twice without a `mouseleave`', () => {
+        it('leaves no callback behind that `cleanup` cannot reach', () => {
+            const { handleMouseEnter, cleanup } =
+                getMouseEventHandlers(element);
+
+            handleMouseEnter();
+            handleMouseEnter();
+            cleanup();
+            moveMouse();
+
+            expect(element.style.getPropertyValue(TILT)).toBe('');
+        });
+    });
+
+    it('does not throw when cleaned up before ever being hovered', () => {
+        const { cleanup } = getMouseEventHandlers(element);
+
+        expect(() => cleanup()).not.toThrow();
+    });
+});

--- a/src/util/3d-tilt-hover-effect.ts
+++ b/src/util/3d-tilt-hover-effect.ts
@@ -50,7 +50,8 @@
  * 3. **Initialize in your component**:
  *
  * Use `getMouseEventHandlers()` to attach the required mouse event listeners
- * to the "interactive element" (`the-3d-element`). For example:
+ * to the "interactive element" (`the-3d-element`), and call the `cleanup()` it
+ * returns when the component is disconnected. For example:
  *
  * ```tsx
  * @Element()
@@ -58,15 +59,29 @@
  *
  * private handleMouseEnter: () => void;
  * private handleMouseLeave: () => void;
+ * private cleanup3dHoverEffect?: () => void;
  *
  * public componentWillLoad() {
- *     const { handleMouseEnter, handleMouseLeave } = getMouseEventHandlers(
- *         this.host.querySelector('.the-3d-element'),
- *     );
+ *     const { handleMouseEnter, handleMouseLeave, cleanup } =
+ *         getMouseEventHandlers(
+ *             this.host.querySelector<HTMLElement>('.the-3d-element'),
+ *         );
  *     this.handleMouseEnter = handleMouseEnter;
  *     this.handleMouseLeave = handleMouseLeave;
+ *     this.cleanup3dHoverEffect = cleanup;
+ * }
+ *
+ * public disconnectedCallback() {
+ *     this.cleanup3dHoverEffect?.();
  * }
  * ```
+ *
+ * Call it optionally: `disconnectedCallback` can run before
+ * `componentWillLoad` has assigned the field.
+ *
+ * Skipping the `disconnectedCallback` leaks a `document` level `mousemove`
+ * listener every time the element is removed while it is being hovered, and
+ * leaves a moved element stuck at the angle it was last tilted to.
  *
  * 4. **Attach event handlers in your render method**:
  *
@@ -148,20 +163,47 @@ export const tiltFollowingTheCursor =
 export const getMouseEventHandlers = (element: HTMLElement) => {
     let tiltCallback: (e: MouseEvent) => void;
 
-    const handleMouseEnter = () => {
-        const bounds = element.getBoundingClientRect();
-        tiltCallback = tiltFollowingTheCursor(bounds, element);
-        document.addEventListener('mousemove', tiltCallback);
-    };
-
-    const handleMouseLeave = () => {
+    /**
+     * Stops following the cursor and returns the element to rest.
+     *
+     * Safe to call when tracking never started, and safe to call on an
+     * element that has already been detached.
+     */
+    const stopTracking = () => {
         document.removeEventListener('mousemove', tiltCallback);
         element.style.removeProperty('--limel-3d-hover-effect-rotate3d');
         element.style.removeProperty('--limel-3d-hover-effect-glow-position');
     };
 
+    const handleMouseEnter = () => {
+        // A second `mouseenter` without an intervening `mouseleave` would
+        // otherwise strand the previous callback on `document` with nothing
+        // left holding a reference to remove it with.
+        stopTracking();
+
+        const bounds = element.getBoundingClientRect();
+        tiltCallback = tiltFollowingTheCursor(bounds, element);
+        document.addEventListener('mousemove', tiltCallback);
+    };
+
     return {
         handleMouseEnter: handleMouseEnter,
-        handleMouseLeave: handleMouseLeave,
+        handleMouseLeave: stopTracking,
+
+        /**
+         * The same teardown as `handleMouseLeave`, for the case where no
+         * `mouseleave` is coming.
+         *
+         * `mouseleave` never fires for an element that is removed from the
+         * DOM while the pointer is still over it, which in a single page
+         * application is the ordinary case: a click routes away from the
+         * view holding the element. It does not fire when the element is
+         * merely moved within the DOM either, and a move disconnects the
+         * component just like a removal does. Call this from
+         * `disconnectedCallback` so the listener does not outlive the
+         * element it tilts, and so a moved element does not stay stuck at
+         * the angle it was last tilted to.
+         */
+        cleanup: stopTracking,
     };
 };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 3D hover effects now stop correctly when cards, information tiles, or shortcuts are removed.
  - Prevented lingering hover behavior after interactive elements leave the page.
  - Improved reliability when repeatedly entering and leaving interactive elements.

- **Documentation**
  - Added guidance for cleaning up 3D hover effects.

- **Tests**
  - Added coverage for hover movement, glow updates, repeated interactions, mouse-leave behavior, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fix: https://github.com/Lundalogik/lime-elements/issues/4282


## Why

Closes #4282.

`getMouseEventHandlers` in the 3D tilt hover effect added a `document` level `mousemove` listener on `mouseenter` and removed it only on `mouseleave`. An element removed from the DOM while the pointer is still over it never gets a `mouseleave`, so the listener survived it — and `getMouseEventHandlers` returned no handle to that listener, so a consumer had no way to remove it even if it wanted to.

The surviving listener keeps running `tiltFollowingTheCursor` on every mouse move for the rest of the page's life: a `sqrt`, a `log` and two custom property writes against a node that is no longer in the document, while keeping that node and its captured `DOMRect` reachable. Each occurrence leaks one listener plus the element it retains.

In a single page application this is the ordinary case rather than an edge case, because these components are usually links: a click routes away from the view holding them while they are still hovered. Every such navigation leaked another listener and another retained element.

## The commits

| | |
|---|---|
| `fix: stop the 3d tilt hover effect stranding a mousemove listener` | The shared util. No scope, because it is not specific to any one component and has no tag of its own. |
| `fix(card): …` | Adds the `cleanup()` call to the `disconnectedCallback` the card already had, plus a regression test in the new `card.e2e.tsx`. |
| `fix(shortcut): …` | The component had no `disconnectedCallback` at all. Regression test added to `shortcut.e2e.tsx`. |
| `fix(info-tile): …` | Same, and the last of the three consumers still leaking, so this one carries `Closes #4282`. Regression test added to `info-tile.e2e.tsx`. |

The first commit deliberately lands a `cleanup()` that nothing calls yet — it is preparatory, so that each consumer's wiring is its own reviewable commit with its own correct scope and its own changelog line. It is not inert, though: it also stops `handleMouseEnter` stranding a listener it is about to replace, which on its own closes a second leak. Two `mouseenter` events with no `mouseleave` between them used to leave the first listener attached with nothing referencing it, so not even a later `mouseleave` could remove it.

## Things worth a reviewer's attention

**The new spec is a real regression test, not a test of the code as written.** I confirmed both of its key cases **fail** against the unfixed util and pass against the fixed one, by neutering `cleanup` to a no-op and removing the `handleMouseEnter` guard, then running the spec:

```
× when the element is removed while still hovered > stops tilting once cleaned up
× when `mouseenter` fires twice without a `mouseleave` > leaves no callback behind that `cleanup` cannot reach
```

It asserts behaviour rather than spying on `removeEventListener`: it dispatches a real `mousemove` and checks that the element's `--limel-3d-hover-effect-rotate3d` is no longer being written.

**`cleanup()` is the same teardown as `handleMouseLeave`** — it drops the listener *and* clears the two custom properties. It originally left the element alone, on the reasoning that there is no point styling a node being thrown away. Review pointed out that this holds for a removal but not for a DOM *move*, which disconnects the component just the same: the element stays in the document with a stale `rotate3d` still set, and `src/style/mixins.scss` keeps applying it under `&:hover`, so a moved tile sat frozen at its last angle. `removeProperty` on a detached node is free, so one teardown now covers both cases.

**No public API change.** `getMouseEventHandlers` is internal — absent from `src/index.ts` and from `etc/lime-elements.api.md` — so adding `cleanup` to its return type is not a `feat`, and `etc/lime-elements.api.md` needs no update.

**Type choice: `fix`, not `perf`.** These started as `perf` and were retyped during review. `commits-and-prs.md` defines `perf` as a change that *only* improves performance without changing behaviour, and these do change behaviour: the `handleMouseEnter` guard changes what a second `mouseenter` does, and `cleanup()` now resets a moved element. The same doc's carve-out points the same way — "if the performance was previously so bad it could be considered a bug, and that's been fixed, `fix` is a good fit" — and an unbounded listener retaining a detached node is a bug, filed on the bug template as #4282. Both types release as a patch bump, so the version is unaffected.

## Verified

- `npm run lint` clean and the spec suite green (**1203**) at **each of the four commits individually**, not just the tip — checked by walking each SHA, so the branch bisects cleanly.
- The e2e count climbs **16 → 17 → 18 → 19** across the four commits, i.e. each component's regression test lands in the same commit as the fix it guards.
- All four commit messages pass `commitlint`.
- The review fixups were autosquashed content-neutrally: the resulting tree hash is byte-identical to the pre-squash tip, and each of the four intermediate trees matches the preview that was verified commit-by-commit.
- Full e2e suite: 1082 passed, 8 skipped. The one failure is in `src/examples-smoke.e2e.ts`, which is **flaky and unrelated** — it failed on `limel-example-chip-readonly-border` in one run at the tip, on `limel-example-dock-notification` at the base commit `81a8678c3` (before this PR), and passed twice in a row at the tip. Nothing here touches chips or dock.
- #4280 carries copies of these four commits. **They will no longer drop out by patch-id** — the review fixups changed all four patches — so drop them explicitly when rebasing that branch.

## Review round 1

A [6-agent review](https://github.com/Lundalogik/lime-elements/pull/4285#issuecomment-5586995125) found no regression against `main` and no blockers. Four of its six recommendations were applied as fixups, since autosquashed into the four commits:

1. `cleanup3dHoverEffect?.()` with an optional field in all three components, and card's call moved *after* its pre-existing teardown so a throw cannot skip it. Stencil defers `componentWillLoad` to a microtask, so `disconnectedCallback` can run before the field is assigned.
2. `cleanup()` now returns the element to rest (see above).
3. A browser regression test per component, each in that component's own commit.
4. `perf` → `fix` (see above).

Two were left open on purpose, both pre-existing and both better as their own PR: a `@Watch('show3dEffect')` teardown for the case where the prop flips off mid-hover, and the larger question of moving the `mousemove` listener from `document` onto the element, which would make the leak structurally impossible but changes the effect in two edge cases. `limel-popover` has the same leak shape today and deserves its own issue.

Both CodeRabbit comments were valid and are fixed — the spec no longer leaves its own listener attached, and the doc snippet now type-checks. I did not add CodeRabbit's `!` to the `querySelector` call: this repo sets no `strict`/`strictNullChecks`, so `HTMLElement | null` assigns fine and the assertion would only teach a habit the codebase does not need. The `Element` → `HTMLElement` narrowing was the real error.

One correction to my own earlier claim: the util's doc comment is **not** published to the docs site. `src/index.ts` re-exports only `./components` and `./interface`, so the kompendium target never reaches `src/util/3d-tilt-hover-effect.ts`. The warning still reaches a contributor on editor hover, which is the audience that matters, but `src/style-utilities.md` would be the discoverable home for it.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such (none — no API change, and the behaviour changes are the leak fix itself)

### Browsers tested:
Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS

