### PR TITLE
fix(table): skip prop updates while the table is being rebuilt

### DIFF
--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -300,6 +300,52 @@ describe('limel-table aggregate updates', () => {
         expect(tabulator.setColumns).not.toHaveBeenCalled();
         expect(tabulator.recalc).not.toHaveBeenCalled();
     });
+
+    it('does not touch a tabulator that is not built yet', () => {
+        (component as any).initialized = false;
+        const oldAggregates: any[] = [];
+        const newAggregates = [{ field: 'amount', value: 100 }];
+
+        (component as any).updateAggregates(newAggregates, oldAggregates);
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.setColumns).not.toHaveBeenCalled();
+        expect(tabulator.recalc).not.toHaveBeenCalled();
+        expect(tabulator.rowManager.redraw).not.toHaveBeenCalled();
+    });
+
+    it('does not set columns on a tabulator that is not built yet', () => {
+        (component as any).initialized = false;
+
+        (component as any).updateColumns(
+            [{ field: 'amount' }],
+            [{ field: 'name' }]
+        );
+        (component as any).updateSortableColumns();
+
+        expect((component as any).tabulator.setColumns).not.toHaveBeenCalled();
+    });
+
+    it('applies a skipped update once the table is built', () => {
+        (component as any).initialized = false;
+        (component as any).updateAggregates(
+            [{ field: 'amount', value: 100 }],
+            []
+        );
+
+        (component as any).initialized = true;
+        (component as any).applyPendingColumnRefresh();
+
+        const tabulator = (component as any).tabulator;
+        expect(tabulator.setColumns).toHaveBeenCalled();
+        expect(tabulator.recalc).toHaveBeenCalled();
+    });
+
+    it('does not set columns when nothing was skipped', () => {
+        (component as any).applyPendingColumnRefresh();
+
+        expect((component as any).tabulator.setColumns).not.toHaveBeenCalled();
+    });
 });
 
 describe('limel-table has-aggregation detection', () => {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -259,6 +259,7 @@ export class Table {
     private pool: ElementPool;
     private columnFactory: ColumnDefinitionFactory;
     private initialized = false;
+    private pendingColumnRefresh = false;
     private destroyed = false;
     private resizeObserver: ResizeObserver;
     private currentSorting: ColumnSorter[];
@@ -298,6 +299,7 @@ export class Table {
     public disconnectedCallback() {
         this.destroyed = true;
         this.initialized = false;
+        this.pendingColumnRefresh = false;
 
         this.rowDragManager?.destroy();
         this.rowDragManager = null;
@@ -392,7 +394,9 @@ export class Table {
 
     @Watch('columns')
     protected updateColumns(newColumns: Column[], oldColumns: Column[]) {
-        if (!this.tabulator) {
+        if (!this.tabulator || !this.initialized) {
+            this.pendingColumnRefresh = true;
+
             return;
         }
 
@@ -421,7 +425,9 @@ export class Table {
         newAggregates: ColumnAggregate[],
         oldAggregates: ColumnAggregate[]
     ) {
-        if (!this.tabulator) {
+        if (!this.tabulator || !this.initialized) {
+            this.pendingColumnRefresh = true;
+
             return;
         }
 
@@ -469,7 +475,9 @@ export class Table {
     @Watch('sortableColumns')
     protected updateSortableColumns() {
         this.warnOnConflictingMovableAndSortable();
-        if (!this.tabulator) {
+        if (!this.tabulator || !this.initialized) {
+            this.pendingColumnRefresh = true;
+
             return;
         }
 
@@ -657,6 +665,7 @@ export class Table {
                 return;
             }
             this.initialized = true;
+            this.applyPendingColumnRefresh();
             if (this.data?.length) {
                 this.updateData(this.data, []);
 
@@ -669,6 +678,16 @@ export class Table {
         });
 
         return tabulator;
+    }
+
+    private applyPendingColumnRefresh() {
+        if (!this.pendingColumnRefresh || !this.tabulator) {
+            return;
+        }
+
+        this.pendingColumnRefresh = false;
+        this.tabulator.setColumns(this.getColumnDefinitions());
+        this.tabulator.recalc();
     }
 
     private initRowDragManager() {


### PR DESCRIPTION
@coderabbitai summary

Switching an object explorer between the table and list views throws `null is not an object (evaluating 'this.headersElement.firstChild')` from inside Tabulator.

Tabulator is destroyed and recreated asynchronously, so a prop change in between reached `setColumns` on a table with no DOM. The columns, aggregates and sortableColumns watchers now wait for `initialized` like the data watcher does, and reapply the skipped update on `tableBuilt`.

Found by an e2e test that switches views on an explorer with aggregate columns — it fails every attempt on Chromium and WebKit.

## Review:
- [x] Commits are [atomic](https://lundalogik.github.io/lime-elements/versions/latest/#/Home/commits-and-prs.md/)
- [x] Commits have the correct *type* for the changes made
- [x] Commits with *breaking changes* are marked as such

### Browsers tested:
(Check any that applies, it's ok to leave boxes unchecked if testing something didn't seem relevant.)

Windows:
- [ ] Chrome
- [ ] Edge
- [ ] Firefox

Linux:
- [ ] Chrome
- [ ] Firefox

macOS:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Mobile:
- [ ] Chrome on Android
- [ ] iOS
