### PR TITLE
Drop the info tile's 3D hover effect when it is not a link

### DIFF
--- a/src/components/info-tile/examples/info-tile-reduced-presence.tsx
+++ b/src/components/info-tile/examples/info-tile-reduced-presence.tsx
@@ -21,11 +21,11 @@ import { Component, h, Host, State } from '@stencil/core';
  *
  * Set `reducedPresence` to `true` on the tiles whose values are not
  * currently noteworthy. This is better than hiding the individual tiles.
- * This way, the tile keeps its position in a grid layout, and also remains
- * interactive. But is rendered with reduced saturation and opacity,
- * so the eye is drawn to the tiles that actually warrant attention.
- * The dimming clears on hover and keyboard focus, so the tile is
- * still fully readable when the user looks at it.
+ * This way, the tile keeps its position in a grid layout, but is rendered
+ * with reduced saturation and opacity, so the eye is drawn to the tiles
+ * that actually warrant attention. The dimming clears while the pointer is
+ * over the tile, so it is still fully readable when the user looks at it —
+ * and on a tile that has a `link`, keyboard focus clears it too.
  *
  * The example below shows a typical operations dashboard. Four of the
  * six tiles report something unimportant; the other two report something the

--- a/src/components/info-tile/info-tile.e2e.tsx
+++ b/src/components/info-tile/info-tile.e2e.tsx
@@ -14,6 +14,62 @@ describe('limel-info-tile', () => {
         });
     });
 
+    describe('when a link is supplied', () => {
+        it('is a link, and carries the 3d hover effect', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-info-tile
+                    value="1"
+                    link={{ href: 'https://example.com' }}
+                ></limel-info-tile>
+            );
+            await waitForChanges();
+
+            const anchor = root.shadowRoot!.querySelector('a');
+            expect(anchor.classList.contains('is-clickable')).toBe(true);
+            expect(anchor.getAttribute('tabindex')).toEqual('0');
+            expect(
+                anchor.querySelector('limel-3d-hover-effect-glow')
+            ).not.toBeNull();
+        });
+    });
+
+    describe('when no link is supplied', () => {
+        // Nothing to activate, so the tile must not signal that it can be.
+        it('is neither focusable nor given the 3d hover effect', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-info-tile value="1"></limel-info-tile>
+            );
+            await waitForChanges();
+
+            const anchor = root.shadowRoot!.querySelector('a');
+            expect(anchor.classList.contains('is-clickable')).toBe(false);
+            expect(anchor.getAttribute('tabindex')).toBeNull();
+            expect(
+                anchor.querySelector('limel-3d-hover-effect-glow')
+            ).toBeNull();
+        });
+    });
+
+    describe('when a link is supplied but the tile is disabled', () => {
+        it('is neither focusable nor given the 3d hover effect', async () => {
+            const { root, waitForChanges } = await render(
+                <limel-info-tile
+                    value="1"
+                    disabled={true}
+                    link={{ href: 'https://example.com' }}
+                ></limel-info-tile>
+            );
+            await waitForChanges();
+
+            const anchor = root.shadowRoot!.querySelector('a');
+            expect(anchor.classList.contains('is-clickable')).toBe(false);
+            expect(anchor.getAttribute('tabindex')).toBeNull();
+            expect(
+                anchor.querySelector('limel-3d-hover-effect-glow')
+            ).toBeNull();
+        });
+    });
+
     describe('when value is empty', () => {
         it('does not crash and renders the label', async () => {
             const { root, waitForChanges } = await render(

--- a/src/components/info-tile/info-tile.scss
+++ b/src/components/info-tile/info-tile.scss
@@ -411,10 +411,11 @@ limel-3d-hover-effect-glow {
     @include mixins.parent-of-the-3d-element;
 }
 
-a {
+// Only a tile that is actually a link gets the hover elevation, the tilt and
+// the glow. Without a `link` there is nothing to activate, so signalling
+// interactivity would be a lie — the same reasoning as `limel-card`, which
+// gates these on its `clickable` and `show3dEffect` properties.
+a.is-clickable {
     @include mixins.the-3d-element;
-
-    &.is-clickable {
-        @include mixins.the-3d-element--clickable;
-    }
+    @include mixins.the-3d-element--clickable;
 }

--- a/src/components/info-tile/info-tile.tsx
+++ b/src/components/info-tile/info-tile.tsx
@@ -148,11 +148,12 @@ export class InfoTile {
 
         const link = this.disabled ? '#' : this.link?.href;
         const rel = getRel(this.link?.target, this.link?.rel);
+        const isClickable = !!this.link?.href && !this.disabled;
 
         return (
             <Host
-                onMouseEnter={this.handleMouseEnter}
-                onMouseLeave={this.handleMouseLeave}
+                onMouseEnter={isClickable ? this.handleMouseEnter : undefined}
+                onMouseLeave={isClickable ? this.handleMouseLeave : undefined}
                 class={{ 'has-primary-slot-content': this.hasPrimarySlot }}
             >
                 <a
@@ -160,13 +161,13 @@ export class InfoTile {
                     href={link}
                     target={this.link?.target}
                     rel={rel}
-                    tabindex="0"
+                    tabindex={isClickable ? 0 : undefined}
                     aria-label={extendedAriaLabel}
                     aria-disabled={this.disabled}
                     aria-busy={this.loading ? 'true' : 'false'}
                     aria-live="polite"
                     class={{
-                        'is-clickable': !!this.link?.href && !this.disabled,
+                        'is-clickable': isClickable,
                     }}
                 >
                     {this.renderIcon()}
@@ -184,7 +185,7 @@ export class InfoTile {
                         {this.renderSpinner()}
                     </div>
                     {this.renderLabel()}
-                    <limel-3d-hover-effect-glow />
+                    {isClickable && <limel-3d-hover-effect-glow />}
                 </a>
                 {this.renderNotification()}
             </Host>


### PR DESCRIPTION
@coderabbitai summary

Split out of #4280 so it can be reviewed and merged on its own. #4280 still carries this same commit for now; once this merges, that branch gets rebased and it drops out, leaving #4280 as just the documentation example.

## Why

`limel-info-tile` applied the 3D hover effect — the tilt that follows the cursor, the hover elevation and the glow — to every tile, whether or not it had anywhere to go. A tile with no `link` lifted and tilted exactly like one that did, while its cursor stayed `auto` and clicking it did nothing. The component signalled an interaction it could not honour.

The `link` property's own documentation already promised the opposite:

> Supplying a value also adds an elevated effect using a shadow, as well as `cursor: pointer`, which appears on hover.

So this is the implementation catching up with the documented contract, not a new rule. The effect, the `mousemove` tracking that drives it, the `limel-3d-hover-effect-glow` element and the `tabindex` are now all gated on the tile being a link and not disabled — which is what `limel-card` has always done with its `clickable` and `show3dEffect` properties.

## Things worth a reviewer's attention

**This is a visible behaviour change for consumers who drove a tile from a click handler with no `link`.** They lose the effect, and the tile leaves the tab order. Supplying a `Link` with `href` set to `'#'` restores both, exactly as the property's documentation describes.

It is committed as `fix` rather than `feat`, and without a `BREAKING CHANGE:` footer, on the grounds that no API changed and the documented contract is unchanged. **If you would rather it carried the footer to force a major bump and land in the migration notes, say so and I will add one** — it is a judgement call about how loudly to announce it, and the changelog is the only place most consumers will see it.

**Gating `tabindex` has a knock-on effect on the `reducedPresence` example, corrected in this same commit rather than left for a follow-up.** Its prose claimed the dimming clears on hover *and keyboard focus*. The keyboard half only ever worked because a tile with no link was focusable regardless, letting `:focus-within` fire. Verified: a dimmed link-less tile now stays at `opacity: 0.4` after `.focus()`, and still clears on hover. The prose now says the pointer clears it, and that keyboard focus does so on a tile that has a `link`.

The trade-off is deliberate but worth a second opinion: a keyboard-only user can no longer un-dim a `reducedPresence` tile that has no link. The alternative is keeping non-interactive tiles in the tab order, which is the thing this commit is removing.

**`position: relative` was coming from the gated mixin**, so a link-less tile's anchor is now `static`, and its absolutely positioned icon and progress bar resolve against the host instead of the anchor. Both boxes are the same rectangle, so nothing moves — measured rather than assumed: the icon sits 4px from the top and 8px from the right on both a gated and an ungated tile.

## Verified

- Three new cases in `info-tile.e2e.tsx` pin the rule: a link gets `is-clickable`, `tabindex="0"` and the glow element; no link gets none of them; a link plus `disabled` gets none of them either.
- In a browser, per tile: a linked tile tilts (`matrix3d`), elevates, and shows `cursor: pointer`; a link-less tile reports `tilts: false`, `elevated: false`, `cursor: auto`, `focusable: false`. Checked in light and dark mode.
- `npm run lint` clean; spec suite green; full e2e suite green (52 files).
- Applies to `main` on its own, independently of #4285, so the two can merge in either order.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [ ] Commits with *breaking changes* are marked as such — deliberately not marked, see the note above

### Browsers tested:
Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [x] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
